### PR TITLE
Add Anthropic WIF smoke test workflow

### DIFF
--- a/.github/workflows/smoke-anthropic.yml
+++ b/.github/workflows/smoke-anthropic.yml
@@ -1,4 +1,4 @@
-name: Smoke Test (Anthropic WIF)
+name: Smoke Test - Anthropic WIF
 
 # End-to-end smoke test for Anthropic Workload Identity Federation.
 # Manually dispatched. Exchanges the GitHub Actions OIDC token for an
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  smoke-test:
+  smoke-anthropic-wif:
     name: Anthropic WIF Smoke Test
     runs-on: ubuntu-latest
     permissions:
@@ -55,12 +55,21 @@ jobs:
             --prompt "Write the string 'smoke test passed' to a file called hello.txt"
 
       - name: Verify trace outcome
-        run: tail -1 trace.jsonl | jq -e '.outcome == "success"'
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -s trace.jsonl ] || { echo "trace.jsonl is missing or empty" >&2; exit 1; }
+          jq -e '.outcome == "success"' trace.jsonl
+
+      - name: Verify workspace output
+        run: |
+          test -f workspace/hello.txt || { echo "hello.txt was not created" >&2; exit 1; }
+          grep -qF 'smoke test passed' workspace/hello.txt || { echo "hello.txt does not contain expected string" >&2; cat workspace/hello.txt >&2; exit 1; }
 
       - name: Upload trace
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: smoke-trace
+          name: smoke-trace-anthropic-wif
           path: trace.jsonl
           retention-days: 7

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,66 @@
+name: Smoke Test (Anthropic WIF)
+
+# End-to-end smoke test for Anthropic Workload Identity Federation.
+# Manually dispatched. Exchanges the GitHub Actions OIDC token for an
+# Anthropic access token via the four federation identifiers below, then
+# runs the harness against the live Anthropic API with no static API key
+# in scope. The four identifiers are non-secret per Anthropic's WIF docs:
+# they identify the federation rule, organization, and service account
+# but cannot themselves authenticate to the API. Workspace ID is omitted
+# because the federation rule is bound to the default workspace.
+#
+# Refs #130
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    name: Anthropic WIF Smoke Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
+          cache-dependency-path: |
+            harness/go.mod
+            types/go.mod
+            eval/go.mod
+
+      - name: Build stirrup binary
+        working-directory: harness
+        run: go build -o ../stirrup ./cmd/stirrup
+
+      - name: Create workspace
+        run: mkdir -p workspace
+
+      - name: Run smoke test
+        run: |
+          ./stirrup harness \
+            --anthropic-federation-rule-id fdrl_01QJMFE86qFDdWzQXEekhYjY \
+            --anthropic-organization-id 5848ccdc-495f-490b-9275-2caab9db344d \
+            --anthropic-service-account-id svac_01Tf7i7VwZm6WRAFjNAawPw9 \
+            --anthropic-from-github-actions \
+            --model claude-haiku-4-5-20251001 \
+            --workspace workspace \
+            --trace trace.jsonl \
+            --max-turns 5 \
+            --prompt "Write the string 'smoke test passed' to a file called hello.txt"
+
+      - name: Verify trace outcome
+        run: tail -1 trace.jsonl | jq -e '.outcome == "success"'
+
+      - name: Upload trace
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-trace
+          path: trace.jsonl
+          retention-days: 7


### PR DESCRIPTION
## Summary

Adds `.github/workflows/smoke-anthropic.yml`, a manually-dispatched (`workflow_dispatch`) GitHub Actions workflow that exercises the Anthropic Workload Identity Federation (WIF) credential path end-to-end against the live Anthropic API. The workflow holds **no static API key**: it uses the GitHub Actions OIDC token (issued via `permissions: id-token: write`) and exchanges it for an Anthropic access token through the four federation identifiers passed on the command line.

This delivers the smoke-test scope from #16 / #117 follow-up, scoped per #130 to Anthropic only. Other providers (Bedrock, Vertex/Gemini, Azure OpenAI) and a scheduled cron trigger are explicitly out of scope and will land as separate follow-up issues.

Closes #130.

## What it does

1. Builds the `stirrup` binary on `ubuntu-latest` from `go.work`.
2. Runs `stirrup harness` against `claude-haiku-4-5-20251001` with `--max-turns 5` (cost-bounded), prompting the model to write `'smoke test passed'` to `workspace/hello.txt` via the WIF flags:
   - `--anthropic-federation-rule-id fdrl_01QJMFE86qFDdWzQXEekhYjY`
   - `--anthropic-organization-id 5848ccdc-495f-490b-9275-2caab9db344d`
   - `--anthropic-service-account-id svac_01Tf7i7VwZm6WRAFjNAawPw9`
   - `--anthropic-from-github-actions` (explicit GHA OIDC opt-in)
3. Verifies the run via two independent steps:
   - `jq -e '.outcome == "success"' trace.jsonl` — guarded by `[ -s trace.jsonl ]` and `set -euo pipefail` so a missing or empty trace fails loudly rather than silently passing.
   - `test -f workspace/hello.txt && grep -qF 'smoke test passed' ...` — confirms the agent actually exercised the edit path, not just that the loop completed.
4. Uploads `trace.jsonl` as the `smoke-trace-anthropic-wif` artifact (7-day retention) with `if: always()` so failed runs preserve the trace for debugging.

## Why hardcode the federation identifiers in YAML?

Anthropic's WIF documentation (`docs/anthropic-wif.md`) explicitly classifies these four fields as non-secret. They identify the federation rule, organization, and service account but cannot authenticate to the API on their own. The actual authentication factor is the per-run OIDC JWT, which GitHub mints fresh per workflow run and which the federation rule binds to this specific repository (and to a workflow path / branch via the rule's subject claim).

`workspaceId` is omitted entirely (rather than passed as `default`) because the federation rule on the Anthropic side is already bound to the default workspace.

## Naming choices for follow-up smoke tests

The workflow is named `smoke-anthropic.yml` (not `smoke-test.yml`) and the artifact is `smoke-trace-anthropic-wif` (not `smoke-trace`). This is deliberate: when Bedrock/Vertex/Azure smoke tests land, each gets its own file and self-documenting artifact name without retroactive standardisation across multiple PRs.

## Review trail

This branch went through a five-reviewer pass (code, security, spec-compliance, test-coverage, api-design) coordinated locally before opening this PR. The four blocking findings were applied in commit `8baa176` on top of the initial implementation in `cefdaad`:

- **B-1, B-2 (api-design):** Renamed file to `smoke-anthropic.yml`, job key to `smoke-anthropic-wif`, artifact to `smoke-trace-anthropic-wif`, before the pattern propagates to other providers.
- **B-3 (code-reviewer + security-reviewer):** Verify step now uses `set -euo pipefail` + `[ -s trace.jsonl ]` guard + direct `jq -e '.outcome == "success"' trace.jsonl`. Previously, `tail -1 trace.jsonl | jq -e ...` would silently pass on a missing file under GNU coreutils.
- **B-4 (code-reviewer + test-coverage-auditor):** Added a workspace-output verify step. `outcome == "success"` only confirms the loop completed; the new step asserts the agent actually wrote `hello.txt` with the expected content.

Spec-compliance review confirmed all 20 requirements from #130 are met. Security review found no high/critical issues; two LOW notes (no top-level `permissions: {}` default-deny, floating major-version action tags) were both consistent with project precedent in `_verify.yml` / `ci.yml` and were filed as non-blocking.

Out-of-scope per the issue (deferred to follow-ups):

- Scheduled `cron` trigger.
- Smoke tests for Bedrock (IRSA), Vertex/Gemini (GKE WI), and Azure OpenAI (AKS WI).
- Top-level `permissions: {}` and per-workflow `timeout-minutes` defence-in-depth (project-wide hardening, not specific to this PR).

## Test plan

- [ ] CI `verify` job passes (no Go changes; verifies workspace still builds).
- [ ] Manually dispatch the workflow from the Actions tab and confirm:
  - [ ] WIF token exchange succeeds (Anthropic federation rule already configured per #117).
  - [ ] `Run smoke test` step exits 0.
  - [ ] `Verify trace outcome` and `Verify workspace output` both pass.
  - [ ] `smoke-trace-anthropic-wif` artifact uploads with a non-empty `trace.jsonl`.
- [ ] Confirm no `ANTHROPIC_API_KEY` secret is referenced anywhere in the workflow logs.

## References

- Issue: #130
- WIF operator walkthrough: `docs/anthropic-wif.md`
- WIF token exchange: `harness/internal/credential/anthropic_wif.go`
- WIF CLI wiring: `harness/cmd/stirrup/cmd/harness.go`
- Pattern source for Go setup: `.github/workflows/_verify.yml`
- Pattern source for artifact upload: `.github/workflows/ci.yml`