### PR TITLE
feat: async tool dispatch over the transport

### DIFF
--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -48,6 +48,18 @@ const (
 //	  - input:      JSON-encoded tool input (so the control plane can display
 //	                what the tool wants to do).
 //
+//	"tool_result_request"
+//	  - request_id: unique ID for this request; the control plane must echo it
+//	                back in the corresponding tool_result_response ControlEvent.
+//	  - tool_use_id: the tool-use ID assigned by the model for this call (so
+//	                 the control plane can correlate to the original tool_call).
+//	  - tool_name:   the async tool whose result is being requested.
+//	  - input:       JSON-encoded tool input (so the control plane can decide
+//	                 what to do).
+//	  Emitted by the agentic loop when an async tool defers its result to the
+//	  control plane. The harness blocks on the matching tool_result_response
+//	  under ctx cancellation and a per-call timeout.
+//
 //	"done"
 //	  - stop_reason: why the run ended ("end_turn", "max_turns", "timeout",
 //	                 "stalled", "tool_failures", "cancelled", "budget_exceeded").
@@ -68,7 +80,8 @@ type HarnessEvent struct {
 	// Required. The event type discriminator.
 	// Valid values: "text_delta", "tool_call", "tool_result", "done", "error",
 	//
-	//	"warning", "heartbeat", "ready", "permission_request".
+	//	"warning", "heartbeat", "ready", "permission_request",
+	//	"tool_result_request".
 	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	// Incremental text fragment from the model. Set on "text_delta" events.
 	Text string `protobuf:"bytes,2,opt,name=text,proto3" json:"text,omitempty"`
@@ -76,10 +89,11 @@ type HarnessEvent struct {
 	Id string `protobuf:"bytes,3,opt,name=id,proto3" json:"id,omitempty"`
 	// Tool name. Set on "tool_call" events.
 	Name string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
-	// JSON-encoded tool input parameters. Set on "tool_call" and
-	// "permission_request" events.
+	// JSON-encoded tool input parameters. Set on "tool_call",
+	// "permission_request", and "tool_result_request" events.
 	Input []byte `protobuf:"bytes,5,opt,name=input,proto3" json:"input,omitempty"`
-	// The tool-use ID this result corresponds to. Set on "tool_result" events.
+	// The tool-use ID this result corresponds to. Set on "tool_result" and
+	// "tool_result_request" events.
 	ToolUseId string `protobuf:"bytes,6,opt,name=tool_use_id,json=toolUseId,proto3" json:"tool_use_id,omitempty"`
 	// Tool execution result. Set on "tool_result" events.
 	Content string `protobuf:"bytes,7,opt,name=content,proto3" json:"content,omitempty"`
@@ -92,11 +106,12 @@ type HarnessEvent struct {
 	Message string `protobuf:"bytes,9,opt,name=message,proto3" json:"message,omitempty"`
 	// Execution metrics. Set on "done" events.
 	Trace *RunTrace `protobuf:"bytes,10,opt,name=trace,proto3" json:"trace,omitempty"`
-	// Unique request ID for permission correlation. Set on "permission_request"
-	// events. The control plane must echo this back in the permission_response
-	// ControlEvent's request_id field.
+	// Unique request ID for correlation. Set on "permission_request" and
+	// "tool_result_request" events. The control plane must echo this back in
+	// the corresponding permission_response / tool_result_response ControlEvent.
 	RequestId string `protobuf:"bytes,11,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	// The tool requesting permission. Set on "permission_request" events.
+	// The tool name. Set on "permission_request" (tool requesting permission)
+	// and "tool_result_request" (async tool whose result is being requested).
 	ToolName string `protobuf:"bytes,12,opt,name=tool_name,json=toolName,proto3" json:"tool_name,omitempty"`
 	// Build version of the harness binary. Set on "ready" events. The control
 	// plane may use this to verify compatibility before sending a task.
@@ -247,6 +262,16 @@ func (x *HarnessEvent) GetHarnessVersion() string {
 //	  - reason:     optional human-readable explanation for denial; passed
 //	                back to the model as context.
 //
+//	"tool_result_response"
+//	  - request_id: must match the request_id from the corresponding
+//	                tool_result_request HarnessEvent.
+//	  - content:    string result payload to deliver back to the agentic
+//	                loop as the async tool's output.
+//	  - is_error:   when true, the loop treats the result as an error
+//	                (IsError=true on the ToolResult passed to the model).
+//	                Use this for upstream-side failures the model should
+//	                see as a tool error rather than a successful result.
+//
 //	"cancel"
 //	  - (no additional fields) Signals that the run should be aborted. The
 //	    harness terminates the run within one turn boundary: any in-flight
@@ -260,23 +285,30 @@ type ControlEvent struct {
 	// Required. The event type discriminator.
 	// Valid values: "task_assignment", "user_response", "cancel",
 	//
-	//	"permission_response".
+	//	"permission_response", "tool_result_response".
 	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	// The run configuration. Set on "task_assignment" events only. This is the
 	// composition root that drives all harness behaviour for the run.
 	Task *RunConfig `protobuf:"bytes,2,opt,name=task,proto3" json:"task,omitempty"`
 	// Free-text user response. Set on "user_response" events.
 	UserResponse string `protobuf:"bytes,3,opt,name=user_response,json=userResponse,proto3" json:"user_response,omitempty"`
-	// Correlates a permission_response with the originating permission_request.
-	// Set on "permission_response" events. Must match a previously received
-	// HarnessEvent.request_id.
+	// Correlates the response with the originating request HarnessEvent.
+	// Set on "permission_response" and "tool_result_response" events. Must
+	// match a previously received HarnessEvent.request_id.
 	RequestId string `protobuf:"bytes,4,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
 	// The permission decision. Set on "permission_response" events.
 	// True = allow the tool call to proceed. False = deny.
 	Allowed *OptionalBool `protobuf:"bytes,5,opt,name=allowed,proto3" json:"allowed,omitempty"`
 	// Human-readable explanation for a denial. Set on "permission_response"
 	// events when allowed is false. Passed to the model as context.
-	Reason        string `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`
+	Reason string `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`
+	// Async tool result payload. Set on "tool_result_response" events. Delivered
+	// to the agentic loop verbatim as the async tool's output content.
+	Content string `protobuf:"bytes,7,opt,name=content,proto3" json:"content,omitempty"`
+	// When true on a "tool_result_response", the loop marks the resulting
+	// ToolResult as an error so the model sees it as a tool failure. Wrapped
+	// to distinguish unset from explicit-false (proto3 scalar default).
+	IsError       *OptionalBool `protobuf:"bytes,8,opt,name=is_error,json=isError,proto3" json:"is_error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -351,6 +383,20 @@ func (x *ControlEvent) GetReason() string {
 		return x.Reason
 	}
 	return ""
+}
+
+func (x *ControlEvent) GetContent() string {
+	if x != nil {
+		return x.Content
+	}
+	return ""
+}
+
+func (x *ControlEvent) GetIsError() *OptionalBool {
+	if x != nil {
+		return x.IsError
+	}
+	return nil
 }
 
 // OptionalBool wraps a boolean so we can distinguish "not set" from "false"
@@ -2445,7 +2491,7 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\n" +
 	"request_id\x18\v \x01(\tR\trequestId\x12\x1b\n" +
 	"\ttool_name\x18\f \x01(\tR\btoolName\x12'\n" +
-	"\x0fharness_version\x18\r \x01(\tR\x0eharnessVersion\"\xed\x01\n" +
+	"\x0fharness_version\x18\r \x01(\tR\x0eharnessVersion\"\xc4\x02\n" +
 	"\fControlEvent\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x121\n" +
 	"\x04task\x18\x02 \x01(\v2\x1d.stirrup.harness.v1.RunConfigR\x04task\x12#\n" +
@@ -2453,7 +2499,9 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\n" +
 	"request_id\x18\x04 \x01(\tR\trequestId\x12:\n" +
 	"\aallowed\x18\x05 \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aallowed\x12\x16\n" +
-	"\x06reason\x18\x06 \x01(\tR\x06reason\"$\n" +
+	"\x06reason\x18\x06 \x01(\tR\x06reason\x12\x18\n" +
+	"\acontent\x18\a \x01(\tR\acontent\x12;\n" +
+	"\bis_error\x18\b \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aisError\"$\n" +
 	"\fOptionalBool\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\bR\x05value\"\xe8\r\n" +
 	"\tRunConfig\x12\x15\n" +
@@ -2670,38 +2718,39 @@ var file_harness_v1_harness_proto_depIdxs = []int32{
 	6,  // 0: stirrup.harness.v1.HarnessEvent.trace:type_name -> stirrup.harness.v1.RunTrace
 	3,  // 1: stirrup.harness.v1.ControlEvent.task:type_name -> stirrup.harness.v1.RunConfig
 	2,  // 2: stirrup.harness.v1.ControlEvent.allowed:type_name -> stirrup.harness.v1.OptionalBool
-	24, // 3: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
-	7,  // 4: stirrup.harness.v1.RunConfig.provider:type_name -> stirrup.harness.v1.ProviderConfig
-	25, // 5: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
-	10, // 6: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
-	11, // 7: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
-	12, // 8: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
-	13, // 9: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
-	17, // 10: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
-	18, // 11: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
-	19, // 12: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
-	20, // 13: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
-	21, // 14: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
-	22, // 15: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
-	4,  // 16: stirrup.harness.v1.RunConfig.rule_of_two:type_name -> stirrup.harness.v1.RuleOfTwoConfig
-	5,  // 17: stirrup.harness.v1.RunConfig.code_scanner:type_name -> stirrup.harness.v1.CodeScannerConfig
-	8,  // 18: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
-	26, // 19: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
-	9,  // 20: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
-	27, // 21: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
-	14, // 22: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
-	15, // 23: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
-	16, // 24: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
-	18, // 25: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
-	23, // 26: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
-	7,  // 27: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
-	0,  // 28: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
-	1,  // 29: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
-	29, // [29:30] is the sub-list for method output_type
-	28, // [28:29] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	2,  // 3: stirrup.harness.v1.ControlEvent.is_error:type_name -> stirrup.harness.v1.OptionalBool
+	24, // 4: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
+	7,  // 5: stirrup.harness.v1.RunConfig.provider:type_name -> stirrup.harness.v1.ProviderConfig
+	25, // 6: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
+	10, // 7: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
+	11, // 8: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
+	12, // 9: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
+	13, // 10: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
+	17, // 11: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
+	18, // 12: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
+	19, // 13: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
+	20, // 14: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
+	21, // 15: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
+	22, // 16: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
+	4,  // 17: stirrup.harness.v1.RunConfig.rule_of_two:type_name -> stirrup.harness.v1.RuleOfTwoConfig
+	5,  // 18: stirrup.harness.v1.RunConfig.code_scanner:type_name -> stirrup.harness.v1.CodeScannerConfig
+	8,  // 19: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
+	26, // 20: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
+	9,  // 21: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
+	27, // 22: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
+	14, // 23: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
+	15, // 24: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
+	16, // 25: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
+	18, // 26: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
+	23, // 27: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
+	7,  // 28: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
+	0,  // 29: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
+	1,  // 30: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
+	30, // [30:31] is the sub-list for method output_type
+	29, // [29:30] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_harness_v1_harness_proto_init() }

--- a/harness/internal/core/loop_async_test.go
+++ b/harness/internal/core/loop_async_test.go
@@ -190,8 +190,8 @@ func TestAsyncDispatch_HappyPath(t *testing.T) {
 	}
 
 	// Pending entry must be cleaned up after resolution.
-	if loop.asyncCorrelator.PendingCount() != 0 {
-		t.Fatalf("expected 0 pending awaits, got %d", loop.asyncCorrelator.PendingCount())
+	if loop.asyncCorrelatorForTest().PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits, got %d", loop.asyncCorrelatorForTest().PendingCount())
 	}
 }
 
@@ -264,8 +264,8 @@ func TestAsyncDispatch_Timeout(t *testing.T) {
 		t.Fatalf("returned too slowly (%s); per-call timeout override was ignored", elapsed)
 	}
 	// Cleanup: pending entry must be removed.
-	if loop.asyncCorrelator.PendingCount() != 0 {
-		t.Fatalf("expected 0 pending awaits after timeout, got %d", loop.asyncCorrelator.PendingCount())
+	if loop.asyncCorrelatorForTest().PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits after timeout, got %d", loop.asyncCorrelatorForTest().PendingCount())
 	}
 }
 
@@ -301,8 +301,8 @@ func TestAsyncDispatch_CtxCancellation(t *testing.T) {
 	if !strings.Contains(output, "cancelled") {
 		t.Fatalf("expected output to mention 'cancelled', got %q", output)
 	}
-	if loop.asyncCorrelator.PendingCount() != 0 {
-		t.Fatalf("expected 0 pending awaits after ctx cancel, got %d", loop.asyncCorrelator.PendingCount())
+	if loop.asyncCorrelatorForTest().PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits after ctx cancel, got %d", loop.asyncCorrelatorForTest().PendingCount())
 	}
 }
 
@@ -325,8 +325,8 @@ func TestAsyncDispatch_TransportEmitFailure(t *testing.T) {
 		t.Fatalf("expected output to contain 'transport_disconnect', got %q", output)
 	}
 	// Correlator must clean up the pending entry on emit failure.
-	if loop.asyncCorrelator.PendingCount() != 0 {
-		t.Fatalf("expected 0 pending awaits after emit failure, got %d", loop.asyncCorrelator.PendingCount())
+	if loop.asyncCorrelatorForTest().PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits after emit failure, got %d", loop.asyncCorrelatorForTest().PendingCount())
 	}
 }
 
@@ -360,17 +360,32 @@ func TestAsyncDispatch_OutOfOrderResolution(t *testing.T) {
 		r2 <- res{out, ok}
 	}()
 
-	// Wait until both pending awaits are registered (PendingCount == 2)
-	// and both request events have been emitted.
+	// Wait until both pending awaits are registered. We poll the count of
+	// emitted tool_result_request events as a proxy: each in-flight async
+	// dispatch emits exactly one such event before blocking on the
+	// correlator. Reading loop.asyncCorrelator directly from this
+	// goroutine would race with the dispatch goroutines writing it under
+	// sync.Once; the correlator's own state is fine to inspect via
+	// PendingCount() once construction is established.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if loop.asyncCorrelator != nil && loop.asyncCorrelator.PendingCount() == 2 {
+		count := 0
+		for _, e := range tr.Events() {
+			if e.Type == "tool_result_request" {
+				count++
+			}
+		}
+		if count == 2 {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
-	if loop.asyncCorrelator == nil || loop.asyncCorrelator.PendingCount() != 2 {
-		t.Fatalf("expected 2 pending awaits, got %d", loop.asyncCorrelator.PendingCount())
+	correlator := loop.ensureAsyncCorrelator()
+	if correlator == nil {
+		t.Fatalf("expected async correlator to be constructed by now")
+	}
+	if got := correlator.PendingCount(); got != 2 {
+		t.Fatalf("expected 2 pending awaits, got %d", got)
 	}
 
 	// Pull request IDs out of the emitted events. Map them to the tool
@@ -407,9 +422,9 @@ func TestAsyncDispatch_OutOfOrderResolution(t *testing.T) {
 	if !res2.success || res2.output != "result-for-tc2" {
 		t.Fatalf("call2 wrong: success=%v output=%q", res2.success, res2.output)
 	}
-	if loop.asyncCorrelator.PendingCount() != 0 {
+	if loop.asyncCorrelatorForTest().PendingCount() != 0 {
 		t.Fatalf("expected 0 pending awaits after both resolutions, got %d",
-			loop.asyncCorrelator.PendingCount())
+			loop.asyncCorrelatorForTest().PendingCount())
 	}
 }
 
@@ -437,7 +452,7 @@ func TestAsyncDispatch_NullTransportFailsFast(t *testing.T) {
 	if elapsed > 200*time.Millisecond {
 		t.Fatalf("dispatch should fail fast, but took %s", elapsed)
 	}
-	if loop.asyncCorrelator != nil {
+	if loop.asyncCorrelatorForTest() != nil {
 		t.Fatalf("async correlator should not have been constructed for a NullTransport")
 	}
 }
@@ -466,8 +481,8 @@ func TestAsyncDispatch_AsyncHandlerInternalError(t *testing.T) {
 	if len(tr.Events()) != 0 {
 		t.Fatalf("expected no events emitted on preflight error, got %d", len(tr.Events()))
 	}
-	if loop.asyncCorrelator != nil && loop.asyncCorrelator.PendingCount() != 0 {
-		t.Fatalf("expected 0 pending awaits, got %d", loop.asyncCorrelator.PendingCount())
+	if loop.asyncCorrelatorForTest() != nil && loop.asyncCorrelatorForTest().PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits, got %d", loop.asyncCorrelatorForTest().PendingCount())
 	}
 }
 
@@ -501,7 +516,7 @@ func TestSyncToolPath_Unchanged(t *testing.T) {
 		}
 	}
 	// Async correlator must not be constructed for a sync-only call.
-	if loop.asyncCorrelator != nil {
+	if loop.asyncCorrelatorForTest() != nil {
 		t.Fatalf("async correlator should not have been constructed for a sync tool")
 	}
 }

--- a/harness/internal/core/loop_async_test.go
+++ b/harness/internal/core/loop_async_test.go
@@ -226,8 +226,119 @@ func TestAsyncDispatch_UpstreamError(t *testing.T) {
 	if success {
 		t.Fatalf("expected success=false on is_error response")
 	}
-	if output != "upstream said no" {
-		t.Fatalf("expected upstream content verbatim, got %q", output)
+	// The is_error path must wrap the control-plane content with a
+	// structured prefix so the model can disambiguate upstream failures
+	// from harness-side failures (transport_disconnect, timeout,
+	// internal error). Without the prefix, the four error categories
+	// are not textually distinguishable.
+	if !strings.Contains(output, "upstream_error:") {
+		t.Fatalf("expected output to contain 'upstream_error:' prefix, got %q", output)
+	}
+	if !strings.Contains(output, "async_echo") {
+		t.Fatalf("expected output to mention tool name, got %q", output)
+	}
+	if !strings.Contains(output, "upstream said no") {
+		t.Fatalf("expected upstream content preserved after the prefix, got %q", output)
+	}
+}
+
+func TestAsyncDispatch_UpstreamError_ScrubsSecrets(t *testing.T) {
+	// The control plane is partially trusted. A misbehaving or
+	// compromised control plane could embed secret-shaped strings in
+	// the error payload; the failure path forwards content into the
+	// JSONL trace via RecordToolCall.ErrorReason without going through
+	// the transport's outbound scrub, so scrubbing must happen at the
+	// point of entry. Use an Anthropic-API-key-shaped secret so the
+	// existing security.LogScrubber pattern catches it.
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	const rawSecret = "sk-ant-api03-1234567890abcdefXYZ"
+	call := types.ToolCall{
+		ID:    "tc_async_err_secret",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if id := tr.lastRequestID("tool_result_request"); id != "" {
+				yes := true
+				tr.FireControl(types.ControlEvent{
+					Type:      "tool_result_response",
+					RequestID: id,
+					Content:   "auth failed: token=" + rawSecret + " is invalid",
+					IsError:   &yes,
+				})
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	if success {
+		t.Fatalf("expected success=false on is_error response")
+	}
+	if strings.Contains(output, rawSecret) {
+		t.Fatalf("raw secret leaked into tool output: %q", output)
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Fatalf("expected [REDACTED] marker in scrubbed output, got %q", output)
+	}
+	if !strings.Contains(output, "upstream_error:") {
+		t.Fatalf("expected upstream_error: prefix on scrubbed output, got %q", output)
+	}
+}
+
+func TestAsyncDispatch_ContentTruncation(t *testing.T) {
+	// The control plane supplies tool result content as an unbounded
+	// string. The harness must cap it before the value flows into tool
+	// output, message history, or the wire — same discipline as the
+	// 1MB run_command output cap. Send 1MB+1 bytes and assert the
+	// returned content is truncated and carries the harness suffix.
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	const cap = 1 << 20 // matches maxAsyncToolResultBytes
+	oversize := strings.Repeat("a", cap+512)
+
+	call := types.ToolCall{
+		ID:    "tc_async_oversize",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if id := tr.lastRequestID("tool_result_request"); id != "" {
+				tr.FireControl(types.ControlEvent{
+					Type:      "tool_result_response",
+					RequestID: id,
+					Content:   oversize,
+				})
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	if !success {
+		t.Fatalf("expected success on truncated success-path content; got %q", output)
+	}
+	const suffix = "... [truncated by harness]"
+	if !strings.HasSuffix(output, suffix) {
+		tail := output
+		if len(tail) > len(suffix)+16 {
+			tail = tail[len(tail)-len(suffix)-16:]
+		}
+		t.Fatalf("expected output to end with %q, got tail %q", suffix, tail)
+	}
+	if len(output) != cap+len(suffix) {
+		t.Fatalf("expected output length %d (cap+suffix), got %d", cap+len(suffix), len(output))
 	}
 }
 

--- a/harness/internal/core/loop_async_test.go
+++ b/harness/internal/core/loop_async_test.go
@@ -1,0 +1,563 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
+	"github.com/rxbynerd/stirrup/harness/internal/edit"
+	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/permission"
+	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+	"github.com/rxbynerd/stirrup/harness/internal/router"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/harness/internal/verifier"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// asyncTestTransport captures emitted events and lets the test inject
+// control events. It implements the same fan-out OnControl semantics that
+// the production stdio/grpc transports do, so the loop's async correlator
+// can attach normally. emitErr, when non-nil, is returned from Emit
+// (simulating a transport disconnect during async dispatch).
+type asyncTestTransport struct {
+	mu       sync.Mutex
+	handlers []func(types.ControlEvent)
+	events   []types.HarnessEvent
+	emitErr  error
+}
+
+func newAsyncTestTransport() *asyncTestTransport {
+	return &asyncTestTransport{}
+}
+
+func (t *asyncTestTransport) Emit(event types.HarnessEvent) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.emitErr != nil {
+		return t.emitErr
+	}
+	t.events = append(t.events, event)
+	return nil
+}
+
+func (t *asyncTestTransport) OnControl(handler func(types.ControlEvent)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.handlers = append(t.handlers, handler)
+}
+
+func (t *asyncTestTransport) Close() error { return nil }
+
+func (t *asyncTestTransport) FireControl(event types.ControlEvent) {
+	t.mu.Lock()
+	hs := make([]func(types.ControlEvent), len(t.handlers))
+	copy(hs, t.handlers)
+	t.mu.Unlock()
+	for _, h := range hs {
+		h(event)
+	}
+}
+
+func (t *asyncTestTransport) Events() []types.HarnessEvent {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]types.HarnessEvent, len(t.events))
+	copy(out, t.events)
+	return out
+}
+
+func (t *asyncTestTransport) lastRequestID(eventType string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := len(t.events) - 1; i >= 0; i-- {
+		if t.events[i].Type == eventType {
+			return t.events[i].RequestID
+		}
+	}
+	return ""
+}
+
+// buildAsyncTestLoop constructs a loop with the supplied transport and the
+// caller's tool registered. Other components are minimal/no-op so the test
+// can call dispatchToolCall directly.
+func buildAsyncTestLoop(t *testing.T, tr transport.Transport, asyncTool *tool.Tool) *AgenticLoop {
+	t.Helper()
+	registry := tool.NewRegistry()
+	registry.Register(asyncTool)
+	return &AgenticLoop{
+		Provider:     nil,
+		Router:       router.NewStaticRouter("anthropic", "claude-sonnet-4-6"),
+		Prompt:       prompt.NewDefaultPromptBuilder(),
+		Context:      contextpkg.NewSlidingWindowStrategy(),
+		Tools:        registry,
+		Edit:         edit.NewWholeFileStrategy(),
+		Verifier:     verifier.NewNoneVerifier(),
+		Permissions:  permission.NewAllowAll(),
+		Git:          git.NewNoneGitStrategy(),
+		Transport:    tr,
+		Trace:        trace.NewJSONLTraceEmitter(&bytes.Buffer{}),
+		Tracer:       noop.NewTracerProvider().Tracer(""),
+		TraceContext: context.Background(),
+		Metrics:      observability.NewNoopMetrics(),
+		Logger:       slog.Default(),
+	}
+}
+
+// asyncEchoTool is a minimal async tool: its preflight does no work, just
+// hands the request_id back to the loop. The control-plane response carries
+// the actual payload.
+func asyncEchoTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "async_echo",
+		Description: "test async tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		AsyncHandler: func(_ context.Context, _ json.RawMessage) (tool.AsyncDispatch, error) {
+			return tool.AsyncDispatch{}, nil
+		},
+	}
+}
+
+func TestAsyncDispatch_HappyPath(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	call := types.ToolCall{
+		ID:    "tc_async_1",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	// Fire the matching tool_result_response after the loop has emitted
+	// its tool_result_request and registered its pending entry.
+	go func() {
+		// Spin until the request event has been emitted so we know the
+		// pending channel exists.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if id := tr.lastRequestID("tool_result_request"); id != "" {
+				tr.FireControl(types.ControlEvent{
+					Type:      "tool_result_response",
+					RequestID: id,
+					Content:   "async output ok",
+				})
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Errorf("tool_result_request was never emitted")
+	}()
+
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	if !success {
+		t.Fatalf("expected success=true, got false; output=%q", output)
+	}
+	if output != "async output ok" {
+		t.Fatalf("expected output 'async output ok', got %q", output)
+	}
+
+	// Verify the emitted request event carries tool_use_id, tool name,
+	// and request_id.
+	events := tr.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 emitted event, got %d", len(events))
+	}
+	req := events[0]
+	if req.Type != "tool_result_request" {
+		t.Fatalf("expected tool_result_request, got %q", req.Type)
+	}
+	if req.ToolUseID != "tc_async_1" {
+		t.Fatalf("expected ToolUseID tc_async_1, got %q", req.ToolUseID)
+	}
+	if req.ToolName != "async_echo" {
+		t.Fatalf("expected ToolName async_echo, got %q", req.ToolName)
+	}
+	if req.RequestID == "" {
+		t.Fatalf("expected non-empty RequestID")
+	}
+
+	// Pending entry must be cleaned up after resolution.
+	if loop.asyncCorrelator.PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits, got %d", loop.asyncCorrelator.PendingCount())
+	}
+}
+
+func TestAsyncDispatch_UpstreamError(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	call := types.ToolCall{
+		ID:    "tc_async_err",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if id := tr.lastRequestID("tool_result_request"); id != "" {
+				yes := true
+				tr.FireControl(types.ControlEvent{
+					Type:      "tool_result_response",
+					RequestID: id,
+					Content:   "upstream said no",
+					IsError:   &yes,
+				})
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	if success {
+		t.Fatalf("expected success=false on is_error response")
+	}
+	if output != "upstream said no" {
+		t.Fatalf("expected upstream content verbatim, got %q", output)
+	}
+}
+
+func TestAsyncDispatch_Timeout(t *testing.T) {
+	tr := newAsyncTestTransport()
+	tl := asyncEchoTool()
+	tl.AsyncHandler = func(_ context.Context, _ json.RawMessage) (tool.AsyncDispatch, error) {
+		return tool.AsyncDispatch{Timeout: 25 * time.Millisecond}, nil
+	}
+	loop := buildAsyncTestLoop(t, tr, tl)
+
+	call := types.ToolCall{
+		ID:    "tc_async_timeout",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	start := time.Now()
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	elapsed := time.Since(start)
+	if success {
+		t.Fatalf("expected success=false on timeout, got true; output=%q", output)
+	}
+	if !strings.Contains(output, "timeout") {
+		t.Fatalf("expected output to mention 'timeout', got %q", output)
+	}
+	if !strings.Contains(output, "async_echo") {
+		t.Fatalf("expected output to mention tool name, got %q", output)
+	}
+	if elapsed < 20*time.Millisecond {
+		t.Fatalf("returned too quickly (%s); timeout did not fire", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("returned too slowly (%s); per-call timeout override was ignored", elapsed)
+	}
+	// Cleanup: pending entry must be removed.
+	if loop.asyncCorrelator.PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits after timeout, got %d", loop.asyncCorrelator.PendingCount())
+	}
+}
+
+func TestAsyncDispatch_CtxCancellation(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	call := types.ToolCall{
+		ID:    "tc_async_cancel",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after the request is emitted so we exercise the
+	// ctx.Done branch of correlator.Await.
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if tr.lastRequestID("tool_result_request") != "" {
+				cancel()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	output, success := loop.dispatchToolCall(ctx, call)
+	if success {
+		t.Fatalf("expected success=false on ctx cancel")
+	}
+	if !strings.Contains(output, "cancelled") {
+		t.Fatalf("expected output to mention 'cancelled', got %q", output)
+	}
+	if loop.asyncCorrelator.PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits after ctx cancel, got %d", loop.asyncCorrelator.PendingCount())
+	}
+}
+
+func TestAsyncDispatch_TransportEmitFailure(t *testing.T) {
+	tr := newAsyncTestTransport()
+	tr.emitErr = errors.New("simulated transport disconnect")
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	call := types.ToolCall{
+		ID:    "tc_async_emit",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	if success {
+		t.Fatalf("expected success=false on emit failure")
+	}
+	if !strings.Contains(output, "transport_disconnect") {
+		t.Fatalf("expected output to contain 'transport_disconnect', got %q", output)
+	}
+	// Correlator must clean up the pending entry on emit failure.
+	if loop.asyncCorrelator.PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits after emit failure, got %d", loop.asyncCorrelator.PendingCount())
+	}
+}
+
+func TestAsyncDispatch_OutOfOrderResolution(t *testing.T) {
+	// The dispatch loop is sequential, so two async tool calls cannot be
+	// in flight simultaneously via the loop itself. This test exercises
+	// the correlator's out-of-order routing directly: register two
+	// pending Awaits via two concurrent dispatchToolCall invocations,
+	// then resolve them in reverse order. Each should return its own
+	// payload — proof that correlation is by request_id, not order of
+	// arrival.
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	call1 := types.ToolCall{ID: "tc1", Name: "async_echo", Input: json.RawMessage(`{}`)}
+	call2 := types.ToolCall{ID: "tc2", Name: "async_echo", Input: json.RawMessage(`{}`)}
+
+	type res struct {
+		output  string
+		success bool
+	}
+	r1 := make(chan res, 1)
+	r2 := make(chan res, 1)
+
+	go func() {
+		out, ok := loop.dispatchToolCall(context.Background(), call1)
+		r1 <- res{out, ok}
+	}()
+	go func() {
+		out, ok := loop.dispatchToolCall(context.Background(), call2)
+		r2 <- res{out, ok}
+	}()
+
+	// Wait until both pending awaits are registered (PendingCount == 2)
+	// and both request events have been emitted.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if loop.asyncCorrelator != nil && loop.asyncCorrelator.PendingCount() == 2 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if loop.asyncCorrelator == nil || loop.asyncCorrelator.PendingCount() != 2 {
+		t.Fatalf("expected 2 pending awaits, got %d", loop.asyncCorrelator.PendingCount())
+	}
+
+	// Pull request IDs out of the emitted events. Map them to the tool
+	// use IDs so we know which dispatch returned which payload.
+	events := tr.Events()
+	idByToolUseID := map[string]string{}
+	for _, e := range events {
+		if e.Type == "tool_result_request" {
+			idByToolUseID[e.ToolUseID] = e.RequestID
+		}
+	}
+	id1, id2 := idByToolUseID["tc1"], idByToolUseID["tc2"]
+	if id1 == "" || id2 == "" || id1 == id2 {
+		t.Fatalf("expected two distinct request IDs, got %q and %q", id1, id2)
+	}
+
+	// Resolve in reverse order: tc2 first, then tc1.
+	tr.FireControl(types.ControlEvent{
+		Type:      "tool_result_response",
+		RequestID: id2,
+		Content:   "result-for-tc2",
+	})
+	tr.FireControl(types.ControlEvent{
+		Type:      "tool_result_response",
+		RequestID: id1,
+		Content:   "result-for-tc1",
+	})
+
+	res1 := <-r1
+	res2 := <-r2
+	if !res1.success || res1.output != "result-for-tc1" {
+		t.Fatalf("call1 wrong: success=%v output=%q", res1.success, res1.output)
+	}
+	if !res2.success || res2.output != "result-for-tc2" {
+		t.Fatalf("call2 wrong: success=%v output=%q", res2.success, res2.output)
+	}
+	if loop.asyncCorrelator.PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits after both resolutions, got %d",
+			loop.asyncCorrelator.PendingCount())
+	}
+}
+
+func TestAsyncDispatch_NullTransportFailsFast(t *testing.T) {
+	// Sub-agents run with NullTransport. An async tool there must not
+	// block, must not register a pending entry, and must surface a
+	// recoverable error to the model.
+	loop := buildAsyncTestLoop(t, transport.NewNullTransport(), asyncEchoTool())
+
+	call := types.ToolCall{
+		ID:    "tc_null",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+
+	start := time.Now()
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	elapsed := time.Since(start)
+	if success {
+		t.Fatalf("expected success=false on NullTransport, got true; output=%q", output)
+	}
+	if !strings.Contains(output, "unavailable") {
+		t.Fatalf("expected output to mention 'unavailable', got %q", output)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("dispatch should fail fast, but took %s", elapsed)
+	}
+	if loop.asyncCorrelator != nil {
+		t.Fatalf("async correlator should not have been constructed for a NullTransport")
+	}
+}
+
+func TestAsyncDispatch_AsyncHandlerInternalError(t *testing.T) {
+	tr := newAsyncTestTransport()
+	tl := asyncEchoTool()
+	tl.AsyncHandler = func(_ context.Context, _ json.RawMessage) (tool.AsyncDispatch, error) {
+		return tool.AsyncDispatch{}, errors.New("preflight blew up")
+	}
+	loop := buildAsyncTestLoop(t, tr, tl)
+
+	call := types.ToolCall{
+		ID:    "tc_pre",
+		Name:  "async_echo",
+		Input: json.RawMessage(`{}`),
+	}
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	if success {
+		t.Fatalf("expected success=false on AsyncHandler error")
+	}
+	if !strings.Contains(output, "internal error") {
+		t.Fatalf("expected 'internal error' in output, got %q", output)
+	}
+	// No event should have been emitted, and no pending entry registered.
+	if len(tr.Events()) != 0 {
+		t.Fatalf("expected no events emitted on preflight error, got %d", len(tr.Events()))
+	}
+	if loop.asyncCorrelator != nil && loop.asyncCorrelator.PendingCount() != 0 {
+		t.Fatalf("expected 0 pending awaits, got %d", loop.asyncCorrelator.PendingCount())
+	}
+}
+
+func TestSyncToolPath_Unchanged(t *testing.T) {
+	// A purely synchronous tool (no AsyncHandler) must still work. This
+	// guards the "async-handler-nil = sync" contract.
+	tr := newAsyncTestTransport()
+	syncTool := &tool.Tool{
+		Name:        "sync_test",
+		Description: "purely synchronous test tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "sync result", nil
+		},
+	}
+	loop := buildAsyncTestLoop(t, tr, syncTool)
+
+	call := types.ToolCall{
+		ID:    "tc_sync",
+		Name:  "sync_test",
+		Input: json.RawMessage(`{}`),
+	}
+	output, success := loop.dispatchToolCall(context.Background(), call)
+	if !success || output != "sync result" {
+		t.Fatalf("sync tool: success=%v output=%q", success, output)
+	}
+	// No tool_result_request event should have been emitted.
+	for _, e := range tr.Events() {
+		if e.Type == "tool_result_request" {
+			t.Fatalf("sync tool should not emit tool_result_request, got %+v", e)
+		}
+	}
+	// Async correlator must not be constructed for a sync-only call.
+	if loop.asyncCorrelator != nil {
+		t.Fatalf("async correlator should not have been constructed for a sync tool")
+	}
+}
+
+func TestAsyncDispatch_StallDetectionStillFires(t *testing.T) {
+	// Three identical async resolutions should still trigger
+	// stallDetector — the dispatch path is still synchronous from the
+	// stall detector's point of view (one record per call).
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, asyncEchoTool())
+
+	stall := &stallDetector{}
+	input := json.RawMessage(`{"x":1}`)
+
+	for i := 0; i < 3; i++ {
+		// Each iteration: register a one-shot resolver that fires as
+		// soon as this iteration's request lands on the wire. Counting
+		// emitted events == iteration index disambiguates from earlier
+		// iterations' (already resolved) requests.
+		expectedIndex := i + 1
+		done := make(chan struct{})
+		go func(turn int) {
+			defer close(done)
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				events := tr.Events()
+				if len(events) >= expectedIndex {
+					req := events[expectedIndex-1]
+					if req.Type == "tool_result_request" && req.RequestID != "" {
+						tr.FireControl(types.ControlEvent{
+							Type:      "tool_result_response",
+							RequestID: req.RequestID,
+							Content:   fmt.Sprintf("repeat-%d", turn),
+						})
+						return
+					}
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}(i)
+
+		output, success := loop.dispatchToolCall(context.Background(), types.ToolCall{
+			ID:    fmt.Sprintf("tc_stall_%d", i),
+			Name:  "async_echo",
+			Input: input,
+		})
+		<-done
+		if !success {
+			t.Fatalf("turn %d: dispatch failed: %s", i, output)
+		}
+		outcome := stall.recordToolCall("async_echo", input, success)
+		if i < 2 && outcome != "" {
+			t.Fatalf("turn %d: unexpected stall outcome %q", i, outcome)
+		}
+		if i == 2 && outcome != "stalled" {
+			t.Fatalf("turn 2: expected 'stalled' outcome, got %q", outcome)
+		}
+	}
+}

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -40,6 +40,16 @@ import (
 // "wait for a control-plane response" timeouts.
 const DefaultAsyncToolTimeout = 60 * time.Second
 
+// maxAsyncToolResultBytes caps the length of control-plane-supplied tool
+// result content. The control plane is partially trusted; an unbounded
+// string here is a DoS vector (CWE-400). 1MB matches the existing command
+// output cap used by the run_command sync tool.
+const maxAsyncToolResultBytes = 1 << 20 // 1MB
+
+// asyncResultTruncationSuffix is appended when content exceeds
+// maxAsyncToolResultBytes. The model and the trace see this marker.
+const asyncResultTruncationSuffix = "... [truncated by harness]"
+
 // AgenticLoop drives the ReAct loop. All dependencies are injected as struct
 // fields — the loop has no imports from concrete implementations, no environment
 // variable reads, no direct file system access.
@@ -91,14 +101,23 @@ type asyncToolResult struct {
 
 // extractAsyncToolResult is the PayloadExtractor for tool_result_response
 // control events. Returns an empty id (and so is ignored) for any other
-// event type.
+// event type. Content is truncated at maxAsyncToolResultBytes before
+// flowing into tool output, message history, or the wire — the cap is
+// applied here, at the extraction boundary, so it is enforced regardless
+// of how the payload is later consumed (success path, error path, trace).
+// Truncation happens in bytes (not runes) to keep the bound predictable;
+// downstream consumers do not assume valid UTF-8.
 func extractAsyncToolResult(event types.ControlEvent) (string, any) {
 	if event.Type != "tool_result_response" {
 		return "", nil
 	}
+	content := event.Content
+	if len(content) > maxAsyncToolResultBytes {
+		content = content[:maxAsyncToolResultBytes] + asyncResultTruncationSuffix
+	}
 	isErr := event.IsError != nil && *event.IsError
 	return event.RequestID, asyncToolResult{
-		content: event.Content,
+		content: content,
 		isError: isErr,
 	}
 }
@@ -343,7 +362,18 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		return fmt.Sprintf("async tool %s internal error: unexpected payload type %T", call.Name, payload), false
 	}
 	if resp.isError {
-		return resp.content, false
+		// The control plane is partially trusted: a compromised or
+		// misbehaving control plane could embed secret-shaped strings
+		// in the error payload, and the failure path forwards this
+		// content into the JSONL trace via RecordToolCall.ErrorReason
+		// without going through the transport's outbound scrub. Scrub
+		// at the point of entry so both the model context and the
+		// trace see the redacted form. The structured prefix matches
+		// the other three error taxonomy paths (transport_disconnect,
+		// timeout, internal error) so the model can disambiguate
+		// upstream failures from harness-side failures.
+		scrubbed := security.Scrub(resp.content)
+		return fmt.Sprintf("async tool %s upstream_error: %s", call.Name, scrubbed), false
 	}
 	return resp.content, true
 }

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -4,11 +4,14 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -30,6 +33,12 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/verifier"
 	"github.com/rxbynerd/stirrup/types"
 )
+
+// DefaultAsyncToolTimeout is the per-call wait used by the async tool
+// dispatch path when a tool's AsyncDispatch.Timeout is non-positive.
+// Matches permission.DefaultAskUpstreamTimeout for consistency; both are
+// "wait for a control-plane response" timeouts.
+const DefaultAsyncToolTimeout = 60 * time.Second
 
 // AgenticLoop drives the ReAct loop. All dependencies are injected as struct
 // fields — the loop has no imports from concrete implementations, no environment
@@ -62,6 +71,51 @@ type AgenticLoop struct {
 	// callback registered in Run. atomic ensures the read in the OTel
 	// collection goroutine sees a complete value.
 	lastContextTokens atomic.Int64
+
+	// asyncOnce guards lazy construction of asyncCorrelator. The
+	// correlator is created and attached to the transport on the first
+	// async tool dispatch — most runs never use any async tools and pay
+	// no cost.
+	asyncOnce       sync.Once
+	asyncCorrelator *transport.Correlator
+}
+
+// asyncToolResult carries the resolved payload of an async tool call from
+// the transport correlator back to the dispatch path.
+type asyncToolResult struct {
+	content string
+	isError bool
+}
+
+// extractAsyncToolResult is the PayloadExtractor for tool_result_response
+// control events. Returns an empty id (and so is ignored) for any other
+// event type.
+func extractAsyncToolResult(event types.ControlEvent) (string, any) {
+	if event.Type != "tool_result_response" {
+		return "", nil
+	}
+	isErr := event.IsError != nil && *event.IsError
+	return event.RequestID, asyncToolResult{
+		content: event.Content,
+		isError: isErr,
+	}
+}
+
+// ensureAsyncCorrelator returns the loop's async tool correlator, lazily
+// constructing it and attaching it to the loop's transport on first use.
+// Safe to call concurrently. Returns nil when the loop's transport has no
+// way to deliver responses (NullTransport / nil); callers should handle
+// nil by failing the dispatch fast.
+func (l *AgenticLoop) ensureAsyncCorrelator() *transport.Correlator {
+	if l.Transport == nil || transport.IsNull(l.Transport) {
+		return nil
+	}
+	l.asyncOnce.Do(func() {
+		c := transport.NewCorrelator("async-tool")
+		c.AttachTo(l.Transport, extractAsyncToolResult)
+		l.asyncCorrelator = c
+	})
+	return l.asyncCorrelator
 }
 
 // TokenTracker tracks cumulative token usage per run and enforces token budgets.
@@ -173,13 +227,119 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 		}
 	}
 
+	// Async tools resolve their result via the transport correlator: the
+	// preflight returns an AsyncDispatch describing the request_id and
+	// per-call timeout to use, the loop emits a tool_result_request event,
+	// and blocks until a tool_result_response arrives (or ctx is cancelled
+	// / the timeout fires). Permission and security checks above already
+	// ran and gated dispatch identically to the sync path.
+	if t.AsyncHandler != nil {
+		return l.dispatchAsyncToolCall(ctx, t, call, inputForCall)
+	}
+
 	// Execute the tool handler with the cleaned input so the handler does not
 	// see prototype-pollution keys either.
+	if t.Handler == nil {
+		return fmt.Sprintf("Tool %s has no handler registered", call.Name), false
+	}
 	output, err := t.Handler(ctx, inputForCall)
 	if err != nil {
 		return "Tool error: " + err.Error(), false
 	}
 	return output, true
+}
+
+// dispatchAsyncToolCall runs the async tool path:
+//
+//  1. Refuse the call up front when the transport cannot deliver responses
+//     (NullTransport): an async tool here would block until the per-call
+//     timeout for nothing. Returning a clear error lets the model recover.
+//  2. Invoke the tool's AsyncHandler as a preflight. The handler may
+//     populate AsyncDispatch.RequestID to drive its own bookkeeping; the
+//     loop allocates one when it doesn't.
+//  3. Emit a "tool_result_request" HarnessEvent carrying the request_id,
+//     the model's tool_use_id, the tool name, and the input.
+//  4. Block on the matching "tool_result_response" via the loop's async
+//     correlator under run-context cancellation and the per-call timeout.
+//
+// The error taxonomy surfaced via the returned content string is documented
+// in dispatchAsyncToolCall's call sites (see the constants below); the
+// model sees IsError=true on every failure path.
+func (l *AgenticLoop) dispatchAsyncToolCall(
+	ctx context.Context,
+	t *tool.Tool,
+	call types.ToolCall,
+	inputForCall json.RawMessage,
+) (string, bool) {
+	correlator := l.ensureAsyncCorrelator()
+	if correlator == nil {
+		// NullTransport (sub-agent) — no control plane to round-trip
+		// through. Fail fast rather than burning the per-call timeout.
+		return fmt.Sprintf(
+			"async tool %s unavailable: this loop has no live control-plane transport",
+			call.Name,
+		), false
+	}
+
+	dispatch, err := t.AsyncHandler(ctx, inputForCall)
+	if err != nil {
+		return fmt.Sprintf("async tool %s internal error: %s", call.Name, err.Error()), false
+	}
+
+	timeout := dispatch.Timeout
+	if timeout <= 0 {
+		timeout = DefaultAsyncToolTimeout
+	}
+
+	// The correlator allocates a request ID when emit is invoked. If the
+	// caller pre-set one, we want it threaded onto the wire event but the
+	// correlator's own ID owns the pending channel. We keep the correlator
+	// ID on the wire (it's what the control plane must echo) and surface
+	// the caller's RequestID as a redundant echo only — but the simpler
+	// contract is "the loop owns the request ID". Any future need for a
+	// caller-supplied ID can extend the correlator API; for now we ignore
+	// dispatch.RequestID at the wire layer to keep correlation single-source.
+	_ = dispatch.RequestID
+
+	payload, err := correlator.Await(ctx, timeout, func(requestID string) error {
+		return l.Transport.Emit(types.HarnessEvent{
+			Type:      "tool_result_request",
+			RequestID: requestID,
+			ToolName:  call.Name,
+			ToolUseID: call.ID,
+			Input:     inputForCall,
+		})
+	})
+	if err != nil {
+		// Distinguish error classes for the model:
+		//   - emit failure   → "transport_disconnect"
+		//   - timeout        → "async tool timeout"
+		//   - ctx cancellation → "async tool cancelled"
+		// The correlator wraps emit errors with "emit failed", timeouts
+		// with "timed out", and ctx errors carry context.Canceled /
+		// context.DeadlineExceeded in the chain.
+		if strings.Contains(err.Error(), "emit failed") {
+			return fmt.Sprintf("async tool %s transport_disconnect: %s", call.Name, err.Error()), false
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Sprintf("async tool %s cancelled: %s", call.Name, err.Error()), false
+		}
+		// Default: timeout (correlator: "timed out after ...") and any
+		// other unexpected wrapping go here.
+		return fmt.Sprintf("async tool %s timeout: %s", call.Name, err.Error()), false
+	}
+
+	resp, ok := payload.(asyncToolResult)
+	if !ok {
+		// Defensive: extractAsyncToolResult only ever delivers
+		// asyncToolResult, so reaching this branch means the correlator
+		// was wired with a different extractor. Treat as a hard error.
+		return fmt.Sprintf("async tool %s internal error: unexpected payload type %T", call.Name, payload), false
+	}
+	if resp.isError {
+		return resp.content, false
+	}
+	return resp.content, true
 }
 
 // buildMessages constructs the initial message list from the user prompt.

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -75,9 +75,11 @@ type AgenticLoop struct {
 	// asyncOnce guards lazy construction of asyncCorrelator. The
 	// correlator is created and attached to the transport on the first
 	// async tool dispatch — most runs never use any async tools and pay
-	// no cost.
+	// no cost. The pointer is held in an atomic so non-dispatcher
+	// goroutines (e.g. tests, diagnostics) can read it safely without
+	// going through Once.Do.
 	asyncOnce       sync.Once
-	asyncCorrelator *transport.Correlator
+	asyncCorrelator atomic.Pointer[transport.Correlator]
 }
 
 // asyncToolResult carries the resolved payload of an async tool call from
@@ -113,9 +115,18 @@ func (l *AgenticLoop) ensureAsyncCorrelator() *transport.Correlator {
 	l.asyncOnce.Do(func() {
 		c := transport.NewCorrelator("async-tool")
 		c.AttachTo(l.Transport, extractAsyncToolResult)
-		l.asyncCorrelator = c
+		l.asyncCorrelator.Store(c)
 	})
-	return l.asyncCorrelator
+	return l.asyncCorrelator.Load()
+}
+
+// asyncCorrelatorForTest returns the loop's async tool correlator if it
+// has been constructed, nil otherwise. Race-safe with concurrent
+// dispatchAsyncToolCall calls because the underlying field is an
+// atomic.Pointer. Used by tests that want to assert correlator state
+// (e.g. PendingCount) without forcing construction.
+func (l *AgenticLoop) asyncCorrelatorForTest() *transport.Correlator {
+	return l.asyncCorrelator.Load()
 }
 
 // TokenTracker tracks cumulative token usage per run and enforces token budgets.

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -265,9 +265,9 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 //  1. Refuse the call up front when the transport cannot deliver responses
 //     (NullTransport): an async tool here would block until the per-call
 //     timeout for nothing. Returning a clear error lets the model recover.
-//  2. Invoke the tool's AsyncHandler as a preflight. The handler may
-//     populate AsyncDispatch.RequestID to drive its own bookkeeping; the
-//     loop allocates one when it doesn't.
+//  2. Invoke the tool's AsyncHandler as a preflight. The handler returns
+//     an AsyncDispatch carrying any per-call timeout override; the loop
+//     owns the wire request ID via its transport correlator.
 //  3. Emit a "tool_result_request" HarnessEvent carrying the request_id,
 //     the model's tool_use_id, the tool name, and the input.
 //  4. Block on the matching "tool_result_response" via the loop's async
@@ -302,15 +302,10 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		timeout = DefaultAsyncToolTimeout
 	}
 
-	// The correlator allocates a request ID when emit is invoked. If the
-	// caller pre-set one, we want it threaded onto the wire event but the
-	// correlator's own ID owns the pending channel. We keep the correlator
-	// ID on the wire (it's what the control plane must echo) and surface
-	// the caller's RequestID as a redundant echo only — but the simpler
-	// contract is "the loop owns the request ID". Any future need for a
-	// caller-supplied ID can extend the correlator API; for now we ignore
-	// dispatch.RequestID at the wire layer to keep correlation single-source.
-	_ = dispatch.RequestID
+	// The correlator allocates the wire request ID. The AsyncDispatch
+	// struct intentionally does not expose that ID to tool authors —
+	// correlation is a loop concern, single source of truth, and a
+	// tool-supplied value would be silently overridden.
 
 	payload, err := correlator.Await(ctx, timeout, func(requestID string) error {
 		return l.Transport.Emit(types.HarnessEvent{

--- a/harness/internal/permission/askupstream.go
+++ b/harness/internal/permission/askupstream.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -17,6 +18,10 @@ const DefaultAskUpstreamTimeout = 60 * time.Second
 // Transport is a minimal interface matching the subset of transport.Transport
 // needed by AskUpstreamPolicy. Defined locally to avoid a circular import
 // between the permission and transport packages.
+//
+// (The transport package itself does not import permission, so this is
+// strictly a hygiene measure: it keeps callers free to substitute a fake
+// in tests without depending on the full transport.Transport interface.)
 type Transport interface {
 	Emit(event types.HarnessEvent) error
 	OnControl(handler func(event types.ControlEvent))
@@ -43,10 +48,12 @@ type AskUpstreamPolicy struct {
 	// auto-allowed.
 	approvalTools map[string]bool
 
-	mu       sync.Mutex
-	nextID   int
-	pending  map[string]chan permissionResponse
-	attached bool
+	mu sync.Mutex
+
+	// correlator pairs outbound permission_request events with their
+	// corresponding permission_response control events. It owns the
+	// pending-channel map and the request-ID counter.
+	correlator *transport.Correlator
 }
 
 type permissionResponse struct {
@@ -59,18 +66,31 @@ type permissionResponse struct {
 // plane; calls to those tools are forwarded as permission_request events
 // and block until a permission_response arrives. If timeout is zero,
 // DefaultAskUpstreamTimeout (60s) is used.
-func NewAskUpstreamPolicy(transport Transport, approvalTools map[string]bool, timeout time.Duration) *AskUpstreamPolicy {
+func NewAskUpstreamPolicy(t Transport, approvalTools map[string]bool, timeout time.Duration) *AskUpstreamPolicy {
 	if timeout <= 0 {
 		timeout = DefaultAskUpstreamTimeout
 	}
 	p := &AskUpstreamPolicy{
-		transport:     transport,
+		transport:     t,
 		Timeout:       timeout,
 		approvalTools: approvalTools,
-		pending:       make(map[string]chan permissionResponse),
+		correlator:    transport.NewCorrelator("perm"),
 	}
-	p.attachHandler()
+	p.correlator.AttachTo(t, extractPermissionResponse)
 	return p
+}
+
+// extractPermissionResponse turns a control event into a permissionResponse
+// payload, or returns an empty id to ignore unrelated events.
+func extractPermissionResponse(event types.ControlEvent) (string, any) {
+	if event.Type != "permission_response" {
+		return "", nil
+	}
+	allowed := event.Allowed != nil && *event.Allowed
+	return event.RequestID, permissionResponse{
+		allowed: allowed,
+		reason:  event.Reason,
+	}
 }
 
 // ApprovalToolNames returns a snapshot of tool names that require upstream
@@ -97,34 +117,6 @@ func (p *AskUpstreamPolicy) AddApprovalTool(name string) {
 	p.approvalTools[name] = true
 }
 
-// attachHandler registers a control event handler on the transport to route
-// permission_response events to their waiting Check calls.
-func (p *AskUpstreamPolicy) attachHandler() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.attached {
-		return
-	}
-	p.attached = true
-
-	p.transport.OnControl(func(event types.ControlEvent) {
-		if event.Type != "permission_response" {
-			return
-		}
-		p.mu.Lock()
-		ch, ok := p.pending[event.RequestID]
-		if ok {
-			delete(p.pending, event.RequestID)
-		}
-		p.mu.Unlock()
-
-		if ok {
-			allowed := event.Allowed != nil && *event.Allowed
-			ch <- permissionResponse{allowed: allowed, reason: event.Reason}
-		}
-	})
-}
-
 // Check implements PermissionPolicy. Tools that do not require upstream
 // approval are auto-allowed. Approval-required tools emit a
 // permission_request event via Transport and block until the control plane
@@ -137,51 +129,31 @@ func (p *AskUpstreamPolicy) Check(ctx context.Context, tool types.ToolDefinition
 		return &PermissionResult{Allowed: true}, nil
 	}
 
-	requestID := p.nextRequestID()
-	ch := make(chan permissionResponse, 1)
-
-	p.mu.Lock()
-	p.pending[requestID] = ch
-	p.mu.Unlock()
-
-	err := p.transport.Emit(types.HarnessEvent{
-		Type:      "permission_request",
-		RequestID: requestID,
-		ToolName:  tool.Name,
-		Input:     input,
+	payload, err := p.correlator.Await(ctx, p.Timeout, func(requestID string) error {
+		return p.transport.Emit(types.HarnessEvent{
+			Type:      "permission_request",
+			RequestID: requestID,
+			ToolName:  tool.Name,
+			Input:     input,
+		})
 	})
 	if err != nil {
-		p.mu.Lock()
-		delete(p.pending, requestID)
-		p.mu.Unlock()
-		return nil, fmt.Errorf("emit permission request: %w", err)
+		// Surface a domain-specific error message while preserving the
+		// underlying cause (timeout, ctx, emit failure) for callers that
+		// inspect the chain via errors.Is.
+		return nil, fmt.Errorf("permission check: %w", err)
 	}
 
-	timer := time.NewTimer(p.Timeout)
-	defer timer.Stop()
-
-	select {
-	case resp := <-ch:
-		return &PermissionResult{
-			Allowed: resp.allowed,
-			Reason:  resp.reason,
-		}, nil
-	case <-timer.C:
-		p.mu.Lock()
-		delete(p.pending, requestID)
-		p.mu.Unlock()
-		return nil, fmt.Errorf("permission check timed out after %s waiting for upstream response", p.Timeout)
-	case <-ctx.Done():
-		p.mu.Lock()
-		delete(p.pending, requestID)
-		p.mu.Unlock()
-		return nil, fmt.Errorf("permission check cancelled: %w", ctx.Err())
+	resp, ok := payload.(permissionResponse)
+	if !ok {
+		// Defensive: extractPermissionResponse only ever delivers
+		// permissionResponse, so reaching this branch means the
+		// correlator was wired with a different extractor than we
+		// installed. Treat as a hard error rather than panicking.
+		return nil, fmt.Errorf("permission check: unexpected payload type %T", payload)
 	}
-}
-
-func (p *AskUpstreamPolicy) nextRequestID() string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.nextID++
-	return fmt.Sprintf("perm-%d", p.nextID)
+	return &PermissionResult{
+		Allowed: resp.allowed,
+		Reason:  resp.reason,
+	}, nil
 }

--- a/harness/internal/permission/askupstream_test.go
+++ b/harness/internal/permission/askupstream_test.go
@@ -227,10 +227,7 @@ func TestAskUpstream_ContextCancellation(t *testing.T) {
 	}
 
 	// Verify that the pending request was cleaned up.
-	policy.mu.Lock()
-	pendingCount := len(policy.pending)
-	policy.mu.Unlock()
-	if pendingCount != 0 {
+	if pendingCount := policy.correlator.PendingCount(); pendingCount != 0 {
 		t.Errorf("expected 0 pending requests after cancellation, got %d", pendingCount)
 	}
 }
@@ -250,10 +247,7 @@ func TestAskUpstream_EmitError(t *testing.T) {
 	}
 
 	// Verify pending map is cleaned up.
-	policy.mu.Lock()
-	pendingCount := len(policy.pending)
-	policy.mu.Unlock()
-	if pendingCount != 0 {
+	if pendingCount := policy.correlator.PendingCount(); pendingCount != 0 {
 		t.Errorf("expected 0 pending requests after emit error, got %d", pendingCount)
 	}
 }
@@ -321,10 +315,7 @@ func TestAskUpstream_Timeout(t *testing.T) {
 	}
 
 	// Verify that the pending request was cleaned up.
-	policy.mu.Lock()
-	pendingCount := len(policy.pending)
-	policy.mu.Unlock()
-	if pendingCount != 0 {
+	if pendingCount := policy.correlator.PendingCount(); pendingCount != 0 {
 		t.Errorf("expected 0 pending requests after timeout, got %d", pendingCount)
 	}
 }

--- a/harness/internal/tool/tool.go
+++ b/harness/internal/tool/tool.go
@@ -11,20 +11,20 @@ import (
 )
 
 // AsyncDispatch carries the metadata an async tool returns from its preflight
-// step. Returning a non-empty AsyncDispatch tells the agentic loop "do not
-// finalise this tool call yet — emit a tool_result_request with this
-// RequestID, then block on the matching tool_result_response under ctx
-// cancellation and the per-call timeout".
+// step. Returning AsyncDispatch tells the agentic loop "do not finalise this
+// tool call yet — emit a tool_result_request, then block on the matching
+// tool_result_response under ctx cancellation and the per-call timeout".
 //
 // Timeout, when positive, overrides the loop's default per-call timeout for
 // just this call. Zero means use the loop default.
 //
-// If RequestID is empty the loop will allocate one via its async correlator
-// and pass it through to the wire event. Tools that need to track their own
-// internal state by request ID may populate it themselves.
+// The loop allocates the wire-level request ID via its transport correlator;
+// tool authors do not control it. This keeps correlation single-source so a
+// caller-supplied value cannot diverge from the value emitted on the wire.
+// The struct is retained as the AsyncHandler return type for future
+// extensibility.
 type AsyncDispatch struct {
-	RequestID string
-	Timeout   time.Duration
+	Timeout time.Duration
 }
 
 // Tool represents a single tool that the model can invoke.

--- a/harness/internal/tool/tool.go
+++ b/harness/internal/tool/tool.go
@@ -5,9 +5,27 @@ package tool
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/rxbynerd/stirrup/types"
 )
+
+// AsyncDispatch carries the metadata an async tool returns from its preflight
+// step. Returning a non-empty AsyncDispatch tells the agentic loop "do not
+// finalise this tool call yet — emit a tool_result_request with this
+// RequestID, then block on the matching tool_result_response under ctx
+// cancellation and the per-call timeout".
+//
+// Timeout, when positive, overrides the loop's default per-call timeout for
+// just this call. Zero means use the loop default.
+//
+// If RequestID is empty the loop will allocate one via its async correlator
+// and pass it through to the wire event. Tools that need to track their own
+// internal state by request ID may populate it themselves.
+type AsyncDispatch struct {
+	RequestID string
+	Timeout   time.Duration
+}
 
 // Tool represents a single tool that the model can invoke.
 //
@@ -25,6 +43,30 @@ import (
 //
 // Tools may set neither, one, or both flags. Read-only tools (read_file,
 // list_directory, search_files) set neither.
+//
+// A tool is async when AsyncHandler is non-nil. The agentic loop will:
+//
+//  1. Run permission and security checks exactly as for a synchronous tool.
+//  2. Invoke AsyncHandler as a preflight. The handler may emit any
+//     side-effecting message it likes (the loop does not require it to);
+//     it returns an AsyncDispatch describing the request_id and per-call
+//     timeout to use.
+//  3. Emit a "tool_result_request" HarnessEvent carrying that request_id,
+//     the tool name, the model's tool_use_id, and the tool input.
+//  4. Block on the matching "tool_result_response" ControlEvent via the
+//     loop's transport correlator, under run-context cancellation and the
+//     per-call timeout. The control plane's response payload becomes the
+//     tool's output; its is_error flag becomes ToolResult.IsError.
+//
+// If both Handler and AsyncHandler are set, the loop prefers AsyncHandler.
+// If neither is set the tool is unusable (Resolve returns it but dispatch
+// will fail with a "tool has no handler" error).
+//
+// Async tools require a transport that can deliver control-plane responses.
+// Sub-agents run with NullTransport (whose OnControl is a no-op), so an
+// async tool dispatched on a sub-agent loop fails fast with a clear error
+// rather than blocking until the per-call timeout — see core/loop.go's
+// async dispatch path.
 type Tool struct {
 	Name              string
 	Description       string
@@ -32,6 +74,14 @@ type Tool struct {
 	WorkspaceMutating bool
 	RequiresApproval  bool
 	Handler           func(ctx context.Context, input json.RawMessage) (string, error)
+
+	// AsyncHandler, when non-nil, marks the tool as async. The loop calls
+	// it after permission/security checks and uses the returned
+	// AsyncDispatch to drive the request/response correlation. The handler
+	// may return an error to abort dispatch before any wire event is
+	// emitted; the error message is surfaced to the model as a tool
+	// internal error.
+	AsyncHandler func(ctx context.Context, input json.RawMessage) (AsyncDispatch, error)
 }
 
 // Definition converts a Tool to the wire-format ToolDefinition used by the

--- a/harness/internal/transport/correlator.go
+++ b/harness/internal/transport/correlator.go
@@ -1,0 +1,179 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// DefaultCorrelatorTimeout is the default per-await timeout used when a
+// caller passes a non-positive timeout to Correlator.Await.
+const DefaultCorrelatorTimeout = 60 * time.Second
+
+// HasOnControl is the minimal Transport surface the correlator needs. It is
+// declared in this package so the helper can be reused without a circular
+// import via consumers (e.g. permission, tool dispatch) that define the same
+// shape locally.
+type HasOnControl interface {
+	OnControl(handler func(event types.ControlEvent))
+}
+
+// PayloadExtractor inspects a control event and returns the request ID it
+// resolves and the payload to deliver to the awaiting goroutine. If the
+// event is unrelated (different type, or otherwise should be ignored),
+// the returned id should be empty.
+type PayloadExtractor func(event types.ControlEvent) (id string, payload any)
+
+// Correlator pairs outbound HarnessEvents with their inbound ControlEvent
+// responses by request ID. It encapsulates the
+// "emit + register pending channel + select on response/timer/ctx + cleanup"
+// pattern so multiple subsystems (permission gating, async tool dispatch)
+// can share one implementation.
+//
+// A single Correlator may be attached to at most one event type per
+// AttachTo call but may be attached multiple times to different types
+// on the same transport. Concurrent calls to Await are safe; each call
+// receives a unique request ID and its own response channel.
+type Correlator struct {
+	idPrefix string
+
+	mu      sync.Mutex
+	nextID  int
+	pending map[string]chan any
+}
+
+// NewCorrelator constructs a Correlator. The idPrefix is used to format
+// request IDs as "<prefix>-<n>" with a monotonic counter starting at 1.
+// If idPrefix is empty, "req" is used.
+func NewCorrelator(idPrefix string) *Correlator {
+	if idPrefix == "" {
+		idPrefix = "req"
+	}
+	return &Correlator{
+		idPrefix: idPrefix,
+		pending:  make(map[string]chan any),
+	}
+}
+
+// AttachTo registers a control handler on the transport that routes
+// matching events to their pending Await calls. The extract function
+// inspects each incoming event and returns the request ID it resolves
+// (empty to ignore the event) along with the payload to deliver.
+//
+// AttachTo may be called multiple times with different extract functions
+// (typically one per response event type). Each registration adds a new
+// handler; none unregister.
+func (c *Correlator) AttachTo(t HasOnControl, extract PayloadExtractor) {
+	if t == nil || extract == nil {
+		return
+	}
+	t.OnControl(func(event types.ControlEvent) {
+		id, payload := extract(event)
+		if id == "" {
+			return
+		}
+		c.deliver(id, payload)
+	})
+}
+
+// deliver routes a payload to the pending channel for the given request
+// ID, if one is registered. The channel is buffered to capacity 1 so a
+// late delivery (after the awaiter has timed out and removed the entry)
+// would never reach this code path; if the entry is missing the delivery
+// is silently dropped.
+func (c *Correlator) deliver(id string, payload any) {
+	c.mu.Lock()
+	ch, ok := c.pending[id]
+	if ok {
+		delete(c.pending, id)
+	}
+	c.mu.Unlock()
+
+	if ok {
+		// Channel has capacity 1 and this is the only sender for this
+		// id (we just removed it from pending under the lock), so the
+		// send cannot block.
+		ch <- payload
+	}
+}
+
+// Await registers a fresh request ID, invokes emit with that ID, and
+// blocks until either:
+//
+//   - a correlated payload is delivered (returns payload, nil)
+//   - timeout elapses (returns nil, error containing "timed out")
+//   - ctx is cancelled (returns nil, error wrapping ctx.Err())
+//   - emit returns an error (returns nil, that error wrapped)
+//
+// The pending entry is removed on every exit path. The emit callback
+// receives the request ID it should attach to its outbound event; this
+// keeps the wire format under the caller's control.
+//
+// A non-positive timeout is replaced with DefaultCorrelatorTimeout.
+func (c *Correlator) Await(
+	ctx context.Context,
+	timeout time.Duration,
+	emit func(requestID string) error,
+) (any, error) {
+	if emit == nil {
+		return nil, errors.New("correlator: emit callback is required")
+	}
+	if timeout <= 0 {
+		timeout = DefaultCorrelatorTimeout
+	}
+
+	requestID := c.nextRequestID()
+	ch := make(chan any, 1)
+
+	c.mu.Lock()
+	c.pending[requestID] = ch
+	c.mu.Unlock()
+
+	if err := emit(requestID); err != nil {
+		c.cancel(requestID)
+		return nil, fmt.Errorf("correlator: emit failed: %w", err)
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case payload := <-ch:
+		// deliver() already removed the pending entry under lock.
+		return payload, nil
+	case <-timer.C:
+		c.cancel(requestID)
+		return nil, fmt.Errorf("correlator: timed out after %s waiting for response (requestId=%s)", timeout, requestID)
+	case <-ctx.Done():
+		c.cancel(requestID)
+		return nil, fmt.Errorf("correlator: cancelled (requestId=%s): %w", requestID, ctx.Err())
+	}
+}
+
+// cancel removes a pending entry. Safe to call when the entry has already
+// been removed (e.g. because deliver() resolved it concurrently with a
+// timeout firing).
+func (c *Correlator) cancel(requestID string) {
+	c.mu.Lock()
+	delete(c.pending, requestID)
+	c.mu.Unlock()
+}
+
+// PendingCount returns the number of in-flight Awaits. Intended for tests
+// and diagnostics.
+func (c *Correlator) PendingCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.pending)
+}
+
+func (c *Correlator) nextRequestID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nextID++
+	return fmt.Sprintf("%s-%d", c.idPrefix, c.nextID)
+}

--- a/harness/internal/transport/correlator_test.go
+++ b/harness/internal/transport/correlator_test.go
@@ -1,0 +1,398 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeOnControl is a minimal HasOnControl for tests. simulate() fans events
+// out to all registered handlers.
+type fakeOnControl struct {
+	mu       sync.Mutex
+	handlers []func(types.ControlEvent)
+}
+
+func (f *fakeOnControl) OnControl(handler func(types.ControlEvent)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers = append(f.handlers, handler)
+}
+
+func (f *fakeOnControl) simulate(event types.ControlEvent) {
+	f.mu.Lock()
+	hs := make([]func(types.ControlEvent), len(f.handlers))
+	copy(hs, f.handlers)
+	f.mu.Unlock()
+	for _, h := range hs {
+		h(event)
+	}
+}
+
+// extractByType returns an extractor that resolves events whose Type matches
+// wantType, surfacing the event itself as the payload.
+func extractByType(wantType string) PayloadExtractor {
+	return func(event types.ControlEvent) (string, any) {
+		if event.Type != wantType {
+			return "", nil
+		}
+		return event.RequestID, event
+	}
+}
+
+func TestCorrelator_HappyPath(t *testing.T) {
+	t.Parallel()
+	fc := &fakeOnControl{}
+	c := NewCorrelator("perm")
+	c.AttachTo(fc, extractByType("permission_response"))
+
+	allowed := true
+	go func() {
+		// Wait briefly for Await to register the pending entry.
+		for c.PendingCount() == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		fc.simulate(types.ControlEvent{
+			Type:      "permission_response",
+			RequestID: "perm-1",
+			Allowed:   &allowed,
+		})
+	}()
+
+	got, err := c.Await(context.Background(), time.Second, func(id string) error {
+		if id != "perm-1" {
+			t.Errorf("expected first id 'perm-1', got %q", id)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ev, ok := got.(types.ControlEvent)
+	if !ok {
+		t.Fatalf("expected ControlEvent payload, got %T", got)
+	}
+	if ev.Allowed == nil || !*ev.Allowed {
+		t.Errorf("expected allowed=true, got %v", ev.Allowed)
+	}
+	if c.PendingCount() != 0 {
+		t.Errorf("expected pending=0 after happy path, got %d", c.PendingCount())
+	}
+}
+
+func TestCorrelator_Timeout(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("perm")
+	// No attach: no extractor will ever resolve this.
+
+	_, err := c.Await(context.Background(), 25*time.Millisecond, func(_ string) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected 'timed out' in error, got: %v", err)
+	}
+	if c.PendingCount() != 0 {
+		t.Errorf("expected pending=0 after timeout, got %d", c.PendingCount())
+	}
+}
+
+func TestCorrelator_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("perm")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		for c.PendingCount() == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		cancel()
+	}()
+
+	_, err := c.Await(ctx, time.Second, func(_ string) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled in chain, got: %v", err)
+	}
+	if c.PendingCount() != 0 {
+		t.Errorf("expected pending=0 after cancellation, got %d", c.PendingCount())
+	}
+}
+
+func TestCorrelator_EmitFailureCleansUp(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("perm")
+
+	emitErr := errors.New("transport broken")
+	_, err := c.Await(context.Background(), time.Second, func(_ string) error {
+		return emitErr
+	})
+	if err == nil {
+		t.Fatal("expected emit error")
+	}
+	if !errors.Is(err, emitErr) {
+		t.Errorf("expected emit error in chain, got: %v", err)
+	}
+	if c.PendingCount() != 0 {
+		t.Errorf("expected pending=0 after emit failure, got %d", c.PendingCount())
+	}
+}
+
+func TestCorrelator_OutOfOrderResolution(t *testing.T) {
+	t.Parallel()
+	fc := &fakeOnControl{}
+	c := NewCorrelator("req")
+	c.AttachTo(fc, extractByType("response"))
+
+	type result struct {
+		id      string
+		payload any
+		err     error
+	}
+	results := make(chan result, 2)
+
+	// Two concurrent awaits. Each goroutine reports back the request ID it
+	// was assigned alongside its eventual payload, so the test does not
+	// depend on goroutine scheduling order.
+	for i := 0; i < 2; i++ {
+		go func() {
+			var assignedID string
+			payload, err := c.Await(context.Background(), 2*time.Second, func(id string) error {
+				assignedID = id
+				return nil
+			})
+			results <- result{id: assignedID, payload: payload, err: err}
+		}()
+	}
+
+	// Wait for both Awaits to register pending entries.
+	deadline := time.Now().Add(time.Second)
+	for c.PendingCount() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if c.PendingCount() != 2 {
+		t.Fatalf("expected 2 pending, got %d", c.PendingCount())
+	}
+
+	// Resolve "req-2" first, then "req-1". Both must surface the right
+	// payload regardless of which goroutine got which id.
+	fc.simulate(types.ControlEvent{Type: "response", RequestID: "req-2", Reason: "second"})
+	fc.simulate(types.ControlEvent{Type: "response", RequestID: "req-1", Reason: "first"})
+
+	wantReasonByID := map[string]string{
+		"req-1": "first",
+		"req-2": "second",
+	}
+	seen := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-results:
+			if r.err != nil {
+				t.Errorf("await id=%s: unexpected error: %v", r.id, r.err)
+				continue
+			}
+			ev, ok := r.payload.(types.ControlEvent)
+			if !ok {
+				t.Errorf("await id=%s: expected ControlEvent payload, got %T", r.id, r.payload)
+				continue
+			}
+			want, known := wantReasonByID[r.id]
+			if !known {
+				t.Errorf("unexpected request id %q", r.id)
+				continue
+			}
+			if seen[r.id] {
+				t.Errorf("duplicate result for id %q", r.id)
+			}
+			seen[r.id] = true
+			if ev.Reason != want {
+				t.Errorf("await id=%s: got reason %q, want %q", r.id, ev.Reason, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Errorf("await %d: timed out waiting for resolution", i)
+		}
+	}
+
+	if c.PendingCount() != 0 {
+		t.Errorf("expected pending=0 after both resolved, got %d", c.PendingCount())
+	}
+}
+
+func TestCorrelator_LateResponseDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	fc := &fakeOnControl{}
+	c := NewCorrelator("perm")
+	c.AttachTo(fc, extractByType("permission_response"))
+
+	goroutinesBefore := runtime.NumGoroutine()
+
+	_, err := c.Await(context.Background(), 25*time.Millisecond, func(_ string) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	// Now deliver a late response with the (now stale) id. Must not panic.
+	// Because the Correlator increments monotonically, the id used was
+	// "perm-1".
+	fc.simulate(types.ControlEvent{
+		Type:      "permission_response",
+		RequestID: "perm-1",
+	})
+
+	if c.PendingCount() != 0 {
+		t.Errorf("expected pending=0 after late response, got %d", c.PendingCount())
+	}
+
+	// Allow the runtime a moment to reap the goroutine that ran Await.
+	time.Sleep(20 * time.Millisecond)
+	goroutinesAfter := runtime.NumGoroutine()
+	// Tolerance for unrelated runtime goroutines, but we should not be
+	// strictly higher than before by more than a small slack.
+	if goroutinesAfter > goroutinesBefore+2 {
+		t.Errorf("possible goroutine leak: before=%d after=%d", goroutinesBefore, goroutinesAfter)
+	}
+}
+
+func TestCorrelator_IgnoresUnrelatedEvents(t *testing.T) {
+	t.Parallel()
+	fc := &fakeOnControl{}
+	c := NewCorrelator("perm")
+	c.AttachTo(fc, extractByType("permission_response"))
+
+	go func() {
+		for c.PendingCount() == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		// Unrelated event type: ignored.
+		fc.simulate(types.ControlEvent{Type: "user_response", RequestID: "perm-1"})
+		// Wrong request id: ignored.
+		fc.simulate(types.ControlEvent{Type: "permission_response", RequestID: "perm-999"})
+		// Finally, the matching event.
+		allowed := true
+		fc.simulate(types.ControlEvent{
+			Type:      "permission_response",
+			RequestID: "perm-1",
+			Allowed:   &allowed,
+		})
+	}()
+
+	got, err := c.Await(context.Background(), time.Second, func(_ string) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ev := got.(types.ControlEvent)
+	if ev.Allowed == nil || !*ev.Allowed {
+		t.Errorf("expected matching allowed event, got %+v", ev)
+	}
+}
+
+func TestCorrelator_RequestIDFormat(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("perm")
+
+	ids := make([]string, 3)
+	for i := range ids {
+		_, _ = c.Await(context.Background(), 5*time.Millisecond, func(id string) error {
+			ids[i] = id
+			return errors.New("stop") // exit fast via emit error
+		})
+	}
+
+	want := []string{"perm-1", "perm-2", "perm-3"}
+	for i, w := range want {
+		if ids[i] != w {
+			t.Errorf("ids[%d] = %q, want %q", i, ids[i], w)
+		}
+	}
+}
+
+func TestCorrelator_DefaultPrefix(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("")
+
+	var got string
+	_, _ = c.Await(context.Background(), 5*time.Millisecond, func(id string) error {
+		got = id
+		return errors.New("stop")
+	})
+	if got != "req-1" {
+		t.Errorf("expected 'req-1' default-prefixed id, got %q", got)
+	}
+}
+
+func TestCorrelator_NilEmit(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("perm")
+	_, err := c.Await(context.Background(), time.Second, nil)
+	if err == nil {
+		t.Fatal("expected error for nil emit")
+	}
+}
+
+// TestCorrelator_DefaultTimeoutWhenZero verifies the per-await timeout falls
+// back to DefaultCorrelatorTimeout when the caller passes zero.
+func TestCorrelator_DefaultTimeoutWhenZero(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("perm")
+
+	// We cannot wait the full default; instead cancel via ctx and assert
+	// that the call did not return immediately because of a zero-timer.
+	ctx, cancel := context.WithCancel(context.Background())
+	start := time.Now()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := c.Await(ctx, 0, func(_ string) error { return nil })
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected ctx error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if elapsed < 15*time.Millisecond {
+		t.Errorf("returned too quickly (%s) — zero timeout may have fired immediately", elapsed)
+	}
+}
+
+// Compile-time interface satisfaction check: Transport implementations all
+// satisfy HasOnControl. This guards against drift if Transport adds methods
+// that aren't in HasOnControl.
+var (
+	_ HasOnControl = (Transport)(nil)
+	_ HasOnControl = (*NullTransport)(nil)
+)
+
+// Sanity: NewCorrelator returns a non-nil instance and PendingCount starts
+// at zero. (Belt-and-braces; covered indirectly above.)
+func TestCorrelator_NewIsEmpty(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("x")
+	if c == nil {
+		t.Fatal("NewCorrelator returned nil")
+	}
+	if c.PendingCount() != 0 {
+		t.Errorf("expected empty correlator, got pending=%d", c.PendingCount())
+	}
+	// Avoid unused-import lint on fmt by referencing it in a tiny check.
+	_ = fmt.Sprintf("ok-%d", c.PendingCount())
+}

--- a/harness/internal/transport/grpc_test.go
+++ b/harness/internal/transport/grpc_test.go
@@ -537,3 +537,135 @@ func TestGRPCTransport_StreamErrorStopsReadLoop(t *testing.T) {
 		t.Fatal("timed out waiting for read loop to exit after stream error")
 	}
 }
+
+func TestGRPCTransport_OnControl_ToolResultResponse_Success(t *testing.T) {
+	// Locks in the gRPC translation of a successful async tool result:
+	// IsError must be omitted (or unset) when the proto wire field is
+	// nil, and Content must round-trip verbatim. A regression in
+	// controlEventFromProto's mapping (e.g. wrong proto tag, dropped
+	// field) is the exact failure mode this guards.
+	srv := newTestServer(&pb.ControlEvent{
+		Type:      "tool_result_response",
+		RequestId: "async-tool-7",
+		Content:   "result body for the model",
+	})
+	tr, _, cleanup := setupTestTransport(t, srv)
+	defer cleanup()
+
+	received := make(chan types.ControlEvent, 1)
+	tr.OnControl(func(event types.ControlEvent) {
+		received <- event
+	})
+
+	select {
+	case ev := <-received:
+		if ev.Type != "tool_result_response" {
+			t.Fatalf("got type %q, want tool_result_response", ev.Type)
+		}
+		if ev.RequestID != "async-tool-7" {
+			t.Errorf("got RequestID %q, want async-tool-7", ev.RequestID)
+		}
+		if ev.Content != "result body for the model" {
+			t.Errorf("got Content %q, want 'result body for the model'", ev.Content)
+		}
+		if ev.IsError != nil {
+			t.Errorf("expected IsError nil for success response, got %v", *ev.IsError)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tool_result_response")
+	}
+}
+
+func TestGRPCTransport_OnControl_ToolResultResponse_IsError(t *testing.T) {
+	// Locks in the IsError=true translation. The proto field is an
+	// OptionalBool wrapper; controlEventFromProto must dereference and
+	// produce a *bool whose value is true. A nil-pointer bug or wrong
+	// field copy would silently downgrade upstream errors to
+	// successes — exactly the kind of regression the harness's error
+	// taxonomy depends on catching.
+	yes := true
+	srv := newTestServer(&pb.ControlEvent{
+		Type:      "tool_result_response",
+		RequestId: "async-tool-9",
+		Content:   "upstream said no",
+		IsError:   &pb.OptionalBool{Value: yes},
+	})
+	tr, _, cleanup := setupTestTransport(t, srv)
+	defer cleanup()
+
+	received := make(chan types.ControlEvent, 1)
+	tr.OnControl(func(event types.ControlEvent) {
+		received <- event
+	})
+
+	select {
+	case ev := <-received:
+		if ev.Type != "tool_result_response" {
+			t.Fatalf("got type %q, want tool_result_response", ev.Type)
+		}
+		if ev.RequestID != "async-tool-9" {
+			t.Errorf("got RequestID %q, want async-tool-9", ev.RequestID)
+		}
+		if ev.Content != "upstream said no" {
+			t.Errorf("got Content %q, want 'upstream said no'", ev.Content)
+		}
+		if ev.IsError == nil {
+			t.Fatal("expected IsError non-nil for error response")
+		}
+		if !*ev.IsError {
+			t.Errorf("expected IsError=true, got false")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tool_result_response")
+	}
+}
+
+func TestGRPCTransport_EmitToolResultRequest(t *testing.T) {
+	// The harness emits tool_result_request when an async tool defers
+	// its result. Lock in the four wire fields the control plane needs
+	// to route the request and emit the matching tool_result_response:
+	// RequestID, ToolUseID, ToolName, and Input. A drop or rename in
+	// harnessEventToProto would silently break async tool dispatch on
+	// the gRPC path.
+	srv := newTestServer()
+	tr, _, cleanup := setupTestTransport(t, srv)
+	defer cleanup()
+
+	input := json.RawMessage(`{"prompt":"hello"}`)
+	event := types.HarnessEvent{
+		Type:      "tool_result_request",
+		RequestID: "async-tool-1",
+		ToolUseID: "tc_1",
+		ToolName:  "async_echo",
+		Input:     input,
+	}
+
+	if err := tr.Emit(event); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	// Close send side so the server's Recv loop completes.
+	_ = tr.stream.CloseSend()
+	time.Sleep(50 * time.Millisecond)
+
+	received := srv.getReceived()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 received event, got %d", len(received))
+	}
+	got := received[0]
+	if got.Type != "tool_result_request" {
+		t.Errorf("got Type %q, want tool_result_request", got.Type)
+	}
+	if got.RequestId != "async-tool-1" {
+		t.Errorf("got RequestId %q, want async-tool-1", got.RequestId)
+	}
+	if got.ToolUseId != "tc_1" {
+		t.Errorf("got ToolUseId %q, want tc_1", got.ToolUseId)
+	}
+	if got.ToolName != "async_echo" {
+		t.Errorf("got ToolName %q, want async_echo", got.ToolName)
+	}
+	if string(got.Input) != `{"prompt":"hello"}` {
+		t.Errorf("got Input %q, want %q", string(got.Input), `{"prompt":"hello"}`)
+	}
+}

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -38,11 +38,17 @@ func controlEventFromProto(pe *pb.ControlEvent) types.ControlEvent {
 		UserResponse: pe.UserResponse,
 		RequestID:    pe.RequestId,
 		Reason:       pe.Reason,
+		Content:      pe.Content,
 	}
 
 	if pe.Allowed != nil {
 		v := pe.Allowed.Value
 		e.Allowed = &v
+	}
+
+	if pe.IsError != nil {
+		v := pe.IsError.Value
+		e.IsError = &v
 	}
 
 	if pe.Task != nil {

--- a/harness/internal/transport/null.go
+++ b/harness/internal/transport/null.go
@@ -20,3 +20,31 @@ func (t *NullTransport) OnControl(_ func(types.ControlEvent)) {}
 
 // Close is a no-op.
 func (t *NullTransport) Close() error { return nil }
+
+// IsNullTransport returns true. Subsystems that depend on a live control
+// plane (e.g. async tool dispatch) check for this capability via the
+// NullCapable interface and fail fast rather than blocking on a transport
+// that will never deliver a response.
+func (t *NullTransport) IsNullTransport() bool { return true }
+
+// NullCapable is satisfied by transports that report whether they are
+// equivalent to a NullTransport for control-event delivery purposes. The
+// async tool dispatch path uses this to refuse to start a request that
+// would never resolve. Other transports may embed NullTransport (e.g. the
+// sub-agent's captureTransport); this interface lets the embedder still be
+// detected as null-equivalent.
+type NullCapable interface {
+	IsNullTransport() bool
+}
+
+// IsNull reports whether t is, or wraps, a NullTransport for control-event
+// delivery. Returns false for nil so callers do not need a separate guard.
+func IsNull(t HasOnControl) bool {
+	if t == nil {
+		return false
+	}
+	if nc, ok := t.(NullCapable); ok {
+		return nc.IsNullTransport()
+	}
+	return false
+}

--- a/harness/internal/transport/null_test.go
+++ b/harness/internal/transport/null_test.go
@@ -29,3 +29,58 @@ func TestNullTransport_OnControlDoesNotPanic(t *testing.T) {
 	// Should not panic even with a non-nil handler.
 	tp.OnControl(func(_ types.ControlEvent) {})
 }
+
+// onControlOnly is a stub HasOnControl that does NOT implement
+// NullCapable. It is the analogue of the production stdio/grpc
+// transports for the purpose of IsNull checks.
+type onControlOnly struct{}
+
+func (onControlOnly) OnControl(_ func(types.ControlEvent)) {}
+
+// embedsNullTransport wraps NullTransport. The async tool dispatch path
+// promotes IsNullTransport through embedding: a sub-agent's
+// captureTransport embeds NullTransport, and IsNull must still report it
+// as null-equivalent so async dispatch fails fast rather than blocking
+// on a transport that never delivers.
+type embedsNullTransport struct {
+	*NullTransport
+}
+
+func TestIsNull_NilReturnsFalse(t *testing.T) {
+	// IsNull(nil) is false by contract. Callers that pass a nil
+	// transport should fail their own nil-check separately; IsNull is
+	// strictly "is this a null-equivalent transport", not "is this a
+	// usable transport".
+	if IsNull(nil) {
+		t.Fatal("IsNull(nil) returned true; expected false")
+	}
+}
+
+func TestIsNull_NullTransport(t *testing.T) {
+	if !IsNull(NewNullTransport()) {
+		t.Fatal("IsNull(NewNullTransport()) returned false; expected true")
+	}
+}
+
+func TestIsNull_NonNullTransport(t *testing.T) {
+	// A transport that exposes OnControl but does NOT implement
+	// NullCapable must be reported as non-null. This guards against a
+	// regression where IsNull's type assertion is loosened to a
+	// structural check that would mistakenly flag every Transport.
+	if IsNull(onControlOnly{}) {
+		t.Fatal("IsNull(onControlOnly{}) returned true; expected false")
+	}
+}
+
+func TestIsNull_EmbeddedNullTransportPromoted(t *testing.T) {
+	// Wrappers that embed *NullTransport inherit IsNullTransport via
+	// method promotion. This is load-bearing for the sub-agent path:
+	// the sub-agent's captureTransport embeds NullTransport, and async
+	// tool dispatch on a sub-agent must see the embedder as null-
+	// equivalent so it fails fast rather than blocking on the per-call
+	// timeout.
+	wrapped := &embedsNullTransport{NullTransport: NewNullTransport()}
+	if !IsNull(wrapped) {
+		t.Fatal("IsNull(embedsNullTransport) returned false; expected true (method promotion)")
+	}
+}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -56,6 +56,18 @@ service HarnessService {
 //     - input:      JSON-encoded tool input (so the control plane can display
 //                   what the tool wants to do).
 //
+//   "tool_result_request"
+//     - request_id: unique ID for this request; the control plane must echo it
+//                   back in the corresponding tool_result_response ControlEvent.
+//     - tool_use_id: the tool-use ID assigned by the model for this call (so
+//                    the control plane can correlate to the original tool_call).
+//     - tool_name:   the async tool whose result is being requested.
+//     - input:       JSON-encoded tool input (so the control plane can decide
+//                    what to do).
+//     Emitted by the agentic loop when an async tool defers its result to the
+//     control plane. The harness blocks on the matching tool_result_response
+//     under ctx cancellation and a per-call timeout.
+//
 //   "done"
 //     - stop_reason: why the run ended ("end_turn", "max_turns", "timeout",
 //                    "stalled", "tool_failures", "cancelled", "budget_exceeded").
@@ -74,7 +86,8 @@ service HarnessService {
 message HarnessEvent {
   // Required. The event type discriminator.
   // Valid values: "text_delta", "tool_call", "tool_result", "done", "error",
-  //              "warning", "heartbeat", "ready", "permission_request".
+  //              "warning", "heartbeat", "ready", "permission_request",
+  //              "tool_result_request".
   string type = 1;
 
   // Incremental text fragment from the model. Set on "text_delta" events.
@@ -86,11 +99,12 @@ message HarnessEvent {
   // Tool name. Set on "tool_call" events.
   string name = 4;
 
-  // JSON-encoded tool input parameters. Set on "tool_call" and
-  // "permission_request" events.
+  // JSON-encoded tool input parameters. Set on "tool_call",
+  // "permission_request", and "tool_result_request" events.
   bytes input = 5;
 
-  // The tool-use ID this result corresponds to. Set on "tool_result" events.
+  // The tool-use ID this result corresponds to. Set on "tool_result" and
+  // "tool_result_request" events.
   string tool_use_id = 6;
 
   // Tool execution result. Set on "tool_result" events.
@@ -107,12 +121,13 @@ message HarnessEvent {
   // Execution metrics. Set on "done" events.
   RunTrace trace = 10;
 
-  // Unique request ID for permission correlation. Set on "permission_request"
-  // events. The control plane must echo this back in the permission_response
-  // ControlEvent's request_id field.
+  // Unique request ID for correlation. Set on "permission_request" and
+  // "tool_result_request" events. The control plane must echo this back in
+  // the corresponding permission_response / tool_result_response ControlEvent.
   string request_id = 11;
 
-  // The tool requesting permission. Set on "permission_request" events.
+  // The tool name. Set on "permission_request" (tool requesting permission)
+  // and "tool_result_request" (async tool whose result is being requested).
   string tool_name = 12;
 
   // Build version of the harness binary. Set on "ready" events. The control
@@ -141,6 +156,16 @@ message HarnessEvent {
 //     - reason:     optional human-readable explanation for denial; passed
 //                   back to the model as context.
 //
+//   "tool_result_response"
+//     - request_id: must match the request_id from the corresponding
+//                   tool_result_request HarnessEvent.
+//     - content:    string result payload to deliver back to the agentic
+//                   loop as the async tool's output.
+//     - is_error:   when true, the loop treats the result as an error
+//                   (IsError=true on the ToolResult passed to the model).
+//                   Use this for upstream-side failures the model should
+//                   see as a tool error rather than a successful result.
+//
 //   "cancel"
 //     - (no additional fields) Signals that the run should be aborted. The
 //       harness terminates the run within one turn boundary: any in-flight
@@ -152,7 +177,7 @@ message HarnessEvent {
 message ControlEvent {
   // Required. The event type discriminator.
   // Valid values: "task_assignment", "user_response", "cancel",
-  //              "permission_response".
+  //              "permission_response", "tool_result_response".
   string type = 1;
 
   // The run configuration. Set on "task_assignment" events only. This is the
@@ -162,9 +187,9 @@ message ControlEvent {
   // Free-text user response. Set on "user_response" events.
   string user_response = 3;
 
-  // Correlates a permission_response with the originating permission_request.
-  // Set on "permission_response" events. Must match a previously received
-  // HarnessEvent.request_id.
+  // Correlates the response with the originating request HarnessEvent.
+  // Set on "permission_response" and "tool_result_response" events. Must
+  // match a previously received HarnessEvent.request_id.
   string request_id = 4;
 
   // The permission decision. Set on "permission_response" events.
@@ -174,6 +199,15 @@ message ControlEvent {
   // Human-readable explanation for a denial. Set on "permission_response"
   // events when allowed is false. Passed to the model as context.
   string reason = 6;
+
+  // Async tool result payload. Set on "tool_result_response" events. Delivered
+  // to the agentic loop verbatim as the async tool's output content.
+  string content = 7;
+
+  // When true on a "tool_result_response", the loop marks the resulting
+  // ToolResult as an error so the model sees it as a tool failure. Wrapped
+  // to distinguish unset from explicit-false (proto3 scalar default).
+  OptionalBool is_error = 8;
 }
 
 // OptionalBool wraps a boolean so we can distinguish "not set" from "false"

--- a/types/events.go
+++ b/types/events.go
@@ -41,8 +41,20 @@ type StreamParams struct {
 }
 
 // HarnessEvent is an event emitted by the harness to the control plane.
+//
+// Type discriminates the event shape. Recognised values:
+//
+//   - "text_delta", "tool_call", "tool_result", "done", "error", "warning",
+//     "heartbeat", "ready"
+//   - "permission_request"   — emitted by the AskUpstreamPolicy when a tool
+//     call needs operator approval; correlated by RequestID with the
+//     incoming "permission_response" ControlEvent.
+//   - "tool_result_request"  — emitted by the agentic loop when an async
+//     tool defers its result; correlated by RequestID with the incoming
+//     "tool_result_response" ControlEvent. Carries ToolUseID, ToolName and
+//     Input so the control plane can correlate to the original tool_call.
 type HarnessEvent struct {
-	Type           string          `json:"type"` // "text_delta" | "tool_call" | "tool_result" | "done" | "error" | "heartbeat" | "ready" | "permission_request"
+	Type           string          `json:"type"`
 	Text           string          `json:"text,omitempty"`
 	ID             string          `json:"id,omitempty"`
 	Name           string          `json:"name,omitempty"`
@@ -52,19 +64,32 @@ type HarnessEvent struct {
 	StopReason     string          `json:"stopReason,omitempty"`
 	Message        string          `json:"message,omitempty"`
 	Trace          *RunTrace       `json:"trace,omitempty"`
-	RequestID      string          `json:"requestId,omitempty"`      // correlates permission_request with permission_response
-	ToolName       string          `json:"toolName,omitempty"`       // tool name in permission_request
+	RequestID      string          `json:"requestId,omitempty"`      // correlates permission/tool-result requests with their responses
+	ToolName       string          `json:"toolName,omitempty"`       // tool name on permission_request and tool_result_request
 	HarnessVersion string          `json:"harnessVersion,omitempty"` // harness build version (set on "ready" events)
 }
 
 // ControlEvent is an event received from the control plane.
+//
+// Type discriminates the event shape. Recognised values:
+//
+//   - "task_assignment", "user_response", "cancel"
+//   - "permission_response"   — completes a "permission_request" HarnessEvent.
+//     RequestID echoes the originating request; Allowed (and optional Reason)
+//     carry the decision.
+//   - "tool_result_response"  — completes a "tool_result_request" HarnessEvent
+//     for an async tool. RequestID echoes the originating request; Content
+//     carries the result payload; IsError, when set, marks the result as a
+//     tool failure (the model sees IsError=true on the ToolResult).
 type ControlEvent struct {
-	Type         string     `json:"type"` // "task_assignment" | "user_response" | "cancel" | "permission_response"
+	Type         string     `json:"type"`
 	Task         *RunConfig `json:"task,omitempty"`
 	UserResponse string     `json:"userResponse,omitempty"`
-	RequestID    string     `json:"requestId,omitempty"` // correlates permission_response with permission_request
-	Allowed      *bool      `json:"allowed,omitempty"`   // permission decision
-	Reason       string     `json:"reason,omitempty"`    // explanation for denial
+	RequestID    string     `json:"requestId,omitempty"` // correlates response with the originating request
+	Allowed      *bool      `json:"allowed,omitempty"`   // permission decision (permission_response only)
+	Reason       string     `json:"reason,omitempty"`    // explanation for denial (permission_response only)
+	Content      string     `json:"content,omitempty"`   // async tool result payload (tool_result_response only)
+	IsError      *bool      `json:"isError,omitempty"`   // mark async tool result as an error (tool_result_response only)
 }
 
 // HarnessLifecycleEvent represents lifecycle signals sent on the transport.


### PR DESCRIPTION
Closes #53.

## Summary

Adds an async tool dispatch path so a tool implementation can return a "pending" result and have the agentic loop block until a correlated `tool_result_response` ControlEvent arrives over the transport. Existing synchronous tools work unchanged. The synchronous case stays the simple case; the async path is opt-in via a new `AsyncHandler` field on `tool.Tool`.

The issue itself is mechanism-only — no specific consumer is added in this PR. The seam exists so future tools can delegate work upstream rather than running inline.

## Architecture

| Layer | Change |
|---|---|
| Correlator | New `harness/internal/transport/correlator.go` — generic request/response correlation primitive (Emit + register pending channel + select on response/timeout/ctx, with cleanup on every exit path). Replaces the inline implementation that previously lived in `permission/askupstream.go`. |
| Permission | `permission.AskUpstreamPolicy` migrated to consume the shared correlator (commit `3b9f8ce`). Public API unchanged. |
| Wire format | New `HarnessEvent` type `tool_result_request` (loop → control plane) and `ControlEvent` type `tool_result_response` (control plane → loop) — symmetrical with `permission_request`/`permission_response`. `ControlEvent.is_error` uses `OptionalBool` for the same disambiguation reason as `permission_response.allowed`. |
| Tool | `tool.Tool.AsyncHandler` (optional). When non-nil and `Handler == nil`, the dispatch loop routes through `dispatchAsyncToolCall`. Existing builtins set only `Handler` — zero edits to `harness/internal/tool/builtins/`. |
| Loop | `dispatchAsyncToolCall` in `harness/internal/core/types.go` runs all the same pre-dispatch checks (`StripDangerousKeysFromInput`, `ValidateJSONSchema`, `GuardToolCall`, permission check) as the sync path, then calls `Correlator.Await`. The OTel span and `ToolCallDuration` histogram surround the full dispatch, so duration reflects wall-clock from dispatch to resolution. |
| Sub-agents | `transport.NullCapable` interface + `transport.IsNull()` helper. Sub-agents wrap `NullTransport` in `captureTransport`; method promotion via embedding makes `IsNull()` see through the wrapper without reflection. Async tools dispatched on a sub-agent loop fail fast with a clear error rather than hanging. |
| Error taxonomy | Four distinct `ToolResult.Content` prefixes: `transport_disconnect`, `upstream_error`, `timeout`, `tool_internal_error`, plus `cancelled`. All set `IsError=true`. |
| Stall detection | `stallDetector.recordToolCall` is still called once per dispatch with the resolved success bool. Identical-call detection works for async tools (verified by `TestAsyncDispatch_StallDetectionStillFires`). |

## Commits (10 total, in landing order)

1. `f1d3aef` transport: add generic request/response correlator
2. `3b9f8ce` permission: migrate AskUpstreamPolicy to shared correlator
3. `33ee9ba` proto, types: add async tool result wire format
4. `4545e64` tool, transport: declare async tool seam
5. `7c871b3` core: dispatch async tools via transport correlator
6. `51c9727` core: tests for async tool dispatch path
7. `cf6a373` core: race-safe access to async correlator pointer
8. `ba3cc4b` core, tool: remove unused AsyncDispatch.RequestID field *(remediation)*
9. `93cea78` core: structured prefix, scrub, and 1MB cap on async tool results *(remediation)*
10. `40e1134` transport: tests for IsNull and tool_result wire format *(remediation)*

## Review cycle

Five-reviewer cycle (code, security, spec-compliance, test-coverage, api-design) ran on commits `f1d3aef..cf6a373`. The synthesizer produced a "ship-with-fixes" verdict; commits 8–10 above are the remediation pass. Highlights:

### Blocking findings — fixed in remediation
- **Spec/consistency** — the `is_error=true` branch of `dispatchAsyncToolCall` returned the raw control-plane content with no error-taxonomy prefix, while the other three error paths (`transport_disconnect`, `timeout`, `tool_internal_error`) all prefixed `"async tool <name> <category>: ..."`. Fixed in `93cea78` so the model can distinguish upstream errors from the other failure modes.
- **Security / data-leakage** — content from a `tool_result_response` flowed into the JSONL trace's `RecordToolCall.ErrorReason` without `security.Scrub()`. Sync tool errors come from trusted in-process code; this string comes from the partially-trusted control plane. Fixed in `93cea78`: `security.Scrub` runs on `resp.content` before it is wrapped, so the trace and the model context both see the redacted form.
- **Security / DoS** — async tool result content was uncapped. Sync paths cap at 1MB (commands) or 10MB (file reads); the async path accepted unbounded content from the control plane, which then entered message history. Fixed in `93cea78`: `extractAsyncToolResult` truncates at 1MB with a `"... [truncated by harness]"` suffix.

### Should-fix — addressed
- **`AsyncDispatch.RequestID` field was a documentation lie** — declared as a field tools could populate for their own bookkeeping, but the loop silently discarded it (`_ = dispatch.RequestID`). The correlator owns the wire ID unconditionally; there is no consumer for a tool-supplied ID. Field removed in `ba3cc4b`. The struct stays in place for future extensibility.
- **gRPC translation and `IsNull` had zero direct test coverage** — a field-mapping bug in `controlEventFromProto` or a regression in `IsNull`'s nil guard would have passed all existing tests silently. `40e1134` adds 4 `TestIsNull_*` tests (nil, NullTransport, non-null, embedded-via-promotion) plus 3 wire-format tests (`tool_result_response` success/is-error round-trip, `tool_result_request` emit round-trip).

### Deferred (with rationale)
- **Predictable monotonic request IDs** (security MEDIUM-3). Same threat model already applies to `permission_request` IDs and is unaddressed there; switching to `crypto/rand` here without a unified policy would create inconsistency. Trust-model-documentation fix or a follow-up issue covering both is the right shape.
- **Test-coverage P2/P3 items** — `IsError: &false` non-nil branch, permission-denial-blocks-dispatch test, `ToolCallDuration` histogram assertion for async path, `context.DeadlineExceeded` branch, `Correlator.AttachTo` nil-t guard. All would lock in current behaviour but none would catch a current regression. Filing as a "test-coverage gaps for #53" follow-up.
- **API-design future-work** — `errors.Is` with exported sentinel errors instead of `strings.Contains(err.Error(), "emit failed")` for error classification; useful when the first real consumer is written.
- **Code review nits** — comment additions for the `atomic.Pointer + sync.Once` pattern, the buffered-channel cap-1 invariant, the lazy correlator construction ordering. Will fold into a single nits commit on the next touch of these files.

## Acceptance criteria (from #53)

- [x] **AC1** — Async tool returns "pending"; loop blocks on correlated event with ctx cancellation and per-call timeout. Implemented via `Correlator.Await`.
- [x] **AC2** — All existing built-in tools work unchanged. `git diff main..HEAD -- harness/internal/tool/builtins/` is empty.
- [x] **AC3** — Correlation primitive shared with `AskUpstreamPolicy`. `transport.Correlator` is consumed by both (commit `3b9f8ce` migrated `AskUpstreamPolicy`).
- [x] **AC4** — Tests cover happy-path, timeout, ctx cancellation, transport emit failure, out-of-order resolution. All five present in `harness/internal/core/loop_async_test.go` and independently in `harness/internal/transport/correlator_test.go`.
- [x] **AC5** — Trace span and `ToolCallDuration` measure wall-clock from dispatch to resolution. The existing instrumentation in `loop.go:611-651` surrounds the full `dispatchToolCall` call, which now blocks until resolution for async tools.
- [x] **AC6** — `go test ./harness/... ./types/...` and `golangci-lint run` pass clean (also `-race` clean).
- [x] **AC7** — No changes to `harnessapi/`. `git diff main..HEAD -- harness/harnessapi/` is empty.
- [x] **AC8** — `proto/harness/v1/harness.proto` regenerated via `buf generate`; `gen/harness/v1/harness.pb.go` is committed.

## Non-goals (preserved)

- **No parallel tool dispatch.** The loop is still conceptually one-call-at-a-time. The correlator design does not preclude future parallelism, but adding it is out of scope here.
- **No new transport messages beyond what async tool resolution requires.**
- **No specific consumer of the new capability.** Mechanism only.
- **No changes to the `harnessapi/` public surface.**

## Test plan

- [x] `go build ./harness/... ./types/...` — clean
- [x] `go test ./harness/... ./types/... ./eval/...` — clean (~22 new test functions across `correlator_test.go`, `loop_async_test.go`, `null_test.go`, `grpc_test.go`)
- [x] `go test -race ./harness/... ./types/...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `buf generate` — clean; regenerated proto committed; no hand edits to `gen/`
- [ ] Reviewer: scrutinise the chosen wire-format names (`tool_result_request` / `tool_result_response`) — they avoid the pre-existing harness→control `tool_result` event but introduce a longer name pair. Acceptable?
- [ ] Reviewer: confirm the `AsyncDispatch` struct keeping a single `Timeout` field is the right shape for future extension (vs. shrinking it to nothing or merging into a different type)
- [ ] Reviewer: confirm the deferred-items list is the right boundary between "this PR" and "follow-up issue"

🤖 Generated with [Claude Code](https://claude.com/claude-code)