### PR TITLE
Add OpenAI Responses API provider adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ stirrup/
     internal/
       core/                  # AgenticLoop, factory, token tracking, sub-agent spawning, stall detection
       credential/            # Cross-cloud credential federation
-      provider/              # ProviderAdapter: Anthropic, Bedrock, OpenAI-compatible
+      provider/              # ProviderAdapter: Anthropic, Bedrock, OpenAI-compatible, OpenAI Responses
       router/                # ModelRouter: static, per-mode, dynamic
       prompt/                # PromptBuilder: per-mode templates, composed fragments, overrides
       context/               # ContextStrategy: sliding window, summarise, offload-to-file
@@ -70,7 +70,7 @@ Requires `ANTHROPIC_API_KEY` environment variable for the default Anthropic prov
 | `--prompt` | (required) | User prompt, also accepted as a positional argument |
 | `--mode`, `-m` | `execution` | Run mode: execution, planning, review, research, toil |
 | `--model` | `claude-sonnet-4-6` | Model to use |
-| `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible |
+| `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible (Chat Completions), openai-responses (Responses API) |
 | `--api-key-ref` | `secret://ANTHROPIC_API_KEY` | Secret reference for API key |
 | `--workspace`, `-w` | current directory | Workspace directory |
 | `--max-turns` | `20` | Maximum agentic loop turns |
@@ -85,7 +85,7 @@ Requires `ANTHROPIC_API_KEY` environment variable for the default Anthropic prov
 
 12 swappable components, all interface-based:
 
-1. **ProviderAdapter** - streams completions from LLMs (Anthropic, Bedrock, OpenAI-compatible)
+1. **ProviderAdapter** - streams completions from LLMs (Anthropic, Bedrock, OpenAI-compatible, OpenAI Responses)
 2. **ModelRouter** - selects provider+model per turn (static, per-mode, dynamic)
 3. **PromptBuilder** - assembles system prompt (default per-mode templates, composed fragments, overrides)
 4. **ContextStrategy** - manages message history (sliding window, summarise, offload-to-file)
@@ -105,6 +105,7 @@ The core loop is a pure function of its interfaces. All dependencies are injecte
 - **Anthropic** (`provider/anthropic.go`) - SSE streaming via `net/http` + `bufio.Scanner`. Hand-rolled, no SDK dependency.
 - **Bedrock** (`provider/bedrock.go`) - AWS ConverseStream API via `aws-sdk-go-v2`. Auth is IAM, with optional credential federation.
 - **OpenAI-compatible** (`provider/openai.go`) - OpenAI chat completions streaming. Works with OpenAI, LiteLLM, Azure OpenAI, vLLM, Ollama via configurable `baseURL`.
+- **OpenAI Responses** (`provider/openai_responses.go`) - OpenAI Responses API (`POST /v1/responses`) streaming. Distinct wire format from Chat Completions: top-level `instructions`, typed `input[]` items, flat tool schema, `max_output_tokens`, explicit `store: false`, and named SSE events. Selected explicitly via `provider.type: "openai-responses"` - no auto-detection between the two OpenAI adapters.
 
 ### Container Executor
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ stirrup/
     internal/
       core/                  # AgenticLoop, factory, token tracking, sub-agent spawning, stall detection
       credential/            # Cross-cloud credential federation (token sources + credential sources)
-      provider/              # ProviderAdapter: Anthropic, Bedrock, OpenAI-compatible
+      provider/              # ProviderAdapter: Anthropic, Bedrock, OpenAI-compatible, OpenAI Responses
       router/                # ModelRouter: static, per-mode, dynamic
       prompt/                # PromptBuilder: per-mode templates
       context/               # ContextStrategy: sliding window, summarise, offload-to-file
@@ -72,7 +72,7 @@ Requires `ANTHROPIC_API_KEY` environment variable.
 | `--prompt` | (required) | User prompt (also accepted as positional arg) |
 | `--mode`, `-m` | `execution` | Run mode: execution, planning, review, research, toil |
 | `--model` | `claude-sonnet-4-6` | Model to use |
-| `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible |
+| `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible (Chat Completions), openai-responses (Responses API) |
 | `--api-key-ref` | `secret://ANTHROPIC_API_KEY` | Secret reference for API key |
 | `--workspace`, `-w` | current directory | Workspace directory |
 | `--max-turns` | `20` | Maximum agentic loop turns |
@@ -125,7 +125,7 @@ go build -o stirrup-eval ./eval/cmd/eval
 
 12 swappable components, all interface-based:
 
-1. **ProviderAdapter** — streams completions from LLMs (Anthropic, Bedrock, OpenAI-compatible)
+1. **ProviderAdapter** — streams completions from LLMs (Anthropic, Bedrock, OpenAI-compatible, OpenAI Responses)
 2. **ModelRouter** — selects provider+model per turn (static, per-mode, dynamic)
 3. **PromptBuilder** — assembles system prompt (default per-mode templates, composed)
 4. **ContextStrategy** — manages message history (sliding window, summarise, offload-to-file)
@@ -145,6 +145,7 @@ The core loop is a pure function of its interfaces. All dependencies are injecte
 - **Anthropic** (`provider/anthropic.go`) — SSE streaming via `net/http` + `bufio.Scanner`. Hand-rolled, no SDK dependency.
 - **Bedrock** (`provider/bedrock.go`) — AWS ConverseStream API via `aws-sdk-go-v2`. Translates between internal types and Bedrock's union-type wire format. Auth is IAM (not API key); uses `config.LoadDefaultConfig()`. Accepts optional `aws.CredentialsProvider` for cross-cloud credential federation.
 - **OpenAI-compatible** (`provider/openai.go`) — OpenAI chat completions streaming. Works with OpenAI, LiteLLM, Azure OpenAI, vLLM, Ollama via configurable `baseURL`.
+- **OpenAI Responses** (`provider/openai_responses.go`) — OpenAI Responses API (`POST /v1/responses`) streaming. Distinct wire format from Chat Completions: top-level `instructions` field, typed `input[]` items (`message` / `function_call` / `function_call_output`), flat tool schema, `max_output_tokens`, explicit `store: false`, and named SSE events (`response.output_text.delta`, `response.function_call_arguments.delta`, `response.completed`, `response.incomplete`, `response.failed`). Selected explicitly via `provider.type: "openai-responses"` — there is no auto-detection between the two OpenAI adapters because silent fallback would mask configuration errors. Built-in OpenAI-side tools (`web_search`, `file_search`, `computer_use`, `code_interpreter`), server-side state via `previous_response_id`, and reasoning controls are intentionally not supported in this adapter; the harness manages its own conversation history.
 
 ### Credential federation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A coding agent harness for building composable AI agents. Built in Go with 12 sw
 
 - **Modular architecture**: 12 interface-based components for LLM providers, routing, prompts, context, tools, execution, editing, verification, permissions, transport, git, and tracing
 - **Unified CLI**: `stirrup harness` for local runs and `stirrup job` for Kubernetes control-plane jobs
-- **Streaming support**: Anthropic SSE, AWS Bedrock ConverseStream, OpenAI-compatible chat completions, stdio transport, and gRPC bidi streaming
+- **Streaming support**: Anthropic SSE, AWS Bedrock ConverseStream, OpenAI-compatible chat completions, OpenAI Responses API, stdio transport, and gRPC bidi streaming
 - **Security-first**: secret redaction, full JSON Schema validation, restrictive read-only modes, environment filtering, SSRF protection, path containment, HTTP timeouts, and loop stall detection
 - **Multi-mode operation**: execution, planning, review, research, and toil modes
 - **Token accounting**: input/output token tracking with configurable budget limits
@@ -49,7 +49,7 @@ go run ./harness/cmd/stirrup harness --prompt "Your task here"
 | `--prompt` | (required) | User prompt, also accepted as a positional argument |
 | `--mode`, `-m` | `execution` | Run mode: execution, planning, review, research, toil |
 | `--model` | `claude-sonnet-4-6` | Model to use |
-| `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible |
+| `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible (Chat Completions), openai-responses (Responses API) |
 | `--api-key-ref` | `secret://ANTHROPIC_API_KEY` | Secret reference for API key |
 | `--workspace`, `-w` | current directory | Workspace directory |
 | `--max-turns` | `20` | Maximum agentic loop turns |
@@ -114,7 +114,7 @@ go build -o stirrup-eval ./eval/cmd/eval
 
 The harness is composed of 12 swappable, interface-based components:
 
-1. **ProviderAdapter** - Streams completions from LLMs: Anthropic, Bedrock, OpenAI-compatible
+1. **ProviderAdapter** - Streams completions from LLMs: Anthropic, Bedrock, OpenAI-compatible (Chat Completions), OpenAI Responses
 2. **ModelRouter** - Selects provider and model per turn: static, per-mode, dynamic
 3. **PromptBuilder** - Assembles system prompts: default per-mode templates, composed fragments, overrides
 4. **ContextStrategy** - Manages conversation history: sliding window, summarise, offload-to-file
@@ -145,7 +145,7 @@ stirrup/
     internal/
       core/                  # AgenticLoop, factory, token tracking, sub-agents, stall detection
       credential/            # Cross-cloud credential federation
-      provider/              # Anthropic, Bedrock, OpenAI-compatible adapters
+      provider/              # Anthropic, Bedrock, OpenAI-compatible, OpenAI Responses adapters
       router/                # Static, per-mode, dynamic model routers
       prompt/                # Prompt builders and system prompt templates
       context/               # Sliding window, summarise, offload-to-file

--- a/examples/runconfig/README.md
+++ b/examples/runconfig/README.md
@@ -19,6 +19,7 @@ fails fast with a clear error rather than being silently dropped.
 | File | What it demonstrates |
 |---|---|
 | [`full.json`](full.json) | Container executor, multi edit strategy, OTel trace emitter, deterministic git, dynamic model router, allow-all permission policy, and one MCP server. Passes `types.ValidateRunConfig` end-to-end. |
+| [`openai_responses.json`](openai_responses.json) | OpenAI Responses API provider (`POST /v1/responses`), local executor, multi edit strategy, JSONL trace emitter, static router on `gpt-4.1`. Use this template when you want the Responses wire format (top-level `instructions`, typed `input[]` items, `max_output_tokens`) rather than Chat Completions. |
 
 ## Precedence
 

--- a/examples/runconfig/openai_responses.json
+++ b/examples/runconfig/openai_responses.json
@@ -1,0 +1,55 @@
+{
+  "runId": "example-openai-responses",
+  "mode": "execution",
+  "prompt": "Replace this prompt with the task you want the harness to run.",
+  "provider": {
+    "type": "openai-responses",
+    "apiKeyRef": "secret://OPENAI_API_KEY",
+    "baseUrl": "https://api.openai.com/v1"
+  },
+  "modelRouter": {
+    "type": "static",
+    "provider": "openai-responses",
+    "model": "gpt-4.1"
+  },
+  "promptBuilder": {
+    "type": "default"
+  },
+  "contextStrategy": {
+    "type": "sliding-window",
+    "maxTokens": 200000
+  },
+  "executor": {
+    "type": "local"
+  },
+  "editStrategy": {
+    "type": "multi"
+  },
+  "verifier": {
+    "type": "none"
+  },
+  "permissionPolicy": {
+    "type": "allow-all"
+  },
+  "gitStrategy": {
+    "type": "none"
+  },
+  "transport": {
+    "type": "stdio"
+  },
+  "traceEmitter": {
+    "type": "jsonl"
+  },
+  "tools": {
+    "builtIn": [
+      "read_file",
+      "list_directory",
+      "search_files",
+      "edit_file",
+      "run_command"
+    ]
+  },
+  "maxTurns": 20,
+  "timeout": 600,
+  "logLevel": "info"
+}

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -210,7 +210,7 @@ func init() {
 	f.String("config", "", "Path to a JSON RunConfig file (mirrors proto/harness/v1/harness.proto). Explicit flags still override individual fields; unset flags do not.")
 	f.StringP("mode", "m", "execution", "Run mode: execution, planning, review, research, toil")
 	f.String("model", "claude-sonnet-4-6", "Model to use (sets ModelRouter.Model; for dynamic/per-mode routers in --config files this only sets the default-model field, not the cheap/expensive override)")
-	f.String("provider", "anthropic", "Provider type: anthropic, bedrock, openai-compatible")
+	f.String("provider", "anthropic", "Provider type: anthropic, bedrock, openai-compatible (Chat Completions), openai-responses (Responses API). The two OpenAI variants speak different wire formats and must be selected explicitly.")
 	f.String("api-key-ref", "secret://ANTHROPIC_API_KEY", "Secret reference for API key")
 	f.StringP("workspace", "w", "", "Workspace directory (default: current directory)")
 	f.Int("max-turns", 20, "Maximum agentic loop turns")

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -66,6 +66,35 @@ func TestBuildHarnessRunConfig_AllModesValidate(t *testing.T) {
 	}
 }
 
+// TestBuildHarnessRunConfig_OpenAIResponsesProvider verifies that the
+// openai-responses provider type is accepted by both the CLI option-to-
+// RunConfig path and ValidateRunConfig. Before this case existed, picking
+// --provider openai-responses would crash at validation.
+func TestBuildHarnessRunConfig_OpenAIResponsesProvider(t *testing.T) {
+	cfg := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "execution",
+		Prompt:        "test",
+		ProviderType:  "openai-responses",
+		APIKeyRef:     "secret://OPENAI_API_KEY",
+		Model:         "gpt-4.1",
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+
+	if cfg.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q, want openai-responses", cfg.Provider.Type)
+	}
+	if cfg.ModelRouter.Provider != "openai-responses" {
+		t.Errorf("ModelRouter.Provider = %q, want openai-responses", cfg.ModelRouter.Provider)
+	}
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		t.Fatalf("ValidateRunConfig rejected openai-responses: %v", err)
+	}
+}
+
 // TestBuildHarnessRunConfig_FillsDefaultReadOnlyToolList verifies that
 // when no explicit Tools.BuiltIn list is supplied, read-only modes get
 // the documented default list rather than passing validation by accident.

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -213,6 +213,9 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		case *provider.OpenAICompatibleAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics
+		case *provider.OpenAIResponsesAdapter:
+			pa.Tracer = tracer
+			pa.Metrics = metrics
 		case *provider.BedrockAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics
@@ -308,10 +311,12 @@ func buildProvider(ctx context.Context, cfg types.ProviderConfig, secrets securi
 		return provider.NewAnthropicAdapter(cred.BearerToken), nil
 	case "openai-compatible":
 		return provider.NewOpenAICompatibleAdapter(cred.BearerToken, cfg.BaseURL), nil
+	case "openai-responses":
+		return provider.NewOpenAIResponsesAdapter(cred.BearerToken, cfg.BaseURL), nil
 	case "bedrock":
 		return provider.NewBedrockAdapter(cfg.Region, cfg.Profile, cred.AWSCredentials)
 	default:
-		return nil, fmt.Errorf("unsupported provider type: %q (supported: anthropic, bedrock, openai-compatible)", cfg.Type)
+		return nil, fmt.Errorf("unsupported provider type: %q (supported: anthropic, bedrock, openai-compatible, openai-responses)", cfg.Type)
 	}
 }
 

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/git"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+	"github.com/rxbynerd/stirrup/harness/internal/provider"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
 	"github.com/rxbynerd/stirrup/harness/internal/trace"
 	"github.com/rxbynerd/stirrup/harness/internal/transport"
@@ -1196,6 +1197,51 @@ func TestBuildLoopWithTransport_ReadOnlyModesAllowWebFetch(t *testing.T) {
 				t.Fatalf("mode %q permission policy denied web_fetch: %q", mode, result.Reason)
 			}
 		})
+	}
+}
+
+// --- buildProvider ---
+
+func TestBuildProvider_OpenAIResponses(t *testing.T) {
+	secrets := &stubSecretStore{secrets: map[string]string{"secret://OPENAI_KEY": "sk-test"}}
+	prov, err := buildProvider(context.Background(), types.ProviderConfig{
+		Type:      "openai-responses",
+		APIKeyRef: "secret://OPENAI_KEY",
+		BaseURL:   "https://api.openai.com/v1",
+	}, secrets)
+	if err != nil {
+		t.Fatalf("buildProvider returned error: %v", err)
+	}
+	if _, ok := prov.(*provider.OpenAIResponsesAdapter); !ok {
+		t.Errorf("buildProvider type = %T, want *provider.OpenAIResponsesAdapter", prov)
+	}
+}
+
+func TestBuildProvider_OpenAICompatibleStillWorks(t *testing.T) {
+	secrets := &stubSecretStore{secrets: map[string]string{"secret://OPENAI_KEY": "sk-test"}}
+	prov, err := buildProvider(context.Background(), types.ProviderConfig{
+		Type:      "openai-compatible",
+		APIKeyRef: "secret://OPENAI_KEY",
+	}, secrets)
+	if err != nil {
+		t.Fatalf("buildProvider returned error: %v", err)
+	}
+	if _, ok := prov.(*provider.OpenAICompatibleAdapter); !ok {
+		t.Errorf("buildProvider type = %T, want *provider.OpenAICompatibleAdapter", prov)
+	}
+}
+
+func TestBuildProvider_UnknownTypeMentionsResponses(t *testing.T) {
+	secrets := &stubSecretStore{secrets: map[string]string{"secret://OPENAI_KEY": "sk-test"}}
+	_, err := buildProvider(context.Background(), types.ProviderConfig{
+		Type:      "nonsense",
+		APIKeyRef: "secret://OPENAI_KEY",
+	}, secrets)
+	if err == nil {
+		t.Fatal("expected error for unknown provider type")
+	}
+	if !strings.Contains(err.Error(), "openai-responses") {
+		t.Errorf("error message should advertise openai-responses, got: %v", err)
 	}
 }
 

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -1,0 +1,802 @@
+package provider
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// OpenAIResponsesAdapter implements ProviderAdapter for the OpenAI Responses
+// API (POST /v1/responses). The Responses API is a separate endpoint from
+// Chat Completions with a different request/response shape: a top-level
+// "instructions" field replaces the system message, conversation history is
+// expressed as a typed "input" array (message / function_call /
+// function_call_output items), tools use a flatter schema, and the streaming
+// SSE protocol uses named events such as "response.output_text.delta" and
+// "response.function_call_arguments.delta".
+//
+// The two adapters are kept separate (rather than auto-detecting) because
+// users who have explicitly opted into one or the other shape want it to be
+// honoured deterministically — silent fallback would mask configuration
+// errors and complicate observability.
+type OpenAIResponsesAdapter struct {
+	apiKey     string
+	httpClient *http.Client
+	baseURL    string
+	Tracer     oteltrace.Tracer       // optional, set by factory for span instrumentation
+	Metrics    *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
+}
+
+// NewOpenAIResponsesAdapter creates an adapter for the OpenAI Responses API.
+// The baseURL should be the API root (e.g. "https://api.openai.com/v1");
+// the /responses path is appended automatically. Pass an empty string for
+// the default OpenAI URL — kept consistent with NewOpenAICompatibleAdapter
+// so callers can switch the provider type without re-deriving the URL.
+func NewOpenAIResponsesAdapter(apiKey, baseURL string) *OpenAIResponsesAdapter {
+	if baseURL == "" {
+		baseURL = openaiDefaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &OpenAIResponsesAdapter{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+			Transport: &http.Transport{
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 30 * time.Second,
+				IdleConnTimeout:       90 * time.Second,
+			},
+		},
+		baseURL: baseURL,
+	}
+}
+
+// --- Responses API wire format ---
+
+// responsesRequest is the JSON body sent to POST /v1/responses.
+//
+// The `store` field is set explicitly to false: stirrup manages its own
+// conversation history and does not rely on OpenAI-side state. Leaving
+// `store` unset would default to server-side persistence on some endpoints
+// (a privacy concern for self-hosted gateways and a billing concern for
+// long-running runs).
+type responsesRequest struct {
+	Model           string           `json:"model"`
+	Instructions    string           `json:"instructions,omitempty"`
+	Input           []responsesInput `json:"input"`
+	Tools           []responsesTool  `json:"tools,omitempty"`
+	MaxOutputTokens int              `json:"max_output_tokens,omitempty"`
+	Temperature     float64          `json:"temperature"`
+	Stream          bool             `json:"stream"`
+	Store           bool             `json:"store"`
+}
+
+// responsesInput is one item in the Responses API input array. The Type
+// field selects which other fields are populated; this matches the
+// discriminated-union shape OpenAI publishes for typed input items.
+type responsesInput struct {
+	Type      string                  `json:"type"`               // "message" | "function_call" | "function_call_output"
+	Role      string                  `json:"role,omitempty"`     // for "message"
+	Content   []responsesContentBlock `json:"content,omitempty"`  // for "message"
+	Name      string                  `json:"name,omitempty"`     // for "function_call"
+	CallID    string                  `json:"call_id,omitempty"`  // for "function_call" / "function_call_output"
+	Arguments string                  `json:"arguments,omitempty"` // for "function_call" — JSON string
+	Output    string                  `json:"output,omitempty"`   // for "function_call_output"
+}
+
+// responsesContentBlock is one part inside a message item.
+// OpenAI uses "input_text" for user/system messages and "output_text" for
+// assistant messages — the asymmetry is part of their wire format.
+type responsesContentBlock struct {
+	Type string `json:"type"` // "input_text" | "output_text"
+	Text string `json:"text"`
+}
+
+// responsesTool describes a tool in the Responses API's flatter format.
+// (Compare with Chat Completions, which nests under a "function" object.)
+type responsesTool struct {
+	Type        string          `json:"type"` // "function"
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// --- SSE event payload types ---
+
+// responsesOutputItem is a single item in the response.output array.
+// Streaming events deliver these incrementally via response.output_item.added
+// and response.output_item.done.
+type responsesOutputItem struct {
+	Type      string `json:"type"` // "message" | "function_call" | "reasoning"
+	ID        string `json:"id,omitempty"`
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+// responsesUsage tracks token usage on response.completed.
+type responsesUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+	TotalTokens  int `json:"total_tokens,omitempty"`
+}
+
+// responsesResponse is the response object delivered on response.completed
+// and response.incomplete. Only the fields stirrup acts on are unmarshalled.
+type responsesResponse struct {
+	Status            string                `json:"status"`
+	IncompleteDetails *struct {
+		Reason string `json:"reason"`
+	} `json:"incomplete_details,omitempty"`
+	Output []responsesOutputItem `json:"output,omitempty"`
+	Usage  *responsesUsage       `json:"usage,omitempty"`
+}
+
+// responsesErrorResponse is the error JSON returned for non-2xx responses.
+// OpenAI uses the same envelope across Chat Completions and Responses.
+type responsesErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code,omitempty"`
+	} `json:"error"`
+}
+
+// responsesCallState tracks an in-flight function call assembled across
+// multiple SSE events. function_call_arguments.delta carries text fragments
+// keyed by item_id (or output_index when item_id is absent on partner
+// gateways); we accumulate them in argsBuf and flush once on the matching
+// .done event.
+type responsesCallState struct {
+	itemID    string
+	outputIdx int
+	callID    string
+	name      string
+	argsBuf   strings.Builder
+	done      bool // set when arguments.done or output_item.done has fired
+	emitted   bool // emitted at most once even if both done events fire
+}
+
+// --- Message translation ---
+
+// translateMessagesResponses converts stirrup's []types.Message format into
+// the Responses API's typed input[] array. The system prompt is NOT placed
+// in input[] — it goes into the top-level "instructions" field, which is
+// returned separately.
+//
+// Tool calls and tool results become standalone function_call /
+// function_call_output items (rather than being attached to the assistant
+// message), matching the Responses API's model.
+func translateMessagesResponses(messages []types.Message) []responsesInput {
+	var out []responsesInput
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "assistant":
+			var textParts []string
+			var calls []responsesInput
+
+			for _, block := range msg.Content {
+				switch block.Type {
+				case "text":
+					textParts = append(textParts, block.Text)
+				case "tool_use":
+					args := string(block.Input)
+					if args == "" {
+						args = "{}"
+					}
+					calls = append(calls, responsesInput{
+						Type:      "function_call",
+						CallID:    block.ID,
+						Name:      block.Name,
+						Arguments: args,
+					})
+				}
+			}
+
+			if len(textParts) > 0 {
+				out = append(out, responsesInput{
+					Type: "message",
+					Role: "assistant",
+					Content: []responsesContentBlock{
+						{Type: "output_text", Text: strings.Join(textParts, "")},
+					},
+				})
+			}
+			out = append(out, calls...)
+
+		case "user":
+			var textParts []string
+			for _, block := range msg.Content {
+				switch block.Type {
+				case "text":
+					textParts = append(textParts, block.Text)
+				case "tool_result":
+					content := block.Content
+					if block.IsError {
+						content = "Error: " + content
+					}
+					out = append(out, responsesInput{
+						Type:   "function_call_output",
+						CallID: block.ToolUseID,
+						Output: content,
+					})
+				}
+			}
+			if len(textParts) > 0 {
+				out = append(out, responsesInput{
+					Type: "message",
+					Role: "user",
+					Content: []responsesContentBlock{
+						{Type: "input_text", Text: strings.Join(textParts, "")},
+					},
+				})
+			}
+		}
+	}
+
+	return out
+}
+
+// translateToolsResponses converts stirrup ToolDefinitions into the
+// Responses API's flatter tool schema. Unlike Chat Completions, there is no
+// nested "function" object — the name/description/parameters live directly
+// on the tool item.
+func translateToolsResponses(tools []types.ToolDefinition) []responsesTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]responsesTool, len(tools))
+	for i, t := range tools {
+		out[i] = responsesTool{
+			Type:        "function",
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  t.InputSchema,
+		}
+	}
+	return out
+}
+
+// Stream sends a streaming request to the OpenAI Responses API and returns
+// a channel of StreamEvents. The channel is closed when the stream ends or
+// an error occurs. Cancelling the context terminates the stream.
+func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.StreamParams) (<-chan types.StreamEvent, error) {
+	start := time.Now()
+	metricAttrs := metric.WithAttributes(
+		attribute.String("provider.type", "openai-responses"),
+		attribute.String("provider.model", params.Model),
+	)
+
+	reqBody := responsesRequest{
+		Model:           params.Model,
+		Instructions:    params.System,
+		Input:           translateMessagesResponses(params.Messages),
+		Tools:           translateToolsResponses(params.Tools),
+		MaxOutputTokens: params.MaxTokens,
+		Temperature:     params.Temperature,
+		Stream:          true,
+		Store:           false,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		o.recordLatency(ctx, start, metricAttrs)
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := o.baseURL + "/responses"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		o.recordLatency(ctx, start, metricAttrs)
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	if o.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	}
+
+	resp, err := o.httpClient.Do(req)
+	if err != nil {
+		o.recordLatency(ctx, start, metricAttrs)
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+
+	if o.Tracer != nil {
+		span := oteltrace.SpanFromContext(ctx)
+		span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+		if resp.StatusCode == 429 {
+			retryAfter := resp.Header.Get("Retry-After")
+			span.AddEvent("rate_limited", oteltrace.WithAttributes(
+				attribute.String("retry_after", retryAfter),
+			))
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		defer func() { _ = resp.Body.Close() }()
+		o.recordLatency(ctx, start, metricAttrs)
+		var errResp responsesErrorResponse
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&errResp); err == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("openai responses API returned status %d: %s", resp.StatusCode, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("openai responses API returned status %d", resp.StatusCode)
+	}
+
+	ch := make(chan types.StreamEvent, 64)
+	go func() {
+		o.consumeSSE(ctx, resp, ch, start, metricAttrs)
+		o.recordLatency(ctx, start, metricAttrs)
+	}()
+	return ch, nil
+}
+
+// recordLatency records the total provider request latency to the
+// ProviderLatency histogram. Safe to call when Metrics is nil.
+func (o *OpenAIResponsesAdapter) recordLatency(ctx context.Context, start time.Time, attrs metric.MeasurementOption) {
+	if o.Metrics == nil {
+		return
+	}
+	o.Metrics.ProviderLatency.Record(ctx, float64(time.Since(start).Milliseconds()), attrs)
+}
+
+// consumeSSE reads named-event SSE records from the response body and
+// dispatches them. Records are separated by blank lines and may contain
+// `event: <name>` and `data: <payload>` fields. Unlike the Chat Completions
+// adapter (which only reads `data:` lines), Responses streaming relies on
+// the event name to disambiguate payloads — there is no `[DONE]` sentinel.
+func (o *OpenAIResponsesAdapter) consumeSSE(ctx context.Context, resp *http.Response, ch chan<- types.StreamEvent, streamStart time.Time, metricAttrs metric.MeasurementOption) {
+	defer close(ch)
+	defer func() { _ = resp.Body.Close() }()
+
+	ttfbRecorded := false
+	emitEvent := func(ev types.StreamEvent) {
+		if !ttfbRecorded && o.Metrics != nil {
+			o.Metrics.ProviderTTFB.Record(ctx, float64(time.Since(streamStart).Milliseconds()), metricAttrs)
+			ttfbRecorded = true
+		}
+		ch <- ev
+	}
+
+	// Track in-flight function calls. Indexed by a stable key (item_id when
+	// present, falling back to a stringified output_index). The value's
+	// outputIdx field is preserved so we can flush in deterministic order.
+	calls := make(map[string]*responsesCallState)
+
+	scanner := bufio.NewScanner(resp.Body)
+	// Increase the buffer ceiling so a single SSE record carrying a large
+	// JSON payload (e.g. a response.completed envelope) does not trip
+	// bufio's default 64KB scanner limit.
+	scanner.Buffer(make([]byte, 0, 64*1024), openaiMaxToolInputSize)
+
+	var currentEvent string
+	var dataParts []string
+
+	flushRecord := func() bool {
+		// Reset event-record state on return; defer-style guard so any
+		// early return below still leaves a clean slate. We do this
+		// via explicit assignment because we need the captured values
+		// inside the dispatch.
+		eventName := currentEvent
+		data := strings.Join(dataParts, "\n")
+		currentEvent = ""
+		dataParts = dataParts[:0]
+
+		if eventName == "" || data == "" {
+			return true
+		}
+		return o.dispatchEvent(eventName, data, calls, emitEvent)
+	}
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			emitEvent(types.StreamEvent{Type: "error", Error: ctx.Err()})
+			return
+		default:
+		}
+
+		line := scanner.Text()
+
+		// Blank line terminates an SSE record. Process the accumulated
+		// event/data and reset.
+		if line == "" {
+			if !flushRecord() {
+				return
+			}
+			continue
+		}
+
+		// SSE comments start with ":" and must be ignored.
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			currentEvent = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "event:"):
+			currentEvent = strings.TrimPrefix(line, "event:")
+		case strings.HasPrefix(line, "data: "):
+			dataParts = append(dataParts, strings.TrimPrefix(line, "data: "))
+		case strings.HasPrefix(line, "data:"):
+			dataParts = append(dataParts, strings.TrimPrefix(line, "data:"))
+		}
+	}
+
+	// Flush any trailing record without a terminating blank line. A
+	// well-behaved server will not do this, but tolerating it avoids
+	// dropped final events on premature EOF.
+	if currentEvent != "" || len(dataParts) > 0 {
+		_ = flushRecord()
+	}
+
+	if err := scanner.Err(); err != nil {
+		emitEvent(types.StreamEvent{Type: "error", Error: fmt.Errorf("read SSE stream: %w", err)})
+	}
+}
+
+// dispatchEvent handles a single completed SSE record. It returns false to
+// signal the caller to stop reading (terminal event), true to continue.
+func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[string]*responsesCallState, emit func(types.StreamEvent)) bool {
+	switch name {
+	case "response.created":
+		// Optional metadata; nothing to emit.
+		return true
+
+	case "response.output_item.added":
+		var payload struct {
+			OutputIndex int                 `json:"output_index"`
+			Item        responsesOutputItem `json:"item"`
+		}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse output_item.added: %w", err)})
+			return false
+		}
+		if payload.Item.Type == "function_call" {
+			key := callKey(payload.Item.ID, payload.OutputIndex)
+			st, exists := calls[key]
+			if !exists {
+				st = &responsesCallState{
+					itemID:    payload.Item.ID,
+					outputIdx: payload.OutputIndex,
+				}
+				calls[key] = st
+			}
+			if payload.Item.CallID != "" {
+				st.callID = payload.Item.CallID
+			}
+			if payload.Item.Name != "" {
+				st.name = payload.Item.Name
+			}
+			// Some providers include the (complete) arguments string here
+			// when the model emitted the call atomically. Seed argsBuf
+			// from it so we still produce a tool_call on .done.
+			if payload.Item.Arguments != "" {
+				st.argsBuf.WriteString(payload.Item.Arguments)
+			}
+		}
+		return true
+
+	case "response.output_text.delta":
+		var payload struct {
+			Delta string `json:"delta"`
+		}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse output_text.delta: %w", err)})
+			return false
+		}
+		if payload.Delta != "" {
+			emit(types.StreamEvent{Type: "text_delta", Text: payload.Delta})
+		}
+		return true
+
+	case "response.function_call_arguments.delta":
+		var payload struct {
+			ItemID      string `json:"item_id"`
+			OutputIndex int    `json:"output_index"`
+			Delta       string `json:"delta"`
+		}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse function_call_arguments.delta: %w", err)})
+			return false
+		}
+		key := callKey(payload.ItemID, payload.OutputIndex)
+		st, exists := calls[key]
+		if !exists {
+			// .added not yet observed for this call (or was dropped);
+			// create a state placeholder so we still accumulate.
+			st = &responsesCallState{
+				itemID:    payload.ItemID,
+				outputIdx: payload.OutputIndex,
+			}
+			calls[key] = st
+		}
+		if st.argsBuf.Len()+len(payload.Delta) > openaiMaxToolInputSize {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("tool arguments exceed %d byte limit", openaiMaxToolInputSize)})
+			return false
+		}
+		st.argsBuf.WriteString(payload.Delta)
+		return true
+
+	case "response.function_call_arguments.done":
+		var payload struct {
+			ItemID      string `json:"item_id"`
+			OutputIndex int    `json:"output_index"`
+			Arguments   string `json:"arguments,omitempty"`
+		}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse function_call_arguments.done: %w", err)})
+			return false
+		}
+		key := callKey(payload.ItemID, payload.OutputIndex)
+		st, exists := calls[key]
+		if !exists {
+			st = &responsesCallState{
+				itemID:    payload.ItemID,
+				outputIdx: payload.OutputIndex,
+			}
+			calls[key] = st
+		}
+		// If the .done event echoes the full arguments string and the
+		// streamed deltas are missing, prefer the echoed copy.
+		if st.argsBuf.Len() == 0 && payload.Arguments != "" {
+			if len(payload.Arguments) > openaiMaxToolInputSize {
+				emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("tool arguments exceed %d byte limit", openaiMaxToolInputSize)})
+				return false
+			}
+			st.argsBuf.WriteString(payload.Arguments)
+		}
+		st.done = true
+		if !flushOneCall(st, emit) {
+			return false
+		}
+		return true
+
+	case "response.output_item.done":
+		var payload struct {
+			OutputIndex int                 `json:"output_index"`
+			Item        responsesOutputItem `json:"item"`
+		}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse output_item.done: %w", err)})
+			return false
+		}
+		if payload.Item.Type != "function_call" {
+			return true
+		}
+		key := callKey(payload.Item.ID, payload.OutputIndex)
+		st, exists := calls[key]
+		if !exists {
+			st = &responsesCallState{
+				itemID:    payload.Item.ID,
+				outputIdx: payload.OutputIndex,
+			}
+			calls[key] = st
+		}
+		if payload.Item.CallID != "" {
+			st.callID = payload.Item.CallID
+		}
+		if payload.Item.Name != "" {
+			st.name = payload.Item.Name
+		}
+		// If the .done event carries the full arguments string and the
+		// streamed deltas were never seen, prefer the echoed copy.
+		if st.argsBuf.Len() == 0 && payload.Item.Arguments != "" {
+			if len(payload.Item.Arguments) > openaiMaxToolInputSize {
+				emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("tool arguments exceed %d byte limit", openaiMaxToolInputSize)})
+				return false
+			}
+			st.argsBuf.WriteString(payload.Item.Arguments)
+		}
+		st.done = true
+		if !flushOneCall(st, emit) {
+			return false
+		}
+		return true
+
+	case "response.completed":
+		// Flush any tool calls that never received a .done event (defensive).
+		if !flushPendingCalls(calls, emit) {
+			return false
+		}
+		var payload struct {
+			Response responsesResponse `json:"response"`
+		}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse response.completed: %w", err)})
+			return false
+		}
+		ev := types.StreamEvent{
+			Type:       "message_complete",
+			StopReason: deriveStopReason(payload.Response),
+		}
+		if payload.Response.Usage != nil {
+			ev.OutputTokens = payload.Response.Usage.OutputTokens
+		}
+		emit(ev)
+		return false
+
+	case "response.incomplete":
+		if !flushPendingCalls(calls, emit) {
+			return false
+		}
+		var payload struct {
+			Response responsesResponse `json:"response"`
+		}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse response.incomplete: %w", err)})
+			return false
+		}
+		stop := "incomplete"
+		if payload.Response.IncompleteDetails != nil {
+			reason := payload.Response.IncompleteDetails.Reason
+			// "max_output_tokens" / "max_tokens" both map to our existing
+			// max_tokens stop reason. Anything else passes through verbatim
+			// for diagnostic visibility.
+			if reason == "max_output_tokens" || reason == "max_tokens" {
+				stop = "max_tokens"
+			} else if reason != "" {
+				stop = reason
+			}
+		}
+		ev := types.StreamEvent{
+			Type:       "message_complete",
+			StopReason: stop,
+		}
+		if payload.Response.Usage != nil {
+			ev.OutputTokens = payload.Response.Usage.OutputTokens
+		}
+		emit(ev)
+		return false
+
+	case "response.failed":
+		var payload struct {
+			Response struct {
+				Error *struct {
+					Message string `json:"message"`
+					Type    string `json:"type"`
+				} `json:"error"`
+				Status string `json:"status"`
+			} `json:"response"`
+		}
+		_ = json.Unmarshal([]byte(data), &payload)
+		msg := "openai responses API: response failed"
+		if payload.Response.Error != nil && payload.Response.Error.Message != "" {
+			msg = "openai responses API: " + payload.Response.Error.Message
+		}
+		emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("%s", msg)})
+		return false
+
+	case "error":
+		var payload struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		}
+		_ = json.Unmarshal([]byte(data), &payload)
+		msg := "openai responses API stream error"
+		if payload.Message != "" {
+			msg = "openai responses API stream error: " + payload.Message
+		}
+		emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("%s", msg)})
+		return false
+
+	default:
+		// Forward-compatible: unknown events (e.g. reasoning summaries,
+		// content_part lifecycle, partial-image deltas) are ignored.
+		return true
+	}
+}
+
+// callKey produces a stable identifier for a function call. item_id is
+// preferred when the server provides one; falling back to output_index keeps
+// us robust against partner gateways that omit it.
+func callKey(itemID string, outputIndex int) string {
+	if itemID != "" {
+		return itemID
+	}
+	return fmt.Sprintf("idx:%d", outputIndex)
+}
+
+// flushOneCall emits a tool_call event for the supplied call state, parsing
+// its accumulated arguments JSON. Returns false on a fatal parse error
+// (caller should stop reading the stream). Marks the call as emitted so a
+// duplicate .done event does not fire it twice.
+func flushOneCall(st *responsesCallState, emit func(types.StreamEvent)) bool {
+	if st.emitted {
+		return true
+	}
+	st.emitted = true
+	var input map[string]any
+	raw := st.argsBuf.String()
+	if raw != "" {
+		if err := json.Unmarshal([]byte(raw), &input); err != nil {
+			emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse tool arguments JSON: %w", err)})
+			return false
+		}
+	}
+	emit(types.StreamEvent{
+		Type:  "tool_call",
+		ID:    st.callID,
+		Name:  st.name,
+		Input: input,
+	})
+	return true
+}
+
+// flushPendingCalls emits any tool calls that were left in flight when the
+// terminal response.completed / response.incomplete event arrived. Order is
+// stable by output_index so multi-call responses are deterministic.
+func flushPendingCalls(calls map[string]*responsesCallState, emit func(types.StreamEvent)) bool {
+	pending := make([]*responsesCallState, 0, len(calls))
+	for _, st := range calls {
+		if !st.emitted {
+			pending = append(pending, st)
+		}
+	}
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].outputIdx < pending[j].outputIdx
+	})
+	for _, st := range pending {
+		if !flushOneCall(st, emit) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveStopReason maps a Responses API response object to stirrup's stop
+// reason vocabulary. Tool calls take precedence over plain end_turn so the
+// agentic loop knows to dispatch tools before treating the turn as final.
+func deriveStopReason(resp responsesResponse) string {
+	hasTool := false
+	for _, item := range resp.Output {
+		if item.Type == "function_call" {
+			hasTool = true
+			break
+		}
+	}
+	switch resp.Status {
+	case "completed":
+		if hasTool {
+			return "tool_use"
+		}
+		return "end_turn"
+	case "incomplete":
+		if resp.IncompleteDetails != nil {
+			r := resp.IncompleteDetails.Reason
+			if r == "max_output_tokens" || r == "max_tokens" {
+				return "max_tokens"
+			}
+			if r != "" {
+				return r
+			}
+		}
+		return "incomplete"
+	default:
+		if resp.Status != "" {
+			return resp.Status
+		}
+		if hasTool {
+			return "tool_use"
+		}
+		return "end_turn"
+	}
+}

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -220,6 +220,18 @@ func translateMessagesResponses(messages []types.Message) []responsesInput {
 			out = append(out, calls...)
 
 		case "user":
+			// User message emission order is deliberate and contract-pinned:
+			// function_call_output items are emitted first in document order
+			// as they appear in msg.Content, and any text blocks are batched
+			// into a single trailing input_text message item. This ordering
+			// is documented (rather than fixed to strict document order)
+			// because the harness's own message construction never produces
+			// mixed user messages — text-then-tool_result-then-text inputs
+			// only arise from external callers, and reordering text after
+			// tool results matches the Responses API's preference for
+			// function_call_output items to precede the next user turn's
+			// instructions. See TestTranslateMessagesResponses_UserTextAndToolResultOrder
+			// for the pinned behaviour.
 			var textParts []string
 			for _, block := range msg.Content {
 				switch block.Type {

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -167,7 +168,6 @@ type responsesCallState struct {
 	callID    string
 	name      string
 	argsBuf   strings.Builder
-	done      bool // set when arguments.done or output_item.done has fired
 	emitted   bool // emitted at most once even if both done events fire
 }
 
@@ -342,7 +342,12 @@ func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.Stream
 	ch := make(chan types.StreamEvent, 64)
 	go func() {
 		o.consumeSSE(ctx, resp, ch, start, metricAttrs)
-		o.recordLatency(ctx, start, metricAttrs)
+		// Record latency on a background context: the caller's `ctx` may
+		// already have been cancelled by the time the stream completes
+		// (the agentic loop has moved on), and some OTel exporters drop
+		// measurements on cancelled contexts. Synchronous error paths
+		// above use the live `ctx` because the caller is still waiting.
+		o.recordLatency(context.Background(), start, metricAttrs)
 	}()
 	return ch, nil
 }
@@ -366,12 +371,24 @@ func (o *OpenAIResponsesAdapter) consumeSSE(ctx context.Context, resp *http.Resp
 	defer func() { _ = resp.Body.Close() }()
 
 	ttfbRecorded := false
-	emitEvent := func(ev types.StreamEvent) {
-		if !ttfbRecorded && o.Metrics != nil {
+	// emitEvent forwards an event to the consumer, recording TTFB on the
+	// first substantive event. Returns false if the consumer has gone
+	// away (context cancelled) so the caller can unwind without leaking
+	// the goroutine on the open HTTP body.
+	emitEvent := func(ev types.StreamEvent) bool {
+		// TTFB is meant to capture time-to-first-substantive-output; gate
+		// it on event types that represent actual model inference output
+		// so error-path zero latencies do not pollute the histogram.
+		if !ttfbRecorded && o.Metrics != nil && (ev.Type == "text_delta" || ev.Type == "tool_call") {
 			o.Metrics.ProviderTTFB.Record(ctx, float64(time.Since(streamStart).Milliseconds()), metricAttrs)
 			ttfbRecorded = true
 		}
-		ch <- ev
+		select {
+		case ch <- ev:
+			return true
+		case <-ctx.Done():
+			return false
+		}
 	}
 
 	// Track in-flight function calls. Indexed by a stable key (item_id when
@@ -387,6 +404,7 @@ func (o *OpenAIResponsesAdapter) consumeSSE(ctx context.Context, resp *http.Resp
 
 	var currentEvent string
 	var dataParts []string
+	var dataLen int // aggregate byte length of dataParts; capped to prevent OOM
 
 	flushRecord := func() bool {
 		// Reset event-record state on return; defer-style guard so any
@@ -397,11 +415,12 @@ func (o *OpenAIResponsesAdapter) consumeSSE(ctx context.Context, resp *http.Resp
 		data := strings.Join(dataParts, "\n")
 		currentEvent = ""
 		dataParts = dataParts[:0]
+		dataLen = 0
 
 		if eventName == "" || data == "" {
 			return true
 		}
-		return o.dispatchEvent(eventName, data, calls, emitEvent)
+		return o.dispatchEvent(ctx, eventName, data, calls, emitEvent)
 	}
 
 	for scanner.Scan() {
@@ -428,15 +447,35 @@ func (o *OpenAIResponsesAdapter) consumeSSE(ctx context.Context, resp *http.Resp
 			continue
 		}
 
+		// appendData stages a data payload chunk, enforcing the aggregate
+		// size cap before allocating. Returns false if the cap was hit
+		// (caller should stop reading the stream).
+		appendData := func(chunk string) bool {
+			if dataLen+len(chunk) > openaiMaxToolInputSize {
+				emitEvent(types.StreamEvent{
+					Type:  "error",
+					Error: fmt.Errorf("SSE record data exceeds %d byte limit", openaiMaxToolInputSize),
+				})
+				return false
+			}
+			dataLen += len(chunk)
+			dataParts = append(dataParts, chunk)
+			return true
+		}
+
 		switch {
 		case strings.HasPrefix(line, "event: "):
 			currentEvent = strings.TrimPrefix(line, "event: ")
 		case strings.HasPrefix(line, "event:"):
 			currentEvent = strings.TrimPrefix(line, "event:")
 		case strings.HasPrefix(line, "data: "):
-			dataParts = append(dataParts, strings.TrimPrefix(line, "data: "))
+			if !appendData(strings.TrimPrefix(line, "data: ")) {
+				return
+			}
 		case strings.HasPrefix(line, "data:"):
-			dataParts = append(dataParts, strings.TrimPrefix(line, "data:"))
+			if !appendData(strings.TrimPrefix(line, "data:")) {
+				return
+			}
 		}
 	}
 
@@ -444,7 +483,9 @@ func (o *OpenAIResponsesAdapter) consumeSSE(ctx context.Context, resp *http.Resp
 	// well-behaved server will not do this, but tolerating it avoids
 	// dropped final events on premature EOF.
 	if currentEvent != "" || len(dataParts) > 0 {
-		_ = flushRecord()
+		if !flushRecord() {
+			return
+		}
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -453,8 +494,13 @@ func (o *OpenAIResponsesAdapter) consumeSSE(ctx context.Context, resp *http.Resp
 }
 
 // dispatchEvent handles a single completed SSE record. It returns false to
-// signal the caller to stop reading (terminal event), true to continue.
-func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[string]*responsesCallState, emit func(types.StreamEvent)) bool {
+// signal the caller to stop reading (terminal event or consumer cancelled),
+// true to continue.
+//
+// `emit` returns false when the consumer has gone away (context cancelled);
+// every emit call site propagates that to abandon the stream rather than
+// pretending to keep going.
+func (o *OpenAIResponsesAdapter) dispatchEvent(ctx context.Context, name, data string, calls map[string]*responsesCallState, emit func(types.StreamEvent) bool) bool {
 	switch name {
 	case "response.created":
 		// Optional metadata; nothing to emit.
@@ -503,7 +549,9 @@ func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[stri
 			return false
 		}
 		if payload.Delta != "" {
-			emit(types.StreamEvent{Type: "text_delta", Text: payload.Delta})
+			if !emit(types.StreamEvent{Type: "text_delta", Text: payload.Delta}) {
+				return false
+			}
 		}
 		return true
 
@@ -563,7 +611,6 @@ func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[stri
 			}
 			st.argsBuf.WriteString(payload.Arguments)
 		}
-		st.done = true
 		if !flushOneCall(st, emit) {
 			return false
 		}
@@ -605,7 +652,6 @@ func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[stri
 			}
 			st.argsBuf.WriteString(payload.Item.Arguments)
 		}
-		st.done = true
 		if !flushOneCall(st, emit) {
 			return false
 		}
@@ -631,6 +677,8 @@ func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[stri
 			ev.OutputTokens = payload.Response.Usage.OutputTokens
 		}
 		emit(ev)
+		// Terminal event: signal caller to stop reading regardless of
+		// whether the consumer accepted the message_complete event.
 		return false
 
 	case "response.incomplete":
@@ -681,7 +729,7 @@ func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[stri
 		if payload.Response.Error != nil && payload.Response.Error.Message != "" {
 			msg = "openai responses API: " + payload.Response.Error.Message
 		}
-		emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("%s", msg)})
+		emit(types.StreamEvent{Type: "error", Error: errors.New(msg)})
 		return false
 
 	case "error":
@@ -695,12 +743,20 @@ func (o *OpenAIResponsesAdapter) dispatchEvent(name, data string, calls map[stri
 		if payload.Message != "" {
 			msg = "openai responses API stream error: " + payload.Message
 		}
-		emit(types.StreamEvent{Type: "error", Error: fmt.Errorf("%s", msg)})
+		emit(types.StreamEvent{Type: "error", Error: errors.New(msg)})
 		return false
 
 	default:
 		// Forward-compatible: unknown events (e.g. reasoning summaries,
-		// content_part lifecycle, partial-image deltas) are ignored.
+		// content_part lifecycle, partial-image deltas) are ignored. We
+		// add a span event so production operators can spot a flood of
+		// new event types from a future API revision instead of silently
+		// dropping content.
+		if span := oteltrace.SpanFromContext(ctx); span != nil && span.IsRecording() {
+			span.AddEvent("openai_responses.unknown_sse_event",
+				oteltrace.WithAttributes(attribute.String("event.type", name)),
+			)
+		}
 		return true
 	}
 }
@@ -716,10 +772,11 @@ func callKey(itemID string, outputIndex int) string {
 }
 
 // flushOneCall emits a tool_call event for the supplied call state, parsing
-// its accumulated arguments JSON. Returns false on a fatal parse error
-// (caller should stop reading the stream). Marks the call as emitted so a
-// duplicate .done event does not fire it twice.
-func flushOneCall(st *responsesCallState, emit func(types.StreamEvent)) bool {
+// its accumulated arguments JSON. Returns false on a fatal parse error or
+// when the consumer has gone away (caller should stop reading the stream).
+// Marks the call as emitted so a duplicate .done event does not fire it
+// twice.
+func flushOneCall(st *responsesCallState, emit func(types.StreamEvent) bool) bool {
 	if st.emitted {
 		return true
 	}
@@ -732,19 +789,18 @@ func flushOneCall(st *responsesCallState, emit func(types.StreamEvent)) bool {
 			return false
 		}
 	}
-	emit(types.StreamEvent{
+	return emit(types.StreamEvent{
 		Type:  "tool_call",
 		ID:    st.callID,
 		Name:  st.name,
 		Input: input,
 	})
-	return true
 }
 
 // flushPendingCalls emits any tool calls that were left in flight when the
 // terminal response.completed / response.incomplete event arrived. Order is
 // stable by output_index so multi-call responses are deterministic.
-func flushPendingCalls(calls map[string]*responsesCallState, emit func(types.StreamEvent)) bool {
+func flushPendingCalls(calls map[string]*responsesCallState, emit func(types.StreamEvent) bool) bool {
 	pending := make([]*responsesCallState, 0, len(calls))
 	for _, st := range calls {
 		if !st.emitted {

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -88,13 +88,13 @@ type responsesRequest struct {
 // field selects which other fields are populated; this matches the
 // discriminated-union shape OpenAI publishes for typed input items.
 type responsesInput struct {
-	Type      string                  `json:"type"`               // "message" | "function_call" | "function_call_output"
-	Role      string                  `json:"role,omitempty"`     // for "message"
-	Content   []responsesContentBlock `json:"content,omitempty"`  // for "message"
-	Name      string                  `json:"name,omitempty"`     // for "function_call"
-	CallID    string                  `json:"call_id,omitempty"`  // for "function_call" / "function_call_output"
+	Type      string                  `json:"type"`                // "message" | "function_call" | "function_call_output"
+	Role      string                  `json:"role,omitempty"`      // for "message"
+	Content   []responsesContentBlock `json:"content,omitempty"`   // for "message"
+	Name      string                  `json:"name,omitempty"`      // for "function_call"
+	CallID    string                  `json:"call_id,omitempty"`   // for "function_call" / "function_call_output"
 	Arguments string                  `json:"arguments,omitempty"` // for "function_call" — JSON string
-	Output    string                  `json:"output,omitempty"`   // for "function_call_output"
+	Output    string                  `json:"output,omitempty"`    // for "function_call_output"
 }
 
 // responsesContentBlock is one part inside a message item.
@@ -138,7 +138,7 @@ type responsesUsage struct {
 // responsesResponse is the response object delivered on response.completed
 // and response.incomplete. Only the fields stirrup acts on are unmarshalled.
 type responsesResponse struct {
-	Status            string                `json:"status"`
+	Status            string `json:"status"`
 	IncompleteDetails *struct {
 		Reason string `json:"reason"`
 	} `json:"incomplete_details,omitempty"`

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -1,0 +1,992 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// makeResponsesEvent builds a named SSE record terminated by a blank line —
+// the wire shape the Responses API streams.
+func makeResponsesEvent(name, data string) string {
+	return fmt.Sprintf("event: %s\ndata: %s\n\n", name, data)
+}
+
+func TestOpenAIResponsesAdapter_StreamTextDelta(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.created", `{"response":{"id":"resp_1","status":"in_progress"}}`),
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant"}}`),
+		makeResponsesEvent("response.output_text.delta", `{"item_id":"msg_1","output_index":0,"delta":"Hello"}`),
+		makeResponsesEvent("response.output_text.delta", `{"item_id":"msg_1","output_index":0,"delta":" world"}`),
+		makeResponsesEvent("response.completed", `{"response":{"id":"resp_1","status":"completed","output":[{"type":"message","id":"msg_1"}],"usage":{"input_tokens":10,"output_tokens":5}}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/responses") {
+			t.Errorf("expected path ending in /responses, got %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gpt-4.1",
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "text_delta" || events[0].Text != "Hello" {
+		t.Errorf("event[0] = %+v, want text_delta/Hello", events[0])
+	}
+	if events[1].Type != "text_delta" || events[1].Text != " world" {
+		t.Errorf("event[1] = %+v, want text_delta/ world", events[1])
+	}
+	if events[2].Type != "message_complete" || events[2].StopReason != "end_turn" {
+		t.Errorf("event[2] = %+v, want message_complete/end_turn", events[2])
+	}
+	if events[2].OutputTokens != 5 {
+		t.Errorf("event[2].OutputTokens = %d, want 5", events[2].OutputTokens)
+	}
+}
+
+func TestOpenAIResponsesAdapter_StreamToolCall(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_abc","name":"read_file"}}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_1","output_index":0,"delta":"{\"path\":"}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_1","output_index":0,"delta":"\"main.go\"}"}`),
+		makeResponsesEvent("response.function_call_arguments.done", `{"item_id":"fc_1","output_index":0,"arguments":"{\"path\":\"main.go\"}"}`),
+		makeResponsesEvent("response.completed", `{"response":{"id":"resp_2","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_abc","name":"read_file","arguments":"{\"path\":\"main.go\"}"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gpt-4.1",
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "tool_call" {
+		t.Fatalf("event[0].Type = %q, want tool_call", events[0].Type)
+	}
+	if events[0].ID != "call_abc" {
+		t.Errorf("event[0].ID = %q, want call_abc", events[0].ID)
+	}
+	if events[0].Name != "read_file" {
+		t.Errorf("event[0].Name = %q, want read_file", events[0].Name)
+	}
+	if events[0].Input["path"] != "main.go" {
+		t.Errorf("event[0].Input[path] = %v, want main.go", events[0].Input["path"])
+	}
+	if events[1].Type != "message_complete" || events[1].StopReason != "tool_use" {
+		t.Errorf("event[1] = %+v, want message_complete/tool_use", events[1])
+	}
+}
+
+func TestOpenAIResponsesAdapter_MultipleToolCalls(t *testing.T) {
+	// Two function calls in flight concurrently. Their argument-deltas
+	// arrive interleaved (bbb then aaa) but the .done events fire in
+	// output_index order, which is OpenAI's natural emission contract.
+	// The adapter must emit each tool_call at .done (no later, so the
+	// agentic loop can dispatch tools as soon as they're complete) AND
+	// preserve the output_index ordering across the resulting events.
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"function_call","id":"fc_aaa","call_id":"call_aaa","name":"read_file"}}`),
+		makeResponsesEvent("response.output_item.added", `{"output_index":1,"item":{"type":"function_call","id":"fc_bbb","call_id":"call_bbb","name":"write_file"}}`),
+		// Interleaved deltas: server is still composing both calls.
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_bbb","output_index":1,"delta":"{\"path\":\"b.go\","}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_aaa","output_index":0,"delta":"{\"path\":"}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_bbb","output_index":1,"delta":"\"content\":\"x\"}"}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_aaa","output_index":0,"delta":"\"a.go\"}"}`),
+		// .done events fire in output_index order (the realistic OpenAI
+		// contract) so per-call emission already produces deterministic
+		// ordering.
+		makeResponsesEvent("response.output_item.done", `{"output_index":0,"item":{"type":"function_call","id":"fc_aaa","call_id":"call_aaa","name":"read_file"}}`),
+		makeResponsesEvent("response.output_item.done", `{"output_index":1,"item":{"type":"function_call","id":"fc_bbb","call_id":"call_bbb","name":"write_file"}}`),
+		makeResponsesEvent("response.completed", `{"response":{"id":"resp_3","status":"completed","output":[{"type":"function_call","id":"fc_aaa","call_id":"call_aaa","name":"read_file"},{"type":"function_call","id":"fc_bbb","call_id":"call_bbb","name":"write_file"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gpt-4.1",
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	var toolCalls []types.StreamEvent
+	for _, ev := range events {
+		if ev.Type == "error" {
+			t.Fatalf("unexpected error event: %v", ev.Error)
+		}
+		if ev.Type == "tool_call" {
+			toolCalls = append(toolCalls, ev)
+		}
+	}
+	if len(toolCalls) != 2 {
+		t.Fatalf("expected 2 tool_call events, got %d", len(toolCalls))
+	}
+	// Sort by output_index ascending: a then b.
+	if toolCalls[0].ID != "call_aaa" || toolCalls[0].Name != "read_file" {
+		t.Errorf("toolCalls[0] = %+v, want call_aaa/read_file", toolCalls[0])
+	}
+	if toolCalls[0].Input["path"] != "a.go" {
+		t.Errorf("toolCalls[0].Input[path] = %v, want a.go", toolCalls[0].Input["path"])
+	}
+	if toolCalls[1].ID != "call_bbb" || toolCalls[1].Name != "write_file" {
+		t.Errorf("toolCalls[1] = %+v, want call_bbb/write_file", toolCalls[1])
+	}
+	if toolCalls[1].Input["path"] != "b.go" {
+		t.Errorf("toolCalls[1].Input[path] = %v, want b.go", toolCalls[1].Input["path"])
+	}
+}
+
+func TestOpenAIResponsesAdapter_DeferredFlushOrderedByOutputIndex(t *testing.T) {
+	// A defensive case: if no .done events fire for two concurrent
+	// function calls (e.g. server abbreviates the stream), the adapter
+	// must still flush them on response.completed in deterministic
+	// output_index ascending order. State map iteration in Go is
+	// randomised, so the explicit sort matters.
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":1,"item":{"type":"function_call","id":"fc_b","call_id":"call_b","name":"write_file"}}`),
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"read_file"}}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_b","output_index":1,"delta":"{\"path\":\"b\"}"}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_a","output_index":0,"delta":"{\"path\":\"a\"}"}`),
+		// Note: no .done events. Calls are pending when completion arrives.
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed","output":[{"type":"function_call","id":"fc_a","call_id":"call_a","name":"read_file"},{"type":"function_call","id":"fc_b","call_id":"call_b","name":"write_file"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	for i := 0; i < 5; i++ { // run a few times because map iteration is randomised
+		ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+		if err != nil {
+			t.Fatalf("Stream() error: %v", err)
+		}
+		events := collectEvents(t, ch)
+
+		var calls []types.StreamEvent
+		for _, ev := range events {
+			if ev.Type == "tool_call" {
+				calls = append(calls, ev)
+			}
+		}
+		if len(calls) != 2 {
+			t.Fatalf("iter %d: expected 2 tool_calls, got %d", i, len(calls))
+		}
+		if calls[0].ID != "call_a" || calls[1].ID != "call_b" {
+			t.Errorf("iter %d: order = [%s, %s], want [call_a, call_b]", i, calls[0].ID, calls[1].ID)
+		}
+	}
+}
+
+func TestOpenAIResponsesAdapter_TextThenToolCall(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant"}}`),
+		makeResponsesEvent("response.output_text.delta", `{"item_id":"msg_1","output_index":0,"delta":"Let me read that file."}`),
+		makeResponsesEvent("response.output_item.added", `{"output_index":1,"item":{"type":"function_call","id":"fc_1","call_id":"call_xyz","name":"read_file"}}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_1","output_index":1,"delta":"{\"path\":\"main.go\"}"}`),
+		makeResponsesEvent("response.function_call_arguments.done", `{"item_id":"fc_1","output_index":1}`),
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed","output":[{"type":"message","id":"msg_1"},{"type":"function_call","id":"fc_1","call_id":"call_xyz","name":"read_file"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gpt-4.1",
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "text_delta" {
+		t.Errorf("event[0].Type = %q, want text_delta", events[0].Type)
+	}
+	if events[1].Type != "tool_call" {
+		t.Errorf("event[1].Type = %q, want tool_call", events[1].Type)
+	}
+	if events[2].Type != "message_complete" || events[2].StopReason != "tool_use" {
+		t.Errorf("event[2] = %+v, want message_complete/tool_use", events[2])
+	}
+}
+
+func TestOpenAIResponsesAdapter_IncompleteMaxTokens(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant"}}`),
+		makeResponsesEvent("response.output_text.delta", `{"item_id":"msg_1","output_index":0,"delta":"hi"}`),
+		makeResponsesEvent("response.incomplete", `{"response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":5,"output_tokens":1}}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	last := events[len(events)-1]
+	if last.Type != "message_complete" || last.StopReason != "max_tokens" {
+		t.Errorf("last event = %+v, want message_complete/max_tokens", last)
+	}
+	if last.OutputTokens != 1 {
+		t.Errorf("OutputTokens = %d, want 1", last.OutputTokens)
+	}
+}
+
+func TestOpenAIResponsesAdapter_FailedEventEmitsError(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant"}}`),
+		makeResponsesEvent("response.failed", `{"response":{"status":"failed","error":{"message":"server overloaded","type":"server_error"}}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	last := events[len(events)-1]
+	if last.Type != "error" {
+		t.Errorf("last event type = %q, want error", last.Type)
+	}
+	if last.Error == nil || !strings.Contains(last.Error.Error(), "server overloaded") {
+		t.Errorf("expected error to mention server overloaded, got: %v", last.Error)
+	}
+	// No message_complete should be emitted on a failed response.
+	for _, ev := range events {
+		if ev.Type == "message_complete" {
+			t.Errorf("unexpected message_complete on failed response: %+v", ev)
+		}
+	}
+}
+
+func TestOpenAIResponsesAdapter_ErrorEvent(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("error", `{"message":"upstream timeout","type":"timeout","code":"E_TIMEOUT"}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "error" {
+		t.Errorf("event[0].Type = %q, want error", events[0].Type)
+	}
+	if events[0].Error == nil || !strings.Contains(events[0].Error.Error(), "upstream timeout") {
+		t.Errorf("expected error to mention upstream timeout, got: %v", events[0].Error)
+	}
+}
+
+func TestOpenAIResponsesAdapter_MalformedToolArguments(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_bad","name":"read_file"}}`),
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_1","output_index":0,"delta":"{NOT VALID"}`),
+		makeResponsesEvent("response.function_call_arguments.done", `{"item_id":"fc_1","output_index":0}`),
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_bad","name":"read_file"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	foundError := false
+	for _, ev := range events {
+		if ev.Type == "error" {
+			foundError = true
+			if ev.Error == nil {
+				t.Error("error event has nil Error field")
+			} else if !strings.Contains(ev.Error.Error(), "tool arguments JSON") {
+				t.Errorf("expected tool arguments JSON error, got: %v", ev.Error)
+			}
+		}
+	}
+	if !foundError {
+		t.Error("expected an error event for malformed tool arguments JSON")
+	}
+}
+
+func TestOpenAIResponsesAdapter_ToolArgumentsExceedSizeLimit(t *testing.T) {
+	// Build several reasonably-sized deltas whose cumulative size exceeds
+	// the openaiMaxToolInputSize cap. The accumulated buffer check should
+	// trip on the chunk that crosses the limit, emit an error event, and
+	// tear down the stream before any tool_call is produced.
+	const chunkSize = 512 * 1024 // 512KB
+	chunkText := strings.Repeat("A", chunkSize)
+	encoded, _ := json.Marshal(chunkText)
+	chunkPayload := fmt.Sprintf(`{"item_id":"fc_1","output_index":0,"delta":%s}`, string(encoded))
+
+	parts := []string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_big","name":"read_file"}}`),
+	}
+	// 22 chunks of 512KB = 11MB > 10MB cap.
+	for i := 0; i < 22; i++ {
+		parts = append(parts, makeResponsesEvent("response.function_call_arguments.delta", chunkPayload))
+	}
+	parts = append(parts,
+		makeResponsesEvent("response.function_call_arguments.done", `{"item_id":"fc_1","output_index":0}`),
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`),
+	)
+	body := strings.Join(parts, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	foundOversize := false
+	for _, ev := range events {
+		if ev.Type == "error" && ev.Error != nil && strings.Contains(ev.Error.Error(), "byte limit") {
+			foundOversize = true
+		}
+		if ev.Type == "tool_call" {
+			t.Errorf("tool_call should not be emitted when args exceed cap: %+v", ev)
+		}
+	}
+	if !foundOversize {
+		t.Error("expected an error event citing the byte limit")
+	}
+}
+
+func TestOpenAIResponsesAdapter_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"Invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}`)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("bad-key", srv.URL)
+
+	_, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err == nil {
+		t.Fatal("expected error for 401 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("expected error to contain 'Invalid API key', got: %v", err)
+	}
+}
+
+func TestOpenAIResponsesAdapter_HTTPErrorLargeBody(t *testing.T) {
+	largeMsg := strings.Repeat("x", 8192)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprintf(w, `{"error":{"message":"%s","type":"invalid_request_error"}}`, largeMsg)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("key", srv.URL)
+
+	_, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+	// The 4096-byte LimitReader truncates the JSON before it can decode, so
+	// we fall back to the generic status-code error. The key assertion is
+	// that the call returns cleanly without consuming unbounded memory.
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("expected status code in error, got: %v", err)
+	}
+}
+
+func TestOpenAIResponsesAdapter_RequestBody(t *testing.T) {
+	var received responsesRequest
+	var rawBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 1<<20)
+		n, _ := r.Body.Read(buf)
+		rawBody = buf[:n]
+		if err := json.Unmarshal(rawBody, &received); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/responses") {
+			t.Errorf("expected /responses path, got %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`))
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+
+	tools := []types.ToolDefinition{
+		{
+			Name:        "read_file",
+			Description: "Read a file",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+		},
+	}
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:       "gpt-4.1",
+		System:      "You are helpful.",
+		MaxTokens:   4096,
+		Temperature: 0.5,
+		Tools:       tools,
+		Messages: []types.Message{
+			{
+				Role: "user",
+				Content: []types.ContentBlock{
+					{Type: "text", Text: "Hello"},
+				},
+			},
+			{
+				Role: "assistant",
+				Content: []types.ContentBlock{
+					{Type: "text", Text: "I will read it."},
+					{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+				},
+			},
+			{
+				Role: "user",
+				Content: []types.ContentBlock{
+					{Type: "tool_result", ToolUseID: "call_1", Content: "package main"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	for range ch {
+	}
+
+	if !received.Stream {
+		t.Error("expected stream=true")
+	}
+	if received.Store {
+		t.Error("expected store=false in request body")
+	}
+	if received.Instructions != "You are helpful." {
+		t.Errorf("instructions = %q, want 'You are helpful.'", received.Instructions)
+	}
+	if received.Model != "gpt-4.1" {
+		t.Errorf("model = %q, want gpt-4.1", received.Model)
+	}
+	if received.MaxOutputTokens != 4096 {
+		t.Errorf("max_output_tokens = %d, want 4096", received.MaxOutputTokens)
+	}
+	if received.Temperature != 0.5 {
+		t.Errorf("temperature = %v, want 0.5", received.Temperature)
+	}
+
+	// Raw body must NOT contain a Chat Completions-style top-level "messages"
+	// field, and must NOT contain a Chat Completions "max_tokens" key.
+	if strings.Contains(string(rawBody), `"messages"`) {
+		t.Error("request body contains 'messages' field — Responses API uses 'input'")
+	}
+	if strings.Contains(string(rawBody), `"max_tokens"`) {
+		t.Error("request body contains 'max_tokens' — Responses API uses 'max_output_tokens'")
+	}
+	if !strings.Contains(string(rawBody), `"store":false`) {
+		t.Error("request body must contain explicit store:false")
+	}
+
+	// Input shape: user message, assistant message + function_call, function_call_output.
+	if len(received.Input) < 4 {
+		t.Fatalf("expected >=4 input items, got %d: %+v", len(received.Input), received.Input)
+	}
+	if received.Input[0].Type != "message" || received.Input[0].Role != "user" {
+		t.Errorf("input[0] = %+v, want message/user", received.Input[0])
+	}
+	if len(received.Input[0].Content) == 0 || received.Input[0].Content[0].Type != "input_text" {
+		t.Errorf("input[0].content[0].type = %+v, want input_text", received.Input[0].Content)
+	}
+	if received.Input[1].Type != "message" || received.Input[1].Role != "assistant" {
+		t.Errorf("input[1] = %+v, want message/assistant", received.Input[1])
+	}
+	if len(received.Input[1].Content) == 0 || received.Input[1].Content[0].Type != "output_text" {
+		t.Errorf("input[1].content[0].type = %+v, want output_text", received.Input[1].Content)
+	}
+	if received.Input[2].Type != "function_call" {
+		t.Errorf("input[2].Type = %q, want function_call", received.Input[2].Type)
+	}
+	if received.Input[2].CallID != "call_1" {
+		t.Errorf("input[2].CallID = %q, want call_1", received.Input[2].CallID)
+	}
+	if received.Input[2].Name != "read_file" {
+		t.Errorf("input[2].Name = %q, want read_file", received.Input[2].Name)
+	}
+	if received.Input[3].Type != "function_call_output" {
+		t.Errorf("input[3].Type = %q, want function_call_output", received.Input[3].Type)
+	}
+	if received.Input[3].CallID != "call_1" {
+		t.Errorf("input[3].CallID = %q, want call_1", received.Input[3].CallID)
+	}
+
+	// Tools should use the flatter shape (no nested "function" object).
+	if len(received.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(received.Tools))
+	}
+	if received.Tools[0].Type != "function" {
+		t.Errorf("tools[0].Type = %q, want function", received.Tools[0].Type)
+	}
+	if received.Tools[0].Name != "read_file" {
+		t.Errorf("tools[0].Name = %q, want read_file", received.Tools[0].Name)
+	}
+	if received.Tools[0].Description != "Read a file" {
+		t.Errorf("tools[0].Description = %q, want 'Read a file'", received.Tools[0].Description)
+	}
+	if strings.Contains(string(rawBody), `"function":{"name"`) {
+		t.Error("request body contains nested 'function' object — Responses API uses a flat tool shape")
+	}
+}
+
+func TestOpenAIResponsesAdapter_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch, err := adapter.Stream(ctx, types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	cancel()
+
+	events := collectEvents(t, ch)
+	if len(events) == 0 {
+		t.Fatal("expected at least one event after cancellation")
+	}
+	last := events[len(events)-1]
+	if last.Type != "error" {
+		t.Errorf("last event type = %q, want error", last.Type)
+	}
+}
+
+func TestOpenAIResponsesAdapter_DefaultBaseURL(t *testing.T) {
+	adapter := NewOpenAIResponsesAdapter("key", "")
+	if adapter.baseURL != openaiDefaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", adapter.baseURL, openaiDefaultBaseURL)
+	}
+}
+
+func TestOpenAIResponsesAdapter_TrailingSlashBaseURL(t *testing.T) {
+	adapter := NewOpenAIResponsesAdapter("key", "https://example.com/v1/")
+	if adapter.baseURL != "https://example.com/v1" {
+		t.Errorf("baseURL = %q, want https://example.com/v1", adapter.baseURL)
+	}
+}
+
+func TestOpenAIResponsesAdapter_HasTimeout(t *testing.T) {
+	adapter := NewOpenAIResponsesAdapter("test-key", "")
+	if adapter.httpClient.Timeout == 0 {
+		t.Error("HTTP client should have a non-zero timeout")
+	}
+	tr, ok := adapter.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if tr.TLSHandshakeTimeout == 0 {
+		t.Error("TLSHandshakeTimeout should be non-zero")
+	}
+	if tr.ResponseHeaderTimeout == 0 {
+		t.Error("ResponseHeaderTimeout should be non-zero")
+	}
+}
+
+func TestOpenAIResponsesAdapter_RecordsLatencyAndTTFB(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant"}}`),
+		makeResponsesEvent("response.output_text.delta", `{"item_id":"msg_1","output_index":0,"delta":"Hi"}`),
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed","output":[{"type":"message","id":"msg_1"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	reader := sdkmetric.NewManualReader()
+	prov := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = prov.Shutdown(context.Background()) })
+	metrics, err := observability.NewMetricsForTesting(prov)
+	if err != nil {
+		t.Fatalf("NewMetricsForTesting: %v", err)
+	}
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	adapter.Metrics = metrics
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+
+	if got := providerHistogramTotalCount(t, reader, "stirrup.harness.provider_latency"); got != 1 {
+		t.Errorf("provider_latency count = %d, want 1", got)
+	}
+	if got := providerHistogramTotalCount(t, reader, "stirrup.harness.provider_ttfb"); got != 1 {
+		t.Errorf("provider_ttfb count = %d, want 1", got)
+	}
+	h, ok := providerHistogramFinder(t, reader, "stirrup.harness.provider_latency")
+	if !ok || len(h.DataPoints) == 0 {
+		t.Fatal("expected provider_latency data point")
+	}
+	attrs := h.DataPoints[0].Attributes
+	if v, ok := attrs.Value("provider.type"); !ok || v.AsString() != "openai-responses" {
+		t.Errorf("provider.type = %v ok=%v, want openai-responses", v.AsString(), ok)
+	}
+	if v, ok := attrs.Value("provider.model"); !ok || v.AsString() != "gpt-4.1" {
+		t.Errorf("provider.model = %v ok=%v, want gpt-4.1", v.AsString(), ok)
+	}
+}
+
+func TestOpenAIResponsesAdapter_RecordsLatencyOnHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"bad"}}`)
+	}))
+	defer srv.Close()
+
+	reader := sdkmetric.NewManualReader()
+	prov := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = prov.Shutdown(context.Background()) })
+	metrics, err := observability.NewMetricsForTesting(prov)
+	if err != nil {
+		t.Fatalf("NewMetricsForTesting: %v", err)
+	}
+
+	adapter := NewOpenAIResponsesAdapter("bad-key", srv.URL)
+	adapter.Metrics = metrics
+
+	if _, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024}); err == nil {
+		t.Fatal("expected error")
+	}
+	if got := providerHistogramTotalCount(t, reader, "stirrup.harness.provider_latency"); got != 1 {
+		t.Errorf("provider_latency count = %d, want 1", got)
+	}
+	if got := providerHistogramTotalCount(t, reader, "stirrup.harness.provider_ttfb"); got != 0 {
+		t.Errorf("provider_ttfb count = %d, want 0", got)
+	}
+}
+
+// --- Translation unit tests ---
+
+func TestTranslateMessagesResponses(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role: "user",
+			Content: []types.ContentBlock{
+				{Type: "text", Text: "Hello"},
+			},
+		},
+		{
+			Role: "assistant",
+			Content: []types.ContentBlock{
+				{Type: "text", Text: "Let me check."},
+				{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+			},
+		},
+		{
+			Role: "user",
+			Content: []types.ContentBlock{
+				{Type: "tool_result", ToolUseID: "call_1", Content: "package main"},
+			},
+		},
+	}
+
+	result := translateMessagesResponses(messages)
+
+	// user message -> 1 item (input_text)
+	// assistant text + tool_use -> 1 message item + 1 function_call item
+	// tool_result -> 1 function_call_output item
+	if len(result) != 4 {
+		t.Fatalf("expected 4 input items, got %d: %+v", len(result), result)
+	}
+	if result[0].Type != "message" || result[0].Role != "user" {
+		t.Errorf("result[0] = %+v, want message/user", result[0])
+	}
+	if result[0].Content[0].Type != "input_text" {
+		t.Errorf("result[0].Content[0].Type = %q, want input_text", result[0].Content[0].Type)
+	}
+	if result[1].Type != "message" || result[1].Role != "assistant" {
+		t.Errorf("result[1] = %+v, want message/assistant", result[1])
+	}
+	if result[1].Content[0].Type != "output_text" {
+		t.Errorf("result[1].Content[0].Type = %q, want output_text", result[1].Content[0].Type)
+	}
+	if result[2].Type != "function_call" || result[2].CallID != "call_1" || result[2].Name != "read_file" {
+		t.Errorf("result[2] = %+v, want function_call(call_1,read_file)", result[2])
+	}
+	if result[3].Type != "function_call_output" || result[3].CallID != "call_1" || result[3].Output != "package main" {
+		t.Errorf("result[3] = %+v, want function_call_output(call_1,package main)", result[3])
+	}
+}
+
+func TestTranslateMessagesResponses_ErrorToolResult(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role: "user",
+			Content: []types.ContentBlock{
+				{Type: "tool_result", ToolUseID: "call_1", Content: "file not found", IsError: true},
+			},
+		},
+	}
+
+	result := translateMessagesResponses(messages)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+	if result[0].Type != "function_call_output" {
+		t.Errorf("type = %q, want function_call_output", result[0].Type)
+	}
+	if !strings.HasPrefix(result[0].Output, "Error: ") {
+		t.Errorf("expected error-prefixed output, got %q", result[0].Output)
+	}
+}
+
+func TestTranslateMessagesResponses_AssistantToolUseEmptyInput(t *testing.T) {
+	// An assistant tool_use block with empty Input should serialise as
+	// "{}", not "" — a missing Arguments field would be ambiguous.
+	messages := []types.Message{
+		{
+			Role: "assistant",
+			Content: []types.ContentBlock{
+				{Type: "tool_use", ID: "c1", Name: "noop", Input: nil},
+			},
+		},
+	}
+	result := translateMessagesResponses(messages)
+	if len(result) != 1 || result[0].Type != "function_call" {
+		t.Fatalf("expected one function_call item, got %+v", result)
+	}
+	if result[0].Arguments != "{}" {
+		t.Errorf("Arguments = %q, want \"{}\"", result[0].Arguments)
+	}
+}
+
+func TestTranslateToolsResponses(t *testing.T) {
+	tools := []types.ToolDefinition{
+		{
+			Name:        "read_file",
+			Description: "Read a file",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		{
+			Name:        "write_file",
+			Description: "Write a file",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+	}
+	result := translateToolsResponses(tools)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(result))
+	}
+	for i, tool := range result {
+		if tool.Type != "function" {
+			t.Errorf("tools[%d].Type = %q, want function", i, tool.Type)
+		}
+		if tool.Name == "" {
+			t.Errorf("tools[%d].Name is empty", i)
+		}
+	}
+	if result[0].Name != "read_file" || result[1].Name != "write_file" {
+		t.Errorf("tool names = [%q, %q], want [read_file, write_file]", result[0].Name, result[1].Name)
+	}
+}
+
+func TestTranslateToolsResponses_Empty(t *testing.T) {
+	if got := translateToolsResponses(nil); got != nil {
+		t.Errorf("translateToolsResponses(nil) = %+v, want nil", got)
+	}
+	if got := translateToolsResponses([]types.ToolDefinition{}); got != nil {
+		t.Errorf("translateToolsResponses(empty) = %+v, want nil", got)
+	}
+}
+
+func TestDeriveStopReason(t *testing.T) {
+	tests := []struct {
+		name string
+		in   responsesResponse
+		want string
+	}{
+		{
+			name: "completed text only",
+			in:   responsesResponse{Status: "completed", Output: []responsesOutputItem{{Type: "message"}}},
+			want: "end_turn",
+		},
+		{
+			name: "completed with function call",
+			in:   responsesResponse{Status: "completed", Output: []responsesOutputItem{{Type: "function_call"}}},
+			want: "tool_use",
+		},
+		{
+			name: "incomplete due to max_output_tokens",
+			in:   responsesResponse{Status: "incomplete", IncompleteDetails: &struct{ Reason string `json:"reason"` }{Reason: "max_output_tokens"}},
+			want: "max_tokens",
+		},
+		{
+			name: "incomplete with other reason",
+			in:   responsesResponse{Status: "incomplete", IncompleteDetails: &struct{ Reason string `json:"reason"` }{Reason: "content_filter"}},
+			want: "content_filter",
+		},
+		{
+			name: "incomplete with no reason",
+			in:   responsesResponse{Status: "incomplete"},
+			want: "incomplete",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveStopReason(tt.in); got != tt.want {
+				t.Errorf("deriveStopReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAIResponsesAdapter_NoAPIKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("expected no Authorization header, got %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`))
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("", srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "local", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	for range ch {
+	}
+}

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -948,12 +948,16 @@ func TestDeriveStopReason(t *testing.T) {
 		},
 		{
 			name: "incomplete due to max_output_tokens",
-			in:   responsesResponse{Status: "incomplete", IncompleteDetails: &struct{ Reason string `json:"reason"` }{Reason: "max_output_tokens"}},
+			in: responsesResponse{Status: "incomplete", IncompleteDetails: &struct {
+				Reason string `json:"reason"`
+			}{Reason: "max_output_tokens"}},
 			want: "max_tokens",
 		},
 		{
 			name: "incomplete with other reason",
-			in:   responsesResponse{Status: "incomplete", IncompleteDetails: &struct{ Reason string `json:"reason"` }{Reason: "content_filter"}},
+			in: responsesResponse{Status: "incomplete", IncompleteDetails: &struct {
+				Reason string `json:"reason"`
+			}{Reason: "content_filter"}},
 			want: "content_filter",
 		},
 		{

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -8,8 +8,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/types"
@@ -675,13 +678,16 @@ func TestOpenAIResponsesAdapter_ContextCancellation(t *testing.T) {
 	}
 	cancel()
 
+	// After cancellation, the channel must close in bounded time. We
+	// don't strictly require an error event: the new emit-with-cancel
+	// path may discard the trailing error if the consumer was already
+	// gone. The contract is that the goroutine must not leak; the
+	// closed channel below proves it.
 	events := collectEvents(t, ch)
-	if len(events) == 0 {
-		t.Fatal("expected at least one event after cancellation")
-	}
-	last := events[len(events)-1]
-	if last.Type != "error" {
-		t.Errorf("last event type = %q, want error", last.Type)
+	for _, ev := range events {
+		if ev.Type == "message_complete" {
+			t.Errorf("unexpected message_complete after cancel: %+v", ev)
+		}
 	}
 }
 
@@ -992,5 +998,658 @@ func TestOpenAIResponsesAdapter_NoAPIKey(t *testing.T) {
 		t.Fatalf("Stream() error: %v", err)
 	}
 	for range ch {
+	}
+}
+
+// --- B1: backpressure / cancellation ---
+
+// TestOpenAIResponsesAdapter_BackpressureCancellation verifies that the
+// streaming goroutine does not leak when the consumer cancels context
+// while the producer is still trying to send. Pre-fix, emitEvent did an
+// unconditional send; with the channel buffer full, the goroutine would
+// block on the send forever because nothing else was draining the
+// channel.
+func TestOpenAIResponsesAdapter_BackpressureCancellation(t *testing.T) {
+	// Continuously stream small SSE records as fast as possible so the
+	// channel buffer fills before the consumer gets a chance to drain.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			_, err := fmt.Fprint(w, makeResponsesEvent("response.output_text.delta",
+				`{"item_id":"msg_1","output_index":0,"delta":"x"}`))
+			if err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch, err := adapter.Stream(ctx, types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	// Drain a handful of events so the goroutine starts producing, then
+	// stop reading and cancel. The goroutine must observe ctx.Done()
+	// instead of blocking on the channel.
+	for i := 0; i < 4; i++ {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out reading initial events")
+		}
+	}
+	cancel()
+
+	// The channel must close in bounded time. If emitEvent still did an
+	// unconditional send, the consumer-cancelled goroutine would never
+	// reach the close(ch) defer and this would deadlock.
+	closed := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("channel did not close within 3s after cancel — goroutine likely leaked")
+	}
+}
+
+// --- B2: SSE record size cap ---
+
+// TestOpenAIResponsesAdapter_SSERecordSizeCapEnforced verifies that when
+// a single SSE record's accumulated `data:` lines exceed the input cap,
+// the adapter emits a bounded error event and tears down the stream
+// without materialising the full concatenated payload in memory.
+func TestOpenAIResponsesAdapter_SSERecordSizeCapEnforced(t *testing.T) {
+	// Two data: lines, each just under 6MB, totalling > 10MB.
+	const half = 6 * 1024 * 1024
+	bigChunk := strings.Repeat("z", half)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "event: response.output_text.delta\n")
+		_, _ = fmt.Fprintf(w, "data: %s\n", bigChunk)
+		if flusher != nil {
+			flusher.Flush()
+		}
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", bigChunk)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 event, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "error" {
+		t.Errorf("event[0].Type = %q, want error", events[0].Type)
+	}
+	if events[0].Error == nil || !strings.Contains(events[0].Error.Error(), "byte limit") {
+		t.Errorf("expected error citing byte limit, got: %v", events[0].Error)
+	}
+}
+
+// --- H1: latency recorded across context cancellation ---
+
+// TestOpenAIResponsesAdapter_LatencyRecordedAfterContextCancel verifies
+// that provider_latency is recorded even when the caller cancels their
+// context after Stream() returns. Pre-fix, the deferred recordLatency
+// call ran on the (now-cancelled) caller context, and OTel exporters
+// that drop measurements on cancelled contexts would silently lose the
+// measurement.
+func TestOpenAIResponsesAdapter_LatencyRecordedAfterContextCancel(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.output_item.added", `{"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant"}}`),
+		makeResponsesEvent("response.output_text.delta", `{"item_id":"msg_1","output_index":0,"delta":"hi"}`),
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed","output":[{"type":"message","id":"msg_1"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	reader := sdkmetric.NewManualReader()
+	prov := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = prov.Shutdown(context.Background()) })
+	metrics, err := observability.NewMetricsForTesting(prov)
+	if err != nil {
+		t.Fatalf("NewMetricsForTesting: %v", err)
+	}
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	adapter.Metrics = metrics
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := adapter.Stream(ctx, types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	// Cancel BEFORE draining the channel — exposes the case where the
+	// caller's ctx is dead by the time the goroutine reaches the
+	// deferred recordLatency call.
+	cancel()
+	for range ch {
+	}
+
+	// Give the goroutine a moment to record latency.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := providerHistogramTotalCount(t, reader, "stirrup.harness.provider_latency"); got == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("provider_latency count = %d, want 1 (latency must be recorded against background ctx)",
+		providerHistogramTotalCount(t, reader, "stirrup.harness.provider_latency"))
+}
+
+// --- H2: malformed terminal event emits error ---
+
+// TestOpenAIResponsesAdapter_MalformedCompletedEvent verifies that a
+// malformed JSON payload on response.completed surfaces as an error
+// event rather than silently dropping the terminal message_complete.
+func TestOpenAIResponsesAdapter_MalformedCompletedEvent(t *testing.T) {
+	body := makeResponsesEvent("response.completed", `NOT_VALID_JSON`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "error" {
+		t.Errorf("event[0].Type = %q, want error", events[0].Type)
+	}
+	if events[0].Error == nil || !strings.Contains(events[0].Error.Error(), "parse response.completed") {
+		t.Errorf("expected error mentioning parse response.completed, got: %v", events[0].Error)
+	}
+	for _, ev := range events {
+		if ev.Type == "message_complete" {
+			t.Errorf("message_complete must not be emitted on malformed completed: %+v", ev)
+		}
+	}
+}
+
+// TestOpenAIResponsesAdapter_MalformedDispatchEvents covers parse-error
+// branches across every dispatch case that captures the unmarshal
+// error. Each variant must emit an error event and terminate the stream.
+func TestOpenAIResponsesAdapter_MalformedDispatchEvents(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventName string
+		errSubstr string
+	}{
+		{"output_item.added", "response.output_item.added", "parse output_item.added"},
+		{"output_text.delta", "response.output_text.delta", "parse output_text.delta"},
+		{"function_call_arguments.delta", "response.function_call_arguments.delta", "parse function_call_arguments.delta"},
+		{"function_call_arguments.done", "response.function_call_arguments.done", "parse function_call_arguments.done"},
+		{"output_item.done", "response.output_item.done", "parse output_item.done"},
+		{"response.incomplete", "response.incomplete", "parse response.incomplete"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			body := makeResponsesEvent(tc.eventName, "{NOT JSON")
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, body)
+			}))
+			defer srv.Close()
+
+			adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+			ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+			if err != nil {
+				t.Fatalf("Stream() error: %v", err)
+			}
+			events := collectEvents(t, ch)
+			if len(events) != 1 {
+				t.Fatalf("expected 1 event, got %d: %+v", len(events), events)
+			}
+			if events[0].Type != "error" {
+				t.Errorf("event[0].Type = %q, want error", events[0].Type)
+			}
+			if events[0].Error == nil || !strings.Contains(events[0].Error.Error(), tc.errSubstr) {
+				t.Errorf("expected error mentioning %q, got: %v", tc.errSubstr, events[0].Error)
+			}
+		})
+	}
+}
+
+// --- H3: callKey fallback ---
+
+// TestCallKey_FallbackToIndex verifies the idx: fallback when item_id
+// is empty (some partner gateways omit the ID).
+func TestCallKey_FallbackToIndex(t *testing.T) {
+	if got := callKey("", 3); got != "idx:3" {
+		t.Errorf("callKey(\"\", 3) = %q, want idx:3", got)
+	}
+	if got := callKey("real_id", 3); got != "real_id" {
+		t.Errorf("callKey(real_id, 3) = %q, want real_id", got)
+	}
+}
+
+// TestOpenAIResponsesAdapter_DeltaBeforeAdded verifies the lazy state
+// creation when an arguments delta arrives before its corresponding
+// output_item.added (defensive for partner gateways that abbreviate the
+// stream). The adapter must accumulate the delta and still emit the
+// tool_call when the .done event fires.
+func TestOpenAIResponsesAdapter_DeltaBeforeAdded(t *testing.T) {
+	body := strings.Join([]string{
+		// No output_item.added — straight to delta. The state should be
+		// created on first delta.
+		makeResponsesEvent("response.function_call_arguments.delta", `{"item_id":"fc_lazy","output_index":0,"delta":"{\"k\":1}"}`),
+		// done event echoes the call metadata so we have a callID/name.
+		makeResponsesEvent("response.output_item.done", `{"output_index":0,"item":{"type":"function_call","id":"fc_lazy","call_id":"call_lazy","name":"noop"}}`),
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed","output":[{"type":"function_call","id":"fc_lazy","call_id":"call_lazy","name":"noop"}]}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	var toolCall *types.StreamEvent
+	for i := range events {
+		if events[i].Type == "tool_call" {
+			toolCall = &events[i]
+			break
+		}
+	}
+	if toolCall == nil {
+		t.Fatalf("expected a tool_call event, got: %+v", events)
+	}
+	if toolCall.ID != "call_lazy" || toolCall.Name != "noop" {
+		t.Errorf("toolCall = %+v, want call_lazy/noop", toolCall)
+	}
+	if v, _ := toolCall.Input["k"].(float64); v != 1 {
+		t.Errorf("toolCall.Input[k] = %v, want 1", toolCall.Input["k"])
+	}
+}
+
+// TestOpenAIResponsesAdapter_DeltaBeforeAddedNoItemIDFallback exercises
+// the callKey fallback path inline in dispatchEvent: the delta arrives
+// without an item_id, so the call must be keyed on idx:N and still
+// produce a tool_call when .done arrives (with item_id, but matching
+// the same output_index — the .done path also falls back).
+func TestOpenAIResponsesAdapter_DeltaBeforeAddedNoItemIDFallback(t *testing.T) {
+	body := strings.Join([]string{
+		makeResponsesEvent("response.function_call_arguments.delta", `{"output_index":2,"delta":"{\"a\":\"b\"}"}`),
+		makeResponsesEvent("response.function_call_arguments.done", `{"output_index":2,"arguments":"{\"a\":\"b\"}"}`),
+		// Note: no item_id, no echoed call_id/name. The .done event
+		// state still flushes a tool_call with empty ID/Name. We assert
+		// that no error event fires and the args parse cleanly.
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	var sawToolCall bool
+	for _, ev := range events {
+		if ev.Type == "error" {
+			t.Errorf("unexpected error event: %v", ev.Error)
+		}
+		if ev.Type == "tool_call" {
+			sawToolCall = true
+			if v, _ := ev.Input["a"].(string); v != "b" {
+				t.Errorf("Input[a] = %v, want b", ev.Input["a"])
+			}
+		}
+	}
+	if !sawToolCall {
+		t.Errorf("expected tool_call event, got: %+v", events)
+	}
+}
+
+// TestDeriveStopReason_DefaultUnknownStatus exercises the default branch
+// of deriveStopReason — an unknown Responses status (e.g. cancelled)
+// passes through verbatim so the agentic loop can surface it as the
+// run outcome.
+func TestDeriveStopReason_DefaultUnknownStatus(t *testing.T) {
+	got := deriveStopReason(responsesResponse{Status: "cancelled"})
+	if got != "cancelled" {
+		t.Errorf("deriveStopReason(cancelled) = %q, want cancelled", got)
+	}
+	// Default branch with no status and a function_call → tool_use.
+	got = deriveStopReason(responsesResponse{Status: "", Output: []responsesOutputItem{{Type: "function_call"}}})
+	if got != "tool_use" {
+		t.Errorf("deriveStopReason(empty,function_call) = %q, want tool_use", got)
+	}
+	// Default branch with no status and only message → end_turn.
+	got = deriveStopReason(responsesResponse{Status: ""})
+	if got != "end_turn" {
+		t.Errorf("deriveStopReason(empty) = %q, want end_turn", got)
+	}
+}
+
+// TestDeriveStopReason_MaxTokensSpelling exercises the second OR arm
+// of the max_tokens detection (`max_tokens` literal, not
+// `max_output_tokens`).
+func TestDeriveStopReason_MaxTokensSpelling(t *testing.T) {
+	in := responsesResponse{
+		Status: "incomplete",
+		IncompleteDetails: &struct {
+			Reason string `json:"reason"`
+		}{Reason: "max_tokens"},
+	}
+	if got := deriveStopReason(in); got != "max_tokens" {
+		t.Errorf("deriveStopReason(max_tokens spelling) = %q, want max_tokens", got)
+	}
+}
+
+// TestOpenAIResponsesAdapter_IncompleteMaxTokensAlternateSpelling
+// covers the same alternate spelling path inside the SSE dispatch for
+// response.incomplete.
+func TestOpenAIResponsesAdapter_IncompleteMaxTokensAlternateSpelling(t *testing.T) {
+	body := makeResponsesEvent("response.incomplete",
+		`{"response":{"status":"incomplete","incomplete_details":{"reason":"max_tokens"}}}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+	if len(events) == 0 {
+		t.Fatalf("expected at least 1 event")
+	}
+	last := events[len(events)-1]
+	if last.Type != "message_complete" || last.StopReason != "max_tokens" {
+		t.Errorf("last = %+v, want message_complete/max_tokens", last)
+	}
+}
+
+// TestOpenAIResponsesAdapter_SSEParserDefensiveBranches exercises the
+// SSE parser's tolerant branches: comment lines (`:` prefix), header
+// lines without trailing space (`event:`/`data:`), and trailing record
+// flushed at EOF without a terminating blank line.
+func TestOpenAIResponsesAdapter_SSEParserDefensiveBranches(t *testing.T) {
+	// Note: no terminating blank line on the last record — relies on
+	// the EOF-flush path.
+	body := ":heartbeat\n" +
+		":another comment\n" +
+		"event:response.output_item.added\n" +
+		"data:{\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\"}}\n" +
+		"\n" +
+		"event:response.output_text.delta\n" +
+		"data:{\"item_id\":\"msg_1\",\"output_index\":0,\"delta\":\"hi\"}\n" +
+		"\n" +
+		// Trailing record without final blank line — must still flush.
+		"event:response.completed\n" +
+		"data:{\"response\":{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"id\":\"msg_1\"}]}}\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	events := collectEvents(t, ch)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (text_delta, message_complete), got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "text_delta" || events[0].Text != "hi" {
+		t.Errorf("event[0] = %+v, want text_delta/hi", events[0])
+	}
+	if events[1].Type != "message_complete" || events[1].StopReason != "end_turn" {
+		t.Errorf("event[1] = %+v, want message_complete/end_turn", events[1])
+	}
+}
+
+// TestOpenAIResponsesAdapter_NetworkError exercises the httpClient.Do
+// connection-level failure path (server closed before request).
+func TestOpenAIResponsesAdapter_NetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	addr := srv.URL
+	srv.Close() // close before any request fires.
+
+	adapter := NewOpenAIResponsesAdapter("test-key", addr)
+	_, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err == nil {
+		t.Fatal("expected network error, got nil")
+	}
+	if !strings.Contains(err.Error(), "execute request") {
+		t.Errorf("expected execute-request error, got: %v", err)
+	}
+}
+
+// TestOpenAIResponsesAdapter_5xxNoBody exercises the 5xx fallback path
+// where the body is absent or unparseable: the adapter returns the
+// generic status-code error rather than crashing.
+func TestOpenAIResponsesAdapter_5xxNoBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	_, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err == nil {
+		t.Fatal("expected error for 503, got nil")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected status code in error, got: %v", err)
+	}
+}
+
+// TestOpenAIResponsesAdapter_429RetryAfterSpanEvent verifies the 429
+// rate-limit branch attaches a span event with the Retry-After header.
+func TestOpenAIResponsesAdapter_429RetryAfterSpanEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "42")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"slow down"}}`)
+	}))
+	defer srv.Close()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	tracer := tp.Tracer("test")
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	adapter.Tracer = tracer
+
+	// We need the span to be in ctx so SpanFromContext finds it.
+	ctx, span := tracer.Start(context.Background(), "test")
+
+	_, err := adapter.Stream(ctx, types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err == nil {
+		t.Fatal("expected error for 429, got nil")
+	}
+	span.End()
+
+	stubs := exporter.GetSpans()
+	if len(stubs) == 0 {
+		t.Fatal("expected at least one finished span")
+	}
+	var found bool
+	for _, s := range stubs {
+		for _, ev := range s.Events {
+			if ev.Name == "rate_limited" {
+				found = true
+				var retryAfter string
+				for _, attr := range ev.Attributes {
+					if string(attr.Key) == "retry_after" {
+						retryAfter = attr.Value.AsString()
+					}
+				}
+				if retryAfter != "42" {
+					t.Errorf("rate_limited.retry_after = %q, want 42", retryAfter)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a rate_limited span event")
+	}
+}
+
+// Note: the dispatch-level arg cap on `.function_call_arguments.done`
+// (lines 559–563) and `.output_item.done` (lines 601–606) is defensive
+// only. The same byte limit is enforced by the SSE scanner's per-line
+// cap and by the B2 dataParts aggregate cap, both of which trip before
+// dispatch is reached. The brief flagged these as coverage gaps; they
+// are unreachable in production with the current cap configuration. We
+// keep the checks for defense-in-depth (so any future relaxation of the
+// scanner cap does not silently uncap tool arguments) but do not
+// fabricate tests for unreachable paths.
+
+// TestOpenAIResponsesAdapter_UnknownEventSpanEvent verifies that an
+// unknown SSE event type emits a span event for production
+// observability (M1).
+func TestOpenAIResponsesAdapter_UnknownEventSpanEvent(t *testing.T) {
+	body := strings.Join([]string{
+		// Unknown event type — must be ignored but tagged on the span.
+		makeResponsesEvent("response.reasoning_summary.delta", `{"text":"thinking..."}`),
+		makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`),
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	tracer := tp.Tracer("test")
+
+	adapter := NewOpenAIResponsesAdapter("test-key", srv.URL)
+	adapter.Tracer = tracer
+
+	ctx, span := tracer.Start(context.Background(), "test")
+	ch, err := adapter.Stream(ctx, types.StreamParams{Model: "gpt-4.1", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+	span.End()
+
+	stubs := exporter.GetSpans()
+	var foundUnknown bool
+	for _, s := range stubs {
+		for _, ev := range s.Events {
+			if ev.Name == "openai_responses.unknown_sse_event" {
+				foundUnknown = true
+				var typ string
+				for _, attr := range ev.Attributes {
+					if string(attr.Key) == "event.type" {
+						typ = attr.Value.AsString()
+					}
+				}
+				if typ != "response.reasoning_summary.delta" {
+					t.Errorf("event.type = %q, want response.reasoning_summary.delta", typ)
+				}
+			}
+		}
+	}
+	if !foundUnknown {
+		t.Error("expected an openai_responses.unknown_sse_event span event")
+	}
+}
+
+// TestTranslateMessagesResponses_UserTextAndToolResultOrder pins the
+// emission ordering for a user message containing
+// [text, tool_result, text]. The current contract is: function_call_output
+// items emit first (in their document order); user text is batched into
+// a single trailing input_text item. See the comment in
+// translateMessagesResponses for rationale (M4).
+func TestTranslateMessagesResponses_UserTextAndToolResultOrder(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role: "user",
+			Content: []types.ContentBlock{
+				{Type: "text", Text: "Before. "},
+				{Type: "tool_result", ToolUseID: "call_1", Content: "first result"},
+				{Type: "text", Text: "After."},
+			},
+		},
+	}
+	result := translateMessagesResponses(messages)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 items, got %d: %+v", len(result), result)
+	}
+	if result[0].Type != "function_call_output" {
+		t.Errorf("result[0].Type = %q, want function_call_output", result[0].Type)
+	}
+	if result[1].Type != "message" || result[1].Role != "user" {
+		t.Errorf("result[1] = %+v, want message/user", result[1])
+	}
+	if len(result[1].Content) == 0 || result[1].Content[0].Text != "Before. After." {
+		t.Errorf("result[1].Content = %+v, want concatenated 'Before. After.'", result[1].Content)
 	}
 }

--- a/types/events.go
+++ b/types/events.go
@@ -3,6 +3,21 @@ package types
 import "encoding/json"
 
 // StreamEvent represents a single event from the model's streaming response.
+//
+// StopReason is only populated on a "message_complete" event. The harness
+// recognises these canonical values:
+//
+//   - "end_turn"   — model finished a normal turn with no further action
+//   - "tool_use"   — model emitted one or more tool calls; the agentic
+//     loop should dispatch them and continue the conversation
+//   - "max_tokens" — provider stopped because of an output token budget
+//   - "error"      — provider returned an empty stop reason (defensive)
+//   - "incomplete" — Responses-API status with no specific reason
+//
+// Any other value is passed through verbatim to the agentic loop and
+// surfaces as the run's outcome string. The authoritative consumer is
+// harness/internal/core/loop.go (see the run loop's stop-reason switch
+// near the end of the turn handler).
 type StreamEvent struct {
 	Type         string         `json:"type"` // "text_delta" | "tool_call" | "message_complete" | "error"
 	Text         string         `json:"text,omitempty"`

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -107,11 +107,11 @@ func (rc RunConfig) Redact() RunConfig {
 
 // ProviderConfig selects the model provider implementation.
 type ProviderConfig struct {
-	Type       string            `json:"type"`                 // "anthropic" | "bedrock" | "openai-compatible"
+	Type       string            `json:"type"`                 // "anthropic" | "bedrock" | "openai-compatible" | "openai-responses"
 	APIKeyRef  string            `json:"apiKeyRef,omitempty"`  // e.g. "secret://anthropic-key"
 	Region     string            `json:"region,omitempty"`     // bedrock
 	Profile    string            `json:"profile,omitempty"`    // bedrock
-	BaseURL    string            `json:"baseUrl,omitempty"`    // openai-compatible
+	BaseURL    string            `json:"baseUrl,omitempty"`    // openai-compatible, openai-responses
 	Credential *CredentialConfig `json:"credential,omitempty"` // cross-cloud credential federation (nil = infer from provider type)
 }
 
@@ -254,6 +254,7 @@ var validProviderTypes = map[string]bool{
 	"anthropic":         true,
 	"bedrock":           true,
 	"openai-compatible": true,
+	"openai-responses":  true,
 }
 
 var validModelRouterTypes = map[string]bool{

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -442,6 +442,17 @@ func TestValidateRunConfig_NilBudgetsPass(t *testing.T) {
 	}
 }
 
+func TestValidateRunConfig_OpenAIResponsesProvider(t *testing.T) {
+	// The new openai-responses provider type must be accepted by validation.
+	// Before this case existed, callers who configured a Responses adapter
+	// would be rejected at validation time.
+	c := validConfig()
+	c.Provider = ProviderConfig{Type: "openai-responses", APIKeyRef: "secret://OPENAI_KEY"}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("expected openai-responses to be accepted, got: %v", err)
+	}
+}
+
 func TestValidateRunConfig_CredentialNilPassesValidation(t *testing.T) {
 	c := validConfig()
 	c.Provider.Credential = nil


### PR DESCRIPTION
## Summary

Adds a new `OpenAIResponsesAdapter` (`harness/internal/provider/openai_responses.go`) implementing `ProviderAdapter` for OpenAI's Responses API (`POST /v1/responses`), alongside the existing Chat Completions adapter. Provider type is explicit (`--provider openai-responses`); no auto-detection.

- New provider type wired into RunConfig validation, factory (incl. tracer/metrics assignment), and CLI `--provider` help text.
- Translates `[]types.Message` (text + tool_use + tool_result) into Responses `input[]` typed items, flatter `tools[]` shape, top-level `instructions`, `max_output_tokens`, explicit `store: false`, `stream: true`.
- Named-event SSE parser (`response.created`, `output_item.added`, `output_text.delta`, `function_call_arguments.delta/done`, `output_item.done`, `response.completed`, `response.incomplete`, `response.failed`, `error`).
- Tool calls accumulated by `output_index`/`item_id`, emitted once per call when arguments complete, deterministic `output_index` ordering across multiple concurrent calls, 10MB cap.
- Stop-reason mapping per the issue table (`end_turn` / `tool_use` / `max_tokens` / `error`).
- OTel: ProviderLatency once per request including HTTP error paths, ProviderTTFB on first text/tool-call event, low-cardinality span attributes (`provider.type=openai-responses`, `provider.model`, `http.status_code`).
- Hardened: cancellable channel sends (no goroutine leak under consumer backpressure), aggregate SSE record byte cap (DoS resistance against multi-line `data:` accumulation), background-context latency recording (metric not lost when caller cancels post-stream), parse-error to error-event for every terminal/state-initialising SSE event.
- Docs: CLAUDE.md (new "OpenAI Responses" subsection + `--provider` flag table), README, `examples/runconfig/openai_responses.json`, `examples/runconfig/README.md`.

## Non-goals (deferred per issue body)

- Server-side state via `previous_response_id`
- Built-in OpenAI tools (`web_search`, `file_search`, `computer_use`, `code_interpreter`)
- Reasoning controls (`reasoning.effort`, `reasoning.summary`)
- `store: true`
- Multi-modal beyond text + tool blocks

Out-of-scope follow-ups identified during review (each track separately): HTTPS scheme enforcement on `BaseURL`, concurrent-calls-map cap, multi-modal `ContentBlock` default-case handling. None are regressions in this PR; all pre-exist in `openai.go`.

## Review process

End-to-end orchestration: feature-implementer -> parallel reviewers (code, security, spec-compliance, test-coverage, api-design) -> review-synthesizer -> remediation pass.

Results after remediation:
- 0 BLOCKERs / 0 HIGHs outstanding
- Per-file statement coverage on `openai_responses.go`: **90.8%** (target was 85%)
- Per-function: NewOpenAIResponsesAdapter / translateMessagesResponses / translateToolsResponses / recordLatency / callKey / deriveStopReason all at 100%; consumeSSE 96.4%; flushOneCall / flushPendingCalls 90.0%; Stream 89.7%; dispatchEvent 84.3%
- `just test` green
- `just lint` 0 issues

## Test plan

- [x] `just test` (all modules pass)
- [x] `just lint` (0 issues)
- [x] `go test -cover ./harness/internal/provider/...` (>=85% statement coverage on `openai_responses.go`)
- [x] Factory test asserts `--provider openai-responses` constructs `*OpenAIResponsesAdapter`
- [x] CLI test asserts `--provider openai-responses` propagates through to RunConfig
- [x] RunConfig validation test accepts `openai-responses`
- [x] Wire-format httptest assertions: `instructions`, `input[]`, flatter `tools`, `max_output_tokens`, `store:false`, `stream:true`, endpoint suffix `/responses`
- [x] SSE event coverage: created/output_text.delta/output_item.added/function_call_arguments.delta/.done/output_item.done/response.completed/response.incomplete/response.failed/error
- [x] Tool-call streaming: single, multiple deterministic order, deferred flush, malformed JSON, oversized arguments
- [x] Backpressure cancellation does not leak goroutines
- [x] Latency metric recorded even when caller cancels context post-stream
- [x] Parse error on terminal events emits `error` StreamEvent and closes channel
- [ ] **Manual: live OpenAI API smoke test** (AC 7) -- not codifiable in committed tests; run before production deploy: `./stirrup harness --provider openai-responses --model <openai-model> --prompt "Say hello"` and confirm full turn with non-zero usage tokens.

Closes #44.