### PR TITLE
core: surface provider errors via slog and transport warning

### DIFF
--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -515,9 +515,29 @@ func (l *AgenticLoop) runInnerLoop(
 			// value would land in OTLP exports unredacted. RecordError
 			// keeps the raw error so the span retains type information;
 			// only the user-visible status message is scrubbed.
+			scrubbedErr := security.Scrub(err.Error())
 			providerSpan.RecordError(err)
-			providerSpan.SetStatus(codes.Error, security.Scrub(err.Error()))
+			providerSpan.SetStatus(codes.Error, scrubbedErr)
 			providerSpan.End()
+			// Surface the failure outside of OTel: log it and emit a
+			// transport warning. Without this, operators running without
+			// an OTLP collector see only outcome=error with no detail.
+			// ScrubHandler only intercepts string-kind slog attrs, so a
+			// raw error value would slip through as KindAny — pass the
+			// pre-scrubbed string explicitly. Skip when the context is
+			// already cancelled: the cancel/timeout path below produces
+			// the user-visible message.
+			if ctx.Err() == nil {
+				l.Logger.Error("provider stream failed",
+					"provider", selection.Provider,
+					"model", selection.Model,
+					"error", scrubbedErr,
+				)
+				_ = l.Transport.Emit(types.HarnessEvent{
+					Type:    "warning",
+					Message: fmt.Sprintf("provider %s (%s): %s", selection.Provider, selection.Model, scrubbedErr),
+				})
+			}
 			// Rollback: don't append anything on error.
 			l.Metrics.ProviderErrors.Add(ctx, 1, providerAttrs)
 			l.Trace.RecordTurn(types.TurnTrace{
@@ -543,9 +563,23 @@ func (l *AgenticLoop) runInnerLoop(
 			// stream errors can wrap *url.Error or other strings derived
 			// from HTTP transport state, and the OTel span status string
 			// is not covered by ScrubHandler.
+			scrubbedErr := security.Scrub(streamErr.Error())
 			providerSpan.RecordError(streamErr)
-			providerSpan.SetStatus(codes.Error, security.Scrub(streamErr.Error()))
+			providerSpan.SetStatus(codes.Error, scrubbedErr)
 			providerSpan.End()
+			// Surface the failure outside of OTel — see the matching
+			// log + emit at the Stream() call above for rationale.
+			if ctx.Err() == nil {
+				l.Logger.Error("provider stream failed",
+					"provider", selection.Provider,
+					"model", selection.Model,
+					"error", scrubbedErr,
+				)
+				_ = l.Transport.Emit(types.HarnessEvent{
+					Type:    "warning",
+					Message: fmt.Sprintf("provider %s (%s): %s", selection.Provider, selection.Model, scrubbedErr),
+				})
+			}
 			// Rollback on stream error — don't append partial content.
 			l.Metrics.ProviderErrors.Add(ctx, 1, providerAttrs)
 			l.Trace.RecordTurn(types.TurnTrace{

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+	"github.com/rxbynerd/stirrup/harness/internal/provider"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
@@ -652,6 +653,72 @@ func TestLoop_StreamEventError(t *testing.T) {
 	}
 	if runTrace.Outcome != "error" {
 		t.Errorf("expected outcome 'error', got %q", runTrace.Outcome)
+	}
+}
+
+// TestLoop_ProviderError_SurfacesViaTransport guards against a regression
+// where the loop swallowed provider/stream errors into OTel spans only,
+// leaving operators without an OTLP collector with no idea why a run
+// failed. The error string must be reachable on the transport stream and
+// the slog log output.
+func TestLoop_ProviderError_SurfacesViaTransport(t *testing.T) {
+	cases := []struct {
+		name   string
+		prov   provider.ProviderAdapter
+		needle string
+	}{
+		{
+			name:   "stream-init",
+			prov:   &errorProvider{err: errors.New("ValidationException: bad model id")},
+			needle: "ValidationException: bad model id",
+		},
+		{
+			name:   "stream-event",
+			prov:   &streamErrorProvider{err: errors.New("upstream 503 retrying")},
+			needle: "upstream 503 retrying",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var transportBuf, logBuf bytes.Buffer
+
+			registry := tool.NewRegistry()
+			loop := &AgenticLoop{
+				Provider:    tc.prov,
+				Router:      router.NewStaticRouter("bedrock", "claude-sonnet-4-6"),
+				Prompt:      prompt.NewDefaultPromptBuilder(),
+				Context:     contextpkg.NewSlidingWindowStrategy(),
+				Tools:       registry,
+				Edit:        edit.NewWholeFileStrategy(),
+				Verifier:    verifier.NewNoneVerifier(),
+				Permissions: permission.NewAllowAll(),
+				Git:         git.NewNoneGitStrategy(),
+				Transport:   transport.NewStdioTransport(&transportBuf, &bytes.Buffer{}),
+				Trace:       trace.NewJSONLTraceEmitter(&bytes.Buffer{}),
+				Tracer:      noop.NewTracerProvider().Tracer(""),
+				Metrics:     observability.NewNoopMetrics(),
+				Logger:      slog.New(slog.NewJSONHandler(&logBuf, nil)),
+			}
+
+			runTrace, err := loop.Run(context.Background(), buildTestConfig())
+			if err != nil {
+				t.Fatalf("Run() returned Go error: %v", err)
+			}
+			if runTrace.Outcome != "error" {
+				t.Fatalf("expected outcome 'error', got %q", runTrace.Outcome)
+			}
+
+			if !strings.Contains(transportBuf.String(), tc.needle) {
+				t.Errorf("transport stream missing error detail %q; got:\n%s", tc.needle, transportBuf.String())
+			}
+			if !strings.Contains(transportBuf.String(), `"type":"warning"`) {
+				t.Errorf("expected a warning event on the transport stream; got:\n%s", transportBuf.String())
+			}
+			if !strings.Contains(logBuf.String(), tc.needle) {
+				t.Errorf("slog output missing error detail %q; got:\n%s", tc.needle, logBuf.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

When `Provider.Stream()` or the stream consumer returned an error, the agentic loop recorded it only on the OTel span and a metric counter, then returned `outcome=error` with no other signal. Operators on the default `--trace-emitter jsonl` path saw only `outcome: error` and could not distinguish a Bedrock `ValidationException` from an expired SSO session, an IAM denial, throttling, or a network blip.

Reproduced via:
```sh
./stirrup harness --provider bedrock --prompt "What model are you?"
```
which fails because the default `claude-sonnet-4-6` is an Anthropic-API alias, not a Bedrock model id. The actual `ValidationException: The provided model identifier is invalid.` was completely swallowed.

This change makes provider errors visible without changing the loop's control flow:

- Scrub the error string once at each of the two error sites in `loop.go` and reuse for the existing OTel `SetStatus` plus the new outputs.
- Log via `slog.Error` with `provider` / `model` / `error` attributes. The scrubbed string is passed explicitly because `ScrubHandler` only intercepts string-kind attrs - a raw `error` value would slip through as `KindAny` unscrubbed.
- Emit a `warning` HarnessEvent on the transport, mirroring the existing git-finalise-failure pattern at `loop.go:258`. The terminal `done` event with `stopReason=error` is unchanged, so this is additive for control-plane clients.
- Skip both new emissions when `ctx.Err() != nil` so the cancel/timeout path remains the single source of truth for cancellation messaging.

After the change, the same Bedrock invocation now prints:
```
{"level":"ERROR","msg":"provider stream failed","provider":"bedrock","model":"claude-sonnet-4-6","error":"bedrock ConverseStream: ... ValidationException: The provided model identifier is invalid."}
{"type":"warning","message":"provider bedrock (claude-sonnet-4-6): bedrock ConverseStream: ... ValidationException: The provided model identifier is invalid."}
{"type":"done","stopReason":"error"}
```

## Test plan
- [x] `go test ./harness/... ./types/... ./eval/...` - all pass
- [x] New `TestLoop_ProviderError_SurfacesViaTransport` covers both the init-error and stream-event-error paths and asserts the error text reaches both the transport stream and the slog output
- [x] Existing `TestLoop_ProviderStreamError`, `TestLoop_StreamEventError`, and `TestLoop_ContextCancelled` still pass (cancellation path correctly skips the new emit)
- [x] `golangci-lint run ./harness/internal/core/...` - no new findings on changed files
- [x] End-to-end manual repro: real Bedrock call with the bad default model now surfaces the underlying `ValidationException` instead of opaque `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)