### PR TITLE
fix(otel): attach service.name resource to traces and metrics

### DIFF
--- a/harness/internal/observability/metrics.go
+++ b/harness/internal/observability/metrics.go
@@ -65,6 +65,7 @@ func NewMetrics(ctx context.Context, endpoint string) (*Metrics, error) {
 
 	provider := sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
+		sdkmetric.WithResource(Resource()),
 	)
 	meter := provider.Meter("stirrup-harness")
 

--- a/harness/internal/observability/metrics_test.go
+++ b/harness/internal/observability/metrics_test.go
@@ -91,6 +91,50 @@ func TestMetricsRecording_Histograms(t *testing.T) {
 	assertFloat64HistogramCount(t, histograms, "stirrup.harness.tool_call_duration", 1)
 }
 
+// TestMetricsRecording_Resource is the regression test for the
+// "unknown_service:stirrup" bug on the metrics side: when no Resource is
+// attached to the MeterProvider, OTel-aware backends label the metric
+// stream with the SDK fallback service name. We assert here that the
+// resource carried alongside collected metrics carries service.name=stirrup
+// so this can't silently regress on the metrics path either.
+func TestMetricsRecording_Resource(t *testing.T) {
+	ctx := context.Background()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(Resource()),
+	)
+	meter := provider.Meter("test")
+
+	m, err := newMetricsFromMeter(meter, provider)
+	if err != nil {
+		t.Fatalf("newMetricsFromMeter() error: %v", err)
+	}
+	m.Runs.Add(ctx, 1)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+
+	if rm.Resource == nil {
+		t.Fatal("ResourceMetrics.Resource is nil — MeterProvider was constructed without WithResource")
+	}
+	got := make(map[string]string)
+	for _, kv := range rm.Resource.Attributes() {
+		got[string(kv.Key)] = kv.Value.AsString()
+	}
+	if got["service.name"] != ServiceName {
+		t.Errorf("service.name=%q, want %q", got["service.name"], ServiceName)
+	}
+	if got["service.version"] == "" {
+		t.Errorf("service.version missing from metrics resource")
+	}
+	if got["service.instance.id"] == "" {
+		t.Errorf("service.instance.id missing from metrics resource")
+	}
+}
+
 func TestNoopMetrics_NoPanic(t *testing.T) {
 	ctx := context.Background()
 	m := NewNoopMetrics()

--- a/harness/internal/observability/resource.go
+++ b/harness/internal/observability/resource.go
@@ -1,0 +1,80 @@
+// Package observability provides OTel resource construction shared by the
+// trace emitter and the metrics provider. Both signals must be tagged with
+// the same resource so backends can correlate traces and metrics for one
+// running Stirrup process.
+package observability
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+
+	"github.com/rxbynerd/stirrup/types/version"
+)
+
+// ServiceName is the value emitted as service.name on every span and metric.
+// It is the canonical identifier the harness presents to OTel-aware backends
+// (Zipkin, Jaeger, Tempo, Honeycomb, Datadog, etc.).
+const ServiceName = "stirrup"
+
+var (
+	instanceIDOnce sync.Once
+	instanceID     string
+)
+
+// InstanceID returns a stable random identifier for the current process.
+// It is generated once at first call and reused for the rest of the
+// process's lifetime. Used as service.instance.id so concurrent harness
+// processes can be distinguished in OTel-aware backends.
+//
+// 16 bytes (128 bits) of randomness is enough that collisions across all
+// running Stirrup processes are vanishingly unlikely. The fallback string
+// "unknown" is only ever returned if crypto/rand.Read fails, which on Unix
+// would imply /dev/urandom is unreadable — an environment in which
+// stirrup cannot meaningfully run anyway.
+func InstanceID() string {
+	instanceIDOnce.Do(func() {
+		var b [16]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			instanceID = "unknown"
+			return
+		}
+		instanceID = hex.EncodeToString(b[:])
+	})
+	return instanceID
+}
+
+// Resource builds the OTel Resource that identifies this Stirrup process.
+//
+// It merges three sources, in order of increasing specificity (later wins):
+//  1. resource.Default() — provides telemetry.sdk.{name,language,version},
+//     host.name, and any operator-supplied OTEL_RESOURCE_ATTRIBUTES.
+//     resource.Default() also seeds service.name as
+//     "unknown_service:<binary>"; our overlay below replaces it.
+//  2. Stirrup-specific service identity — service.name, service.version,
+//     service.instance.id.
+//
+// The Default resource's SchemaURL is reused for the overlay so resource.Merge
+// always succeeds. If Merge nonetheless fails (e.g. a future SDK changes the
+// merge contract), we fall back to a schemaless resource carrying just the
+// Stirrup attributes; that still fixes "unknown_service:stirrup", which is
+// the user-visible problem we're solving.
+func Resource() *resource.Resource {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(ServiceName),
+		semconv.ServiceVersion(version.Version()),
+		semconv.ServiceInstanceID(InstanceID()),
+	}
+
+	base := resource.Default()
+	overlay := resource.NewWithAttributes(base.SchemaURL(), attrs...)
+	merged, err := resource.Merge(base, overlay)
+	if err != nil {
+		return resource.NewSchemaless(attrs...)
+	}
+	return merged
+}

--- a/harness/internal/observability/resource_test.go
+++ b/harness/internal/observability/resource_test.go
@@ -1,0 +1,71 @@
+package observability
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+
+	"github.com/rxbynerd/stirrup/types/version"
+)
+
+// TestResource_HasServiceIdentity locks down the spec-required attributes:
+// the OpenTelemetry semantic conventions list service.name as required for
+// every signal, and recommend service.version + service.instance.id. If any
+// of these go missing, downstream backends (Zipkin, Jaeger, Tempo, ...)
+// fall back to "unknown_service:<binary>", which is the regression this
+// test exists to prevent.
+func TestResource_HasServiceIdentity(t *testing.T) {
+	got := attrMap(Resource())
+
+	if v := got["service.name"]; v != ServiceName {
+		t.Errorf("service.name: got %q, want %q", v, ServiceName)
+	}
+	if v := got["service.version"]; v != version.Version() {
+		t.Errorf("service.version: got %q, want %q", v, version.Version())
+	}
+	if got["service.instance.id"] == "" {
+		t.Errorf("service.instance.id: got empty string, want a stable identifier")
+	}
+}
+
+// TestResource_HasSDKAttributes verifies the merge with resource.Default()
+// preserves the telemetry.sdk.* attributes the OTel spec mandates be set
+// by the SDK itself. Without these, exporters can't tell which SDK
+// produced a signal — useful when debugging.
+func TestResource_HasSDKAttributes(t *testing.T) {
+	got := attrMap(Resource())
+
+	for _, key := range []string{
+		"telemetry.sdk.name",
+		"telemetry.sdk.language",
+		"telemetry.sdk.version",
+	} {
+		if got[key] == "" {
+			t.Errorf("%s: missing from merged resource", key)
+		}
+	}
+}
+
+// TestInstanceID_Stable proves the instance ID is generated once per
+// process and reused for the lifetime of that process. Spec compliance:
+// service.instance.id must uniquely identify a single running instance,
+// not change mid-flight.
+func TestInstanceID_Stable(t *testing.T) {
+	first := InstanceID()
+	second := InstanceID()
+
+	if first == "" {
+		t.Fatalf("InstanceID() returned empty string")
+	}
+	if first != second {
+		t.Errorf("InstanceID not stable across calls: first=%q second=%q", first, second)
+	}
+}
+
+func attrMap(res *resource.Resource) map[string]string {
+	out := make(map[string]string)
+	for _, kv := range res.Attributes() {
+		out[string(kv.Key)] = kv.Value.AsString()
+	}
+	return out
+}

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -11,6 +11,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/types"
 	"github.com/rxbynerd/stirrup/types/version"
 )
@@ -45,6 +46,7 @@ func NewOTelTraceEmitter(ctx context.Context, endpoint string) (*OTelTraceEmitte
 
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(observability.Resource()),
 	)
 	tracer := tp.Tracer("stirrup-harness")
 

--- a/harness/internal/trace/otel_test.go
+++ b/harness/internal/trace/otel_test.go
@@ -7,13 +7,17 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/types"
 )
 
 func newTestOTelEmitter() (*OTelTraceEmitter, *tracetest.InMemoryExporter) {
 	exporter := tracetest.NewInMemoryExporter()
+	// Mirror NewOTelTraceEmitter's TracerProvider construction so resource
+	// attributes round-trip through emitted spans in tests.
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(exporter),
+		sdktrace.WithResource(observability.Resource()),
 	)
 	emitter := newOTelTraceEmitterForTest(tp)
 	return emitter, exporter
@@ -253,6 +257,48 @@ func TestOTelTraceEmitter_SessionNameAbsentWhenEmpty(t *testing.T) {
 	for _, attr := range spans[0].Attributes {
 		if string(attr.Key) == "run.session_name" {
 			t.Errorf("run.session_name should be absent when SessionName is empty, found value %q", attr.Value.AsString())
+		}
+	}
+}
+
+// TestOTelTraceEmitter_ResourceAttributes is the regression test for the
+// "unknown_service:stirrup" bug: when no Resource is attached to the
+// TracerProvider, OTel-aware backends (Zipkin, Jaeger, Tempo, ...) display
+// the service name as "unknown_service:<binary>" because the SDK falls
+// back to that placeholder. We assert here that every emitted span carries
+// service.name=stirrup so this can never silently regress.
+func TestOTelTraceEmitter_ResourceAttributes(t *testing.T) {
+	emitter, exporter := newTestOTelEmitter()
+
+	emitter.Start("run-resource", nil)
+	emitter.RecordToolCall(types.ToolCallTrace{Name: "read_file", DurationMs: 1, Success: true})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+
+	for _, span := range spans {
+		if span.Resource == nil {
+			t.Errorf("span %q: Resource is nil — TracerProvider was constructed without WithResource", span.Name)
+			continue
+		}
+		got := make(map[string]string)
+		for _, kv := range span.Resource.Attributes() {
+			got[string(kv.Key)] = kv.Value.AsString()
+		}
+		if got["service.name"] != observability.ServiceName {
+			t.Errorf("span %q: service.name=%q, want %q",
+				span.Name, got["service.name"], observability.ServiceName)
+		}
+		if got["service.version"] == "" {
+			t.Errorf("span %q: service.version missing", span.Name)
+		}
+		if got["service.instance.id"] == "" {
+			t.Errorf("span %q: service.instance.id missing", span.Name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- The `TracerProvider` in `NewOTelTraceEmitter` and the `MeterProvider` in `NewMetrics` were both constructed without an OTel `Resource`, so the SDK fell back to its default `unknown_service:<binary>` service name. OTel-aware backends (Zipkin, Jaeger, Tempo, Honeycomb, Datadog, ...) then displayed the service as `unknown_service:stirrup`.
- Adds `harness/internal/observability/resource.go`: a shared `Resource()` builder that emits `service.name=stirrup`, `service.version` (from the link-time-injected version label), and a 128-bit random `service.instance.id` generated once per process. Merges with `resource.Default()` to preserve spec-mandated `telemetry.sdk.*` attributes and pull in `OTEL_RESOURCE_ATTRIBUTES` env vars.
- Wires the same `Resource` into both the `TracerProvider` (`sdktrace.WithResource`) and `MeterProvider` (`sdkmetric.WithResource`) so traces and metrics from one process share an identical resource set — which is what OTel backends expect for trace/metric correlation.

## Why this approach

Per the [OpenTelemetry semantic conventions for service](https://opentelemetry.io/docs/specs/semconv/resource/#service), `service.name` is required on every signal, with `service.version` and `service.instance.id` strongly recommended so concurrent processes can be distinguished. The merge-with-`Default()` pattern is the documented OTel idiom and preserves backend-friendly defaults (`telemetry.sdk.*`, `host.name`) plus operator overrides via `OTEL_RESOURCE_ATTRIBUTES`.

`InstanceID()` deliberately uses `crypto/rand` rather than pulling in a UUID dependency, consistent with the project's minimal-dependency philosophy. 128 bits of randomness makes collisions across all running Stirrup processes vanishingly unlikely.

## Test plan

- [x] `go test ./harness/... ./types/... ./eval/...` passes
- [x] `golangci-lint run ./internal/observability/... ./internal/trace/...` is clean (pre-existing lint findings elsewhere are unaffected)
- [x] New regression tests pin the fix at three levels:
  - `observability.Resource()` directly: service identity attrs present, `telemetry.sdk.*` preserved through the merge, `InstanceID()` stable across calls
  - `OTelTraceEmitter`: in-memory test helper updated to mirror production wiring; emitted spans carry `service.name=stirrup` etc.
  - `Metrics`: collected `ResourceMetrics.Resource` carries `service.name=stirrup` etc.
- [ ] Manual verification: send traces through the user's `otelcol.yml` (otlp → zipkin) and confirm Zipkin shows `stirrup` as the service name instead of `unknown_service:stirrup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)