### PR TITLE
feat: support --name session label

### DIFF
--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -487,8 +487,13 @@ type RunConfig struct {
 	// bypassing prompt_builder mode selection. Workspace path, turn budget,
 	// and dynamic_context sections are still appended by the harness.
 	SystemPromptOverride string `protobuf:"bytes,23,opt,name=system_prompt_override,json=systemPromptOverride,proto3" json:"system_prompt_override,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Optional. Human-readable label attached to the run for reporting.
+	// Surfaces in structured logs (sessionName), JSONL traces (config.sessionName),
+	// and OTel root spans (run.session_name). Metadata only — never injected
+	// into the model's prompt or conversation history.
+	SessionName   *string `protobuf:"bytes,24,opt,name=session_name,json=sessionName,proto3,oneof" json:"session_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RunConfig) Reset() {
@@ -678,6 +683,13 @@ func (x *RunConfig) GetLogLevel() string {
 func (x *RunConfig) GetSystemPromptOverride() string {
 	if x != nil {
 		return x.SystemPromptOverride
+	}
+	return ""
+}
+
+func (x *RunConfig) GetSessionName() string {
+	if x != nil && x.SessionName != nil {
+		return *x.SessionName
 	}
 	return ""
 }
@@ -1817,8 +1829,16 @@ func (x *VerifierConfig) GetModel() string {
 	return ""
 }
 
-// PermissionPolicyConfig selects the permission gating strategy for
-// side-effecting tools (write_file, run_command, etc.).
+// PermissionPolicyConfig selects the permission gating strategy for tools
+// that mutate the workspace or that otherwise require operator approval.
+//
+// The harness distinguishes two independent tool flags:
+//   - WorkspaceMutating: the tool modifies workspace state (e.g. write_file,
+//     run_command, edit_file). Read-only modes must reject these.
+//   - RequiresApproval:  the tool should be gated by an upstream approval
+//     policy. Set on every WorkspaceMutating tool plus non-mutating tools
+//     whose effects an operator may want to gate (web_fetch makes outbound
+//     network requests; spawn_agent consumes additional model budget).
 //
 // Cross-field constraint: read-only modes ("planning", "review", "research",
 // "toil") must use "deny-side-effects" or "ask-upstream" — never "allow-all".
@@ -1829,12 +1849,16 @@ type PermissionPolicyConfig struct {
 	//
 	//	"allow-all"         — all tool calls are allowed without gating. Only
 	//	                      valid for "execution" mode.
-	//	"deny-side-effects" — read tools are allowed; write tools are denied
-	//	                      automatically.
-	//	"ask-upstream"      — side-effecting tool calls trigger a
-	//	                      permission_request HarnessEvent. The control plane
-	//	                      must respond with a permission_response ControlEvent
-	//	                      within the timeout.
+	//	"deny-side-effects" — denies tools that mutate the workspace. Read
+	//	                      tools and approval-required-but-non-mutating
+	//	                      tools (web_fetch, spawn_agent) are still
+	//	                      allowed; this is what makes "research" mode
+	//	                      able to call web_fetch.
+	//	"ask-upstream"      — approval-required tool calls trigger a
+	//	                      permission_request HarnessEvent. The control
+	//	                      plane must respond with a permission_response
+	//	                      ControlEvent within the timeout. Tools that
+	//	                      do not require approval are auto-allowed.
 	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	// For "ask-upstream": seconds to wait for a permission_response before
 	// auto-denying. 0 means use the harness default (60 seconds).
@@ -2189,7 +2213,7 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\aallowed\x18\x05 \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aallowed\x12\x16\n" +
 	"\x06reason\x18\x06 \x01(\tR\x06reason\"$\n" +
 	"\fOptionalBool\x12\x14\n" +
-	"\x05value\x18\x01 \x01(\bR\x05value\"\xa0\f\n" +
+	"\x05value\x18\x01 \x01(\bR\x05value\"\xd9\f\n" +
 	"\tRunConfig\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\tR\x04mode\x12\x16\n" +
@@ -2214,7 +2238,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\atimeout\x18\x13 \x01(\x05H\x02R\atimeout\x88\x01\x01\x12+\n" +
 	"\x0ffollow_up_grace\x18\x15 \x01(\x05H\x03R\rfollowUpGrace\x88\x01\x01\x12\x1b\n" +
 	"\tlog_level\x18\x16 \x01(\tR\blogLevel\x124\n" +
-	"\x16system_prompt_override\x18\x17 \x01(\tR\x14systemPromptOverride\x1aA\n" +
+	"\x16system_prompt_override\x18\x17 \x01(\tR\x14systemPromptOverride\x12&\n" +
+	"\fsession_name\x18\x18 \x01(\tH\x04R\vsessionName\x88\x01\x01\x1aA\n" +
 	"\x13DynamicContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a`\n" +
@@ -2225,7 +2250,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\x10_max_cost_budgetB\n" +
 	"\n" +
 	"\b_timeoutB\x12\n" +
-	"\x10_follow_up_grace\"\xdc\x01\n" +
+	"\x10_follow_up_graceB\x0f\n" +
+	"\r_session_name\"\xdc\x01\n" +
 	"\bRunTrace\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x14\n" +
 	"\x05turns\x18\x02 \x01(\x05R\x05turns\x12!\n" +

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -21,6 +21,7 @@ import (
 type harnessCLIOptions struct {
 	RunID         string
 	Mode          string
+	SessionName   string
 	Prompt        string
 	ProviderType  string
 	APIKeyRef     string
@@ -91,9 +92,10 @@ func buildHarnessRunConfig(opts harnessCLIOptions) *types.RunConfig {
 	}
 
 	config := &types.RunConfig{
-		RunID:  opts.RunID,
-		Mode:   opts.Mode,
-		Prompt: opts.Prompt,
+		RunID:       opts.RunID,
+		Mode:        opts.Mode,
+		SessionName: opts.SessionName,
+		Prompt:      opts.Prompt,
 		Provider: types.ProviderConfig{
 			Type:      opts.ProviderType,
 			APIKeyRef: opts.APIKeyRef,
@@ -221,6 +223,7 @@ func init() {
 	f.Int("followup-grace", 0, "Seconds to keep gRPC transport open for follow-up requests (0 = disabled; env: STIRRUP_FOLLOWUP_GRACE)")
 	f.String("log-level", "info", "Log level: debug, info, warn, error")
 	f.String("prompt", "", "User prompt (can also be passed as a positional argument)")
+	f.String("name", "", "Human-readable session label (metadata only, not injected into prompt)")
 
 	// Component-selection flags. Escape hatches for callers who don't want
 	// a full --config file but need to switch a single component. These
@@ -244,6 +247,9 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) {
 
 	if changed("mode") {
 		cfg.Mode, _ = f.GetString("mode")
+	}
+	if changed("name") {
+		cfg.SessionName, _ = f.GetString("name")
 	}
 	if changed("prompt") {
 		cfg.Prompt, _ = f.GetString("prompt")
@@ -373,6 +379,7 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	}
 
 	mode, _ := f.GetString("mode")
+	sessionName, _ := f.GetString("name")
 	model, _ := f.GetString("model")
 	providerType, _ := f.GetString("provider")
 	apiKeyRef, _ := f.GetString("api-key-ref")
@@ -403,6 +410,7 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	config := buildHarnessRunConfig(harnessCLIOptions{
 		RunID:            generateRunID(),
 		Mode:             mode,
+		SessionName:      sessionName,
 		Prompt:           prompt,
 		ProviderType:     providerType,
 		APIKeyRef:        apiKeyRef,

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -367,6 +367,7 @@ func newTestHarnessCommand() *cobra.Command {
 	f.Int("followup-grace", 0, "")
 	f.String("log-level", "info", "")
 	f.String("prompt", "", "")
+	f.String("name", "", "")
 	f.String("executor", "local", "")
 	f.String("edit-strategy", "multi", "")
 	f.String("verifier", "none", "")
@@ -546,6 +547,66 @@ func TestApplyOverrides_ExplicitFlagsOverride(t *testing.T) {
 	}
 	if cfg.TraceEmitter.Endpoint != "otel.flag:4317" {
 		t.Errorf("OTel endpoint override failed: %q", cfg.TraceEmitter.Endpoint)
+	}
+}
+
+// TestApplyOverrides_SessionNameExplicit verifies that --name is wired
+// through applyOverrides: when set on the command line, the flag value
+// must overwrite the file's SessionName.
+func TestApplyOverrides_SessionNameExplicit(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	cfg.SessionName = "from-file"
+
+	if err := cmd.Flags().Set("name", "from-flag"); err != nil {
+		t.Fatalf("set name: %v", err)
+	}
+	applyOverrides(cmd, cfg, nil)
+
+	if cfg.SessionName != "from-flag" {
+		t.Errorf("explicit --name should win, got %q", cfg.SessionName)
+	}
+}
+
+// TestApplyOverrides_SessionNameFilePreserved guards the precedence rule
+// for --name: when the user does NOT pass the flag, a SessionName loaded
+// from --config must survive applyOverrides intact. This is the central
+// "default flag does not clobber file value" invariant for the new flag.
+func TestApplyOverrides_SessionNameFilePreserved(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	cfg.SessionName = "from-file"
+
+	applyOverrides(cmd, cfg, nil)
+
+	if cfg.SessionName != "from-file" {
+		t.Errorf("SessionName from file should survive, got %q", cfg.SessionName)
+	}
+}
+
+// TestBuildHarnessRunConfig_SessionNamePropagates verifies the flag-only
+// build path: a SessionName provided in harnessCLIOptions must end up on
+// the constructed RunConfig.
+func TestBuildHarnessRunConfig_SessionNamePropagates(t *testing.T) {
+	cfg := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "execution",
+		SessionName:   "nightly-eval",
+		Prompt:        "test",
+		ProviderType:  "anthropic",
+		APIKeyRef:     "secret://ANTHROPIC_API_KEY",
+		Model:         "claude-sonnet-4-6",
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+
+	if cfg.SessionName != "nightly-eval" {
+		t.Errorf("SessionName: got %q, want %q", cfg.SessionName, "nightly-eval")
+	}
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		t.Fatalf("ValidateRunConfig: %v", err)
 	}
 }
 

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -110,6 +110,14 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	// Build logger early so MCP connection warnings go through the ScrubHandler.
 	logLevel := parseLogLevel(config.LogLevel)
 	logger := observability.NewLoggerWithSecurity(config.RunID, logLevel, os.Stderr, secLogger)
+	if config.SessionName != "" {
+		// Attach SessionName as a default log attribute so every line
+		// emitted from this loop (and any sub-loop sharing this logger)
+		// carries the operator-supplied label. Reassigned, not shadowed,
+		// so the value propagates into AgenticLoop.Logger below — a local
+		// copy would be discarded.
+		logger = logger.With("sessionName", config.SessionName)
+	}
 
 	// 6b. MCP tool discovery — connect to remote MCP servers and register
 	// their tools into the registry alongside the built-in tools.

--- a/harness/internal/observability/logger_test.go
+++ b/harness/internal/observability/logger_test.go
@@ -43,6 +43,32 @@ func (s *spyNotifier) snapshot() []notifierCall {
 // alphanumeric characters; ScrubWithStats must redact it.
 const anthropicKeyFixture = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
+// TestLogger_WithSessionNameAttribute verifies that a logger built via
+// NewLoggerWithSecurity preserves caller-attached default attributes
+// (e.g. sessionName) on every record. This is the property the harness
+// factory relies on when it does logger = logger.With("sessionName", ...).
+// If a future change makes the returned logger not chain .With() correctly,
+// this test will catch it before sessionName silently disappears from
+// production logs.
+func TestLogger_WithSessionNameAttribute(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger("test-run", slog.LevelInfo, &buf)
+	logger = logger.With("sessionName", "nightly-eval")
+
+	logger.Info("hello")
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("unmarshal log record: %v\n%s", err, buf.String())
+	}
+	if got, ok := record["sessionName"].(string); !ok || got != "nightly-eval" {
+		t.Errorf("sessionName attribute missing or wrong: %v", record)
+	}
+	if got, ok := record["runId"].(string); !ok || got != "test-run" {
+		t.Errorf("runId attribute missing or wrong: %v", record)
+	}
+}
+
 func TestScrubHandler_RedactsAnthropicKey(t *testing.T) {
 	var buf bytes.Buffer
 	logger := NewLogger("test-run", slog.LevelInfo, &buf)

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -89,6 +89,47 @@ func TestJSONLTraceEmitter_FullLifecycle(t *testing.T) {
 	}
 }
 
+// TestJSONLTraceEmitter_SessionNameRoundTrip pins that a SessionName set
+// on the RunConfig flows into the JSONL trace and survives a JSON round
+// trip. The eval lakehouse and replay tooling rely on this — without it,
+// a run labelled --name "nightly-eval" would not be filterable by label
+// in downstream analysis. (Construction-style test rather than booting
+// the full agentic loop, which would require a provider, executor, etc.;
+// the round-trip is the load-bearing property.)
+func TestJSONLTraceEmitter_SessionNameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+
+	timeout := 60
+	config := &types.RunConfig{
+		RunID:       "run-session",
+		Mode:        "execution",
+		SessionName: "nightly-eval",
+		MaxTurns:    5,
+		Timeout:     &timeout,
+		Provider:    types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://X"},
+	}
+	emitter.Start("run-session", config)
+	tr, err := emitter.Finish(context.Background(), "success")
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Trace returned in memory should carry SessionName.
+	if tr.Config.SessionName != "nightly-eval" {
+		t.Errorf("returned trace SessionName: got %q, want nightly-eval", tr.Config.SessionName)
+	}
+
+	// And the persisted JSONL line must round-trip the field.
+	var written types.RunTrace
+	if err := json.Unmarshal(buf.Bytes(), &written); err != nil {
+		t.Fatalf("unmarshal JSONL: %v\n%s", err, buf.String())
+	}
+	if written.Config.SessionName != "nightly-eval" {
+		t.Errorf("written SessionName: got %q, want nightly-eval", written.Config.SessionName)
+	}
+}
+
 func TestJSONLTraceEmitter_EmptyRun(t *testing.T) {
 	var buf bytes.Buffer
 	emitter := NewJSONLTraceEmitter(&buf)

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -100,6 +100,12 @@ func (e *OTelTraceEmitter) Start(runID string, config *types.RunConfig) {
 		if config.ModelRouter.Model != "" {
 			span.SetAttributes(attribute.String("run.model", config.ModelRouter.Model))
 		}
+		if config.SessionName != "" {
+			// Set on the root span so child spans inherit access via context.
+			// Skipped when empty so we don't pollute traces with empty
+			// attributes for runs that did not specify a label.
+			span.SetAttributes(attribute.String("run.session_name", config.SessionName))
+		}
 	}
 
 	e.rootSpan = span

--- a/harness/internal/trace/otel_test.go
+++ b/harness/internal/trace/otel_test.go
@@ -198,6 +198,65 @@ func TestOTelTraceEmitter_ToolCallAttributes(t *testing.T) {
 	assertAttribute(t, toolSpan, "tool.name", "shell")
 }
 
+// TestOTelTraceEmitter_SessionNameAttribute verifies that SessionName, when
+// set on the RunConfig, appears as run.session_name on the root span.
+// Child spans inherit access to it via context, so setting it on the root
+// is sufficient.
+func TestOTelTraceEmitter_SessionNameAttribute(t *testing.T) {
+	emitter, exporter := newTestOTelEmitter()
+
+	timeout := 60
+	config := &types.RunConfig{
+		RunID:       "run-session-1",
+		Mode:        "execution",
+		SessionName: "nightly-eval",
+		MaxTurns:    5,
+		Timeout:     &timeout,
+		Provider:    types.ProviderConfig{Type: "anthropic"},
+	}
+	emitter.Start("run-session-1", config)
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	assertAttribute(t, spans[0], "run.session_name", "nightly-eval")
+}
+
+// TestOTelTraceEmitter_SessionNameAbsentWhenEmpty pins the inverse: when
+// no session name is set, the run.session_name attribute must not appear
+// on the root span. Empty attributes pollute downstream filtering and
+// would cost real money on usage-billed backends.
+func TestOTelTraceEmitter_SessionNameAbsentWhenEmpty(t *testing.T) {
+	emitter, exporter := newTestOTelEmitter()
+
+	timeout := 60
+	config := &types.RunConfig{
+		RunID:    "run-no-session",
+		Mode:     "execution",
+		MaxTurns: 5,
+		Timeout:  &timeout,
+		Provider: types.ProviderConfig{Type: "anthropic"},
+	}
+	emitter.Start("run-no-session", config)
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	for _, attr := range spans[0].Attributes {
+		if string(attr.Key) == "run.session_name" {
+			t.Errorf("run.session_name should be absent when SessionName is empty, found value %q", attr.Value.AsString())
+		}
+	}
+}
+
 // assertAttribute checks that a span has the expected string attribute value.
 func assertAttribute(t *testing.T, span tracetest.SpanStub, key, want string) {
 	t.Helper()

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -152,6 +152,7 @@ func runConfigFromProto(pc *pb.RunConfig) types.RunConfig {
 
 	rc.LogLevel = pc.LogLevel
 	rc.SystemPromptOverride = pc.SystemPromptOverride
+	rc.SessionName = pc.GetSessionName()
 
 	return rc
 }

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -1,0 +1,38 @@
+package transport
+
+import (
+	"testing"
+
+	pb "github.com/rxbynerd/stirrup/gen/harness/v1"
+)
+
+// TestRunConfigFromProto_SessionNamePropagates ensures that a SessionName set
+// on the proto RunConfig (the wire format used by the gRPC / K8s job path) is
+// copied into the internal types.RunConfig. Without this, every job dispatched
+// via the control plane would silently lose its session label.
+func TestRunConfigFromProto_SessionNamePropagates(t *testing.T) {
+	name := "nightly-eval"
+	pc := &pb.RunConfig{
+		SessionName: &name,
+	}
+
+	rc := runConfigFromProto(pc)
+
+	if rc.SessionName != "nightly-eval" {
+		t.Fatalf("SessionName not propagated: got %q, want %q", rc.SessionName, "nightly-eval")
+	}
+}
+
+// TestRunConfigFromProto_SessionNameAbsentWhenNil documents the safe default:
+// when the proto omits SessionName (the field is a proto3 optional, so the
+// zero value is a nil pointer), the internal RunConfig must surface the empty
+// string rather than panicking on a nil dereference.
+func TestRunConfigFromProto_SessionNameAbsentWhenNil(t *testing.T) {
+	pc := &pb.RunConfig{}
+
+	rc := runConfigFromProto(pc)
+
+	if rc.SessionName != "" {
+		t.Fatalf("SessionName should be empty when proto field is nil, got %q", rc.SessionName)
+	}
+}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -299,6 +299,12 @@ message RunConfig {
   // bypassing prompt_builder mode selection. Workspace path, turn budget,
   // and dynamic_context sections are still appended by the harness.
   string system_prompt_override = 23;
+
+  // Optional. Human-readable label attached to the run for reporting.
+  // Surfaces in structured logs (sessionName), JSONL traces (config.sessionName),
+  // and OTel root spans (run.session_name). Metadata only — never injected
+  // into the model's prompt or conversation history.
+  optional string session_name = 24;
 }
 
 // RunTrace is included with "done" HarnessEvents. It provides execution

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -3,6 +3,8 @@ package types
 import (
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -18,6 +20,11 @@ const (
 
 	// maxTokenBudget is the maximum allowed token budget.
 	maxTokenBudget = 50_000_000
+
+	// maxSessionNameLength is the maximum allowed length, in bytes, of
+	// SessionName. Capped to keep log lines, OTel attribute values, and
+	// trace JSON predictable; well above any genuine human-readable label.
+	maxSessionNameLength = 255
 )
 
 // RunConfig fully describes a single harness run. It is the composition root:
@@ -25,8 +32,9 @@ const (
 // the CLI builds it from flags/env.
 type RunConfig struct {
 	// Identity
-	RunID string `json:"runId"`
-	Mode  string `json:"mode"` // "execution" | "planning" | "review" | "research" | "toil"
+	RunID       string `json:"runId"`
+	Mode        string `json:"mode"`                  // "execution" | "planning" | "review" | "research" | "toil"
+	SessionName string `json:"sessionName,omitempty"` // human-readable label; never injected into the model's context
 
 	// What to do
 	Prompt         string            `json:"prompt"`
@@ -393,6 +401,7 @@ type ModePreset struct {
 func ValidateRunConfig(config *RunConfig) error {
 	var errs []string
 
+	validateSessionName(config.SessionName, &errs)
 	validateRequiredType("provider", config.Provider.Type, validProviderTypes, &errs)
 	validateOptionalType("modelRouter", config.ModelRouter.Type, validModelRouterTypes, &errs)
 	validateOptionalType("promptBuilder", config.PromptBuilder.Type, validPromptBuilderTypes, &errs)
@@ -522,6 +531,33 @@ func validateProviderConfigs(config *RunConfig, errs *[]string) {
 	for mode, spec := range config.ModelRouter.ModeModels {
 		if providerName, _, ok := strings.Cut(spec, "/"); ok {
 			checkProviderRef(fmt.Sprintf("modelRouter.modeModels[%s]", mode), providerName)
+		}
+	}
+}
+
+// validateSessionName enforces the SessionName invariants: bounded length and
+// printable, non-control characters only. Empty is valid (means unset). The
+// goal is to keep the value safe to drop into a log line, an OTel attribute,
+// or a trace JSON record without truncation, escaping, or line corruption.
+func validateSessionName(name string, errs *[]string) {
+	if name == "" {
+		return
+	}
+	if len(name) > maxSessionNameLength {
+		*errs = append(*errs, fmt.Sprintf("sessionName must be <= %d bytes, got %d", maxSessionNameLength, len(name)))
+		return
+	}
+	if !utf8.ValidString(name) {
+		*errs = append(*errs, "sessionName must be valid UTF-8")
+		return
+	}
+	for i, r := range name {
+		// Reject every non-printable rune, including line terminators,
+		// tabs, NUL, and DEL. unicode.IsPrint returns false for control
+		// characters and for the Unicode separators we don't want either.
+		if !unicode.IsPrint(r) {
+			*errs = append(*errs, fmt.Sprintf("sessionName contains non-printable character at byte %d (U+%04X)", i, r))
+			return
 		}
 	}
 }

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -442,6 +442,84 @@ func TestValidateRunConfig_NilBudgetsPass(t *testing.T) {
 	}
 }
 
+func TestValidateRunConfig_SessionNameEmpty(t *testing.T) {
+	c := validConfig()
+	c.SessionName = ""
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("empty SessionName should pass validation, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_SessionNameValid(t *testing.T) {
+	cases := []string{
+		"nightly-eval",
+		"PR #123 sweep",
+		"café-run",            // unicode letter with diacritic
+		"文字列-test",            // CJK characters are printable
+		"emoji-ok-\xe2\x9c\x85", // U+2705 white heavy check mark (valid printable symbol)
+		strings.Repeat("a", 255),
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := validConfig()
+			c.SessionName = name
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("SessionName %q should pass validation, got: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_SessionNameTooLong(t *testing.T) {
+	c := validConfig()
+	c.SessionName = strings.Repeat("a", 256)
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for SessionName > 255 bytes")
+	}
+	if !strings.Contains(err.Error(), "sessionName") || !strings.Contains(err.Error(), "255") {
+		t.Errorf("error should describe the limit, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_SessionNameRejectsControlChars(t *testing.T) {
+	cases := map[string]string{
+		"newline":  "bad\nname",
+		"tab":      "bad\tname",
+		"nul":      "bad\x00name",
+		"del":      "bad\x7fname",
+		"carriage": "bad\rname",
+		"vtab":     "bad\vname",
+		"escape":   "bad\x1bname",
+	}
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := validConfig()
+			c.SessionName = value
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("expected error for SessionName containing %s", name)
+			}
+			if !strings.Contains(err.Error(), "sessionName") {
+				t.Errorf("error should mention sessionName, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_SessionNameRejectsInvalidUTF8(t *testing.T) {
+	c := validConfig()
+	// 0xff is never valid as a leading UTF-8 byte.
+	c.SessionName = "bad\xffname"
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8 in SessionName")
+	}
+	if !strings.Contains(err.Error(), "sessionName") {
+		t.Errorf("error should mention sessionName, got: %v", err)
+	}
+}
+
 func TestValidateRunConfig_OpenAIResponsesProvider(t *testing.T) {
 	// The new openai-responses provider type must be accepted by validation.
 	// Before this case existed, callers who configured a Responses adapter

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -81,6 +81,22 @@ func TestRedact_MCPServersAPIKeys(t *testing.T) {
 	}
 }
 
+// TestRedact_SessionNamePreserved pins that SessionName survives Redact().
+// SessionName is not a secret — it's the operator's chosen label and it
+// must appear in persisted traces so logs and traces can be cross-
+// referenced. If Redact() ever starts stripping SessionName, downstream
+// trace consumers (eval lakehouse, JSONL replay) lose the link.
+func TestRedact_SessionNamePreserved(t *testing.T) {
+	rc := RunConfig{
+		SessionName: "nightly-eval",
+		Provider:    ProviderConfig{APIKeyRef: "secret://k"},
+	}
+	redacted := rc.Redact()
+	if redacted.SessionName != "nightly-eval" {
+		t.Errorf("SessionName should be preserved, got %q", redacted.SessionName)
+	}
+}
+
 func TestRedact_EmptyConfig(t *testing.T) {
 	rc := RunConfig{}
 	redacted := rc.Redact()
@@ -454,8 +470,8 @@ func TestValidateRunConfig_SessionNameValid(t *testing.T) {
 	cases := []string{
 		"nightly-eval",
 		"PR #123 sweep",
-		"café-run",            // unicode letter with diacritic
-		"文字列-test",            // CJK characters are printable
+		"café-run",              // unicode letter with diacritic
+		"文字列-test",              // CJK characters are printable
 		"emoji-ok-\xe2\x9c\x85", // U+2705 white heavy check mark (valid printable symbol)
 		strings.Repeat("a", 255),
 	}


### PR DESCRIPTION
## Summary

Closes #50.

Adds `--name <label>` to `stirrup harness` so operators can attach a human-readable identifier to a run. The label is metadata only — it is **not** injected into the model's context. It flows through three telemetry channels for downstream cost/usage reporting:

- **Structured logs**: `sessionName` slog attribute on every line of a run
- **OpenTelemetry**: `run.session_name` attribute on the root run span (inherited by all child spans)
- **JSONL traces**: serialised automatically via the embedded `RunConfig`

## Changes

| Layer | Change |
|---|---|
| Proto | `RunConfig.session_name = 24` (optional) |
| Generated proto | `gen/harness/v1/harness.pb.go` regenerated via `buf generate` |
| Types | `RunConfig.SessionName string` with `json:"sessionName,omitempty"` |
| Validation | `validateSessionName`: ≤255 bytes, valid UTF-8, only `unicode.IsPrint` runes; rejects newline/tab/NUL/DEL, bidi overrides, zero-width chars; descriptive error |
| CLI | `--name` flag on `stirrup harness`; `applyOverrides` only writes when explicitly set, preserving `--config` file values |
| Logger | `factory.BuildLoopWithTransport` attaches `sessionName` after `runId` when non-empty |
| OTel | `run.session_name` attribute set on the root span inside `Start()` when non-empty |
| gRPC translate | `runConfigFromProto` now propagates `SessionName` (was silently dropped on the K8s job path — caught in review) |
| JSONL | No code change required; field flows via `RunConfig` embedding |

## Commits

1. `8bfd94a` proto: add optional session_name field to RunConfig
2. `1b357e0` types: add SessionName field with validation
3. `268a4f7` cmd: add --name flag to stirrup harness
4. `71f7699` core, observability: attach SessionName to structured logger
5. `681ec08` trace: surface SessionName on OTel root span and verify JSONL persistence
6. `2b2e218` transport: propagate SessionName through gRPC RunConfig translation *(remediation; see Review notes)*

## Review notes

This branch went through a five-reviewer cycle (code, security, spec-compliance, test-coverage, api-design) followed by synthesis and a remediation pass. Highlights:

- **Blocking — fixed**: `runConfigFromProto` originally did not call `pc.GetSessionName()`, so every K8s job dispatched via the gRPC control plane silently lost the label. The issue assumed the field would "propagate automatically once it is in the proto" but the translate function maps every field by hand. Fixed in `2b2e218` with two new unit tests in `grpc_translate_test.go`.
- **Security — clean**: `slog.NewJSONHandler` and `attribute.String` both encode strings safely. Bidi overrides, ZWJ, ZWNJ, BOM, and zero-width characters all return `IsPrint=false` and are rejected by validation. `RunConfig.Redact()` correctly preserves `SessionName` (operator-chosen, not a secret) — pinned by `TestRedact_SessionNamePreserved`. `SessionName` does not appear in any prompt/context path (verified by grep).
- **Spec — compliant** in every functional respect. The spec requested a "logger wiring" test "via factory.BuildLoop"; the implementation tests it via the `observability` package directly. Functional coverage is equivalent; a factory-level test is deferred.
- **Tests — 14 new tests passing**:
  - `types/runconfig_test.go` (validation: empty / valid printables incl. unicode / 255-byte boundary / 256-byte rejection / 7 control-char cases / invalid UTF-8 / `Redact()` preservation)
  - `harness/cmd/stirrup/cmd/harness_test.go` (CLI: explicit override, file value preserved when flag omitted, end-to-end propagation)
  - `harness/internal/observability/logger_test.go` (slog attribute attachment)
  - `harness/internal/trace/otel_test.go` (presence + absence on root span)
  - `harness/internal/trace/jsonl_test.go` (round-trip through `JSONLTraceEmitter.Finish` — substituted for the integration test per spec allowance)
  - `harness/internal/transport/grpc_translate_test.go` (propagation + nil pointer safety)
- **API design — one deferred recommendation**: rename `--name` → `--session-name` to match the kebab-case multi-word convention used by every other flag in `harness.go` (`--api-key-ref`, `--max-turns`, etc.) and to avoid a future collision with a possible `stirrup eval --name`. The issue spec explicitly chose `--name`; the rename is left to the issue author's discretion before merge.

Other deferred non-blocking items: factory-level logger wiring test, validation-ordering tidy in `validateSessionName`, proto cross-reference comment distinguishing `RunConfig.session_name` from `CredentialConfig.session_name`, optional doc note that `--name ""` clears a file-level label, optional addition to `examples/runconfig/full.json`.

## Non-goals (preserved)

- `SessionName` is **not** injected into the model's prompt or `DynamicContext`.
- No uniqueness constraint — `runId` remains the unique identifier.
- No new UI or API surface beyond the CLI flag and the proto field.

## Test plan

- [x] `just test` — all suites pass (no new failures; 14 new tests added)
- [x] `just build` — both binaries build clean
- [x] `just lint` — 0 issues
- [x] `buf generate` — generated proto committed; no hand edits
- [ ] Manual smoke: `./stirrup harness --name "my-session" --prompt "hi"` and confirm `sessionName=my-session` appears in stderr slog output and in the JSONL trace under `config.sessionName`
- [ ] Decide whether to rename `--name` → `--session-name` before merge (see Review notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)