### PR TITLE
eval: bounded runner concurrency and per-task artifact retention

### DIFF
--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -90,7 +90,7 @@ func cmdRun(args []string) {
 	suitePath := fs.String("suite", "", "Path to eval suite HCL file (required)")
 	harnessPath := fs.String("harness", "", "Path to stirrup binary (default: stirrup)")
 	outputDir := fs.String("output", "", "Output directory for results (default: current directory)")
-	concurrency := fs.Int("concurrency", 1, "Requested task concurrency (currently tasks run sequentially)")
+	concurrency := fs.Int("concurrency", 1, "Maximum number of tasks to run in parallel (values <= 0 are treated as 1)")
 	dryRun := fs.Bool("dry-run", false, "Validate suite without executing tasks")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
@@ -126,13 +126,22 @@ func cmdRun(args []string) {
 		log.Fatalf("running suite: %v", err)
 	}
 
+	// Write the canonical per-suite result alongside the per-task artifact
+	// tree the runner already created. The top-level result.json is kept
+	// for backward compatibility with CI workflows and downstream tooling
+	// that currently read <outputDir>/result.json — duplicating it is
+	// cheap and keeps blast radius minimal.
+	suiteResultPath := filepath.Join(*outputDir, result.SuiteID, "result.json")
+	if err := writeJSON(suiteResultPath, result); err != nil {
+		log.Fatalf("writing per-suite result: %v", err)
+	}
 	resultPath := filepath.Join(*outputDir, "result.json")
 	if err := writeJSON(resultPath, result); err != nil {
 		log.Fatalf("writing result: %v", err)
 	}
 
 	printSummary(result)
-	fmt.Fprintf(os.Stderr, "\nResults written to %s\n", resultPath)
+	fmt.Fprintf(os.Stderr, "\nResults written to %s (per-suite copy at %s)\n", resultPath, suiteResultPath)
 }
 
 func cmdCompare(args []string) {

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -41,6 +41,100 @@ func TestRun_Version(t *testing.T) {
 	}
 }
 
+// TestCmdRun_DualWrite pins the backward-compatibility guarantee that
+// `eval run` writes result.json in two places: <outputDir>/result.json
+// (the legacy location existing CI workflows read) and
+// <outputDir>/<suiteID>/result.json (the per-suite canonical location
+// that lives alongside per-task artifact directories). Both must exist
+// after a run, and the two files must be byte-identical so neither
+// reader sees a stale snapshot. A regression that, for example, dropped
+// the top-level write would silently break downstream tooling without
+// any test catching it.
+//
+// We use --dry-run to avoid needing a fake harness binary; dry-run
+// still walks the output-directory creation and both writeJSON calls
+// in cmdRun, which is the surface this test is here to cover.
+func TestCmdRun_DualWrite(t *testing.T) {
+	dir := t.TempDir()
+	suitePath := filepath.Join(dir, "dual-write.hcl")
+	hclSrc := `
+suite "dual-write-suite" {
+  description = "fixture for TestCmdRun_DualWrite"
+
+  task "task-a" {
+    prompt = "do task a"
+    judge {
+      type = "test-command"
+      command = "true"
+    }
+  }
+
+  task "task-b" {
+    prompt = "do task b"
+    judge {
+      type = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	if err := os.WriteFile(suitePath, []byte(hclSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputDir := filepath.Join(dir, "out")
+	// Note: cmdRun uses log.Fatalf on error, which would os.Exit the
+	// test binary. The success path with --dry-run does not hit that
+	// branch, so we can exercise it from inside a test. If this ever
+	// regresses to call log.Fatalf on the happy path, the test process
+	// will die loudly — which is itself a useful signal.
+	exitCode := run([]string{
+		"run",
+		"--suite", suitePath,
+		"--output", outputDir,
+		"--dry-run",
+	}, io.Discard)
+	if exitCode != 0 {
+		t.Fatalf("run() exit code = %d, want 0", exitCode)
+	}
+
+	topLevel := filepath.Join(outputDir, "result.json")
+	perSuite := filepath.Join(outputDir, "dual-write-suite", "result.json")
+
+	topLevelData, err := os.ReadFile(topLevel)
+	if err != nil {
+		t.Fatalf("reading top-level result.json: %v", err)
+	}
+	perSuiteData, err := os.ReadFile(perSuite)
+	if err != nil {
+		t.Fatalf("reading per-suite result.json: %v", err)
+	}
+
+	// Both files must contain identical bytes — neither is a partial
+	// snapshot or a different serialisation.
+	if !bytes.Equal(topLevelData, perSuiteData) {
+		t.Errorf("top-level and per-suite result.json differ:\n  top-level:\n%s\n  per-suite:\n%s",
+			topLevelData, perSuiteData)
+	}
+
+	// And both must parse as a SuiteResult with the right SuiteID, so a
+	// regression that wrote an empty file or a different schema would
+	// surface here.
+	var top, per eval.SuiteResult
+	if err := json.Unmarshal(topLevelData, &top); err != nil {
+		t.Fatalf("unmarshal top-level: %v", err)
+	}
+	if err := json.Unmarshal(perSuiteData, &per); err != nil {
+		t.Fatalf("unmarshal per-suite: %v", err)
+	}
+	if top.SuiteID != "dual-write-suite" {
+		t.Errorf("top-level SuiteID = %q, want %q", top.SuiteID, "dual-write-suite")
+	}
+	if per.SuiteID != "dual-write-suite" {
+		t.Errorf("per-suite SuiteID = %q, want %q", per.SuiteID, "dual-write-suite")
+	}
+}
+
 // TestRun_NoArgs documents the empty-args contract: usage goes to stderr,
 // stdout stays untouched, exit code is 1.
 func TestRun_NoArgs(t *testing.T) {

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -210,31 +210,28 @@ func validateSuite(suite types.EvalSuite) error {
 	return nil
 }
 
-// validatePathSegment rejects identifiers that, after filepath.Clean, are not
-// a single non-traversing path component. This blocks `..`, absolute paths,
-// embedded separators (`/` and the platform-native separator), and `.`. The
-// runner uses these IDs verbatim as directory names under OutputDir, so any
-// non-segment value risks artifact paths escaping the configured tree.
+// validatePathSegment rejects identifiers that are not a single non-traversing
+// path component. The runner uses these IDs verbatim as directory names under
+// OutputDir, so any non-segment value risks artifact paths escaping the
+// configured tree.
+//
+// The check is intentionally minimal: ContainsAny("/\\") rejects all path
+// separators (covers POSIX `/` and Windows `\\`, so a separate
+// ContainsRune(os.PathSeparator) check would be dead code), and the explicit
+// `.` / `..` / `..`-prefix checks reject the traversal forms that survive a
+// no-separator input. A redundant filepath.Clean / filepath.IsAbs round-trip
+// would only add reachable branches on Windows quirks irrelevant to this
+// Linux/macOS tool, so they were dropped to keep the validator's surface area
+// honest about what it actually enforces.
 func validatePathSegment(label, id string) error {
-	// Reject embedded separators outright before Clean normalises them away.
 	if strings.ContainsAny(id, "/\\") {
 		return fmt.Errorf("%s %q must not contain path separators", label, id)
 	}
-	if strings.ContainsRune(id, os.PathSeparator) {
-		return fmt.Errorf("%s %q must not contain path separators", label, id)
-	}
-	cleaned := filepath.Clean(id)
-	if cleaned != id {
-		return fmt.Errorf("%s %q is not a normalised path segment", label, id)
-	}
-	if cleaned == "." || cleaned == ".." {
+	if id == "." || id == ".." {
 		return fmt.Errorf("%s %q is a reserved path segment", label, id)
 	}
-	if strings.HasPrefix(cleaned, "..") {
+	if strings.HasPrefix(id, "..") {
 		return fmt.Errorf("%s %q must not start with traversal sequence", label, id)
-	}
-	if filepath.IsAbs(cleaned) {
-		return fmt.Errorf("%s %q must not be an absolute path", label, id)
 	}
 	return nil
 }

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -4,12 +4,15 @@ package runner
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/rxbynerd/stirrup/eval"
@@ -23,11 +26,16 @@ type RunConfig struct {
 	// If empty, defaults to "stirrup" on PATH.
 	HarnessPath string
 
-	// OutputDir is created before running so callers can write suite artifacts there.
+	// OutputDir, when non-empty, enables per-task artifact retention. The
+	// runner writes trace.jsonl, harness.stdout.txt, and harness.stderr.txt
+	// for every task under <OutputDir>/<suiteID>/<taskID>/. The temporary
+	// workspace is intentionally NOT copied: it can be large for repo-cloned
+	// tasks and is out of scope for issue #31.
 	OutputDir string
 
-	// Concurrency is the desired number of parallel tasks.
-	// TODO: not yet implemented; tasks currently run sequentially.
+	// Concurrency caps the number of tasks executed in parallel. Values <= 0
+	// fall back to 1 (sequential). Values larger than the task count are
+	// capped at len(tasks) so we never spawn idle workers.
 	Concurrency int
 
 	// DryRun if true, validates the suite without executing tasks.
@@ -35,6 +43,8 @@ type RunConfig struct {
 }
 
 // RunSuite executes all tasks in a suite and returns the aggregate result.
+// Returned SuiteResult.Tasks preserves suite task order regardless of the
+// order in which the workers actually finished.
 func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.SuiteResult, error) {
 	if err := validateSuite(suite); err != nil {
 		return eval.SuiteResult{}, err
@@ -44,9 +54,16 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 		cfg.HarnessPath = "stirrup"
 	}
 
+	suiteArtifactDir := ""
 	if cfg.OutputDir != "" {
 		if err := os.MkdirAll(cfg.OutputDir, 0o755); err != nil {
 			return eval.SuiteResult{}, fmt.Errorf("creating output directory: %w", err)
+		}
+		// suite.ID has already been validated as a safe single-segment path,
+		// so this join cannot escape OutputDir.
+		suiteArtifactDir = filepath.Join(cfg.OutputDir, suite.ID)
+		if err := os.MkdirAll(suiteArtifactDir, 0o755); err != nil {
+			return eval.SuiteResult{}, fmt.Errorf("creating suite artifact directory: %w", err)
 		}
 	}
 
@@ -75,22 +92,18 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 		}, nil
 	}
 
-	tasks := make([]eval.TaskResult, 0, len(suite.Tasks))
-	for _, t := range suite.Tasks {
-		result := runTask(ctx, t, cfg)
-		tasks = append(tasks, result)
-	}
+	results := runTasksConcurrently(ctx, suite.Tasks, cfg, suiteArtifactDir)
 
 	passCount := 0
-	for _, tr := range tasks {
+	for _, tr := range results {
 		if tr.Outcome == "pass" {
 			passCount++
 		}
 	}
 
 	passRate := float64(0)
-	if len(tasks) > 0 {
-		passRate = float64(passCount) / float64(len(tasks))
+	if len(results) > 0 {
+		passRate = float64(passCount) / float64(len(results))
 	}
 
 	return eval.SuiteResult{
@@ -98,24 +111,139 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 		RunID:       runID,
 		StartedAt:   startedAt,
 		CompletedAt: time.Now(),
-		Tasks:       tasks,
+		Tasks:       results,
 		PassRate:    passRate,
 	}, nil
 }
 
-// validateSuite checks that a suite has the minimum required fields.
+// runTasksConcurrently dispatches tasks across a bounded worker pool while
+// preserving the input order in the returned slice. Concurrency is capped at
+// len(tasks) so we never spawn idle workers; values <= 0 collapse to 1
+// (the historical sequential behaviour). Per-task errors do not abort
+// siblings — every task contributes a TaskResult.
+func runTasksConcurrently(ctx context.Context, tasks []types.EvalTask, cfg RunConfig, suiteArtifactDir string) []eval.TaskResult {
+	concurrency := cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	if concurrency > len(tasks) {
+		concurrency = len(tasks)
+	}
+
+	results := make([]eval.TaskResult, len(tasks))
+
+	type job struct {
+		idx  int
+		task types.EvalTask
+	}
+	jobs := make(chan job)
+
+	var wg sync.WaitGroup
+	for w := 0; w < concurrency; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				results[j.idx] = runTask(ctx, j.task, cfg, suiteArtifactDir)
+			}
+		}()
+	}
+
+	// Feed jobs; honour ctx cancellation so we don't deadlock if all workers
+	// have exited (e.g. on context cancellation, runTask still produces a
+	// result via the harness exec error path, but the dispatcher needs to
+	// stop pushing too).
+	for i, t := range tasks {
+		select {
+		case <-ctx.Done():
+			// Drain remaining tasks as cancellation errors so the result
+			// slice stays in sync with the input slice.
+			for ; i < len(tasks); i++ {
+				results[i] = eval.TaskResult{
+					TaskID:  tasks[i].ID,
+					Outcome: "error",
+					Error:   ctx.Err().Error(),
+					JudgeVerdict: eval.JudgeVerdict{
+						Passed: false,
+						Reason: ctx.Err().Error(),
+					},
+				}
+			}
+			close(jobs)
+			wg.Wait()
+			return results
+		case jobs <- job{idx: i, task: t}:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	return results
+}
+
+// validateSuite checks that a suite has the minimum required fields and that
+// every task ID is a path-safe single segment (so per-task artifact directories
+// cannot escape OutputDir via traversal sequences).
 func validateSuite(suite types.EvalSuite) error {
 	if suite.ID == "" {
 		return fmt.Errorf("suite ID is required")
 	}
+	if err := validatePathSegment("suite ID", suite.ID); err != nil {
+		return err
+	}
 	if len(suite.Tasks) == 0 {
 		return fmt.Errorf("suite must contain at least one task")
+	}
+	seen := make(map[string]struct{}, len(suite.Tasks))
+	for _, t := range suite.Tasks {
+		if t.ID == "" {
+			return fmt.Errorf("task ID is required")
+		}
+		if err := validatePathSegment("task ID", t.ID); err != nil {
+			return err
+		}
+		if _, dup := seen[t.ID]; dup {
+			return fmt.Errorf("duplicate task ID %q", t.ID)
+		}
+		seen[t.ID] = struct{}{}
 	}
 	return nil
 }
 
-// runTask executes a single eval task and returns the result.
-func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig) eval.TaskResult {
+// validatePathSegment rejects identifiers that, after filepath.Clean, are not
+// a single non-traversing path component. This blocks `..`, absolute paths,
+// embedded separators (`/` and the platform-native separator), and `.`. The
+// runner uses these IDs verbatim as directory names under OutputDir, so any
+// non-segment value risks artifact paths escaping the configured tree.
+func validatePathSegment(label, id string) error {
+	// Reject embedded separators outright before Clean normalises them away.
+	if strings.ContainsAny(id, "/\\") {
+		return fmt.Errorf("%s %q must not contain path separators", label, id)
+	}
+	if strings.ContainsRune(id, os.PathSeparator) {
+		return fmt.Errorf("%s %q must not contain path separators", label, id)
+	}
+	cleaned := filepath.Clean(id)
+	if cleaned != id {
+		return fmt.Errorf("%s %q is not a normalised path segment", label, id)
+	}
+	if cleaned == "." || cleaned == ".." {
+		return fmt.Errorf("%s %q is a reserved path segment", label, id)
+	}
+	if strings.HasPrefix(cleaned, "..") {
+		return fmt.Errorf("%s %q must not start with traversal sequence", label, id)
+	}
+	if filepath.IsAbs(cleaned) {
+		return fmt.Errorf("%s %q must not be an absolute path", label, id)
+	}
+	return nil
+}
+
+// runTask executes a single eval task and returns the result. If
+// suiteArtifactDir is non-empty, the task's trace and harness output streams
+// are copied into <suiteArtifactDir>/<taskID>/ before the temp workspace is
+// removed.
+func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtifactDir string) eval.TaskResult {
 	start := time.Now()
 
 	tmpDir, err := os.MkdirTemp("", "eval-task-"+task.ID+"-")
@@ -144,13 +272,26 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig) eval.TaskR
 
 	cmd := exec.CommandContext(ctx, cfg.HarnessPath, args...)
 	cmd.Dir = workspaceDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	cmdErr := cmd.Run()
+
+	// Persist artifacts before consuming results so we capture state even
+	// when the harness exits non-zero. retainArtifacts is best-effort:
+	// retention failures must not mask the harness/judge result.
+	if suiteArtifactDir != "" {
+		retainArtifacts(suiteArtifactDir, task.ID, traceFile, stdoutBuf.Bytes(), stderrBuf.Bytes())
+	}
+
+	if cmdErr != nil {
 		// The harness may still have produced a trace even on failure.
 		// Try to parse it before giving up entirely.
 		trace, traceErr := parseTraceFile(traceFile)
 		if traceErr != nil {
-			return errorResult(task.ID, start, fmt.Errorf("harness failed: %w\noutput: %s", err, output))
+			return errorResult(task.ID, start, fmt.Errorf("harness failed: %w\nstdout: %s\nstderr: %s", cmdErr, stdoutBuf.String(), stderrBuf.String()))
 		}
 		// Harness failed but left a trace — use it for the result.
 		verdict, judgeErr := judge.Evaluate(ctx, task.Judge, judge.JudgeContext{
@@ -175,6 +316,32 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig) eval.TaskR
 	}
 
 	return buildResult(task.ID, start, trace, verdict)
+}
+
+// retainArtifacts copies the per-task harness output and trace into the
+// suite's artifact directory. taskID has already been validated as a safe
+// single-segment path. Retention errors are intentionally swallowed — they
+// must not mask the underlying TaskResult — but failures are still reported
+// via stderr so an operator can see when the artifact tree is incomplete.
+func retainArtifacts(suiteArtifactDir, taskID, traceFile string, stdout, stderr []byte) {
+	taskDir := filepath.Join(suiteArtifactDir, taskID)
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: mkdir: %v\n", taskID, err)
+		return
+	}
+	// Copy the trace file (best-effort: if the harness never wrote one, skip
+	// silently — that case is already reflected in the TaskResult).
+	if data, err := os.ReadFile(traceFile); err == nil {
+		if err := os.WriteFile(filepath.Join(taskDir, "trace.jsonl"), data, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: trace: %v\n", taskID, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "harness.stdout.txt"), stdout, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: stdout: %v\n", taskID, err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "harness.stderr.txt"), stderr, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: stderr: %v\n", taskID, err)
+	}
 }
 
 // cloneRepo clones a git repository at the given ref into the target directory.

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -346,16 +346,21 @@ func writeFakeHarness(t *testing.T, body string) string {
 
 // TestRunSuite_ConcurrencyOrdersDeterministically verifies the worker pool
 // preserves suite task order in the returned SuiteResult.Tasks slice
-// regardless of which workers finished first. The fake harness sleeps for a
-// per-task amount inferred from the workspace path so earlier tasks return
-// LATER than later ones — exactly the ordering hazard a naive append-as-
-// you-finish loop would expose.
+// regardless of which workers actually finished first. The fake harness
+// records a completion-order log keyed by task ID; the assertion is on
+// (a) the result-slice order matching the input order, and (b) the
+// completion-order log being a non-input order — i.e. concurrency
+// genuinely happened. We avoid wall-clock thresholds because they're
+// notoriously flaky under load (issue #31 review).
 func TestRunSuite_ConcurrencyOrdersDeterministically(t *testing.T) {
-	// Sleep ms is decoded from the workspace path: the fake harness extracts
-	// the leading numeric component of the workspace basename. We pass the
-	// expected sleep via the prompt because cmd.Dir is not visible to the
-	// shell wrapper on stdin.
-	script := `#!/bin/sh
+	logDir := t.TempDir()
+	completionLog := filepath.Join(logDir, "completion.log")
+
+	// Per-task sleep is decoded from the prompt; the harness appends the
+	// task ID to completionLog atomically (using a tempfile rename trick is
+	// unnecessary because we only need the *finishing order* of distinct
+	// IDs, and POSIX guarantees small (<= PIPE_BUF) appends are atomic).
+	script := fmt.Sprintf(`#!/bin/sh
 PROMPT=""
 TRACE=""
 while [ $# -gt 0 ]; do
@@ -367,39 +372,33 @@ while [ $# -gt 0 ]; do
 done
 # PROMPT format: "<sleep-ms>:<task-id>".
 SLEEP_MS=$(echo "$PROMPT" | cut -d: -f1)
-# busybox/dash sleep accepts decimals; convert ms -> seconds.
-SLEEP_S=$(awk -v ms="$SLEEP_MS" 'BEGIN { printf "%.3f", ms/1000 }')
+TASK_ID=$(echo "$PROMPT" | cut -d: -f2)
+SLEEP_S=$(awk -v ms="$SLEEP_MS" 'BEGIN { printf "%%.3f", ms/1000 }')
 sleep "$SLEEP_S"
-if [ -n "$TRACE" ]; then
-  echo "{\"id\":\"trace-$PROMPT\",\"turns\":1,\"outcome\":\"success\"}" > "$TRACE"
-fi
-`
+echo "$TASK_ID" >> %q
+[ -n "$TRACE" ] && echo "{\"id\":\"trace-$TASK_ID\",\"turns\":1,\"outcome\":\"success\"}" > "$TRACE"
+`, completionLog)
 	harness := writeFakeHarness(t, script)
 
-	// Pre-create a workspace file each task asserts the existence of, so all
-	// judges pass and we get a deterministic outcome distribution.
-	// Sleeps are chosen so that (a) the sum-of-sleeps is large enough for
-	// concurrency to make a measurable dent, and (b) the spread across tasks
-	// is wide enough to make ordering-by-completion-time differ from
-	// ordering-by-input. Each fork+exec of /bin/sh adds ~30–90ms of
-	// platform-dependent overhead which we conservatively bound below.
+	// Sleeps are chosen so that finishing order strictly differs from input
+	// order under any realistic concurrency level: the longest sleep is on
+	// the first task so a sequential run would put t1 first in the
+	// completion log, but a concurrent run will not.
 	tasks := []types.EvalTask{
-		{ID: "t1", Prompt: "500:t1", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
-		{ID: "t2", Prompt: "50:t2", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
-		{ID: "t3", Prompt: "400:t3", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
-		{ID: "t4", Prompt: "20:t4", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
-		{ID: "t5", Prompt: "300:t5", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t1", Prompt: "300:t1", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t2", Prompt: "20:t2", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t3", Prompt: "200:t3", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t4", Prompt: "10:t4", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t5", Prompt: "100:t5", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
 	}
 	suite := types.EvalSuite{ID: "concurrency-suite", Tasks: tasks}
 
 	out := t.TempDir()
-	start := time.Now()
 	result, err := RunSuite(context.Background(), suite, RunConfig{
 		HarnessPath: harness,
 		OutputDir:   out,
 		Concurrency: 4,
 	})
-	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -413,15 +412,20 @@ fi
 		}
 	}
 
-	// Sanity-check that we actually exploited concurrency. Total serial
-	// sleep time is 1270ms; concurrency=4 with one straggler should bring
-	// wall-clock well under that. We pick a generous 80% bound (1016ms) so
-	// the test stays stable on slow CI runners while still catching a
-	// regression to fully sequential execution.
-	totalSerial := 500 + 50 + 400 + 20 + 300
-	bound := time.Duration(float64(totalSerial)*0.8) * time.Millisecond
-	if elapsed >= bound {
-		t.Errorf("elapsed %v looks sequential (>= %v of %dms total)", elapsed, bound, totalSerial)
+	// Concurrency must have actually happened — the completion order must
+	// differ from the input order. With concurrency=4 and t1 sleeping
+	// longest, t1 cannot be first in the completion log on any machine
+	// that's not pathologically slow.
+	logBytes, err := os.ReadFile(completionLog)
+	if err != nil {
+		t.Fatalf("reading completion log: %v", err)
+	}
+	completionOrder := strings.Fields(string(logBytes))
+	if len(completionOrder) != len(tasks) {
+		t.Fatalf("completion log has %d entries, want %d: %q", len(completionOrder), len(tasks), completionOrder)
+	}
+	if completionOrder[0] == "t1" {
+		t.Errorf("first task to finish was t1 (longest sleep): suggests sequential execution. log=%v", completionOrder)
 	}
 }
 

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rxbynerd/stirrup/eval"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -427,6 +428,18 @@ echo "$TASK_ID" >> %q
 	if completionOrder[0] == "t1" {
 		t.Errorf("first task to finish was t1 (longest sleep): suggests sequential execution. log=%v", completionOrder)
 	}
+	// Stronger assertion: with a 300ms sleep on t1 and 10–200ms on the
+	// others, t1 must finish *last* under concurrency=4. A non-last t1
+	// would mean a faster task got dispatched after t1 yet still finished
+	// later — which is impossible without contention we don't introduce.
+	// This catches regressions where the scheduler drops to effective
+	// concurrency=1 but the first dispatch still happened to be a fast
+	// task (which would satisfy the not-first check).
+	last := completionOrder[len(completionOrder)-1]
+	if last != "t1" {
+		t.Errorf("expected t1 (300ms sleep) to finish last under concurrency=4; got %q; full order: %v",
+			last, completionOrder)
+	}
 }
 
 // TestRunSuite_ConcurrencyZeroDefaultsToOne pins the documented behaviour
@@ -622,6 +635,13 @@ func TestRunSuite_RejectsTraversalIDs(t *testing.T) {
 		{name: "task absolute path", suiteID: "ok", taskID: "/etc/passwd", wantSub: "task ID"},
 		{name: "task with separator", suiteID: "ok", taskID: "sub/dir", wantSub: "task ID"},
 		{name: "task dot segment", suiteID: "ok", taskID: "..", wantSub: "task ID"},
+		// `..`-prefixed IDs that are not exactly ".." must still be rejected,
+		// otherwise an attacker could land artifacts in directories the runner
+		// never intended (e.g. "..foo" on a hostile filesystem). These cover
+		// the HasPrefix(id, "..") branch of validatePathSegment specifically.
+		{name: "task dotdot prefix short", suiteID: "ok", taskID: "..foo", wantSub: "task ID"},
+		{name: "task triple dot prefix", suiteID: "ok", taskID: "...evil", wantSub: "task ID"},
+		{name: "task dotdot prefix hidden", suiteID: "ok", taskID: "..hidden", wantSub: "task ID"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -644,4 +664,119 @@ func TestRunSuite_RejectsTraversalIDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunSuite_ContextCancellation exercises the dispatcher's ctx.Done()
+// drain branch: when the context is cancelled mid-suite, the runner must
+// (a) return promptly without deadlocking, (b) return a result slice with
+// every slot populated (no zero-value TaskResults), and (c) record at
+// least the un-dispatched tasks as outcome="error" carrying the
+// ctx.Err() message. In-flight workers continue writing into their own
+// disjoint slots, so all slots end up populated by exactly one writer
+// (drain or worker) — confirming the ownership invariant the
+// implementation comment relies on.
+//
+// Without this test the goroutine-leak prevention path has zero coverage
+// and a regression that, for example, miscounted the drain start index
+// (leaving zero-value slots) or dropped wg.Wait() (leaking workers
+// writing into a returned slice) would not be caught.
+func TestRunSuite_ContextCancellation(t *testing.T) {
+	// A harness that sleeps 500ms so the dispatcher is guaranteed to be
+	// blocked on `jobs <-` for the un-dispatched tail when cancellation
+	// fires.
+	script := `#!/bin/sh
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+sleep 0.5
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`
+	harness := writeFakeHarness(t, script)
+
+	tasks := make([]types.EvalTask, 8)
+	for i := range tasks {
+		tasks[i] = types.EvalTask{
+			ID:     fmt.Sprintf("c%d", i),
+			Prompt: "p",
+			Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+		}
+	}
+	suite := types.EvalSuite{ID: "cancel-suite", Tasks: tasks}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Fire cancellation 50ms after start. With concurrency=2 and a 500ms
+	// per-task sleep, only the first 2 tasks have a chance to dispatch
+	// before cancel; the remaining 6 must take the drain branch.
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	type runOutcome struct {
+		result []eval.TaskResult
+		err    error
+	}
+	done := make(chan runOutcome, 1)
+	go func() {
+		res, err := RunSuite(ctx, suite, RunConfig{
+			HarnessPath: harness,
+			Concurrency: 2,
+		})
+		done <- runOutcome{result: res.Tasks, err: err}
+	}()
+
+	var outcome runOutcome
+	select {
+	case outcome = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunSuite did not return after context cancellation (deadlock?)")
+	}
+
+	if outcome.err != nil {
+		t.Fatalf("RunSuite returned suite-level error after cancel: %v", outcome.err)
+	}
+
+	if len(outcome.result) != len(tasks) {
+		t.Fatalf("got %d task results, want %d (drain must populate every slot)",
+			len(outcome.result), len(tasks))
+	}
+	for i, tr := range outcome.result {
+		// Zero-value TaskResult would have empty TaskID and empty Outcome.
+		// Either branch (worker or drain) must produce a non-zero result.
+		if tr.TaskID == "" {
+			t.Errorf("Tasks[%d] has empty TaskID — drain left a zero-value slot", i)
+		}
+		if tr.Outcome == "" {
+			t.Errorf("Tasks[%d] (%s) has empty Outcome — slot was never written", i, tr.TaskID)
+		}
+		if tr.TaskID != tasks[i].ID {
+			t.Errorf("Tasks[%d].TaskID = %q, want %q (input order not preserved)",
+				i, tr.TaskID, tasks[i].ID)
+		}
+	}
+
+	// The drain path must have flagged at least one task as outcome="error"
+	// with the cancellation cause. (Tasks dispatched before cancel may
+	// finish either way depending on whether the harness exec returns
+	// before or after ctx cancel propagates; only the drain branch is
+	// deterministic about producing error outcomes.)
+	errCount := 0
+	for _, tr := range outcome.result {
+		if tr.Outcome == "error" && strings.Contains(tr.Error, "context canceled") {
+			errCount++
+		}
+	}
+	if errCount == 0 {
+		t.Errorf("expected at least one task to record context-canceled error; got outcomes: %v",
+			collectOutcomes(outcome.result))
+	}
+}
+
+func collectOutcomes(results []eval.TaskResult) []string {
+	out := make([]string, len(results))
+	for i, r := range results {
+		out[i] = fmt.Sprintf("%s=%s", r.TaskID, r.Outcome)
+	}
+	return out
 }

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -3,9 +3,13 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -260,6 +264,46 @@ func TestValidateSuite(t *testing.T) {
 			name:  "valid",
 			suite: types.EvalSuite{ID: "s1", Tasks: []types.EvalTask{{ID: "t1"}}},
 		},
+		{
+			name: "traversal in suite ID",
+			suite: types.EvalSuite{
+				ID:    "../evil",
+				Tasks: []types.EvalTask{{ID: "t1"}},
+			},
+			wantErr: `suite ID "../evil" must not contain path separators`,
+		},
+		{
+			name: "absolute suite ID",
+			suite: types.EvalSuite{
+				ID:    "/etc/passwd",
+				Tasks: []types.EvalTask{{ID: "t1"}},
+			},
+			wantErr: `suite ID "/etc/passwd" must not contain path separators`,
+		},
+		{
+			name: "duplicate task IDs",
+			suite: types.EvalSuite{
+				ID:    "s1",
+				Tasks: []types.EvalTask{{ID: "t1"}, {ID: "t1"}},
+			},
+			wantErr: `duplicate task ID "t1"`,
+		},
+		{
+			name: "traversal in task ID",
+			suite: types.EvalSuite{
+				ID:    "s1",
+				Tasks: []types.EvalTask{{ID: "../escape"}},
+			},
+			wantErr: `task ID "../escape" must not contain path separators`,
+		},
+		{
+			name: "dot-segment task ID",
+			suite: types.EvalSuite{
+				ID:    "s1",
+				Tasks: []types.EvalTask{{ID: "."}},
+			},
+			wantErr: `task ID "." is a reserved path segment`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -276,6 +320,323 @@ func TestValidateSuite(t *testing.T) {
 			}
 			if err.Error() != tt.wantErr {
 				t.Fatalf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// writeFakeHarness writes a POSIX-shell harness double that records its
+// invocation order, optionally sleeps for a per-task amount, optionally
+// exits non-zero, and writes a minimal trace file. It returns the harness
+// path and an "order log" path the caller can inspect to see which task
+// the harness was last called with. Skips on non-Unix runners since
+// /bin/sh is not portable to Windows.
+func writeFakeHarness(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake harness uses /bin/sh; skipped on Windows")
+	}
+	harnessDir := t.TempDir()
+	path := filepath.Join(harnessDir, "fake-harness")
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestRunSuite_ConcurrencyOrdersDeterministically verifies the worker pool
+// preserves suite task order in the returned SuiteResult.Tasks slice
+// regardless of which workers finished first. The fake harness sleeps for a
+// per-task amount inferred from the workspace path so earlier tasks return
+// LATER than later ones — exactly the ordering hazard a naive append-as-
+// you-finish loop would expose.
+func TestRunSuite_ConcurrencyOrdersDeterministically(t *testing.T) {
+	// Sleep ms is decoded from the workspace path: the fake harness extracts
+	// the leading numeric component of the workspace basename. We pass the
+	// expected sleep via the prompt because cmd.Dir is not visible to the
+	// shell wrapper on stdin.
+	script := `#!/bin/sh
+PROMPT=""
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt) PROMPT="$2"; shift 2 ;;
+    --trace)  TRACE="$2";  shift 2 ;;
+    *) shift ;;
+  esac
+done
+# PROMPT format: "<sleep-ms>:<task-id>".
+SLEEP_MS=$(echo "$PROMPT" | cut -d: -f1)
+# busybox/dash sleep accepts decimals; convert ms -> seconds.
+SLEEP_S=$(awk -v ms="$SLEEP_MS" 'BEGIN { printf "%.3f", ms/1000 }')
+sleep "$SLEEP_S"
+if [ -n "$TRACE" ]; then
+  echo "{\"id\":\"trace-$PROMPT\",\"turns\":1,\"outcome\":\"success\"}" > "$TRACE"
+fi
+`
+	harness := writeFakeHarness(t, script)
+
+	// Pre-create a workspace file each task asserts the existence of, so all
+	// judges pass and we get a deterministic outcome distribution.
+	// Sleeps are chosen so that (a) the sum-of-sleeps is large enough for
+	// concurrency to make a measurable dent, and (b) the spread across tasks
+	// is wide enough to make ordering-by-completion-time differ from
+	// ordering-by-input. Each fork+exec of /bin/sh adds ~30–90ms of
+	// platform-dependent overhead which we conservatively bound below.
+	tasks := []types.EvalTask{
+		{ID: "t1", Prompt: "500:t1", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t2", Prompt: "50:t2", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t3", Prompt: "400:t3", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t4", Prompt: "20:t4", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		{ID: "t5", Prompt: "300:t5", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+	}
+	suite := types.EvalSuite{ID: "concurrency-suite", Tasks: tasks}
+
+	out := t.TempDir()
+	start := time.Now()
+	result, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		OutputDir:   out,
+		Concurrency: 4,
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Tasks) != len(tasks) {
+		t.Fatalf("got %d task results, want %d", len(result.Tasks), len(tasks))
+	}
+	for i, want := range tasks {
+		if result.Tasks[i].TaskID != want.ID {
+			t.Errorf("Tasks[%d].TaskID = %q, want %q (suite order not preserved)", i, result.Tasks[i].TaskID, want.ID)
+		}
+	}
+
+	// Sanity-check that we actually exploited concurrency. Total serial
+	// sleep time is 1270ms; concurrency=4 with one straggler should bring
+	// wall-clock well under that. We pick a generous 80% bound (1016ms) so
+	// the test stays stable on slow CI runners while still catching a
+	// regression to fully sequential execution.
+	totalSerial := 500 + 50 + 400 + 20 + 300
+	bound := time.Duration(float64(totalSerial)*0.8) * time.Millisecond
+	if elapsed >= bound {
+		t.Errorf("elapsed %v looks sequential (>= %v of %dms total)", elapsed, bound, totalSerial)
+	}
+}
+
+// TestRunSuite_ConcurrencyZeroDefaultsToOne pins the documented behaviour
+// that Concurrency<=0 collapses to a sequential run. The test passes when
+// the run completes successfully; a regression that, for example, blocked
+// on a zero-buffered channel with no workers would deadlock here.
+func TestRunSuite_ConcurrencyZeroDefaultsToOne(t *testing.T) {
+	script := `#!/bin/sh
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "seq-suite",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+			{ID: "t2", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, err := RunSuite(context.Background(), suite, RunConfig{
+			HarnessPath: harness,
+			Concurrency: 0,
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// expected
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunSuite with Concurrency=0 deadlocked")
+	}
+}
+
+// TestRunSuite_FailureDoesNotAbortSiblings verifies the per-task error
+// containment invariant: if one task's harness returns non-zero (or its
+// trace is malformed), the other tasks still produce TaskResults and the
+// suite result still surfaces all of them.
+func TestRunSuite_FailureDoesNotAbortSiblings(t *testing.T) {
+	// The fake harness fails iff prompt == "boom", otherwise writes a valid trace.
+	script := `#!/bin/sh
+PROMPT=""
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt) PROMPT="$2"; shift 2 ;;
+    --trace)  TRACE="$2";  shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "$PROMPT" = "boom" ]; then
+  echo "harness boom" >&2
+  exit 7
+fi
+[ -n "$TRACE" ] && echo '{"id":"ok","turns":1,"outcome":"success"}' > "$TRACE"
+`
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "failure-suite",
+		Tasks: []types.EvalTask{
+			{ID: "ok-1", Prompt: "ok", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+			{ID: "broken", Prompt: "boom", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+			{ID: "ok-2", Prompt: "ok", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		Concurrency: 2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected suite error: %v", err)
+	}
+
+	if len(result.Tasks) != 3 {
+		t.Fatalf("got %d task results, want 3 (sibling failures must not abort)", len(result.Tasks))
+	}
+	if result.Tasks[0].TaskID != "ok-1" || result.Tasks[1].TaskID != "broken" || result.Tasks[2].TaskID != "ok-2" {
+		t.Errorf("Tasks ordering = [%s, %s, %s], want [ok-1, broken, ok-2]",
+			result.Tasks[0].TaskID, result.Tasks[1].TaskID, result.Tasks[2].TaskID)
+	}
+	if result.Tasks[1].Outcome != "error" {
+		t.Errorf("broken task Outcome = %q, want %q", result.Tasks[1].Outcome, "error")
+	}
+	// Siblings must each get a verdict, even if it's a fail (the placeholder
+	// file does not exist in the temp workspace).
+	for _, idx := range []int{0, 2} {
+		if result.Tasks[idx].Outcome == "" {
+			t.Errorf("sibling task %s has empty outcome", result.Tasks[idx].TaskID)
+		}
+	}
+}
+
+// TestRunSuite_RetainsArtifacts asserts that, when OutputDir is set, every
+// task gets a per-task directory under <OutputDir>/<suiteID>/<taskID>/ with
+// trace.jsonl, harness.stdout.txt, and harness.stderr.txt files. The
+// stdout/stderr files exist even when empty (so consumers don't need to
+// branch on file existence).
+func TestRunSuite_RetainsArtifacts(t *testing.T) {
+	script := `#!/bin/sh
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo "stdout chatter"
+echo "stderr chatter" >&2
+[ -n "$TRACE" ] && echo '{"id":"trace-1","turns":1,"outcome":"success"}' > "$TRACE"
+`
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "artifact-suite",
+		Tasks: []types.EvalTask{
+			{ID: "alpha", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+			{ID: "beta", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	out := t.TempDir()
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		OutputDir:   out,
+		Concurrency: 2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, taskID := range []string{"alpha", "beta"} {
+		base := filepath.Join(out, "artifact-suite", taskID)
+		for _, name := range []string{"trace.jsonl", "harness.stdout.txt", "harness.stderr.txt"} {
+			p := filepath.Join(base, name)
+			info, err := os.Stat(p)
+			if err != nil {
+				t.Errorf("missing artifact %s: %v", p, err)
+				continue
+			}
+			if info.IsDir() {
+				t.Errorf("artifact %s is a directory, want regular file", p)
+			}
+		}
+
+		// Trace content should be the harness's last JSON line.
+		traceData, err := os.ReadFile(filepath.Join(base, "trace.jsonl"))
+		if err == nil && !strings.Contains(string(traceData), `"id":"trace-1"`) {
+			t.Errorf("trace.jsonl for %s did not contain expected payload: %q", taskID, string(traceData))
+		}
+		// Stdout/stderr files should contain the chatter we emitted.
+		stdout, _ := os.ReadFile(filepath.Join(base, "harness.stdout.txt"))
+		if !strings.Contains(string(stdout), "stdout chatter") {
+			t.Errorf("harness.stdout.txt for %s = %q, want to contain %q", taskID, string(stdout), "stdout chatter")
+		}
+		stderr, _ := os.ReadFile(filepath.Join(base, "harness.stderr.txt"))
+		if !strings.Contains(string(stderr), "stderr chatter") {
+			t.Errorf("harness.stderr.txt for %s = %q, want to contain %q", taskID, string(stderr), "stderr chatter")
+		}
+	}
+}
+
+// TestRunSuite_RejectsTraversalIDs is the load-bearing security test: any
+// suite/task ID that would resolve outside <OutputDir>/<suiteID>/<taskID>/
+// must be rejected at validation time so the runner never attempts the
+// MkdirAll. We pick the rejection strategy (over silent sanitisation)
+// because silently rewriting an attacker-controlled ID into a different
+// path would shadow legitimate IDs and produce nondeterministic artifact
+// trees.
+func TestRunSuite_RejectsTraversalIDs(t *testing.T) {
+	cases := []struct {
+		name    string
+		suiteID string
+		taskID  string
+		wantSub string
+	}{
+		{name: "suite parent traversal", suiteID: "../evil", taskID: "t", wantSub: "suite ID"},
+		{name: "task parent traversal", suiteID: "ok", taskID: "../evil", wantSub: "task ID"},
+		{name: "task absolute path", suiteID: "ok", taskID: "/etc/passwd", wantSub: "task ID"},
+		{name: "task with separator", suiteID: "ok", taskID: "sub/dir", wantSub: "task ID"},
+		{name: "task dot segment", suiteID: "ok", taskID: "..", wantSub: "task ID"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			suite := types.EvalSuite{
+				ID:    tc.suiteID,
+				Tasks: []types.EvalTask{{ID: tc.taskID, Prompt: "p"}},
+			}
+			_, err := RunSuite(context.Background(), suite, RunConfig{OutputDir: t.TempDir()})
+			if err == nil {
+				t.Fatal("expected validation error for traversal ID")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tc.wantSub)
+			}
+			// Belt-and-braces: the error must come back BEFORE any directory
+			// creation under OutputDir. We verify the error payload does not
+			// leak a path that escaped the sandbox.
+			if strings.Contains(err.Error(), fmt.Sprintf("%c..%c", os.PathSeparator, os.PathSeparator)) {
+				t.Errorf("error contains escaped path traversal: %q", err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
Closes #31.

## Summary

The eval runner now executes tasks through a bounded worker pool (controlled
by `RunConfig.Concurrency` / `--concurrency`), and per-task artifacts are
retained on disk under a stable path layout when `--output` is set. The change
is confined to the `eval` module; the harness and types modules are
untouched.

- **Concurrency.** `runTasksConcurrently` dispatches tasks across
  `min(Concurrency, len(tasks))` workers. `Concurrency <= 0` collapses to
  `1` (the historical sequential behaviour). The dispatcher honours
  `ctx.Done()`, draining undispatched tasks as cancellation errors and
  joining in-flight workers before returning. `SuiteResult.Tasks`
  preserves input order regardless of completion order, via a
  pre-allocated indexed result slice (workers and the cancel-drain own
  disjoint index ranges, so there is no write-write race).
- **Artifact retention.** When `OutputDir` is non-empty, each task writes
  `trace.jsonl`, `harness.stdout.txt`, and `harness.stderr.txt` under
  `<OutputDir>/<suiteID>/<taskID>/` after the harness exits. Retention
  is best-effort (failures log to stderr but never mask the task
  result). Temp workspaces are still removed; copying the workspace is
  out of scope for #31.
- **Path safety.** Suite and task IDs are validated as single
  non-traversing path segments before any filesystem write
  (`validatePathSegment`). The reject-over-rewrite strategy avoids
  silent ID rewrites that could shadow legitimate IDs nondeterministically.
- **CLI dual-write.** `eval run` now writes `result.json` to both
  `<OutputDir>/result.json` (legacy, read by the existing CI
  `eval-gate` job) and `<OutputDir>/<suiteID>/result.json` (the new
  canonical path). The CI workflow needs no changes — the existing
  recursive `eval/results/` artifact upload already captures the
  per-task tree.

## Design choices (documented in commit messages)

| Decision | Choice | Rationale |
|---|---|---|
| `Concurrency <= 0` handling | Silent default to `1` | `RunConfig` is a Go struct API; rejecting zero would force every caller to write `Concurrency: 1`. The CLI already defaults to 1. |
| Path-traversal IDs | Reject at `validateSuite` | Silent rewriting could cause legitimate IDs to collide nondeterministically. |
| `result.json` location | Dual-write | Lowest-blast-radius for the existing CI workflow; both files have identical content. |
| Workspace retention | Not copied to artifacts | Out of scope per #31; potentially large for repo-cloned tasks. |
| stdout/stderr files | Split (`harness.stdout.txt` + `harness.stderr.txt`) | Simpler post-mortem grepping; aligns with the spec's primary suggestion. |

## Review history

Five reviewers ran independently (code, security, spec compliance,
test coverage, API design). Reports and the consolidated synthesis live
under `.coordinator-scratch/reviews-gh-31/` (intentionally untracked).

The synthesiser found **zero true blockers** — two CRITICAL findings
from the code reviewer were verified false-positives on code reading
(no race in the cancel drain because workers and the drain own
disjoint index ranges; no `ENOENT` in the dry-run path because the
suite artifact directory is created before the dry-run branch). All
six high-priority follow-ups (H1–H6) have been applied in the last
three commits:

- `963fc61` — Prune dead branches from `validatePathSegment` (H1+H2;
  the redundant `os.PathSeparator` check and the unreachable
  `cleaned != id` and `IsAbs` checks are gone).
- `759948e` — Cover the context-cancellation drain, strengthen the
  ordering assertion to require `t1` finishes last, and add
  `..foo`/`...evil`/`..hidden` traversal cases (H3+H5+H6).
- `7356743` — Add `TestCmdRun_DualWrite` covering both result.json
  paths and asserting identical content (H4).

Items deferred to follow-up issues (called out in the synthesis):

- Concurrency upper-bound cap independent of `len(tasks)`.
- Streaming stdout/stderr to disk (instead of buffering) for memory
  bounds at high concurrency.
- Symlink TOCTOU on the artifact directory (`O_NOFOLLOW` on parent
  fd).
- Tightening artifact file permissions from `0o644` to `0o600` on
  shared-host deployments.
- Null-byte / very-long-ID rejection in `validatePathSegment`.

## Test plan

- [x] `go test ./harness/... ./types/... ./eval/...` — full suite green.
- [x] `go test -race ./eval/runner/...` — race detector clean (specifically
      verifies the cancel-drain).
- [x] `go build -o /tmp/stirrup ./harness/cmd/stirrup` and
      `go build -o /tmp/stirrup-eval ./eval/cmd/eval`.
- [x] New tests cover: concurrency > 1 with deterministic ordering,
      `Concurrency=0` defaulting to sequential, failure isolation between
      siblings, artifacts written to disk, traversal-rejecting validator,
      context cancellation populating every result slot, CLI dual-write.
- [ ] Manual: run `./stirrup-eval run --suite eval/suites/<any>.hcl
      --output /tmp/out --concurrency 4 --dry-run` and confirm
      `/tmp/out/result.json` and `/tmp/out/<suiteID>/result.json`
      contain identical JSON.