### PR TITLE
core: handle cancel ControlEvent; distinguish cancelled/timeout/error outcomes

### DIFF
--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -248,9 +248,13 @@ func (x *HarnessEvent) GetHarnessVersion() string {
 //	                back to the model as context.
 //
 //	"cancel"
-//	  - (no additional fields) Signals that the run should be aborted.
-//	    NOTE: cancel is defined in the protocol but is not yet handled by
-//	    the harness main loop (no-op on receipt).
+//	  - (no additional fields) Signals that the run should be aborted. The
+//	    harness terminates the run within one turn boundary: any in-flight
+//	    provider stream or tool call is cancelled via context propagation,
+//	    no further turns are started, git finalisation still runs, and the
+//	    final "done" HarnessEvent carries stop_reason="cancelled". If the
+//	    harness is in the follow-up grace window (no active run), the
+//	    stream closes promptly without an additional "done" event.
 type ControlEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. The event type discriminator.

--- a/harness/cmd/stirrup/cmd/job.go
+++ b/harness/cmd/stirrup/cmd/job.go
@@ -69,13 +69,25 @@ func runJob(cmd *cobra.Command, args []string) error {
 	defer func() { _ = health.RemoveProbe("/tmp/healthy") }()
 
 	// 3. Register OnControl and block until a task_assignment arrives.
+	//    Also honour a cancel event received before any task is assigned by
+	//    exiting cleanly — the control plane may want to abort a pod that
+	//    hasn't been dispatched yet.
 	configCh := make(chan *types.RunConfig, 1)
+	preTaskCancelCh := make(chan struct{}, 1)
 	tp.OnControl(func(event types.ControlEvent) {
-		if event.Type == "task_assignment" && event.Task != nil {
+		switch event.Type {
+		case "task_assignment":
+			if event.Task != nil {
+				select {
+				case configCh <- event.Task:
+				default:
+					// Already received a task; ignore duplicates.
+				}
+			}
+		case "cancel":
 			select {
-			case configCh <- event.Task:
+			case preTaskCancelCh <- struct{}{}:
 			default:
-				// Already received a task; ignore duplicates.
 			}
 		}
 	})
@@ -87,6 +99,9 @@ func runJob(cmd *cobra.Command, args []string) error {
 	select {
 	case config = <-configCh:
 		// Got our assignment.
+	case <-preTaskCancelCh:
+		fmt.Fprintln(os.Stderr, "cancel received before task assignment; exiting")
+		return nil
 	case <-assignTimer.C:
 		return fmt.Errorf("no task assignment received within 5 minutes")
 	case <-tp.Done():

--- a/harness/internal/core/cancel_otel_test.go
+++ b/harness/internal/core/cancel_otel_test.go
@@ -1,0 +1,273 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// errCustomCancelSentinel is a non-nil cancel cause that is neither
+// ErrCancelledByControlPlane nor context.DeadlineExceeded nor
+// context.Canceled. It exercises the "unrecognised cause" branch of
+// classifyCtxOutcome (→ "error") and the default return branch of
+// setRootCancelAttribute (no attribute set).
+var errCustomCancelSentinel = errors.New("test custom cancel sentinel")
+
+// fireAndCloseProvider fires a pre-configured action on the first Stream
+// call and then returns a channel containing a single tool_use-stop-reason
+// event followed by channel close. This lets tests deliver a cancel
+// ControlEvent (or perform any other side effect) before the outer loop
+// re-enters runInnerLoop for the next turn boundary — without relying on
+// the provider's ctx being cancelled, which is needed for these OTel
+// tests because the provider sees the trace span context (derived from
+// context.Background) rather than the run context.
+type fireAndCloseProvider struct {
+	onStream func()
+	fired    bool
+}
+
+func (p *fireAndCloseProvider) Stream(_ context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	if !p.fired && p.onStream != nil {
+		p.fired = true
+		p.onStream()
+	}
+	ch := make(chan types.StreamEvent, 2)
+	// Emit a tool_call so the loop completes the turn normally and loops
+	// back to the outer turn-boundary ctx check, where the cancel takes
+	// effect. Using a tool_use stop_reason ensures the loop iterates.
+	ch <- types.StreamEvent{
+		Type:  "tool_call",
+		ID:    "tc_otel_test",
+		Name:  "test_tool",
+		Input: map[string]any{},
+	}
+	ch <- types.StreamEvent{Type: "message_complete", StopReason: "tool_use"}
+	close(ch)
+	return ch, nil
+}
+
+// newInMemoryOTelEmitter wires an OTelTraceEmitter to an in-memory span
+// exporter so tests can assert on emitted span attributes without touching
+// the network. The returned exporter captures spans as they are ended; the
+// root "run" span is ended inside Finish, so GetSpans() after Run returns
+// includes the root span and its attributes.
+func newInMemoryOTelEmitter(t *testing.T) (*trace.OTelTraceEmitter, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	return trace.NewOTelTraceEmitterForTest(tp), exporter
+}
+
+// findRootRunSpanAttribute scans the recorded spans for the root "run"
+// span and returns the value of the given attribute, or an empty string if
+// either the span or the attribute is absent.
+func findRootRunSpanAttribute(spans []tracetest.SpanStub, key string) (string, bool) {
+	for _, s := range spans {
+		if s.Name != "run" {
+			continue
+		}
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == key {
+				return attr.Value.AsString(), true
+			}
+		}
+	}
+	return "", false
+}
+
+// TestLoop_CancelAttribute_ControlPlane covers the OTel
+// run.cancelled_by="control_plane" branch of setRootCancelAttribute. A
+// "cancel" ControlEvent fires between turns so context.Cause(runCtx) is
+// ErrCancelledByControlPlane; the attribute must therefore be
+// "control_plane".
+func TestLoop_CancelAttribute_ControlPlane(t *testing.T) {
+	emitter, exporter := newInMemoryOTelEmitter(t)
+
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(nil)
+	loop.Transport = tr
+	loop.Trace = emitter
+	loop.Provider = &fireAndCloseProvider{
+		onStream: func() {
+			// Fire the cancel BEFORE the next turn boundary ctx check.
+			tr.FireControl(types.ControlEvent{Type: "cancel"})
+		},
+	}
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace.Outcome != "cancelled" {
+		t.Fatalf("prerequisite: expected outcome 'cancelled', got %q", runTrace.Outcome)
+	}
+
+	got, ok := findRootRunSpanAttribute(exporter.GetSpans(), "run.cancelled_by")
+	if !ok {
+		t.Fatal("expected run.cancelled_by attribute on root span, none found")
+	}
+	if got != "control_plane" {
+		t.Errorf("run.cancelled_by: got %q, want %q", got, "control_plane")
+	}
+}
+
+// TestLoop_CancelAttribute_Deadline covers the OTel
+// run.cancelled_by="deadline" branch. A ctx with a short deadline is used
+// so that classifyCtxOutcome sees context.DeadlineExceeded as the cause.
+// The provider emits a normal turn; deadline expiry is detected at the
+// next turn boundary ctx check.
+func TestLoop_CancelAttribute_Deadline(t *testing.T) {
+	emitter, exporter := newInMemoryOTelEmitter(t)
+
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(nil)
+	loop.Transport = tr
+	loop.Trace = emitter
+	loop.Provider = &fireAndCloseProvider{
+		onStream: func() {
+			// Block just long enough for the deadline to fire before the
+			// next turn's ctx check. 150ms against a 50ms deadline is
+			// comfortably deterministic.
+			time.Sleep(150 * time.Millisecond)
+		},
+	}
+
+	config := buildTestConfig()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace.Outcome != "timeout" {
+		t.Fatalf("prerequisite: expected outcome 'timeout', got %q", runTrace.Outcome)
+	}
+
+	got, ok := findRootRunSpanAttribute(exporter.GetSpans(), "run.cancelled_by")
+	if !ok {
+		t.Fatal("expected run.cancelled_by attribute on root span, none found")
+	}
+	if got != "deadline" {
+		t.Errorf("run.cancelled_by: got %q, want %q", got, "deadline")
+	}
+}
+
+// TestSetRootCancelAttribute_NoStartedRunSpan covers the defensive
+// !span.SpanContext().IsValid() early-return branch: if the OTel emitter
+// has not yet been Started (no root span), calling setRootCancelAttribute
+// must be a safe no-op. This cannot happen on the Run() path (Start is
+// always called before any cancel classification), but the guard remains
+// for defence in depth.
+func TestSetRootCancelAttribute_NoStartedRunSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	emitter := trace.NewOTelTraceEmitterForTest(tp)
+
+	// Build a loop with the uninitialised OTel emitter — Start is never
+	// called, so RootContext() returns context.Background() and the span
+	// extracted from it has an invalid SpanContext.
+	loop := buildTestLoop(nil)
+	loop.Trace = emitter
+
+	// Should return quietly without panicking and without setting an
+	// attribute (there is no root span to set it on).
+	loop.setRootCancelAttribute(ErrCancelledByControlPlane)
+
+	for _, s := range exporter.GetSpans() {
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "run.cancelled_by" {
+				t.Errorf("did not expect run.cancelled_by attribute on span %q", s.Name)
+			}
+		}
+	}
+}
+
+// TestLoop_CancelAttribute_UnrecognisedCause covers the default return
+// branch of setRootCancelAttribute: when the cause is non-nil and neither
+// a recognised cancel sentinel nor a deadline, outcome classifies as
+// "error" and NO run.cancelled_by attribute is set on the root span.
+func TestLoop_CancelAttribute_UnrecognisedCause(t *testing.T) {
+	emitter, exporter := newInMemoryOTelEmitter(t)
+
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(nil)
+	loop.Transport = tr
+	loop.Trace = emitter
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	customCause := errCustomCancelSentinel
+	loop.Provider = &fireAndCloseProvider{
+		onStream: func() {
+			cancel(customCause)
+		},
+	}
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace.Outcome != "error" {
+		t.Fatalf("prerequisite: expected outcome 'error' for unrecognised cause, got %q", runTrace.Outcome)
+	}
+
+	// The default branch of setRootCancelAttribute returns without
+	// setting the attribute, so it must be absent from the root span.
+	if _, ok := findRootRunSpanAttribute(exporter.GetSpans(), "run.cancelled_by"); ok {
+		t.Error("expected no run.cancelled_by attribute for unrecognised cause")
+	}
+}
+
+// TestLoop_CancelAttribute_Signal covers the OTel
+// run.cancelled_by="signal" branch. A plain cancel() on the parent ctx
+// propagates context.Canceled as the cause of our WithCancelCause child —
+// the same path SIGINT/SIGTERM takes via the root cobra signal handler.
+func TestLoop_CancelAttribute_Signal(t *testing.T) {
+	emitter, exporter := newInMemoryOTelEmitter(t)
+
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(nil)
+	loop.Transport = tr
+	loop.Trace = emitter
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	loop.Provider = &fireAndCloseProvider{
+		onStream: func() {
+			// Cancel the parent ctx (what a signal handler does); the
+			// outer loop detects it at the next turn-boundary check with
+			// context.Canceled as the cause.
+			cancel()
+		},
+	}
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace.Outcome != "cancelled" {
+		t.Fatalf("prerequisite: expected outcome 'cancelled', got %q", runTrace.Outcome)
+	}
+
+	got, ok := findRootRunSpanAttribute(exporter.GetSpans(), "run.cancelled_by")
+	if !ok {
+		t.Fatal("expected run.cancelled_by attribute on root span, none found")
+	}
+	if got != "signal" {
+		t.Errorf("run.cancelled_by: got %q, want %q", got, "signal")
+	}
+}

--- a/harness/internal/core/cancel_test.go
+++ b/harness/internal/core/cancel_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/verifier"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -172,21 +173,92 @@ func TestLoop_DeadlineExceeded_Timeout(t *testing.T) {
 	}
 }
 
-func TestLoop_CallerCancel_Error(t *testing.T) {
+// cancellingProviderOnStream fires the given callback on every Stream call
+// and then blocks until the run context is cancelled. Unlike
+// cancellingProvider it does not force a FireControl, so callers control
+// when/how the cancel is delivered.
+type cancellingProviderOnStream struct {
+	onStream func()
+}
+
+func (p *cancellingProviderOnStream) Stream(ctx context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	ch := make(chan types.StreamEvent)
+	go func() {
+		defer close(ch)
+		if p.onStream != nil {
+			p.onStream()
+		}
+		<-ctx.Done()
+		ch <- types.StreamEvent{Type: "error", Error: ctx.Err()}
+	}()
+	return ch, nil
+}
+
+// TestLoop_CallerCancel_Cancelled verifies that a plain caller cancel()
+// (no cause attached, as would occur via the root cobra signal handler)
+// produces RunTrace.Outcome == "cancelled" and done.stop_reason == "cancelled".
+//
+// The cancel is fired from inside the provider's Stream call rather than
+// from a sleep-based timer goroutine, so this test deterministically
+// exercises the mid-stream cancel path regardless of CI scheduling jitter.
+func TestLoop_CallerCancel_Cancelled(t *testing.T) {
 	tr := &cancellableTransport{}
 	loop := buildTestLoop(nil)
-	loop.Provider = &slowProvider{}
 	loop.Transport = tr
 
 	config := buildTestConfig()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel shortly after the run starts so that the signal maps to
-	// context.Canceled (not DeadlineExceeded).
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		cancel()
-	}()
+	defer cancel()
+
+	loop.Provider = &cancellingProviderOnStream{
+		onStream: func() {
+			// Cancel from the provider goroutine so the outer Run has
+			// already entered the streaming stage and installed its
+			// cancel handler. The plain cancel() leaves context.Cause
+			// nil, mirroring SIGINT/SIGTERM delivery via the root
+			// signal handler.
+			cancel()
+		},
+	}
+
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+	if runTrace.Outcome != "cancelled" {
+		t.Errorf("expected outcome 'cancelled' for caller cancellation, got %q", runTrace.Outcome)
+	}
+
+	// H1: also assert the wire "done" event carries the expected stop_reason.
+	assertDoneStopReason(t, tr, "cancelled")
+}
+
+// TestLoop_CallerCancelWithCause_Error verifies that a caller-side cancel
+// with a custom non-nil cause (not control-plane, not deadline) maps to
+// outcome="error". This is the code path retained after B1: a non-nil,
+// unrecognised cause cannot be attributed to a known cancel/timeout
+// reason and is surfaced as an error.
+func TestLoop_CallerCancelWithCause_Error(t *testing.T) {
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(nil)
+	loop.Transport = tr
+
+	config := buildTestConfig()
+
+	customCause := errors.New("test sentinel cause")
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	loop.Provider = &cancellingProviderOnStream{
+		onStream: func() {
+			cancel(customCause)
+		},
+	}
 
 	runTrace, err := loop.Run(ctx, config)
 	if err != nil {
@@ -196,13 +268,16 @@ func TestLoop_CallerCancel_Error(t *testing.T) {
 		t.Fatal("expected non-nil RunTrace")
 	}
 	if runTrace.Outcome != "error" {
-		t.Errorf("expected outcome 'error' for caller cancellation, got %q", runTrace.Outcome)
+		t.Errorf("expected outcome 'error' for non-nil unrecognised cause, got %q", runTrace.Outcome)
 	}
+	assertDoneStopReason(t, tr, "error")
 }
 
-func TestLoop_PreExistingCancelledContext_Error(t *testing.T) {
+func TestLoop_PreExistingCancelledContext_Cancelled(t *testing.T) {
 	// When the parent context is cancelled before Run starts, the first
-	// inner-loop ctx check trips and we should classify as "error" (signal).
+	// inner-loop ctx check trips. With no cause attached (plain cancel()),
+	// this now classifies as "cancelled" — matching the user intent of a
+	// signal-initiated or caller-initiated cancel.
 	tr := &cancellableTransport{}
 	loop := buildTestLoop(&mockProvider{
 		events: []types.StreamEvent{
@@ -221,9 +296,89 @@ func TestLoop_PreExistingCancelledContext_Error(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() returned error: %v", err)
 	}
-	if runTrace.Outcome != "error" {
-		t.Errorf("expected outcome 'error', got %q", runTrace.Outcome)
+	if runTrace.Outcome != "cancelled" {
+		t.Errorf("expected outcome 'cancelled', got %q", runTrace.Outcome)
 	}
+	assertDoneStopReason(t, tr, "cancelled")
+}
+
+// assertDoneStopReason pulls the single "done" event off the given
+// cancellableTransport and checks its StopReason matches want.
+func assertDoneStopReason(t *testing.T, tr *cancellableTransport, want string) {
+	t.Helper()
+	var doneEvents []types.HarnessEvent
+	for _, ev := range tr.Events() {
+		if ev.Type == "done" {
+			doneEvents = append(doneEvents, ev)
+		}
+	}
+	if len(doneEvents) != 1 {
+		t.Fatalf("expected exactly one 'done' event, got %d", len(doneEvents))
+	}
+	if doneEvents[0].StopReason != want {
+		t.Errorf("expected done.stop_reason %q, got %q", want, doneEvents[0].StopReason)
+	}
+}
+
+// cancelOnVerifyVerifier fires a cancel ControlEvent the first time Verify
+// is called, then sleeps briefly and returns an error. This reproduces the
+// race where a cancel arrives between the inner loop returning and Verify
+// completing: the naive implementation would set outcome="verification_error"
+// because Verify errored, masking the true cancel cause on the wire.
+type cancelOnVerifyVerifier struct {
+	tr       *cancellableTransport
+	fireOnce sync.Once
+}
+
+func (v *cancelOnVerifyVerifier) Verify(ctx context.Context, _ verifier.VerifyContext) (*types.VerificationResult, error) {
+	v.fireOnce.Do(func() {
+		v.tr.FireControl(types.ControlEvent{Type: "cancel"})
+	})
+	// Give the cancel handler a beat to set ctx.Err() on the run context
+	// before we return. We use a short timer rather than <-ctx.Done() so
+	// the test remains deterministic even if the verifier's own ctx is not
+	// wired to the run ctx in every implementation.
+	select {
+	case <-time.After(25 * time.Millisecond):
+	case <-ctx.Done():
+	}
+	return nil, errors.New("verifier failure triggered alongside cancel")
+}
+
+// TestLoop_CancelDuringVerify_CancelledWinsOverVerificationError covers B3:
+// a cancel ControlEvent arriving while Verify is running must produce
+// RunTrace.Outcome == "cancelled" and done.stop_reason == "cancelled", not
+// "verification_error". Without the runCtx.Err() override in Run, the
+// verifier's error would be recorded as the outcome.
+func TestLoop_CancelDuringVerify_CancelledWinsOverVerificationError(t *testing.T) {
+	tr := &cancellableTransport{}
+
+	// A provider that returns one complete turn so the inner loop exits
+	// with outcome="success" and the outer loop proceeds to Verify.
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "All done."},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+
+	loop := buildTestLoop(prov)
+	loop.Transport = tr
+	loop.Verifier = &cancelOnVerifyVerifier{tr: tr}
+
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+	if runTrace.Outcome != "cancelled" {
+		t.Errorf("expected outcome 'cancelled' (cancel wins over verifier error), got %q", runTrace.Outcome)
+	}
+	assertDoneStopReason(t, tr, "cancelled")
 }
 
 func TestClassifyCtxOutcome(t *testing.T) {
@@ -235,9 +390,17 @@ func TestClassifyCtxOutcome(t *testing.T) {
 		{"control_plane", ErrCancelledByControlPlane, "cancelled"},
 		{"wrapped_control_plane", fmt.Errorf("wrap: %w", ErrCancelledByControlPlane), "cancelled"},
 		{"deadline", context.DeadlineExceeded, "timeout"},
-		{"caller", context.Canceled, "error"},
+		// context.Canceled (either directly via plain cancel(), or
+		// propagated from a parent's WithCancel into our
+		// WithCancelCause child) is the signal-handler / caller-side
+		// cancel path — user-initiated.
+		{"caller_canceled_as_cause", context.Canceled, "cancelled"},
+		{"wrapped_caller_canceled", fmt.Errorf("wrap: %w", context.Canceled), "cancelled"},
+		// No cause attached — plain cancel() on our own WithCancelCause.
+		{"nil", nil, "cancelled"},
+		// A non-nil cause that is neither a recognised cancel sentinel
+		// nor a deadline is an error.
 		{"other", errors.New("something else"), "error"},
-		{"nil", nil, "error"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/harness/internal/core/cancel_test.go
+++ b/harness/internal/core/cancel_test.go
@@ -1,0 +1,256 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// cancellableTransport is a Transport implementation that captures emitted
+// harness events (so tests can assert on the final "done" event) and lets
+// the test inject control events via FireControl. OnControl registrations
+// are fanned out in the same way the production StdioTransport does.
+type cancellableTransport struct {
+	mu       sync.Mutex
+	handlers []func(types.ControlEvent)
+	events   []types.HarnessEvent
+}
+
+func (t *cancellableTransport) Emit(event types.HarnessEvent) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+	return nil
+}
+
+func (t *cancellableTransport) OnControl(handler func(types.ControlEvent)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.handlers = append(t.handlers, handler)
+}
+
+func (t *cancellableTransport) Close() error { return nil }
+
+func (t *cancellableTransport) FireControl(event types.ControlEvent) {
+	t.mu.Lock()
+	hs := make([]func(types.ControlEvent), len(t.handlers))
+	copy(hs, t.handlers)
+	t.mu.Unlock()
+	for _, h := range hs {
+		h(event)
+	}
+}
+
+// Events returns a snapshot of the events emitted so far.
+func (t *cancellableTransport) Events() []types.HarnessEvent {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]types.HarnessEvent, len(t.events))
+	copy(out, t.events)
+	return out
+}
+
+// cancellingProvider fires a cancel ControlEvent on the first call, then
+// blocks the stream until the run context is cancelled. This simulates a
+// slow provider whose outbound call is interrupted by a mid-run cancel.
+type cancellingProvider struct {
+	tr        *cancellableTransport
+	fireOnce  sync.Once
+	calls     int
+	callsLock sync.Mutex
+}
+
+func (p *cancellingProvider) Stream(ctx context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	p.callsLock.Lock()
+	p.calls++
+	p.callsLock.Unlock()
+
+	ch := make(chan types.StreamEvent)
+	go func() {
+		defer close(ch)
+		// Fire cancel from the provider goroutine so the outer Run has
+		// already reached the streaming stage and has registered the
+		// transport's cancel handler.
+		p.fireOnce.Do(func() {
+			p.tr.FireControl(types.ControlEvent{Type: "cancel"})
+		})
+		// Block until the run context is cancelled — then exit the stream
+		// with a ctx.Err error event. runInnerLoop will map this to the
+		// ctx-done sentinel and the outer Run will classify it.
+		<-ctx.Done()
+		ch <- types.StreamEvent{Type: "error", Error: ctx.Err()}
+	}()
+	return ch, nil
+}
+
+// slowProvider blocks on Stream until the context is cancelled. Used to
+// test deadline-based timeout classification.
+type slowProvider struct{}
+
+func (p *slowProvider) Stream(ctx context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	ch := make(chan types.StreamEvent)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+		ch <- types.StreamEvent{Type: "error", Error: ctx.Err()}
+	}()
+	return ch, nil
+}
+
+func TestLoop_CancelControlEvent_Cancelled(t *testing.T) {
+	tr := &cancellableTransport{}
+	provider := &cancellingProvider{tr: tr}
+
+	loop := buildTestLoop(nil)
+	loop.Provider = provider
+	loop.Transport = tr
+
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+	if runTrace.Outcome != "cancelled" {
+		t.Errorf("expected outcome 'cancelled', got %q", runTrace.Outcome)
+	}
+
+	// Verify the "done" HarnessEvent carries stop_reason="cancelled".
+	var doneEvents []types.HarnessEvent
+	for _, ev := range tr.Events() {
+		if ev.Type == "done" {
+			doneEvents = append(doneEvents, ev)
+		}
+	}
+	if len(doneEvents) != 1 {
+		t.Fatalf("expected exactly one 'done' event, got %d", len(doneEvents))
+	}
+	if doneEvents[0].StopReason != "cancelled" {
+		t.Errorf("expected done.stop_reason 'cancelled', got %q", doneEvents[0].StopReason)
+	}
+}
+
+func TestLoop_DeadlineExceeded_Timeout(t *testing.T) {
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(nil)
+	loop.Provider = &slowProvider{}
+	loop.Transport = tr
+
+	config := buildTestConfig()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+	if runTrace.Outcome != "timeout" {
+		t.Errorf("expected outcome 'timeout', got %q", runTrace.Outcome)
+	}
+
+	// Verify the "done" HarnessEvent carries stop_reason="timeout".
+	var gotStopReason string
+	for _, ev := range tr.Events() {
+		if ev.Type == "done" {
+			gotStopReason = ev.StopReason
+		}
+	}
+	if gotStopReason != "timeout" {
+		t.Errorf("expected done.stop_reason 'timeout', got %q", gotStopReason)
+	}
+}
+
+func TestLoop_CallerCancel_Error(t *testing.T) {
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(nil)
+	loop.Provider = &slowProvider{}
+	loop.Transport = tr
+
+	config := buildTestConfig()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the run starts so that the signal maps to
+	// context.Canceled (not DeadlineExceeded).
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+	if runTrace.Outcome != "error" {
+		t.Errorf("expected outcome 'error' for caller cancellation, got %q", runTrace.Outcome)
+	}
+}
+
+func TestLoop_PreExistingCancelledContext_Error(t *testing.T) {
+	// When the parent context is cancelled before Run starts, the first
+	// inner-loop ctx check trips and we should classify as "error" (signal).
+	tr := &cancellableTransport{}
+	loop := buildTestLoop(&mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "Hello"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	})
+	loop.Transport = tr
+
+	config := buildTestConfig()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace.Outcome != "error" {
+		t.Errorf("expected outcome 'error', got %q", runTrace.Outcome)
+	}
+}
+
+func TestClassifyCtxOutcome(t *testing.T) {
+	cases := []struct {
+		name  string
+		cause error
+		want  string
+	}{
+		{"control_plane", ErrCancelledByControlPlane, "cancelled"},
+		{"wrapped_control_plane", fmt.Errorf("wrap: %w", ErrCancelledByControlPlane), "cancelled"},
+		{"deadline", context.DeadlineExceeded, "timeout"},
+		{"caller", context.Canceled, "error"},
+		{"other", errors.New("something else"), "error"},
+		{"nil", nil, "error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyCtxOutcome(tc.cause); got != tc.want {
+				t.Errorf("classifyCtxOutcome(%v) = %q, want %q", tc.cause, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrCancelledByControlPlane_IsMatchable(t *testing.T) {
+	wrapped := fmt.Errorf("outer: %w", ErrCancelledByControlPlane)
+	if !errors.Is(wrapped, ErrCancelledByControlPlane) {
+		t.Error("errors.Is should match wrapped ErrCancelledByControlPlane")
+	}
+}

--- a/harness/internal/core/errors.go
+++ b/harness/internal/core/errors.go
@@ -1,0 +1,11 @@
+package core
+
+import "errors"
+
+// ErrCancelledByControlPlane is the cause attached to the run's context when
+// a "cancel" ControlEvent arrives from the control plane. The outer Run loop
+// inspects context.Cause to distinguish control-plane cancellation from
+// deadline expiry or caller-initiated cancellation, and records the outcome
+// accordingly ("cancelled" vs "timeout" vs "error"). Tests can match it with
+// errors.Is.
+var ErrCancelledByControlPlane = errors.New("cancelled by control plane")

--- a/harness/internal/core/followup_test.go
+++ b/harness/internal/core/followup_test.go
@@ -166,3 +166,33 @@ func TestRunFollowUpLoop_ContextCancelledDuringWait(t *testing.T) {
 		t.Fatal("RunFollowUpLoop did not return within 2s of context cancellation")
 	}
 }
+
+// TestRunFollowUpLoop_CancelControlEventExitsWait verifies that a "cancel"
+// ControlEvent arriving during the grace window causes RunFollowUpLoop to
+// exit promptly via its cancelCh select arm, without waiting for the grace
+// timer to expire. This exercises both the cancel handler registered
+// inside RunFollowUpLoop and the <-cancelCh receive in its select loop.
+func TestRunFollowUpLoop_CancelControlEventExitsWait(t *testing.T) {
+	loop, tr := buildFollowUpTestLoop(t)
+	config := buildTestConfig()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Long grace period — if the cancel arm is not wired correctly,
+		// the test will hang for the full 30s and the timeout below fires.
+		RunFollowUpLoop(context.Background(), loop, config, 30)
+	}()
+
+	// Give OnControl registration a moment to take effect.
+	time.Sleep(50 * time.Millisecond)
+
+	tr.FireControl(types.ControlEvent{Type: "cancel"})
+
+	select {
+	case <-done:
+		// Good — returned promptly via the cancelCh select arm.
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunFollowUpLoop did not return within 2s of cancel ControlEvent")
+	}
+}

--- a/harness/internal/core/integration_test.go
+++ b/harness/internal/core/integration_test.go
@@ -423,6 +423,22 @@ func TestLoop_ReplayProvider_CancelledAfterFirstTurn(t *testing.T) {
 		t.Errorf("expected outcome 'cancelled', got %q", runTrace.Outcome)
 	}
 
+	// H1: the wire-level contract is that done.stop_reason matches the
+	// RunTrace outcome. Assert the transport received exactly one done
+	// event carrying stop_reason="cancelled".
+	var doneEvents []types.HarnessEvent
+	for _, ev := range tr.Events() {
+		if ev.Type == "done" {
+			doneEvents = append(doneEvents, ev)
+		}
+	}
+	if len(doneEvents) != 1 {
+		t.Fatalf("expected exactly one 'done' event, got %d", len(doneEvents))
+	}
+	if doneEvents[0].StopReason != "cancelled" {
+		t.Errorf("expected done.stop_reason 'cancelled', got %q", doneEvents[0].StopReason)
+	}
+
 	// Sanity: the replay provider should have been consumed at most once.
 	// The second turn must not have been executed.
 	if runTrace.Turns > 1 {

--- a/harness/internal/core/integration_test.go
+++ b/harness/internal/core/integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/harness/internal/provider"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/harness/internal/transport"
 	"github.com/rxbynerd/stirrup/types"
@@ -353,5 +354,78 @@ func TestBuildLoop_ResearchModeWebFetchEndToEnd(t *testing.T) {
 	}
 	if !sawWebFetch {
 		t.Fatal("expected at least one web_fetch call in run trace")
+	}
+}
+
+// TestLoop_ReplayProvider_CancelledAfterFirstTurn drives the agentic loop
+// with a ReplayProvider (no network) and injects a cancel ControlEvent via
+// the transport after the first turn completes. The next turn should be
+// aborted and RunTrace.Outcome should be "cancelled".
+func TestLoop_ReplayProvider_CancelledAfterFirstTurn(t *testing.T) {
+	// Two-turn recording: turn 0 calls a read-only tool, turn 1 ends the
+	// run. We inject a cancel between them.
+	turns := []types.TurnRecord{
+		{
+			Turn: 0,
+			ModelOutput: []types.ContentBlock{
+				{
+					Type:  "tool_use",
+					ID:    "tc_1",
+					Name:  "test_tool",
+					Input: json.RawMessage(`{}`),
+				},
+			},
+		},
+		{
+			Turn: 1,
+			ModelOutput: []types.ContentBlock{
+				{Type: "text", Text: "All done."},
+			},
+		},
+	}
+
+	rp := provider.NewReplayProvider(turns)
+	tr := &cancellableTransport{}
+
+	loop := buildTestLoop(nil)
+	loop.Provider = rp
+	loop.Transport = tr
+
+	// The stock "test_tool" in buildTestLoop returns "tool result". Hook the
+	// tool handler so that after it runs, we fire the cancel ControlEvent —
+	// this causes the outer turn-boundary ctx check to trip on the next
+	// iteration.
+	originalRegistry := loop.Tools
+	_ = originalRegistry
+	fireCancel := func() {
+		tr.FireControl(types.ControlEvent{Type: "cancel"})
+	}
+	// Replace the tool handler to fire cancel on completion.
+	if tool := loop.Tools.Resolve("test_tool"); tool != nil {
+		prev := tool.Handler
+		tool.Handler = func(ctx context.Context, input json.RawMessage) (string, error) {
+			out, err := prev(ctx, input)
+			fireCancel()
+			return out, err
+		}
+	}
+
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if runTrace == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+	if runTrace.Outcome != "cancelled" {
+		t.Errorf("expected outcome 'cancelled', got %q", runTrace.Outcome)
+	}
+
+	// Sanity: the replay provider should have been consumed at most once.
+	// The second turn must not have been executed.
+	if runTrace.Turns > 1 {
+		t.Errorf("expected at most 1 recorded turn, got %d", runTrace.Turns)
 	}
 }

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,6 +19,12 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/verifier"
 	"github.com/rxbynerd/stirrup/types"
 )
+
+// outcomeCtxDone is a sentinel outcome returned by runInnerLoop when the
+// loop observes ctx.Done(). The outer Run loop inspects context.Cause to
+// translate this into a user-visible outcome: "cancelled" (control plane),
+// "timeout" (deadline), or "error" (caller/unknown).
+const outcomeCtxDone = "_ctx_done"
 
 const (
 	// maxVerificationRetries is the maximum number of times the verifier can
@@ -59,6 +66,23 @@ const (
 //	  else → feed verifier feedback back into the loop as a user message
 //	}
 func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.RunTrace, error) {
+	// Derive a cancellable context so a "cancel" ControlEvent can abort the
+	// run within one turn boundary. WithCancelCause lets us disambiguate
+	// control-plane cancellation from deadline expiry and caller cancellation
+	// later via context.Cause().
+	runCtx, cancelRun := context.WithCancelCause(ctx)
+	defer cancelRun(nil)
+
+	// Register a cancel handler on the transport. Fan-out OnControl is
+	// supported by all production transports (stdio, gRPC); sub-agents use
+	// NullTransport whose OnControl is a no-op, so this is a harmless no-op
+	// in the sub-agent case.
+	l.Transport.OnControl(func(event types.ControlEvent) {
+		if event.Type == "cancel" {
+			cancelRun(ErrCancelledByControlPlane)
+		}
+	})
+
 	// Start tracing.
 	l.Trace.Start(config.RunID, config)
 
@@ -66,11 +90,11 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	if otelEmitter, ok := l.Trace.(*trace.OTelTraceEmitter); ok {
 		l.TraceContext = otelEmitter.RootContext()
 	} else {
-		l.TraceContext = ctx
+		l.TraceContext = runCtx
 	}
 
 	// Start heartbeat emission so the control plane knows we are alive.
-	stopHeartbeat := l.startHeartbeat(ctx, 30*time.Second)
+	stopHeartbeat := l.startHeartbeat(runCtx, 30*time.Second)
 
 	// Build the system prompt.
 	dynamicContext := config.DynamicContext
@@ -83,23 +107,23 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 			}
 		}
 	}
-	systemPrompt, err := l.Prompt.Build(ctx, prompt.PromptContext{
+	systemPrompt, err := l.Prompt.Build(runCtx, prompt.PromptContext{
 		Mode:           config.Mode,
 		Workspace:      config.Executor.Workspace,
 		MaxTurns:       config.MaxTurns,
 		DynamicContext: dynamicContext,
 	})
 	if err != nil {
-		return l.finishWithError(ctx, fmt.Errorf("build system prompt: %w", err))
+		return l.finishWithError(runCtx, fmt.Errorf("build system prompt: %w", err))
 	}
 
 	// Set up git workspace.
-	_, gitSetupSpan := l.Tracer.Start(l.traceCtx(ctx), "git.setup")
-	if err := l.Git.Setup(ctx, config.Executor.Workspace, config.RunID); err != nil {
+	_, gitSetupSpan := l.Tracer.Start(l.traceCtx(runCtx), "git.setup")
+	if err := l.Git.Setup(runCtx, config.Executor.Workspace, config.RunID); err != nil {
 		gitSetupSpan.RecordError(err)
 		gitSetupSpan.SetStatus(codes.Error, err.Error())
 		gitSetupSpan.End()
-		return l.finishWithError(ctx, fmt.Errorf("git setup: %w", err))
+		return l.finishWithError(runCtx, fmt.Errorf("git setup: %w", err))
 	}
 	gitSetupSpan.End()
 
@@ -121,7 +145,7 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	l.Logger.Info("run started", "mode", config.Mode, "maxTurns", config.MaxTurns)
 
 	runStart := time.Now()
-	l.Metrics.Runs.Add(ctx, 1,
+	l.Metrics.Runs.Add(runCtx, 1,
 		metric.WithAttributes(
 			attribute.String("run.mode", config.Mode),
 		),
@@ -154,7 +178,7 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	for verificationAttempts <= maxVerificationRetries {
 		// Run the inner agentic loop.
 		var innerOutcome string
-		messages, innerOutcome = l.runInnerLoop(ctx, config, systemPrompt, messages, tokenTracker)
+		messages, innerOutcome = l.runInnerLoop(runCtx, config, systemPrompt, messages, tokenTracker)
 
 		if innerOutcome != "success" {
 			outcome = innerOutcome
@@ -162,13 +186,13 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 		}
 
 		// Run verifier.
-		l.Metrics.VerificationAttempts.Add(ctx, 1)
-		_, verifySpan := l.Tracer.Start(l.traceCtx(ctx), "verifier.verify",
+		l.Metrics.VerificationAttempts.Add(runCtx, 1)
+		_, verifySpan := l.Tracer.Start(l.traceCtx(runCtx), "verifier.verify",
 			oteltrace.WithAttributes(
 				attribute.Int("verifier.attempt", verificationAttempts),
 			),
 		)
-		vResult, verifyErr := l.Verifier.Verify(ctx, verifier.VerifyContext{
+		vResult, verifyErr := l.Verifier.Verify(runCtx, verifier.VerifyContext{
 			Mode:     config.Mode,
 			Executor: l.Executor,
 			Messages: messages,
@@ -207,7 +231,16 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 		})
 	}
 
-	// Finalise git.
+	// If the inner loop exited because the context was cancelled, inspect
+	// the cause to distinguish control-plane cancellation ("cancelled"),
+	// deadline expiry ("timeout"), and anything else ("error").
+	if outcome == outcomeCtxDone {
+		outcome = classifyCtxOutcome(context.Cause(runCtx))
+		l.setRootCancelAttribute(outcome)
+	}
+
+	// Finalise git. Use the parent ctx here: if the run was cancelled, we
+	// still want git.Finalise to be able to persist whatever state exists.
 	_, finaliseSpan := l.Tracer.Start(l.traceCtx(ctx), "git.finalise")
 	if _, err := l.Git.Finalise(ctx); err != nil {
 		finaliseSpan.RecordError(err)
@@ -239,13 +272,59 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	// Stop heartbeat before finishing the trace.
 	stopHeartbeat()
 
-	// Finish trace.
+	// Finish trace using the parent ctx — the trace exporter's ForceFlush
+	// should still have a usable deadline even if the run-scoped ctx is
+	// already cancelled.
 	runTrace, traceErr := l.Trace.Finish(ctx, outcome)
 	if traceErr != nil {
 		return nil, fmt.Errorf("finish trace: %w", traceErr)
 	}
 
 	return runTrace, nil
+}
+
+// classifyCtxOutcome maps a context cancellation cause onto the outcome
+// string reported on the "done" event and recorded in RunTrace.Outcome.
+func classifyCtxOutcome(cause error) string {
+	switch {
+	case errors.Is(cause, ErrCancelledByControlPlane):
+		return "cancelled"
+	case errors.Is(cause, context.DeadlineExceeded):
+		return "timeout"
+	case cause != nil:
+		// context.Canceled from the caller or any other wrapped cause.
+		return "error"
+	default:
+		// Unexpected: the inner loop saw ctx.Done() but no cause was set.
+		return "error"
+	}
+}
+
+// setRootCancelAttribute tags the root "run" OTel span with the reason for
+// context cancellation so operators can filter cancelled runs from timed-out
+// or errored runs in tracing backends. Only applied when the run actually
+// ended via ctx cancellation.
+func (l *AgenticLoop) setRootCancelAttribute(outcome string) {
+	otelEmitter, ok := l.Trace.(*trace.OTelTraceEmitter)
+	if !ok {
+		return
+	}
+	span := oteltrace.SpanFromContext(otelEmitter.RootContext())
+	if !span.SpanContext().IsValid() {
+		return
+	}
+	var reason string
+	switch outcome {
+	case "cancelled":
+		reason = "control_plane"
+	case "timeout":
+		reason = "deadline"
+	case "error":
+		reason = "signal"
+	default:
+		return
+	}
+	span.SetAttributes(attribute.String("run.cancelled_by", reason))
 }
 
 // runInnerLoop runs the agentic loop turns until the model says "done",
@@ -270,10 +349,13 @@ func (l *AgenticLoop) runInnerLoop(
 			return messages, "budget_exceeded"
 		}
 
-		// Check context cancellation.
+		// Check context cancellation. Return a sentinel outcome so the
+		// outer Run loop can distinguish control-plane cancellation,
+		// deadline expiry, and caller-initiated cancellation via
+		// context.Cause().
 		select {
 		case <-ctx.Done():
-			return messages, "error"
+			return messages, outcomeCtxDone
 		default:
 		}
 
@@ -314,6 +396,9 @@ func (l *AgenticLoop) runInnerLoop(
 			contextSpan.RecordError(err)
 			contextSpan.SetStatus(codes.Error, err.Error())
 			contextSpan.End()
+			if ctx.Err() != nil {
+				return messages, outcomeCtxDone
+			}
 			return messages, "error"
 		}
 		// Publish the post-Prepare absolute token estimate so the
@@ -399,6 +484,12 @@ func (l *AgenticLoop) runInnerLoop(
 				StopReason: "error",
 				DurationMs: time.Since(turnStart).Milliseconds(),
 			})
+			// If the provider call failed because the run context was
+			// cancelled, surface that so the outer loop can classify the
+			// outcome as cancelled/timeout rather than a generic error.
+			if ctx.Err() != nil {
+				return messages, outcomeCtxDone
+			}
 			return messages, "error"
 		}
 
@@ -417,6 +508,11 @@ func (l *AgenticLoop) runInnerLoop(
 				StopReason: "error",
 				DurationMs: turnDuration.Milliseconds(),
 			})
+			// Distinguish stream-abort-due-to-ctx from other stream errors
+			// so the outer loop can classify the outcome correctly.
+			if ctx.Err() != nil {
+				return messages, outcomeCtxDone
+			}
 			return messages, "error"
 		}
 		providerSpan.SetAttributes(
@@ -583,6 +679,7 @@ func (l *AgenticLoop) runInnerLoop(
 // registration (both GRPCTransport and StdioTransport do).
 func RunFollowUpLoop(ctx context.Context, loop *AgenticLoop, config *types.RunConfig, graceSecs int) {
 	followUpCh := make(chan string, 1)
+	cancelCh := make(chan struct{}, 1)
 
 	loop.Transport.OnControl(func(event types.ControlEvent) {
 		switch event.Type {
@@ -592,6 +689,14 @@ func RunFollowUpLoop(ctx context.Context, loop *AgenticLoop, config *types.RunCo
 			default:
 				// A follow-up is already queued. Drop this one; the control
 				// plane should wait for "done" before sending another request.
+			}
+		case "cancel":
+			// Exit the grace window immediately on cancel. Any in-flight
+			// Run invocation has its own cancel handler and will terminate
+			// on the next turn boundary.
+			select {
+			case cancelCh <- struct{}{}:
+			default:
 			}
 		}
 	})
@@ -620,6 +725,9 @@ func RunFollowUpLoop(ctx context.Context, loop *AgenticLoop, config *types.RunCo
 				// Transport already carries the error event from finishWithError.
 				return
 			}
+
+		case <-cancelCh:
+			return
 
 		case <-timer.C:
 			return

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -22,8 +22,9 @@ import (
 
 // outcomeCtxDone is a sentinel outcome returned by runInnerLoop when the
 // loop observes ctx.Done(). The outer Run loop inspects context.Cause to
-// translate this into a user-visible outcome: "cancelled" (control plane),
-// "timeout" (deadline), or "error" (caller/unknown).
+// translate this into a user-visible outcome: "cancelled" (control plane
+// or plain/signal cancel), "timeout" (deadline), or "error" (non-nil but
+// unrecognised cause).
 const outcomeCtxDone = "_ctx_done"
 
 const (
@@ -231,12 +232,24 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 		})
 	}
 
+	// Cancellation wins over verification-path outcomes. A cancel arriving
+	// between the inner loop returning and Verify completing can otherwise
+	// cause Verify to return a ctx-cancelled error and set
+	// outcome="verification_error", masking the true termination reason on
+	// the wire. If the run context is done, reclassify so the cancel/timeout
+	// path below runs.
+	if runCtx.Err() != nil && outcome != outcomeCtxDone {
+		outcome = outcomeCtxDone
+	}
+
 	// If the inner loop exited because the context was cancelled, inspect
 	// the cause to distinguish control-plane cancellation ("cancelled"),
-	// deadline expiry ("timeout"), and anything else ("error").
+	// deadline expiry ("timeout"), plain/signal cancel ("cancelled"), and
+	// anything else ("error").
 	if outcome == outcomeCtxDone {
-		outcome = classifyCtxOutcome(context.Cause(runCtx))
-		l.setRootCancelAttribute(outcome)
+		cause := context.Cause(runCtx)
+		outcome = classifyCtxOutcome(cause)
+		l.setRootCancelAttribute(cause)
 	}
 
 	// Finalise git. Use the parent ctx here: if the run was cancelled, we
@@ -285,17 +298,25 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 
 // classifyCtxOutcome maps a context cancellation cause onto the outcome
 // string reported on the "done" event and recorded in RunTrace.Outcome.
+//
+// A nil cause or a bare context.Canceled indicates the run was cancelled
+// via a plain cancel() without a cause attached — e.g. SIGINT/SIGTERM via
+// the root cobra signal handler, or a caller invoking context.WithCancel
+// on a parent and then cancel() (which propagates context.Canceled as the
+// cause of our WithCancelCause child). The spec treats this as a
+// user-initiated cancellation, distinct from a deadline-driven timeout or
+// an internal error. A non-nil cause that is neither a recognised cancel
+// sentinel nor a deadline is surfaced as "error" since we cannot attribute
+// it to a known cancel or timeout path.
 func classifyCtxOutcome(cause error) string {
 	switch {
 	case errors.Is(cause, ErrCancelledByControlPlane):
 		return "cancelled"
 	case errors.Is(cause, context.DeadlineExceeded):
 		return "timeout"
-	case cause != nil:
-		// context.Canceled from the caller or any other wrapped cause.
-		return "error"
+	case cause == nil, errors.Is(cause, context.Canceled):
+		return "cancelled"
 	default:
-		// Unexpected: the inner loop saw ctx.Done() but no cause was set.
 		return "error"
 	}
 }
@@ -304,7 +325,17 @@ func classifyCtxOutcome(cause error) string {
 // context cancellation so operators can filter cancelled runs from timed-out
 // or errored runs in tracing backends. Only applied when the run actually
 // ended via ctx cancellation.
-func (l *AgenticLoop) setRootCancelAttribute(outcome string) {
+//
+// The attribute is derived from the context cause so that a plain/signal
+// cancel and a control-plane cancel are distinguished on the span even
+// though both map to outcome="cancelled".
+//
+//	run.cancelled_by="control_plane" — ErrCancelledByControlPlane cause
+//	run.cancelled_by="deadline"      — context.DeadlineExceeded cause
+//	run.cancelled_by="signal"        — nil cause or bare context.Canceled
+//	                                   (plain cancel(), SIGINT, etc.)
+//	(no attribute)                   — non-nil unrecognised cause ("error")
+func (l *AgenticLoop) setRootCancelAttribute(cause error) {
 	otelEmitter, ok := l.Trace.(*trace.OTelTraceEmitter)
 	if !ok {
 		return
@@ -314,14 +345,15 @@ func (l *AgenticLoop) setRootCancelAttribute(outcome string) {
 		return
 	}
 	var reason string
-	switch outcome {
-	case "cancelled":
+	switch {
+	case errors.Is(cause, ErrCancelledByControlPlane):
 		reason = "control_plane"
-	case "timeout":
+	case errors.Is(cause, context.DeadlineExceeded):
 		reason = "deadline"
-	case "error":
+	case cause == nil, errors.Is(cause, context.Canceled):
 		reason = "signal"
 	default:
+		// Non-nil unrecognised cause → outcome=="error"; no attribute.
 		return
 	}
 	span.SetAttributes(attribute.String("run.cancelled_by", reason))

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -666,7 +666,8 @@ func TestLoop_ContextCancelled(t *testing.T) {
 	loop := buildTestLoop(prov)
 	config := buildTestConfig()
 
-	// Cancel the context before running.
+	// Cancel the context before running. With no cause attached this is a
+	// plain/signal-style cancel and maps to outcome="cancelled".
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -677,8 +678,8 @@ func TestLoop_ContextCancelled(t *testing.T) {
 	if runTrace == nil {
 		t.Fatal("expected non-nil RunTrace even on context cancellation")
 	}
-	if runTrace.Outcome != "error" {
-		t.Errorf("expected outcome 'error', got %q", runTrace.Outcome)
+	if runTrace.Outcome != "cancelled" {
+		t.Errorf("expected outcome 'cancelled', got %q", runTrace.Outcome)
 	}
 }
 

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -63,6 +63,15 @@ func newOTelTraceEmitterForTest(tp *sdktrace.TracerProvider) *OTelTraceEmitter {
 	}
 }
 
+// NewOTelTraceEmitterForTest is the exported wrapper of the test-only
+// constructor. It lets tests in other packages (notably core) build an
+// OTelTraceEmitter around an in-memory TracerProvider so they can assert
+// on emitted spans without spinning up an OTLP collector. Not intended for
+// production use.
+func NewOTelTraceEmitterForTest(tp *sdktrace.TracerProvider) *OTelTraceEmitter {
+	return newOTelTraceEmitterForTest(tp)
+}
+
 // Start initialises a new trace with the given run ID and configuration.
 // It creates the root "run" span.
 func (e *OTelTraceEmitter) Start(runID string, config *types.RunConfig) {

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -142,9 +142,13 @@ message HarnessEvent {
 //                   back to the model as context.
 //
 //   "cancel"
-//     - (no additional fields) Signals that the run should be aborted.
-//       NOTE: cancel is defined in the protocol but is not yet handled by
-//       the harness main loop (no-op on receipt).
+//     - (no additional fields) Signals that the run should be aborted. The
+//       harness terminates the run within one turn boundary: any in-flight
+//       provider stream or tool call is cancelled via context propagation,
+//       no further turns are started, git finalisation still runs, and the
+//       final "done" HarnessEvent carries stop_reason="cancelled". If the
+//       harness is in the follow-up grace window (no active run), the
+//       stream closes promptly without an additional "done" event.
 message ControlEvent {
   // Required. The event type discriminator.
   // Valid values: "task_assignment", "user_response", "cancel",

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -21,7 +21,7 @@ type RunTrace struct {
 	TokenUsage          TokenUsage           `json:"tokenUsage"`
 	ToolCalls           []ToolCallSummary    `json:"toolCalls"`
 	VerificationResults []VerificationResult `json:"verificationResults"`
-	Outcome             string               `json:"outcome"` // "success" | "error" | "max_turns" | "verification_failed" | "budget_exceeded"
+	Outcome             string               `json:"outcome"` // "success" | "error" | "max_turns" | "verification_failed" | "verification_error" | "budget_exceeded" | "stalled" | "tool_failures" | "cancelled" | "timeout" | "max_tokens"
 }
 
 // ToolCallSummary records a single tool call's outcome for the trace.


### PR DESCRIPTION
Closes #35.

## Summary

- `cancel` ControlEvent is now honored end-to-end. The control plane can abort a live run; the loop exits within one turn boundary and the `done` event carries `stop_reason="cancelled"`. Previously it was a documented no-op.
- ctx cancellations are now classified honestly: control-plane cancel → `"cancelled"`, deadline → `"timeout"`, signal / plain caller `cancel()` → `"cancelled"` (with `run.cancelled_by` OTel attribute distinguishing `control_plane` / `deadline` / `signal`), unknown non-nil cause → `"error"`. Previously every ctx cancellation flattened to `"error"`.
- `Run` wraps the caller's ctx with `context.WithCancelCause`; a `Transport.OnControl` handler maps `event.Type == "cancel"` to `cancelRun(ErrCancelledByControlPlane)`. The inner loop returns a private `_ctx_done` sentinel so `Run` can inspect `context.Cause(runCtx)` once and route both the outcome string and the OTel attribute off the same value.
- Verifier-cancel race closed: if ctx is done after the turn loop exits but before or during `Verify`, the post-loop check overrides any transient `"verification_error"` back to the cancel classification. Cancel always wins when the context is done.
- `Git.Finalise` and `Trace.Finish` intentionally run on the parent ctx so traces and pending git commits still flush after a cancel.
- `RunFollowUpLoop` now exits promptly on a `cancel` ControlEvent during the grace window.
- `stirrup job` handles a `cancel` arriving before any `task_assignment` — logs and exits 0.
- Proto comment on `ControlEvent.cancel` updated to describe the actual semantics (no schema change); `gen/harness/v1/harness.pb.go` regenerated in a separate commit.
- `types.RunTrace.Outcome` doc comment expanded to enumerate `"cancelled"` and `"timeout"` alongside the existing values.

Ran one implementation wave + four parallel reviewers (code-reviewer, api-design-advisor, spec-compliance-reviewer, test-coverage-auditor) + one remediation pass + focused re-reviews. Four commits:

- `core: handle cancel ControlEvent and distinguish outcomes`
- `proto: document cancel ControlEvent semantics`
- `gen: regenerate from proto comment update`
- `core: remediate cancel outcome fidelity review findings`

The final commit resolves four blockers from the synthesized review: B1 (signal-cancel now produces `"cancelled"`, not `"error"`), B2 (`RunFollowUpLoop` cancel arm gains coverage), B3 (verifier-cancel race fixed with a post-loop `runCtx.Err()` override), B4 (`setRootCancelAttribute` refactored to take `cause error` directly; all three `run.cancelled_by` values covered via `sdktrace.NewTracerProvider` + `tracetest.NewInMemoryExporter`). Three existing tests were renamed `_Error` → `_Cancelled` to match the new signal-cancel classification and gained `done`-event `stop_reason` assertions (H1). A small test-only helper `NewOTelTraceEmitterForTest` is exported from `harness/internal/trace/otel.go`.

## Test plan
- [x] `go test ./harness/... ./types/... ./eval/...` — all green (27 packages)
- [x] `just lint` — 0 issues
- [x] `just build` — stirrup + eval binaries link
- [x] `buf generate` — no drift against committed `gen/`
- [x] Cancel-critical helpers (`classifyCtxOutcome`, `setRootCancelAttribute`) at 100% statement coverage; `RunFollowUpLoop` 90.5% (residual is pre-existing non-cancel branches)
- [x] `harness/internal/core` package coverage: 83.9%

## Out of scope (per issue #35 and tracked as follow-ups)

- mTLS / authenticated cancel (#7).
- Cancel rate-limiting (#7 item 5.3).
- Per-tool cancel granularity beyond ctx propagation.
- Schema additions to `ControlEvent.cancel` (e.g. `reason` field).
- `streamEventsToResult` blocking-receive hardening — deferred (cosmetic if provider adapters cancel their HTTP requests on ctx cancellation; worth a dedicated follow-up that verifies Anthropic/Bedrock/OpenAI adapters propagate ctx to requests).
- `"max_tokens"` outcome missing from proto `stop_reason` enumeration comment — pre-existing, surfaced by this PR's `Outcome` doc update, worth aligning in a separate proto-polish pass.
- `TestLoop_CancelAttribute_Deadline` uses a 150ms sleep with 3x deadline margin — deterministic on developer machines but could flake on heavily loaded CI; low severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)