### PR TITLE
fix(#33): split Tool.SideEffects into WorkspaceMutating + RequiresApproval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ go build -o stirrup-eval ./eval/cmd/eval
 6. **Executor** — sandboxed file I/O and command execution (local, container, API)
 7. **EditStrategy** — how file changes are applied (whole-file, search-replace, udiff, multi-strategy)
 8. **Verifier** — validates run output (none, test-runner, composite, llm-judge)
-9. **PermissionPolicy** — gates side-effecting tools (allow-all, deny-side-effects, ask-upstream)
+9. **PermissionPolicy** — gates tools that mutate the workspace or require operator approval (allow-all, deny-side-effects, ask-upstream). `deny-side-effects` rejects only workspace-mutating tools (write_file, run_command, edit_file); read-only-but-network/budget-touching tools like web_fetch and spawn_agent are still allowed and are gated separately by `ask-upstream`.
 10. **Transport** — streams events to/from control plane (stdio, gRPC bidi streaming, null for sub-agents)
 11. **GitStrategy** — manages branches/commits (none, deterministic)
 12. **TraceEmitter** — records telemetry (JSONL, OpenTelemetry)

--- a/VERSION1.md
+++ b/VERSION1.md
@@ -37,7 +37,7 @@ Every run is fully described by a `RunConfig` — a declarative specification of
 | 6 | Executor (sandbox) | `Executor` | Local (tier 1), container/Docker (tier 2), API/GitHub (tier 0), replay (eval) |
 | 7 | Edit strategy | `EditStrategy` | Whole-file, search-replace, unified diff, multi-strategy with fallback |
 | 8 | Verifier | `Verifier` | None, test-runner, LLM-as-judge, composite |
-| 9 | Permission policy | `PermissionPolicy` | Allow-all, deny-side-effects, ask-upstream (with configurable timeout) |
+| 9 | Permission policy | `PermissionPolicy` | Allow-all, deny-side-effects (denies workspace-mutating tools only), ask-upstream (prompts on tools whose `RequiresApproval` flag is set) |
 | 10 | Transport | `Transport` | Stdio (NDJSON), gRPC bidi streaming, null (sub-agents) |
 | 11 | Git strategy | `GitStrategy` | None, deterministic |
 | 12 | Trace emitter | `TraceEmitter` | JSONL, OpenTelemetry (OTLP/gRPC) |

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -258,6 +258,17 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 			return json.Marshal(result)
 		}
 		registry.Register(builtins.SpawnAgentTool(spawner))
+
+		// The ask-upstream policy snapshots the approval-required tool
+		// set at construction time, but spawn_agent is registered
+		// after the policy is built. Refresh it here so spawn_agent
+		// calls are gated by the control plane rather than silently
+		// auto-allowed. (See TestApprovalRequiredToolSet which asserts
+		// the load-bearing absence of spawn_agent in the unrefreshed
+		// set.)
+		if ask, ok := pp.(*permission.AskUpstreamPolicy); ok {
+			ask.AddApprovalTool("spawn_agent")
+		}
 	}
 
 	return loop, nil

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -545,10 +545,11 @@ func editToolEnabled(enabled []string, actualName string) bool {
 func editStrategyTool(es edit.EditStrategy, exec executor.Executor) *tool.Tool {
 	definition := es.ToolDefinition()
 	return &tool.Tool{
-		Name:        definition.Name,
-		Description: definition.Description,
-		InputSchema: definition.InputSchema,
-		SideEffects: true,
+		Name:              definition.Name,
+		Description:       definition.Description,
+		InputSchema:       definition.InputSchema,
+		WorkspaceMutating: true,
+		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			result, err := es.Apply(ctx, input, exec)
 			if err != nil {
@@ -633,12 +634,15 @@ func buildPermissionPolicy(cfg types.PermissionPolicyConfig, registry *tool.Regi
 }
 
 // sideEffectingToolSet builds a set of tool names that have side effects
-// from the tool registry.
+// from the tool registry. After the WP1 split this combines the
+// WorkspaceMutating and RequiresApproval flags so that legacy callers
+// continue to receive a superset of "tools that need gating". The factory
+// will replace this with the more specific helpers in a follow-up commit.
 func sideEffectingToolSet(registry *tool.Registry) map[string]bool {
 	sideEffecting := make(map[string]bool)
 	for _, td := range registry.List() {
 		t := registry.Resolve(td.Name)
-		if t != nil && t.SideEffects {
+		if t != nil && (t.WorkspaceMutating || t.RequiresApproval) {
 			sideEffecting[td.Name] = true
 		}
 	}

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -621,32 +621,47 @@ func buildPermissionPolicy(cfg types.PermissionPolicyConfig, registry *tool.Regi
 	case "allow-all":
 		return permission.NewAllowAll()
 	case "deny-side-effects":
-		// Build the set of side-effecting tool names from the registry.
-		sideEffecting := sideEffectingToolSet(registry)
-		return permission.NewDenySideEffects(sideEffecting)
+		// DenySideEffects rejects only tools that mutate workspace
+		// state. Tools whose only sensitivity is "operator should
+		// approve" (web_fetch, spawn_agent) are still allowed —
+		// research-mode users explicitly enable them.
+		return permission.NewDenySideEffects(mutatingToolSet(registry))
 	case "ask-upstream":
-		sideEffecting := sideEffectingToolSet(registry)
+		// AskUpstreamPolicy prompts on tools whose RequiresApproval
+		// flag is set. This includes mutating tools but also covers
+		// non-mutating-but-sensitive tools.
 		timeout := time.Duration(cfg.Timeout) * time.Second
-		return permission.NewAskUpstreamPolicy(tp, sideEffecting, timeout)
+		return permission.NewAskUpstreamPolicy(tp, approvalRequiredToolSet(registry), timeout)
 	default:
 		return permission.NewAllowAll()
 	}
 }
 
-// sideEffectingToolSet builds a set of tool names that have side effects
-// from the tool registry. After the WP1 split this combines the
-// WorkspaceMutating and RequiresApproval flags so that legacy callers
-// continue to receive a superset of "tools that need gating". The factory
-// will replace this with the more specific helpers in a follow-up commit.
-func sideEffectingToolSet(registry *tool.Registry) map[string]bool {
-	sideEffecting := make(map[string]bool)
+// mutatingToolSet returns the names of registered tools that mutate
+// workspace state. DenySideEffects denies exactly this set.
+func mutatingToolSet(registry *tool.Registry) map[string]bool {
+	out := make(map[string]bool)
 	for _, td := range registry.List() {
 		t := registry.Resolve(td.Name)
-		if t != nil && (t.WorkspaceMutating || t.RequiresApproval) {
-			sideEffecting[td.Name] = true
+		if t != nil && t.WorkspaceMutating {
+			out[td.Name] = true
 		}
 	}
-	return sideEffecting
+	return out
+}
+
+// approvalRequiredToolSet returns the names of registered tools that
+// require upstream operator approval before being executed.
+// AskUpstreamPolicy prompts on exactly this set.
+func approvalRequiredToolSet(registry *tool.Registry) map[string]bool {
+	out := make(map[string]bool)
+	for _, td := range registry.List() {
+		t := registry.Resolve(td.Name)
+		if t != nil && t.RequiresApproval {
+			out[td.Name] = true
+		}
+	}
+	return out
 }
 
 func buildTransport(ctx context.Context, cfg types.TransportConfig) (transport.Transport, error) {

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -689,16 +689,16 @@ func TestSideEffectingToolSet(t *testing.T) {
 
 	sideEffecting := sideEffectingToolSet(registry)
 
-	// write_file and run_command are side-effecting.
+	// write_file and run_command are workspace-mutating and require approval.
 	if !sideEffecting["write_file"] {
-		t.Fatal("write_file should be side-effecting")
+		t.Fatal("write_file should be in the gating set")
 	}
 	if !sideEffecting["run_command"] {
-		t.Fatal("run_command should be side-effecting")
+		t.Fatal("run_command should be in the gating set")
 	}
-	// read_file is not side-effecting.
+	// read_file does not need gating.
 	if sideEffecting["read_file"] {
-		t.Fatal("read_file should not be side-effecting")
+		t.Fatal("read_file should not be in the gating set")
 	}
 }
 

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -726,6 +726,66 @@ func TestApprovalRequiredToolSet(t *testing.T) {
 			t.Errorf("%s should not require approval", name)
 		}
 	}
+	// spawn_agent is registered post-loop-construction in factory.go (see
+	// BuildLoopWithTransport). Its absence here is load-bearing: if it
+	// ever appears in this set, the AddApprovalTool refresh has become
+	// redundant and the post-registration step in the factory should
+	// be removed.
+	if approval["spawn_agent"] {
+		t.Error("spawn_agent should not be in approvalRequiredToolSet — it is added post-loop-construction in BuildLoopWithTransport")
+	}
+}
+
+// TestBuildLoopWithTransport_AskUpstreamIncludesSpawnAgent asserts the
+// post-registration refresh in BuildLoopWithTransport: spawn_agent must
+// appear in the AskUpstreamPolicy approval set even though it is
+// registered after the policy is built. Without the refresh, spawn_agent
+// calls would bypass the control plane approval gate.
+func TestBuildLoopWithTransport_AskUpstreamIncludesSpawnAgent(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-ask-upstream",
+		Mode:             "execution",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "ask-upstream", Timeout: 60},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	ask, ok := loop.Permissions.(*permission.AskUpstreamPolicy)
+	if !ok {
+		t.Fatalf("expected AskUpstreamPolicy, got %T", loop.Permissions)
+	}
+
+	approval := make(map[string]bool)
+	for _, name := range ask.ApprovalToolNames() {
+		approval[name] = true
+	}
+	for _, name := range []string{"write_file", "run_command", "web_fetch", "spawn_agent"} {
+		if !approval[name] {
+			t.Errorf("ask-upstream policy missing %q in approval set; got %v", name, approval)
+		}
+	}
 }
 
 // --- BuildLoopWithTransport integration ---
@@ -1080,6 +1140,62 @@ func TestBuildLoopWithTransport_ResearchModeAllowsWebFetch(t *testing.T) {
 	}
 	if !result.Allowed {
 		t.Fatalf("research mode permission policy denied web_fetch: %q", result.Reason)
+	}
+}
+
+// TestBuildLoopWithTransport_ReadOnlyModesAllowWebFetch is the WP1
+// regression covering all four read-only modes (research, review, toil,
+// planning). Each must enable web_fetch and have a permission policy
+// that allows it through. Without table coverage, a future change that
+// special-cases just one mode would silently break the others.
+func TestBuildLoopWithTransport_ReadOnlyModesAllowWebFetch(t *testing.T) {
+	modes := []string{"research", "review", "toil", "planning"}
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("TEST_OPENAI_KEY", "test-key")
+			server := newOpenAIServer(t, nil, nil, nil)
+			defer server.Close()
+
+			timeout := 30
+			config := &types.RunConfig{
+				RunID:            "factory-test-readonly-" + mode,
+				Mode:             mode,
+				Prompt:           "hello",
+				Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+				ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+				PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+				ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+				Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+				EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+				Verifier:         types.VerifierConfig{Type: "none"},
+				PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+				GitStrategy:      types.GitStrategyConfig{Type: "none"},
+				TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+				Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+				MaxTurns:         2,
+				Timeout:          &timeout,
+			}
+
+			tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+			loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+			if err != nil {
+				t.Fatalf("BuildLoopWithTransport(mode=%q) error: %v", mode, err)
+			}
+			defer func() { _ = loop.Close() }()
+
+			wf := loop.Tools.Resolve("web_fetch")
+			if wf == nil {
+				t.Fatalf("expected web_fetch to be registered in mode %q", mode)
+			}
+
+			result, err := loop.Permissions.Check(context.Background(), wf.Definition(), nil)
+			if err != nil {
+				t.Fatalf("permission check returned error in mode %q: %v", mode, err)
+			}
+			if !result.Allowed {
+				t.Fatalf("mode %q permission policy denied web_fetch: %q", mode, result.Reason)
+			}
+		})
 	}
 }
 

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -681,24 +681,50 @@ func TestEditToolEnabled_NoMatch(t *testing.T) {
 	}
 }
 
-// --- sideEffectingToolSet ---
+// --- mutatingToolSet ---
 
-func TestSideEffectingToolSet(t *testing.T) {
+func TestMutatingToolSet(t *testing.T) {
 	exec, _ := executor.NewLocalExecutor(t.TempDir())
 	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{})
 
-	sideEffecting := sideEffectingToolSet(registry)
+	mutating := mutatingToolSet(registry)
 
-	// write_file and run_command are workspace-mutating and require approval.
-	if !sideEffecting["write_file"] {
-		t.Fatal("write_file should be in the gating set")
+	// write_file and run_command mutate the workspace.
+	if !mutating["write_file"] {
+		t.Fatal("write_file should be workspace-mutating")
 	}
-	if !sideEffecting["run_command"] {
-		t.Fatal("run_command should be in the gating set")
+	if !mutating["run_command"] {
+		t.Fatal("run_command should be workspace-mutating")
 	}
-	// read_file does not need gating.
-	if sideEffecting["read_file"] {
-		t.Fatal("read_file should not be in the gating set")
+	// Read-only tools are not mutating. (spawn_agent is registered
+	// after the loop is built and is therefore not in this set; see
+	// BuildLoopWithTransport.)
+	for _, name := range []string{"read_file", "list_directory", "search_files", "web_fetch"} {
+		if mutating[name] {
+			t.Errorf("%s should not be workspace-mutating", name)
+		}
+	}
+}
+
+// --- approvalRequiredToolSet ---
+
+func TestApprovalRequiredToolSet(t *testing.T) {
+	exec, _ := executor.NewLocalExecutor(t.TempDir())
+	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+
+	approval := approvalRequiredToolSet(registry)
+
+	// All tools that touch the world require approval: writes, shell, network.
+	for _, name := range []string{"write_file", "run_command", "web_fetch"} {
+		if !approval[name] {
+			t.Errorf("%s should require approval", name)
+		}
+	}
+	// Pure-read tools never require approval.
+	for _, name := range []string{"read_file", "list_directory", "search_files"} {
+		if approval[name] {
+			t.Errorf("%s should not require approval", name)
+		}
 	}
 }
 
@@ -1000,6 +1026,60 @@ func TestBuildLoopWithTransport_SecretResolutionFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "build providers") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestBuildLoopWithTransport_ResearchModeAllowsWebFetch is the WP1
+// regression: research mode (a read-only mode) must enable web_fetch
+// and the deny-side-effects policy must allow it through. Before WP1
+// the conflated SideEffects flag caused the same policy to reject
+// web_fetch as a "side effect", breaking documented research-mode
+// semantics.
+func TestBuildLoopWithTransport_ResearchModeAllowsWebFetch(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-research",
+		Mode:             "research",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	// web_fetch must be registered in research mode.
+	wf := loop.Tools.Resolve("web_fetch")
+	if wf == nil {
+		t.Fatal("expected web_fetch to be registered in research mode")
+	}
+
+	// And the resulting permission policy must let web_fetch through.
+	result, err := loop.Permissions.Check(context.Background(), wf.Definition(), nil)
+	if err != nil {
+		t.Fatalf("permission check returned error: %v", err)
+	}
+	if !result.Allowed {
+		t.Fatalf("research mode permission policy denied web_fetch: %q", result.Reason)
 	}
 }
 

--- a/harness/internal/core/integration_test.go
+++ b/harness/internal/core/integration_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/harness/internal/transport"
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -255,4 +257,101 @@ func newOpenAIServer(t *testing.T, hits *atomic.Int32, responses []string, reque
 
 func openAIChunk(payload string) string {
 	return "data: " + payload + "\n\n"
+}
+
+// TestBuildLoop_ResearchModeWebFetchEndToEnd is the WP1 end-to-end
+// regression. With deny-side-effects active, a research-mode run that
+// asks the model to call web_fetch must not record any
+// "Permission denied" tool result. Before the WP1 fix the conflated
+// SideEffects flag caused every web_fetch to be denied.
+//
+// We replace the real web_fetch handler with a stub after the loop is
+// built so the test does not need network access; the permission gate
+// runs *before* the handler, so this still exercises the policy path.
+func TestBuildLoop_ResearchModeWebFetchEndToEnd(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+
+	server := newOpenAIServer(t, nil, []string{
+		// Turn 1: model requests web_fetch.
+		openAIChunk(`{"id":"rs-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"web_fetch","arguments":"{\"url\":\"https://example.com/\"}"}}]},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"rs-1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`) +
+			"data: [DONE]\n\n",
+		// Turn 2: model produces final answer.
+		openAIChunk(`{"id":"rs-2","choices":[{"index":0,"delta":{"content":"summary"},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"rs-2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`) +
+			"data: [DONE]\n\n",
+	}, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "integration-research-webfetch",
+		Mode:             "research",
+		Prompt:           "Look up example.com",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "gpt-4o-mini"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		MaxTurns:         4,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	// Replace web_fetch with a stub so the test does not depend on
+	// network access. The permission policy runs *before* the handler,
+	// so this still exercises the WP1 gating path.
+	registry, ok := loop.Tools.(*tool.Registry)
+	if !ok {
+		t.Fatalf("expected *tool.Registry, got %T", loop.Tools)
+	}
+	original := registry.Resolve("web_fetch")
+	if original == nil {
+		t.Fatal("expected web_fetch tool to be registered in research mode")
+	}
+	registry.Register(&tool.Tool{
+		Name:              original.Name,
+		Description:       original.Description,
+		InputSchema:       original.InputSchema,
+		WorkspaceMutating: original.WorkspaceMutating,
+		RequiresApproval:  original.RequiresApproval,
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "stubbed body", nil
+		},
+	})
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	if runTrace.Outcome != "success" {
+		t.Fatalf("expected research run to succeed, got outcome %q", runTrace.Outcome)
+	}
+	// At least one web_fetch call should have been recorded, and none
+	// of the recorded calls should report a permission denial.
+	var sawWebFetch bool
+	for _, call := range runTrace.ToolCalls {
+		if call.Name == "web_fetch" {
+			sawWebFetch = true
+		}
+		if !call.Success && strings.Contains(call.ErrorReason, "Permission denied") {
+			t.Errorf("tool call %q was denied by permission policy: %s", call.Name, call.ErrorReason)
+		}
+	}
+	if !sawWebFetch {
+		t.Fatal("expected at least one web_fetch call in run trace")
+	}
 }

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -68,6 +68,15 @@ func buildTestConfig() *types.RunConfig {
 }
 
 func buildTestLoop(prov *mockProvider) *AgenticLoop {
+	return buildTestLoopWithSecurity(prov, nil)
+}
+
+// buildTestLoopWithSecurity is identical to buildTestLoop but wires a
+// SecurityLogger writing to the provided sink. Pass nil to skip security
+// instrumentation. This is required for tests that assert security events
+// are emitted (e.g. PermissionDenied), which the production loop guards
+// behind a nil check.
+func buildTestLoopWithSecurity(prov *mockProvider, securitySink io.Writer) *AgenticLoop {
 	var transportBuf bytes.Buffer
 	registry := tool.NewRegistry()
 	// Register a simple test tool.
@@ -81,6 +90,11 @@ func buildTestLoop(prov *mockProvider) *AgenticLoop {
 			return "tool result", nil
 		},
 	})
+
+	var secLogger *security.SecurityLogger
+	if securitySink != nil {
+		secLogger = security.NewSecurityLogger(securitySink, "test-run")
+	}
 
 	return &AgenticLoop{
 		Provider:    prov,
@@ -97,6 +111,7 @@ func buildTestLoop(prov *mockProvider) *AgenticLoop {
 		Trace:       trace.NewJSONLTraceEmitter(&bytes.Buffer{}),
 		Tracer:      noop.NewTracerProvider().Tracer(""),
 		Metrics:     observability.NewNoopMetrics(),
+		Security:    secLogger,
 		Logger:      slog.Default(),
 	}
 }
@@ -429,7 +444,8 @@ func (c *closeTracker) Close() error {
 }
 
 func TestDispatchToolCall_PermissionDenied(t *testing.T) {
-	loop := buildTestLoop(&mockProvider{})
+	var secBuf bytes.Buffer
+	loop := buildTestLoopWithSecurity(&mockProvider{}, &secBuf)
 
 	// Register a workspace-mutating tool.
 	registry := tool.NewRegistry()
@@ -462,6 +478,16 @@ func TestDispatchToolCall_PermissionDenied(t *testing.T) {
 	}
 	if !strings.Contains(output, "Permission denied") {
 		t.Errorf("expected output to contain 'Permission denied', got %q", output)
+	}
+
+	// Assert the SecurityLogger was actually called. Without this, a
+	// regression that nil-skips the call would silently pass.
+	logged := secBuf.String()
+	if !strings.Contains(logged, "permission_denied") {
+		t.Errorf("expected security log to contain 'permission_denied', got %q", logged)
+	}
+	if !strings.Contains(logged, "dangerous_tool") {
+		t.Errorf("expected security log to contain tool name 'dangerous_tool', got %q", logged)
 	}
 }
 

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -561,10 +561,10 @@ func TestDispatchToolCall_ToolGuardRejectsBeforePermissionAndHandler(t *testing.
 	handlerCalled := false
 	registry := tool.NewRegistry()
 	registry.Register(&tool.Tool{
-		Name:        "run_command",
-		Description: "A shell tool",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}`),
-		SideEffects: true,
+		Name:              "run_command",
+		Description:       "A shell tool",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}`),
+		WorkspaceMutating: true,
 		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
 			handlerCalled = true
 			return "should not reach here", nil

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -72,10 +72,11 @@ func buildTestLoop(prov *mockProvider) *AgenticLoop {
 	registry := tool.NewRegistry()
 	// Register a simple test tool.
 	registry.Register(&tool.Tool{
-		Name:        "test_tool",
-		Description: "A test tool",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
-		SideEffects: false,
+		Name:              "test_tool",
+		Description:       "A test tool",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
 		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
 			return "tool result", nil
 		},
@@ -430,13 +431,14 @@ func (c *closeTracker) Close() error {
 func TestDispatchToolCall_PermissionDenied(t *testing.T) {
 	loop := buildTestLoop(&mockProvider{})
 
-	// Register a side-effecting tool.
+	// Register a workspace-mutating tool.
 	registry := tool.NewRegistry()
 	registry.Register(&tool.Tool{
-		Name:        "dangerous_tool",
-		Description: "A tool with side effects",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
-		SideEffects: true,
+		Name:              "dangerous_tool",
+		Description:       "A tool that mutates the workspace",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: true,
+		RequiresApproval:  true,
 		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
 			return "should not reach here", nil
 		},
@@ -469,10 +471,11 @@ func TestDispatchToolCall_ToolHandlerError(t *testing.T) {
 	// Register a tool whose handler returns an error.
 	registry := tool.NewRegistry()
 	registry.Register(&tool.Tool{
-		Name:        "broken_tool",
-		Description: "A tool that always errors",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
-		SideEffects: false,
+		Name:              "broken_tool",
+		Description:       "A tool that always errors",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
 		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
 			return "", errors.New("handler exploded")
 		},
@@ -500,10 +503,11 @@ func TestDispatchToolCall_InvalidInput(t *testing.T) {
 	// Register a tool that requires a "path" field.
 	registry := tool.NewRegistry()
 	registry.Register(&tool.Tool{
-		Name:        "strict_tool",
-		Description: "A tool with required fields",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
-		SideEffects: false,
+		Name:              "strict_tool",
+		Description:       "A tool with required fields",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
 		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
 			return "should not reach here", nil
 		},

--- a/harness/internal/core/subagent_test.go
+++ b/harness/internal/core/subagent_test.go
@@ -26,20 +26,22 @@ import (
 func buildSubAgentTestLoop(prov *mockProvider) *AgenticLoop {
 	registry := tool.NewRegistry()
 	registry.Register(&tool.Tool{
-		Name:        "test_tool",
-		Description: "A test tool",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
-		SideEffects: false,
+		Name:              "test_tool",
+		Description:       "A test tool",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
 		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
 			return "tool result", nil
 		},
 	})
 	// Register a spawn_agent tool to verify it gets filtered for the child.
 	registry.Register(&tool.Tool{
-		Name:        "spawn_agent",
-		Description: "Spawn a sub-agent",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
-		SideEffects: true,
+		Name:              "spawn_agent",
+		Description:       "Spawn a sub-agent",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: false,
+		RequiresApproval:  true,
 		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
 			return "should not be called", nil
 		},

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -166,6 +166,9 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 		permSpan.SetAttributes(attribute.Bool("permission.allowed", result.Allowed))
 		permSpan.End()
 		if !result.Allowed {
+			if l.Security != nil {
+				l.Security.PermissionDenied(call.Name, result.Reason)
+			}
 			return "Permission denied: " + result.Reason, false
 		}
 	}

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -139,15 +139,18 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false
 	}
 
-	if findings := security.GuardToolCall(call.Name, t.SideEffects, call.Input); len(findings) > 0 {
+	if findings := security.GuardToolCall(call.Name, t.WorkspaceMutating, call.Input); len(findings) > 0 {
 		if l.Security != nil {
 			l.Security.ToolCallGuardTriggered(call.Name, findings)
 		}
 		return fmt.Sprintf("Tool call rejected by security guard for %s", call.Name), false
 	}
 
-	// Check permissions for side-effecting tools.
-	if t.SideEffects {
+	// Check permissions for tools that mutate the workspace or that
+	// otherwise require upstream approval (e.g. network-touching tools
+	// like web_fetch, or budget-consuming tools like spawn_agent). The
+	// permission policy decides what to actually do with each flag.
+	if t.WorkspaceMutating || t.RequiresApproval {
 		_, permSpan := l.Tracer.Start(l.traceCtx(ctx), "permission.check",
 			oteltrace.WithAttributes(
 				attribute.String("tool.name", call.Name),

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -318,7 +318,13 @@ func (c *Client) registerMCPTool(serverName string, sess *serverSession, mt mcpT
 		Name:        prefixedName,
 		Description: mt.Description,
 		InputSchema: mt.InputSchema,
-		SideEffects: true, // MCP tools default to side-effecting
+		// MCP tools are remote and opaque to the harness: we cannot
+		// statically tell whether they mutate the workspace, so be
+		// conservative and assume they do. They also require upstream
+		// approval for the same reason — the operator should be in the
+		// loop on remote tool execution.
+		WorkspaceMutating: true,
+		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			return c.callTool(ctx, remoteSess, remoteName, input)
 		},

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -157,8 +157,11 @@ func TestConnect_ToolDiscovery(t *testing.T) {
 	if resolved == nil {
 		t.Fatal("Resolve returned nil for mcp_docs_search")
 	}
-	if !resolved.SideEffects {
-		t.Error("MCP tools should default to SideEffects=true")
+	if !resolved.WorkspaceMutating {
+		t.Error("MCP tools should default to WorkspaceMutating=true")
+	}
+	if !resolved.RequiresApproval {
+		t.Error("MCP tools should default to RequiresApproval=true")
 	}
 }
 

--- a/harness/internal/permission/askupstream.go
+++ b/harness/internal/permission/askupstream.go
@@ -22,10 +22,14 @@ type Transport interface {
 	OnControl(handler func(event types.ControlEvent))
 }
 
-// AskUpstreamPolicy is a PermissionPolicy that auto-allows read-only tools
-// and sends side-effecting tool calls to the control plane for approval via
-// the Transport. It blocks until a permission_response control event arrives
-// or the context is cancelled.
+// AskUpstreamPolicy is a PermissionPolicy that auto-allows tool calls which
+// do not require operator approval and forwards approval-required tool
+// calls to the control plane via the Transport. It blocks until a
+// permission_response control event arrives or the context is cancelled.
+//
+// The set of approval-required tools is built from the registry by
+// collecting tools whose Tool.RequiresApproval flag is true (see
+// core.factory.approvalRequiredToolSet).
 type AskUpstreamPolicy struct {
 	transport Transport
 
@@ -34,9 +38,10 @@ type AskUpstreamPolicy struct {
 	// window, Check returns an error.
 	Timeout time.Duration
 
-	// sideEffectingTools maps tool names that have side effects. Tools in
-	// this set require upstream approval; all others are auto-allowed.
-	sideEffectingTools map[string]bool
+	// approvalTools maps tool names that require upstream approval. Tools
+	// in this set are forwarded to the control plane; all others are
+	// auto-allowed.
+	approvalTools map[string]bool
 
 	mu       sync.Mutex
 	nextID   int
@@ -49,22 +54,34 @@ type permissionResponse struct {
 	reason  string
 }
 
-// NewAskUpstreamPolicy creates a new AskUpstreamPolicy. The sideEffectingTools
-// map keys are tool names considered to have side effects; calls to those tools
-// are forwarded to the control plane for approval. If timeout is zero,
+// NewAskUpstreamPolicy creates a new AskUpstreamPolicy. The approvalTools
+// map keys are tool names whose calls must be approved by the control
+// plane; calls to those tools are forwarded as permission_request events
+// and block until a permission_response arrives. If timeout is zero,
 // DefaultAskUpstreamTimeout (60s) is used.
-func NewAskUpstreamPolicy(transport Transport, sideEffectingTools map[string]bool, timeout time.Duration) *AskUpstreamPolicy {
+func NewAskUpstreamPolicy(transport Transport, approvalTools map[string]bool, timeout time.Duration) *AskUpstreamPolicy {
 	if timeout <= 0 {
 		timeout = DefaultAskUpstreamTimeout
 	}
 	p := &AskUpstreamPolicy{
-		transport:          transport,
-		Timeout:            timeout,
-		sideEffectingTools: sideEffectingTools,
-		pending:            make(map[string]chan permissionResponse),
+		transport:     transport,
+		Timeout:       timeout,
+		approvalTools: approvalTools,
+		pending:       make(map[string]chan permissionResponse),
 	}
 	p.attachHandler()
 	return p
+}
+
+// ApprovalToolNames returns a snapshot of tool names that require upstream
+// approval. The returned slice is owned by the caller; modifications do
+// not affect the policy. Order is not guaranteed.
+func (p *AskUpstreamPolicy) ApprovalToolNames() []string {
+	names := make([]string, 0, len(p.approvalTools))
+	for name := range p.approvalTools {
+		names = append(names, name)
+	}
+	return names
 }
 
 // attachHandler registers a control event handler on the transport to route
@@ -95,11 +112,12 @@ func (p *AskUpstreamPolicy) attachHandler() {
 	})
 }
 
-// Check implements PermissionPolicy. Read-only tools are auto-allowed.
-// Side-effecting tools emit a permission_request event via Transport and
-// block until the control plane responds or the context is cancelled.
+// Check implements PermissionPolicy. Tools that do not require upstream
+// approval are auto-allowed. Approval-required tools emit a
+// permission_request event via Transport and block until the control plane
+// responds or the context is cancelled.
 func (p *AskUpstreamPolicy) Check(ctx context.Context, tool types.ToolDefinition, input json.RawMessage) (*PermissionResult, error) {
-	if !p.sideEffectingTools[tool.Name] {
+	if !p.approvalTools[tool.Name] {
 		return &PermissionResult{Allowed: true}, nil
 	}
 

--- a/harness/internal/permission/askupstream.go
+++ b/harness/internal/permission/askupstream.go
@@ -77,11 +77,24 @@ func NewAskUpstreamPolicy(transport Transport, approvalTools map[string]bool, ti
 // approval. The returned slice is owned by the caller; modifications do
 // not affect the policy. Order is not guaranteed.
 func (p *AskUpstreamPolicy) ApprovalToolNames() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	names := make([]string, 0, len(p.approvalTools))
 	for name := range p.approvalTools {
 		names = append(names, name)
 	}
 	return names
+}
+
+// AddApprovalTool registers an additional tool name that must be forwarded
+// to the control plane for approval. This is used by the factory to add
+// tools that are registered post-loop-construction (e.g. spawn_agent),
+// which would otherwise miss the snapshot taken at policy creation time.
+// Safe to call concurrently with Check.
+func (p *AskUpstreamPolicy) AddApprovalTool(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.approvalTools[name] = true
 }
 
 // attachHandler registers a control event handler on the transport to route
@@ -117,7 +130,10 @@ func (p *AskUpstreamPolicy) attachHandler() {
 // permission_request event via Transport and block until the control plane
 // responds or the context is cancelled.
 func (p *AskUpstreamPolicy) Check(ctx context.Context, tool types.ToolDefinition, input json.RawMessage) (*PermissionResult, error) {
-	if !p.approvalTools[tool.Name] {
+	p.mu.Lock()
+	required := p.approvalTools[tool.Name]
+	p.mu.Unlock()
+	if !required {
 		return &PermissionResult{Allowed: true}, nil
 	}
 

--- a/harness/internal/permission/askupstream_approvalset_test.go
+++ b/harness/internal/permission/askupstream_approvalset_test.go
@@ -1,0 +1,36 @@
+package permission
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+// TestAskUpstream_ApprovalToolNamesContainsExpectedTools is the WP1
+// regression test for ask-upstream wiring: the policy must prompt on
+// every tool that requires upstream approval — not just workspace-mutating
+// tools. The expected set covers writes (write_file), shell execution
+// (run_command), network (web_fetch), and sub-agent spawning
+// (spawn_agent).
+func TestAskUpstream_ApprovalToolNamesContainsExpectedTools(t *testing.T) {
+	approval := map[string]bool{
+		"write_file":  true,
+		"run_command": true,
+		"web_fetch":   true,
+		"spawn_agent": true,
+	}
+	policy := NewAskUpstreamPolicy(&mockTransport{}, approval, 100*time.Millisecond)
+
+	got := policy.ApprovalToolNames()
+	sort.Strings(got)
+
+	want := []string{"run_command", "spawn_agent", "web_fetch", "write_file"}
+	if len(got) != len(want) {
+		t.Fatalf("ApprovalToolNames length = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Errorf("ApprovalToolNames[%d] = %q, want %q", i, got[i], name)
+		}
+	}
+}

--- a/harness/internal/permission/denysideeffects.go
+++ b/harness/internal/permission/denysideeffects.go
@@ -8,25 +8,33 @@ import (
 )
 
 // DenySideEffects is a PermissionPolicy that rejects tool calls for tools
-// known to have side effects. Tools not in the set are allowed.
+// known to mutate workspace state. Tools not in the set — including
+// non-mutating tools that may still require approval such as web_fetch and
+// spawn_agent — are allowed.
+//
+// The "side effects" name is retained for backwards compatibility with
+// the deny-side-effects RunConfig type; semantically the policy now denies
+// only WorkspaceMutating tools (see Tool.WorkspaceMutating).
 type DenySideEffects struct {
-	sideEffectingTools map[string]bool
+	mutatingTools map[string]bool
 }
 
 // NewDenySideEffects returns a new DenySideEffects policy. The provided map
-// keys are tool names that are considered to have side effects; calls to
-// those tools will be denied.
-func NewDenySideEffects(sideEffectingTools map[string]bool) *DenySideEffects {
-	return &DenySideEffects{sideEffectingTools: sideEffectingTools}
+// keys are tool names that mutate workspace state; calls to those tools are
+// denied. The factory builds this set from the registry by collecting tools
+// whose Tool.WorkspaceMutating flag is true.
+func NewDenySideEffects(mutatingTools map[string]bool) *DenySideEffects {
+	return &DenySideEffects{mutatingTools: mutatingTools}
 }
 
-// Check returns Allowed: false for tools in the side-effecting set, and
-// Allowed: true for all others.
+// Check returns Allowed: false for tools in the workspace-mutating set, and
+// Allowed: true for all others (including approval-required tools like
+// web_fetch and spawn_agent which the operator may still wish to run).
 func (d *DenySideEffects) Check(_ context.Context, tool types.ToolDefinition, _ json.RawMessage) (*PermissionResult, error) {
-	if d.sideEffectingTools[tool.Name] {
+	if d.mutatingTools[tool.Name] {
 		return &PermissionResult{
 			Allowed: false,
-			Reason:  "side effects not permitted in this mode",
+			Reason:  "workspace-mutating tools are not permitted in this mode",
 		}, nil
 	}
 	return &PermissionResult{Allowed: true}, nil

--- a/harness/internal/permission/denysideeffects_test.go
+++ b/harness/internal/permission/denysideeffects_test.go
@@ -1,0 +1,85 @@
+package permission
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestDenySideEffects_DeniesMutatingTools confirms that the policy
+// rejects exactly the tools the factory marks as workspace-mutating
+// (write_file, run_command, edit_file).
+func TestDenySideEffects_DeniesMutatingTools(t *testing.T) {
+	mutating := map[string]bool{
+		"write_file":  true,
+		"run_command": true,
+		"edit_file":   true,
+	}
+	policy := NewDenySideEffects(mutating)
+
+	for _, name := range []string{"write_file", "run_command", "edit_file"} {
+		t.Run(name, func(t *testing.T) {
+			tool := types.ToolDefinition{Name: name}
+			result, err := policy.Check(context.Background(), tool, json.RawMessage(`{}`))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Allowed {
+				t.Fatalf("expected %s to be denied", name)
+			}
+			if result.Reason == "" {
+				t.Errorf("expected non-empty reason on denial of %s", name)
+			}
+		})
+	}
+}
+
+// TestDenySideEffects_AllowsApprovalRequiredButNonMutating is the WP1
+// regression: web_fetch and spawn_agent are read-only as far as the
+// workspace is concerned, so deny-side-effects must let them through.
+// They will still be gated by ask-upstream when configured.
+func TestDenySideEffects_AllowsApprovalRequiredButNonMutating(t *testing.T) {
+	mutating := map[string]bool{
+		"write_file":  true,
+		"run_command": true,
+	}
+	policy := NewDenySideEffects(mutating)
+
+	for _, name := range []string{"web_fetch", "spawn_agent"} {
+		t.Run(name, func(t *testing.T) {
+			tool := types.ToolDefinition{Name: name}
+			result, err := policy.Check(context.Background(), tool, json.RawMessage(`{}`))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.Allowed {
+				t.Fatalf("expected %s to be allowed (it is approval-required but does not mutate the workspace), got reason: %q", name, result.Reason)
+			}
+		})
+	}
+}
+
+// TestDenySideEffects_AllowsPureReadTools confirms the policy never
+// denies read_file, list_directory or search_files.
+func TestDenySideEffects_AllowsPureReadTools(t *testing.T) {
+	mutating := map[string]bool{
+		"write_file":  true,
+		"run_command": true,
+	}
+	policy := NewDenySideEffects(mutating)
+
+	for _, name := range []string{"read_file", "list_directory", "search_files"} {
+		t.Run(name, func(t *testing.T) {
+			tool := types.ToolDefinition{Name: name}
+			result, err := policy.Check(context.Background(), tool, json.RawMessage(`{}`))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.Allowed {
+				t.Fatalf("expected %s to be allowed, got reason: %q", name, result.Reason)
+			}
+		})
+	}
+}

--- a/harness/internal/permission/permission_test.go
+++ b/harness/internal/permission/permission_test.go
@@ -23,11 +23,11 @@ func TestAllowAll_AlwaysAllows(t *testing.T) {
 }
 
 func TestDenySideEffects_DeniesKnownTools(t *testing.T) {
-	sideEffecting := map[string]bool{
+	mutating := map[string]bool{
 		"write_file":        true,
 		"run_shell_command": true,
 	}
-	policy := NewDenySideEffects(sideEffecting)
+	policy := NewDenySideEffects(mutating)
 
 	tool := types.ToolDefinition{Name: "write_file"}
 	result, err := policy.Check(context.Background(), tool, nil)
@@ -35,18 +35,18 @@ func TestDenySideEffects_DeniesKnownTools(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.Allowed {
-		t.Error("should deny side-effecting tool")
+		t.Error("should deny workspace-mutating tool")
 	}
-	if result.Reason != "side effects not permitted in this mode" {
-		t.Errorf("unexpected reason: %q", result.Reason)
+	if result.Reason == "" {
+		t.Error("expected non-empty denial reason")
 	}
 }
 
 func TestDenySideEffects_AllowsReadOnlyTools(t *testing.T) {
-	sideEffecting := map[string]bool{
+	mutating := map[string]bool{
 		"write_file": true,
 	}
-	policy := NewDenySideEffects(sideEffecting)
+	policy := NewDenySideEffects(mutating)
 
 	tool := types.ToolDefinition{Name: "read_file"}
 	result, err := policy.Check(context.Background(), tool, nil)
@@ -54,7 +54,7 @@ func TestDenySideEffects_AllowsReadOnlyTools(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !result.Allowed {
-		t.Error("should allow non-side-effecting tool")
+		t.Error("should allow non-mutating tool")
 	}
 }
 

--- a/harness/internal/security/securityevent.go
+++ b/harness/internal/security/securityevent.go
@@ -173,3 +173,13 @@ func (sl *SecurityLogger) DynamicContextSanitized(event DynamicContextSanitizati
 		"reasons":         event.Reasons,
 	})
 }
+
+// PermissionDenied emits when a permission policy refuses a tool call.
+// This is distinct from a tool error: the tool was never invoked. The
+// reason field is the human-readable string returned by the policy.
+func (sl *SecurityLogger) PermissionDenied(toolName, reason string) {
+	sl.Emit("warn", "permission_denied", map[string]any{
+		"tool":   toolName,
+		"reason": reason,
+	})
+}

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -57,10 +57,11 @@ var listDirectorySchema = json.RawMessage(`{
 // ReadFileTool returns a tool that reads a file from the workspace.
 func ReadFileTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:        "read_file",
-		Description: "Read the contents of a file from the workspace.",
-		InputSchema: readFileSchema,
-		SideEffects: false,
+		Name:              "read_file",
+		Description:       "Read the contents of a file from the workspace.",
+		InputSchema:       readFileSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			var params struct {
 				Path string `json:"path"`
@@ -79,10 +80,11 @@ func ReadFileTool(exec executor.Executor) *tool.Tool {
 // WriteFileTool returns a tool that writes content to a file in the workspace.
 func WriteFileTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:        "write_file",
-		Description: "Write content to a file in the workspace. Creates parent directories as needed.",
-		InputSchema: writeFileSchema,
-		SideEffects: true,
+		Name:              "write_file",
+		Description:       "Write content to a file in the workspace. Creates parent directories as needed.",
+		InputSchema:       writeFileSchema,
+		WorkspaceMutating: true,
+		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			var params struct {
 				Path    string `json:"path"`
@@ -105,10 +107,11 @@ func WriteFileTool(exec executor.Executor) *tool.Tool {
 // ListDirectoryTool returns a tool that lists the contents of a directory.
 func ListDirectoryTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:        "list_directory",
-		Description: "List the contents of a directory in the workspace. Directories have a trailing slash.",
-		InputSchema: listDirectorySchema,
-		SideEffects: false,
+		Name:              "list_directory",
+		Description:       "List the contents of a directory in the workspace. Directories have a trailing slash.",
+		InputSchema:       listDirectorySchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			var params struct {
 				Path string `json:"path"`

--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -39,10 +39,11 @@ const searchTimeout = 30 * time.Second
 // name pattern (glob) within the workspace.
 func SearchFilesTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:        "search_files",
-		Description: "Search for files in the workspace. Use type 'grep' to search file contents with a regex, or 'glob' to find files matching a name pattern.",
-		InputSchema: searchFilesSchema,
-		SideEffects: false,
+		Name:              "search_files",
+		Description:       "Search for files in the workspace. Use type 'grep' to search file contents with a regex, or 'glob' to find files matching a name pattern.",
+		InputSchema:       searchFilesSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			var params struct {
 				Pattern string `json:"pattern"`

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -31,10 +31,11 @@ var runCommandSchema = json.RawMessage(`{
 // RunCommandTool returns a tool that executes a shell command in the workspace.
 func RunCommandTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:        "run_command",
-		Description: "Execute a shell command in the workspace directory. Returns stdout and stderr. The command is killed if it exceeds the timeout.",
-		InputSchema: runCommandSchema,
-		SideEffects: true,
+		Name:              "run_command",
+		Description:       "Execute a shell command in the workspace directory. Returns stdout and stderr. The command is killed if it exceeds the timeout.",
+		InputSchema:       runCommandSchema,
+		WorkspaceMutating: true,
+		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			var params struct {
 				Command string `json:"command"`

--- a/harness/internal/tool/builtins/subagent.go
+++ b/harness/internal/tool/builtins/subagent.go
@@ -46,7 +46,13 @@ func SpawnAgentTool(spawner SubAgentSpawner) *tool.Tool {
 		Name:        "spawn_agent",
 		Description: "Spawn a sub-agent to handle a subtask. The sub-agent has access to the same workspace and tools but runs independently with its own conversation history. Use for tasks that benefit from a fresh context or that can be performed independently.",
 		InputSchema: spawnAgentSchema,
-		SideEffects: true,
+		// The spawn_agent tool itself does not mutate the workspace —
+		// the sub-agent it launches is gated by its own permission
+		// policy. We do however require upstream approval because
+		// spawning an agent consumes additional model budget and the
+		// operator may want to opt in to that.
+		WorkspaceMutating: false,
+		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			var params struct {
 				Prompt   string `json:"prompt"`

--- a/harness/internal/tool/builtins/webfetch.go
+++ b/harness/internal/tool/builtins/webfetch.go
@@ -60,7 +60,11 @@ func newWebFetchTool(opts webFetchOptions) *tool.Tool {
 		Name:        "web_fetch",
 		Description: "Fetch a URL via HTTP GET and return the response body as text. Response is truncated at 100KB.",
 		InputSchema: webFetchSchema,
-		SideEffects: true,
+		// web_fetch does not mutate the workspace, but it makes outbound
+		// network requests on the user's behalf — gate it behind
+		// upstream approval where one is configured.
+		WorkspaceMutating: false,
+		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
 			var params struct {
 				URL string `json:"url"`

--- a/harness/internal/tool/registry_test.go
+++ b/harness/internal/tool/registry_test.go
@@ -103,10 +103,11 @@ func TestRegistry_ReplaceExisting(t *testing.T) {
 
 func TestTool_Definition(t *testing.T) {
 	tool := &Tool{
-		Name:        "my_tool",
-		Description: "My tool description",
-		InputSchema: json.RawMessage(`{"type": "object", "properties": {}}`),
-		SideEffects: true,
+		Name:              "my_tool",
+		Description:       "My tool description",
+		InputSchema:       json.RawMessage(`{"type": "object", "properties": {}}`),
+		WorkspaceMutating: true,
+		RequiresApproval:  true,
 	}
 
 	def := tool.Definition()

--- a/harness/internal/tool/tool.go
+++ b/harness/internal/tool/tool.go
@@ -10,12 +10,28 @@ import (
 )
 
 // Tool represents a single tool that the model can invoke.
+//
+// WorkspaceMutating and RequiresApproval are deliberately separate flags
+// because the two concepts are distinct:
+//
+//   - WorkspaceMutating reports whether the tool modifies workspace state
+//     (files, processes, on-disk artefacts). Read-only modes (research,
+//     review, planning, toil) must reject these.
+//   - RequiresApproval reports whether the tool should be gated by an
+//     upstream approval policy. This includes WorkspaceMutating tools but
+//     also covers non-mutating tools whose effects the operator may still
+//     want to gate (e.g. web_fetch makes network requests; spawn_agent
+//     consumes additional model budget and acts on its own).
+//
+// Tools may set neither, one, or both flags. Read-only tools (read_file,
+// list_directory, search_files) set neither.
 type Tool struct {
-	Name        string
-	Description string
-	InputSchema json.RawMessage // JSON Schema for the tool's input
-	SideEffects bool
-	Handler     func(ctx context.Context, input json.RawMessage) (string, error)
+	Name              string
+	Description       string
+	InputSchema       json.RawMessage // JSON Schema for the tool's input
+	WorkspaceMutating bool
+	RequiresApproval  bool
+	Handler           func(ctx context.Context, input json.RawMessage) (string, error)
 }
 
 // Definition converts a Tool to the wire-format ToolDefinition used by the

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -634,8 +634,16 @@ message VerifierConfig {
   string model = 6;
 }
 
-// PermissionPolicyConfig selects the permission gating strategy for
-// side-effecting tools (write_file, run_command, etc.).
+// PermissionPolicyConfig selects the permission gating strategy for tools
+// that mutate the workspace or that otherwise require operator approval.
+//
+// The harness distinguishes two independent tool flags:
+//   - WorkspaceMutating: the tool modifies workspace state (e.g. write_file,
+//     run_command, edit_file). Read-only modes must reject these.
+//   - RequiresApproval:  the tool should be gated by an upstream approval
+//     policy. Set on every WorkspaceMutating tool plus non-mutating tools
+//     whose effects an operator may want to gate (web_fetch makes outbound
+//     network requests; spawn_agent consumes additional model budget).
 //
 // Cross-field constraint: read-only modes ("planning", "review", "research",
 // "toil") must use "deny-side-effects" or "ask-upstream" — never "allow-all".
@@ -644,12 +652,16 @@ message PermissionPolicyConfig {
   // Valid values:
   //   "allow-all"         — all tool calls are allowed without gating. Only
   //                         valid for "execution" mode.
-  //   "deny-side-effects" — read tools are allowed; write tools are denied
-  //                         automatically.
-  //   "ask-upstream"      — side-effecting tool calls trigger a
-  //                         permission_request HarnessEvent. The control plane
-  //                         must respond with a permission_response ControlEvent
-  //                         within the timeout.
+  //   "deny-side-effects" — denies tools that mutate the workspace. Read
+  //                         tools and approval-required-but-non-mutating
+  //                         tools (web_fetch, spawn_agent) are still
+  //                         allowed; this is what makes "research" mode
+  //                         able to call web_fetch.
+  //   "ask-upstream"      — approval-required tool calls trigger a
+  //                         permission_request HarnessEvent. The control
+  //                         plane must respond with a permission_response
+  //                         ControlEvent within the timeout. Tools that
+  //                         do not require approval are auto-allowed.
   string type = 1;
 
   // For "ask-upstream": seconds to wait for a permission_response before

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -352,7 +352,7 @@ func IsReadOnlyMode(mode string) bool {
 // DefaultReadOnlyBuiltInTools returns the default set of built-in tools
 // enabled for read-only modes when the caller has not supplied an explicit
 // Tools.BuiltIn list. The list deliberately excludes every tool in
-// writeCapableTools so the result always passes ValidateRunConfig for a
+// mutatingTools so the result always passes ValidateRunConfig for a
 // read-only mode.
 func DefaultReadOnlyBuiltInTools() []string {
 	return []string{
@@ -364,7 +364,13 @@ func DefaultReadOnlyBuiltInTools() []string {
 	}
 }
 
-var writeCapableTools = map[string]bool{
+// mutatingTools enumerates built-in tools that mutate workspace state and
+// must therefore be excluded from read-only modes (research, review,
+// planning, toil). Other policy-relevant attributes (such as whether a
+// tool requires upstream approval) live on the Tool struct itself; this
+// list exists purely so RunConfig validation can reject impossible
+// combinations before the harness boots.
+var mutatingTools = map[string]bool{
 	"write_file":  true,
 	"run_command": true,
 }
@@ -417,7 +423,7 @@ func ValidateRunConfig(config *RunConfig) error {
 				config.Mode))
 		} else {
 			for _, tool := range config.Tools.BuiltIn {
-				if writeCapableTools[tool] {
+				if mutatingTools[tool] {
 					errs = append(errs, fmt.Sprintf("read-only mode %q must not enable write tool %q", config.Mode, tool))
 				}
 			}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -334,7 +334,7 @@ func TestValidateRunConfig_ReadOnlyModeWithOnlyReadTools(t *testing.T) {
 // that DefaultReadOnlyBuiltInTools() is always a valid Tools.BuiltIn list
 // for every read-only mode. Callers (notably the stirrup CLI) rely on
 // this: if someone adds a new mode to readOnlyModes, or adds a new tool
-// to writeCapableTools that happens to also live in the default list,
+// to mutatingTools that happens to also live in the default list,
 // this test catches it before ValidateRunConfig starts rejecting every
 // run booted in that mode.
 func TestDefaultReadOnlyBuiltInTools_PassesValidation(t *testing.T) {
@@ -343,10 +343,10 @@ func TestDefaultReadOnlyBuiltInTools_PassesValidation(t *testing.T) {
 		t.Fatal("DefaultReadOnlyBuiltInTools returned an empty list")
 	}
 
-	// Sanity: none of the defaults should be a known write-capable tool.
+	// Sanity: none of the defaults should be a known mutating tool.
 	for _, tool := range defaults {
-		if writeCapableTools[tool] {
-			t.Errorf("DefaultReadOnlyBuiltInTools contains write-capable tool %q", tool)
+		if mutatingTools[tool] {
+			t.Errorf("DefaultReadOnlyBuiltInTools contains mutating tool %q", tool)
 		}
 		if !validBuiltInToolNames[tool] {
 			t.Errorf("DefaultReadOnlyBuiltInTools contains unknown tool %q", tool)


### PR DESCRIPTION
Closes #33.

## Summary

- Split `Tool.SideEffects` into two semantically distinct flags: `WorkspaceMutating` (gates `deny-side-effects`) and `RequiresApproval` (gates `ask-upstream`). This unblocks `web_fetch` and `spawn_agent` in read-only modes (research/review/toil/planning), where they were previously denied despite not mutating the workspace.
- New `SecurityLogger.PermissionDenied(toolName, reason)` helper is emitted from `core/types.go::dispatchToolCall` on every denial, with `LogScrubber` applied so secrets in tool inputs cannot leak.
- Closes a HIGH-severity bypass found in review: `spawn_agent` was registered into the tool registry **after** `buildPermissionPolicy` snapshotted the approval set, so `ask-upstream` was auto-allowing sub-agent invocations without forwarding `permission_request` events to the control plane.

## Commits

| Hash | Message |
|---|---|
| `dc8a492` | tool: rename SideEffects → WorkspaceMutating; add RequiresApproval |
| `f419534` | permission: deny only mutating tools; ask-upstream uses approval flag |
| `9da7e84` | permission: register spawn_agent in ask-upstream approval set; expand test coverage for read-only modes and security event |

## Per-tool flag matrix

| Tool | WorkspaceMutating | RequiresApproval |
|---|---|---|
| `write_file` | true | true |
| `run_command` | true | true |
| `edit_file` (whole-file / search-replace / apply-diff / multi-strategy) | true | true |
| `web_fetch` | false | true |
| `spawn_agent` | false | true |
| `read_file`, `list_directory`, `search_files` | false | false |
| MCP-discovered tools | true (fail-safe) | true (fail-safe) |

## Multi-agent review

The change went through one implementation wave + four parallel reviewers (security, code, spec-compliance, tests) + one synthesis + one remediation wave. The synthesis brief and individual reports were written to `reviews/wave-1-*.md` in the worktree (not included in this branch — they were notes-only artefacts).

Synthesizer surfaced 3 remediation blockers, all addressed in `9da7e84`:

1. **spawn_agent ordering bug** (security HIGH + tests CONCERN, same root cause). Added `AskUpstreamPolicy.AddApprovalTool(name)` (mutex-protected) and call it post-`spawn_agent`-registration in the factory. Added a load-bearing negative assertion in `TestApprovalRequiredToolSet` so the absence at the registry-level test stays documented.
2. **SecurityLogger emission untested.** Split `buildTestLoop` to inject a `bytes.Buffer` security sink; `TestDispatchToolCall_PermissionDenied` now asserts the buffer contains `"permission_denied"` and the tool name.
3. **Only research mode covered.** Added table-driven `TestBuildLoopWithTransport_ReadOnlyModesAllowWebFetch` covering research/review/toil/planning.

The implementer self-validated each new assertion by temporarily breaking the production code and confirming the assertion failed before restoring.

## Out of scope (deferred to follow-up issues)

- `ValidateRunConfig::mutatingTools` map missing `search_replace`/`apply_diff`/`edit_file` — defense-in-depth gap; runtime gate is correct.
- Stale `sideEffectingSet()` helper + `"run_shell_command"` typo in `askupstream_test.go` — pre-existing weakness.
- Stale field comment at `harness.proto:252` — `PermissionPolicyConfig` block is correct, the one-liner one field above is stale.
- `dispatchToolCall` permission-check error path uncovered.
- Explicit `false` on read-only builtins — style only.

## Compatibility note

The denial reason string changed from `"side effects not permitted in this mode"` to `"workspace-mutating tools are not permitted in this mode"`. Control-plane consumers, eval judges, or trace assertions keying off the old exact string will need to update.

## Test plan

- [x] `just lint` → 0 issues
- [x] `go test -race -count=1 ./types/... ./harness/internal/tool/... ./harness/internal/permission/... ./harness/internal/core/...` → all `ok`
- [x] `just test` → 24 packages, all `ok`
- [x] `just build` → both binaries built
- [ ] CI green on this branch
- [ ] Manual smoke in research mode: harness can call `web_fetch` without `Permission denied` (covered by new integration test, but worth a one-shot live run before merge)