### PR TITLE
eval: add JUnit XML exporter and convert subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           for suite in eval/suites/*.hcl; do
             name=$(basename "$suite")
             name="${name%.*}"
+            # JUnit XML is an annotation/artifact only; the eval gate
+            # is enforced by the `compare` step below.
             ./stirrup-eval run \
               --suite "$suite" \
               --harness ./stirrup \
@@ -97,7 +99,11 @@ jobs:
           done
 
       - name: Upload eval results
-        if: steps.check-suites.outputs.has_suites == 'true'
+        # Always upload whatever made it to disk so result.json survives
+        # an unrelated failure (e.g. compare step regression exit, future
+        # secondary-artifact steps). The eval-gate's pass/fail signal is
+        # carried by the compare step's exit code, not artifact presence.
+        if: always() && steps.check-suites.outputs.has_suites == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: eval-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,8 @@ jobs:
             ./stirrup-eval run \
               --suite "$suite" \
               --harness ./stirrup \
-              --output "eval/results/${name}"
+              --output "eval/results/${name}" \
+              --junit "eval/results/${name}/junit.xml"
           done
 
       - name: Compare against baseline

--- a/eval/cmd/eval/convert_test.go
+++ b/eval/cmd/eval/convert_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/eval"
+)
+
+// --- writeJUnit / convert subcommand tests ---
+//
+// cmdRun / cmdConvert call log.Fatal on error and consume os.Args, so we
+// drive the JUnit-side behaviour through the writeJUnit helper plus the
+// loadResult / writeJSON pair that cmdConvert composes. The helper is
+// the only place where file I/O for JUnit lives, so testing it gives us
+// the same coverage as a binary-shelling test without forking.
+
+// junitDoc mirrors enough of the JUnit XML to assert structural facts
+// without leaking reporter package internals into this file.
+type junitDoc struct {
+	XMLName    xml.Name `xml:"testsuites"`
+	TestSuites []struct {
+		Name      string `xml:"name,attr"`
+		Tests     int    `xml:"tests,attr"`
+		Failures  int    `xml:"failures,attr"`
+		Errors    int    `xml:"errors,attr"`
+		TestCases []struct {
+			Name    string `xml:"name,attr"`
+			Failure *struct {
+				Type    string `xml:"type,attr"`
+				Message string `xml:"message,attr"`
+			} `xml:"failure"`
+			Error *struct {
+				Type    string `xml:"type,attr"`
+				Message string `xml:"message,attr"`
+			} `xml:"error"`
+		} `xml:"testcase"`
+	} `xml:"testsuite"`
+}
+
+func sampleResult() eval.SuiteResult {
+	started := time.Date(2026, 5, 9, 9, 0, 0, 0, time.UTC)
+	return eval.SuiteResult{
+		SuiteID:     "convert-suite",
+		RunID:       "run-1",
+		StartedAt:   started,
+		CompletedAt: started.Add(3 * time.Second),
+		PassRate:    0.5,
+		Tasks: []eval.TaskResult{
+			{TaskID: "ok", Outcome: "pass", DurationMs: 100},
+			{TaskID: "bad", Outcome: "fail", DurationMs: 250,
+				JudgeVerdict: eval.JudgeVerdict{Reason: "criterion not met"}},
+		},
+	}
+}
+
+// TestWriteJUnit_CreatesFile validates the helper that backs both --junit
+// on `eval run` and --to-junit on `eval convert`: a file is created at the
+// requested path with well-formed JUnit XML inside.
+func TestWriteJUnit_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "junit.xml")
+
+	if err := writeJUnit(path, sampleResult()); err != nil {
+		t.Fatalf("writeJUnit: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading emitted XML: %v", err)
+	}
+
+	if !strings.HasPrefix(string(data), `<?xml version="1.0" encoding="UTF-8"?>`) {
+		t.Fatalf("missing XML header; first 64 bytes: %q", string(data[:min(len(data), 64)]))
+	}
+
+	var doc junitDoc
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshalling emitted XML: %v\n--- output ---\n%s", err, string(data))
+	}
+	if len(doc.TestSuites) != 1 {
+		t.Fatalf("want 1 testsuite, got %d", len(doc.TestSuites))
+	}
+	suite := doc.TestSuites[0]
+	if suite.Name != "convert-suite" || suite.Tests != 2 || suite.Failures != 1 || suite.Errors != 0 {
+		t.Errorf("suite attrs unexpected: %+v", suite)
+	}
+}
+
+// TestWriteJUnit_BadPath confirms errors propagate when the target
+// directory does not exist. cmdRun / cmdConvert surface this through
+// log.Fatalf, but we want unit-level coverage that an error is returned.
+func TestWriteJUnit_BadPath(t *testing.T) {
+	err := writeJUnit("/nonexistent/dir/junit.xml", sampleResult())
+	if err == nil {
+		t.Fatal("expected error for unwritable path")
+	}
+}
+
+// TestConvertRoundTrip simulates `eval run --output dir` followed by
+// `eval convert --from result.json --to-junit junit.xml`: JSON → in-memory
+// SuiteResult → JUnit XML must preserve task counts and outcomes.
+func TestConvertRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "result.json")
+	xmlPath := filepath.Join(dir, "junit.xml")
+
+	original := sampleResult()
+	original.Tasks = append(original.Tasks, eval.TaskResult{
+		TaskID: "boom", Outcome: "error", DurationMs: 10, Error: "harness exec failed",
+	})
+
+	if err := writeJSON(jsonPath, original); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+
+	loaded, err := loadResult(jsonPath)
+	if err != nil {
+		t.Fatalf("loadResult: %v", err)
+	}
+
+	if err := writeJUnit(xmlPath, loaded); err != nil {
+		t.Fatalf("writeJUnit: %v", err)
+	}
+
+	data, err := os.ReadFile(xmlPath)
+	if err != nil {
+		t.Fatalf("reading XML: %v", err)
+	}
+	var doc junitDoc
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parsing XML: %v", err)
+	}
+	if len(doc.TestSuites) != 1 {
+		t.Fatalf("want 1 testsuite, got %d", len(doc.TestSuites))
+	}
+	suite := doc.TestSuites[0]
+	if suite.Tests != 3 || suite.Failures != 1 || suite.Errors != 1 {
+		t.Errorf("counts unexpected: tests=%d failures=%d errors=%d (want 3/1/1)",
+			suite.Tests, suite.Failures, suite.Errors)
+	}
+	if len(suite.TestCases) != 3 {
+		t.Fatalf("want 3 testcases, got %d", len(suite.TestCases))
+	}
+
+	var passCase, failCase, errCase = false, false, false
+	for _, tc := range suite.TestCases {
+		switch tc.Name {
+		case "ok":
+			if tc.Failure != nil || tc.Error != nil {
+				t.Errorf("pass case has unexpected children: %+v", tc)
+			}
+			passCase = true
+		case "bad":
+			if tc.Failure == nil || tc.Failure.Type != "EvalFailure" {
+				t.Errorf("fail case missing or wrong <failure>: %+v", tc.Failure)
+			}
+			failCase = true
+		case "boom":
+			if tc.Error == nil || tc.Error.Type != "HarnessError" {
+				t.Errorf("error case missing or wrong <error>: %+v", tc.Error)
+			}
+			if tc.Error != nil && tc.Error.Message != "harness exec failed" {
+				t.Errorf("error message = %q, want harness error", tc.Error.Message)
+			}
+			errCase = true
+		}
+	}
+	if !passCase || !failCase || !errCase {
+		t.Errorf("missing one of pass/fail/error cases: pass=%v fail=%v err=%v",
+			passCase, failCase, errCase)
+	}
+}
+
+// TestConvert_LoadResultRejectsBadJSON pins that cmdConvert's loadResult
+// step surfaces a useful error rather than crashing on malformed input.
+// The CLI itself uses log.Fatalf; we exercise the helper directly.
+func TestConvert_LoadResultRejectsBadJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadResult(path)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "parsing result JSON") {
+		t.Errorf("error = %q, want it to mention parsing", err.Error())
+	}
+}

--- a/eval/cmd/eval/convert_test.go
+++ b/eval/cmd/eval/convert_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/xml"
 	"os"
 	"path/filepath"
@@ -203,5 +204,89 @@ func TestConvert_LoadResultRejectsBadJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parsing result JSON") {
 		t.Errorf("error = %q, want it to mention parsing", err.Error())
+	}
+}
+
+// TestRun_ConvertDispatch exercises the `convert` arm of run()'s
+// switch end-to-end: it writes a result.json with writeJSON, calls
+// run([]string{"convert", "--from", ..., "--to-junit", ...}), and
+// asserts the JUnit XML lands at the requested path with the
+// expected header. Without this test, a refactor that miswired the
+// "convert" case (e.g. dispatching to cmdCompare) would have no
+// signal — the convert-side helpers (writeJUnit, loadResult) are
+// well-covered, but the run() dispatcher itself was untested.
+//
+// The two required-flag check paths inside cmdConvert
+// (`-from is required`, `-to-junit is required`) call log.Fatal,
+// which exits the test process. They are not unit-tested here;
+// covering them needs subprocess testing or a fatal-interceptor
+// shim, neither of which is justified for guard clauses this small.
+func TestRun_ConvertDispatch(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "result.json")
+	xmlPath := filepath.Join(dir, "junit.xml")
+
+	if err := writeJSON(jsonPath, sampleResult()); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	code := run([]string{"convert", "--from", jsonPath, "--to-junit", xmlPath}, &stdout)
+	if code != 0 {
+		t.Fatalf("run convert exit code = %d, want 0", code)
+	}
+
+	data, err := os.ReadFile(xmlPath)
+	if err != nil {
+		t.Fatalf("reading emitted XML: %v", err)
+	}
+	if !strings.HasPrefix(string(data), `<?xml version="1.0" encoding="UTF-8"?>`) {
+		t.Fatalf("missing XML header; first 64 bytes: %q", string(data[:min(len(data), 64)]))
+	}
+}
+
+// TestCmdRun_JUnitFlag drives the `run` arm of run()'s switch with
+// --dry-run + --junit and asserts the JUnit XML is created. Dry-run
+// mode short-circuits the harness binary requirement (see
+// runner.RunSuite), so this test works on a bare-bones runner and
+// has no external dependencies beyond a fixture suite.
+//
+// The assertions are deliberately coarse: this is a wiring test for
+// the `*junitPath != ""` guard, the writeJUnit call inside cmdRun,
+// and (post-B2) the warning-not-fatal behaviour. Per-suite content
+// shape is covered by reporter tests; per-helper file shape is
+// covered by TestWriteJUnit_CreatesFile. Here we only need to know
+// the flag value reached writeJUnit.
+func TestCmdRun_JUnitFlag(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "results")
+	xmlPath := filepath.Join(dir, "junit.xml")
+
+	// The fixture is checked in under testdata/ so the test does not
+	// depend on the precise HCL grammar — if the grammar changes,
+	// the fixture is updated alongside it.
+	suitePath, err := filepath.Abs(filepath.Join("testdata", "minimal_suite.hcl"))
+	if err != nil {
+		t.Fatalf("resolving fixture: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	code := run([]string{
+		"run",
+		"--suite", suitePath,
+		"--dry-run",
+		"--output", outputDir,
+		"--junit", xmlPath,
+	}, &stdout)
+	if code != 0 {
+		t.Fatalf("run exit code = %d, want 0", code)
+	}
+
+	data, err := os.ReadFile(xmlPath)
+	if err != nil {
+		t.Fatalf("reading emitted XML: %v", err)
+	}
+	if !strings.HasPrefix(string(data), `<?xml version="1.0" encoding="UTF-8"?>`) {
+		t.Fatalf("missing XML header; first 64 bytes: %q", string(data[:min(len(data), 64)]))
 	}
 }

--- a/eval/cmd/eval/convert_test.go
+++ b/eval/cmd/eval/convert_test.go
@@ -207,6 +207,22 @@ func TestConvert_LoadResultRejectsBadJSON(t *testing.T) {
 	}
 }
 
+// TestConvert_LoadResultMissingFile covers the os.ReadFile failure
+// branch of loadResult. The error shape differs from the bad-JSON
+// branch — it surfaces *PathError directly rather than the
+// "parsing result JSON" wrapper — and a refactor that accidentally
+// wrapped both branches the same way would lose information about
+// "file not found" vs "file present but corrupt".
+func TestConvert_LoadResultMissingFile(t *testing.T) {
+	_, err := loadResult("/nonexistent/path/result.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if strings.Contains(err.Error(), "parsing result JSON") {
+		t.Errorf("error = %q, missing-file path must not be wrapped as a parse error", err.Error())
+	}
+}
+
 // TestRun_ConvertDispatch exercises the `convert` arm of run()'s
 // switch end-to-end: it writes a result.json with writeJSON, calls
 // run([]string{"convert", "--from", ..., "--to-junit", ...}), and

--- a/eval/cmd/eval/convert_test.go
+++ b/eval/cmd/eval/convert_test.go
@@ -89,6 +89,18 @@ func TestWriteJUnit_CreatesFile(t *testing.T) {
 	if suite.Name != "convert-suite" || suite.Tests != 2 || suite.Failures != 1 || suite.Errors != 0 {
 		t.Errorf("suite attrs unexpected: %+v", suite)
 	}
+
+	// File permissions must be a stable 0o644 regardless of the
+	// process umask — CI matrix runners ship with a wide range of
+	// umasks (e.g. 0077 on hardened images) and a JUnit artifact that
+	// the upload step cannot read would silently disappear.
+	stat, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := stat.Mode().Perm(); perm != 0o644 {
+		t.Errorf("file mode = %o, want %o", perm, 0o644)
+	}
 }
 
 // TestWriteJUnit_BadPath confirms errors propagate when the target

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -40,6 +40,7 @@ Commands:
   baseline               Pull production metrics as experiment baselines
   mine-failures          Turn production failures into eval tasks
   drift                  Detect metric changes over time windows
+  convert                Convert a result.json into another format (e.g. JUnit XML)
 
 Run "eval <command> -help" for details.
 `
@@ -78,6 +79,8 @@ func run(args []string, stdout io.Writer) int {
 		cmdDrift(args[1:])
 	case "compare-to-production":
 		cmdCompareToProduction(args[1:])
+	case "convert":
+		cmdConvert(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n%s", args[0], usage)
 		return 1
@@ -92,6 +95,7 @@ func cmdRun(args []string) {
 	outputDir := fs.String("output", "", "Output directory for results (default: current directory)")
 	concurrency := fs.Int("concurrency", 1, "Requested task concurrency (currently tasks run sequentially)")
 	dryRun := fs.Bool("dry-run", false, "Validate suite without executing tasks")
+	junitPath := fs.String("junit", "", "Write JUnit XML to this path after result.json (default: disabled)")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
@@ -131,8 +135,61 @@ func cmdRun(args []string) {
 		log.Fatalf("writing result: %v", err)
 	}
 
+	if *junitPath != "" {
+		if err := writeJUnit(*junitPath, result); err != nil {
+			log.Fatalf("writing JUnit XML: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "JUnit XML written to %s\n", *junitPath)
+	}
+
 	printSummary(result)
 	fmt.Fprintf(os.Stderr, "\nResults written to %s\n", resultPath)
+}
+
+// writeJUnit serialises a SuiteResult to path as JUnit XML using the
+// reporter package. The file is created with 0644 permissions, matching
+// writeJSON. Errors from os.Create or reporter.WriteJUnit are wrapped
+// with file context for the caller's log.Fatalf.
+func writeJUnit(path string, result eval.SuiteResult) error {
+	f, err := os.Create(path) //nolint:gosec // operator-supplied path; same trust model as --output / writeJSON
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := reporter.WriteJUnit(f, result); err != nil {
+		return fmt.Errorf("encoding %s: %w", path, err)
+	}
+	return nil
+}
+
+// cmdConvert converts an existing result.json into another format. Today
+// only --to-junit is supported; the subcommand is shaped so other targets
+// (TAP, GitHub annotations, etc.) can be slotted in without restructuring.
+func cmdConvert(args []string) {
+	fs := flag.NewFlagSet("convert", flag.ExitOnError)
+	fromPath := fs.String("from", "", "Path to a SuiteResult JSON produced by `eval run` (required)")
+	toJUnit := fs.String("to-junit", "", "Write JUnit XML to this path (required)")
+	if err := fs.Parse(args); err != nil {
+		log.Fatalf("parsing flags: %v", err)
+	}
+
+	if *fromPath == "" {
+		log.Fatal("-from is required")
+	}
+	if *toJUnit == "" {
+		log.Fatal("-to-junit is required")
+	}
+
+	result, err := loadResult(*fromPath)
+	if err != nil {
+		log.Fatalf("loading result: %v", err)
+	}
+
+	if err := writeJUnit(*toJUnit, result); err != nil {
+		log.Fatalf("writing JUnit XML: %v", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "JUnit XML written to %s\n", *toJUnit)
 }
 
 func cmdCompare(args []string) {

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -147,17 +147,23 @@ func cmdRun(args []string) {
 }
 
 // writeJUnit serialises a SuiteResult to path as JUnit XML using the
-// reporter package. The file is created with 0644 permissions, matching
-// writeJSON. Errors from os.Create or reporter.WriteJUnit are wrapped
-// with file context for the caller's log.Fatalf.
+// reporter package. The file is created with explicit 0o644 permissions
+// (matching writeJSON; bypassing umask). Close errors are surfaced to
+// the caller — on NFS, tmpfs-over-full-disk, and Docker overlay volumes
+// the underlying write failure only materialises at close(2), not
+// write(2), so a deferred-and-discarded close would silently truncate
+// the file and ship it to CI with exit code 0.
 func writeJUnit(path string, result eval.SuiteResult) error {
-	f, err := os.Create(path) //nolint:gosec // operator-supplied path; same trust model as --output / writeJSON
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644) //nolint:gosec // operator-supplied path; same trust model as --output / writeJSON
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", path, err)
 	}
-	defer func() { _ = f.Close() }()
 	if err := reporter.WriteJUnit(f, result); err != nil {
+		_ = f.Close() // encode error is the meaningful one
 		return fmt.Errorf("encoding %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", path, err)
 	}
 	return nil
 }

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -136,10 +136,17 @@ func cmdRun(args []string) {
 	}
 
 	if *junitPath != "" {
+		// JUnit XML is a secondary derived artifact; result.json has
+		// already been written. Demote a write failure to a warning so
+		// the CI loop's primary artifact survives even when the JUnit
+		// emit fails (e.g. read-only filesystem, exhausted inode quota).
+		// cmdConvert keeps log.Fatalf — it has no prior artifact to
+		// protect.
 		if err := writeJUnit(*junitPath, result); err != nil {
-			log.Fatalf("writing JUnit XML: %v", err)
+			fmt.Fprintf(os.Stderr, "warning: writing JUnit XML: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "JUnit XML written to %s\n", *junitPath)
 		}
-		fmt.Fprintf(os.Stderr, "JUnit XML written to %s\n", *junitPath)
 	}
 
 	printSummary(result)

--- a/eval/cmd/eval/testdata/minimal_suite.hcl
+++ b/eval/cmd/eval/testdata/minimal_suite.hcl
@@ -1,0 +1,23 @@
+# Minimal suite fixture for end-to-end CLI tests.
+#
+# Used by TestCmdRun_JUnitFlag to drive `eval run --dry-run --junit
+# <path>` through the run() dispatcher and assert the --junit flag is
+# wired to writeJUnit. Dry-run mode short-circuits the harness binary
+# requirement, so the test works on bare-bones runners.
+#
+# Keep this fixture tiny and deterministic. New tests that need
+# different shapes should add their own fixture rather than expand
+# this one — orthogonal test inputs are easier to maintain.
+suite "cmdrun-junit-fixture" {
+  description = "minimal suite for cmdRun --junit dispatch test"
+
+  task "marker" {
+    mode   = "execution"
+    prompt = "create marker.txt"
+
+    judge {
+      type    = "test-command"
+      command = "test -f marker.txt"
+    }
+  }
+}

--- a/eval/reporter/junit.go
+++ b/eval/reporter/junit.go
@@ -1,0 +1,193 @@
+package reporter
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rxbynerd/stirrup/eval"
+)
+
+// JUnit XML schema reference: https://github.com/testmoapp/junitxml
+//
+// We emit the common <testsuites>/<testsuite>/<testcase> shape understood by
+// GitHub Actions, GitLab CI, Buildkite, CircleCI, and Jenkins. Only stdlib
+// encoding/xml is used so the eval module gains no new dependencies.
+//
+// Mapping (from issue #129):
+//
+//   SuiteResult → one <testsuite> wrapped in a <testsuites>
+//   TaskResult  → one <testcase>; outcome=="pass" emits no children,
+//                 "fail" emits <failure>, "error" emits <error>.
+//
+// JudgeVerdict.Details (when present) are appended to the <failure> body as
+// "Type: Reason" lines after a blank line separator. We bind body text to a
+// `,chardata` field so encoding/xml takes care of escaping `<`, `>`, `&` and
+// `"` in user-supplied prompts and verdict reasons.
+
+type xmlTestSuites struct {
+	XMLName    xml.Name       `xml:"testsuites"`
+	TestSuites []xmlTestSuite `xml:"testsuite"`
+}
+
+type xmlTestSuite struct {
+	XMLName   xml.Name      `xml:"testsuite"`
+	Name      string        `xml:"name,attr"`
+	Tests     int           `xml:"tests,attr"`
+	Failures  int           `xml:"failures,attr"`
+	Errors    int           `xml:"errors,attr"`
+	Time      string        `xml:"time,attr"`
+	Timestamp string        `xml:"timestamp,attr"`
+	TestCases []xmlTestCase `xml:"testcase"`
+}
+
+type xmlTestCase struct {
+	XMLName   xml.Name    `xml:"testcase"`
+	Name      string      `xml:"name,attr"`
+	Classname string      `xml:"classname,attr"`
+	Time      string      `xml:"time,attr"`
+	Failure   *xmlFailure `xml:"failure,omitempty"`
+	Error     *xmlError   `xml:"error,omitempty"`
+}
+
+type xmlFailure struct {
+	XMLName xml.Name `xml:"failure"`
+	Type    string   `xml:"type,attr"`
+	Message string   `xml:"message,attr"`
+	Body    string   `xml:",chardata"`
+}
+
+type xmlError struct {
+	XMLName xml.Name `xml:"error"`
+	Type    string   `xml:"type,attr"`
+	Message string   `xml:"message,attr"`
+	Body    string   `xml:",chardata"`
+}
+
+// WriteJUnit encodes result as JUnit XML to w. The output begins with a
+// standard XML declaration (`<?xml version="1.0" encoding="UTF-8"?>`)
+// followed by an indented <testsuites> tree containing exactly one
+// <testsuite> per SuiteResult.
+func WriteJUnit(w io.Writer, result eval.SuiteResult) error {
+	suite := buildTestSuite(result)
+	doc := xmlTestSuites{TestSuites: []xmlTestSuite{suite}}
+
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return err
+	}
+
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return err
+	}
+	if err := enc.Close(); err != nil {
+		return err
+	}
+	// Trailing newline for friendlier diffs / POSIX conventions.
+	_, err := io.WriteString(w, "\n")
+	return err
+}
+
+// buildTestSuite converts a SuiteResult into the XML mirror struct.
+func buildTestSuite(result eval.SuiteResult) xmlTestSuite {
+	failures := 0
+	errors := 0
+	cases := make([]xmlTestCase, 0, len(result.Tasks))
+	for _, t := range result.Tasks {
+		switch t.Outcome {
+		case "fail":
+			failures++
+		case "error":
+			errors++
+		}
+		cases = append(cases, buildTestCase(result.SuiteID, t))
+	}
+
+	// Suite duration: prefer wall-clock from CompletedAt-StartedAt; if
+	// unset (zero values, e.g. dry-run results), fall back to the sum of
+	// per-task durations so the field is never negative or nonsensical.
+	var suiteSeconds float64
+	if !result.CompletedAt.IsZero() && !result.StartedAt.IsZero() && result.CompletedAt.After(result.StartedAt) {
+		suiteSeconds = result.CompletedAt.Sub(result.StartedAt).Seconds()
+	} else {
+		var ms int64
+		for _, t := range result.Tasks {
+			ms += t.DurationMs
+		}
+		suiteSeconds = float64(ms) / 1000.0
+	}
+
+	timestamp := ""
+	if !result.StartedAt.IsZero() {
+		timestamp = result.StartedAt.UTC().Format(time.RFC3339)
+	}
+
+	return xmlTestSuite{
+		Name:      result.SuiteID,
+		Tests:     len(result.Tasks),
+		Failures:  failures,
+		Errors:    errors,
+		Time:      formatSeconds(suiteSeconds),
+		Timestamp: timestamp,
+		TestCases: cases,
+	}
+}
+
+// buildTestCase converts a TaskResult into an XML <testcase>.
+func buildTestCase(suiteID string, t eval.TaskResult) xmlTestCase {
+	tc := xmlTestCase{
+		Name:      t.TaskID,
+		Classname: suiteID,
+		Time:      formatSeconds(float64(t.DurationMs) / 1000.0),
+	}
+
+	switch t.Outcome {
+	case "fail":
+		tc.Failure = &xmlFailure{
+			Type:    "EvalFailure",
+			Message: t.JudgeVerdict.Reason,
+			Body:    failureBody(t.JudgeVerdict),
+		}
+	case "error":
+		tc.Error = &xmlError{
+			Type:    "HarnessError",
+			Message: t.Error,
+			Body:    t.Error,
+		}
+	}
+
+	return tc
+}
+
+// failureBody assembles the <failure> body text. The judge verdict reason
+// comes first; when sub-judge details are present, a blank line separates
+// them and each detail is rendered as `Type: Reason`.
+func failureBody(v eval.JudgeVerdict) string {
+	if len(v.Details) == 0 {
+		return v.Reason
+	}
+	var b strings.Builder
+	if v.Reason != "" {
+		b.WriteString(v.Reason)
+		b.WriteString("\n\n")
+	}
+	for i, d := range v.Details {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "%s: %s", d.Type, d.Reason)
+	}
+	return b.String()
+}
+
+// formatSeconds renders a duration in seconds with three decimal places —
+// the precision JUnit consumers (GitHub Actions, mikepenz/action-junit-report,
+// etc.) expect. strconv.FormatFloat is preferred over fmt.Sprintf to avoid
+// the format-string allocation on the hot path.
+func formatSeconds(s float64) string {
+	return strconv.FormatFloat(s, 'f', 3, 64)
+}

--- a/eval/reporter/junit.go
+++ b/eval/reporter/junit.go
@@ -93,6 +93,13 @@ func WriteJUnit(w io.Writer, result eval.SuiteResult) error {
 }
 
 // buildTestSuite converts a SuiteResult into the XML mirror struct.
+//
+// Outcome is a closed set: {"pass", "fail", "error"}. An unknown
+// value (e.g. a future "skipped" we forget to handle here) is
+// promoted to an error so it appears in CI render counts rather
+// than silently inflating Tests without bumping Failures or Errors.
+// buildTestCase mirrors the same default for the per-case child
+// element.
 func buildTestSuite(result eval.SuiteResult) xmlTestSuite {
 	failures := 0
 	errors := 0
@@ -102,6 +109,13 @@ func buildTestSuite(result eval.SuiteResult) xmlTestSuite {
 		case "fail":
 			failures++
 		case "error":
+			errors++
+		case "pass":
+			// no child element
+		default:
+			// Unknown outcome: count as error so suite-level totals
+			// stay consistent with the per-case element emitted by
+			// buildTestCase.
 			errors++
 		}
 		cases = append(cases, buildTestCase(result.SuiteID, t))
@@ -147,9 +161,18 @@ func buildTestCase(suiteID string, t eval.TaskResult) xmlTestCase {
 
 	switch t.Outcome {
 	case "fail":
+		// Synthesise a non-empty Message when the judge verdict has
+		// no top-level Reason but does carry sub-judge Details — UI
+		// renderers (GitHub Actions, Jenkins) display the attribute
+		// as the headline and an empty headline reads as a missing
+		// failure to operators.
+		msg := t.JudgeVerdict.Reason
+		if msg == "" && len(t.JudgeVerdict.Details) > 0 {
+			msg = t.JudgeVerdict.Details[0].Reason
+		}
 		tc.Failure = &xmlFailure{
 			Type:    "EvalFailure",
-			Message: t.JudgeVerdict.Reason,
+			Message: msg,
 			Body:    failureBody(t.JudgeVerdict),
 		}
 	case "error":
@@ -157,6 +180,18 @@ func buildTestCase(suiteID string, t eval.TaskResult) xmlTestCase {
 			Type:    "HarnessError",
 			Message: t.Error,
 			Body:    t.Error,
+		}
+	case "pass":
+		// no child element
+	default:
+		// Unknown outcome — see buildTestSuite for the closed-set
+		// rationale. Surface as <error> so operators can grep for
+		// "UnknownOutcome" in the JUnit XML.
+		msg := fmt.Sprintf("unknown task outcome %q", t.Outcome)
+		tc.Error = &xmlError{
+			Type:    "UnknownOutcome",
+			Message: msg,
+			Body:    msg,
 		}
 	}
 

--- a/eval/reporter/junit_test.go
+++ b/eval/reporter/junit_test.go
@@ -1,0 +1,278 @@
+package reporter
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/eval"
+)
+
+// parseJUnit decodes the JUnit XML produced by WriteJUnit into the same
+// mirror structs used for emission. Tests use this to assert structural
+// invariants without re-implementing an XML parser.
+func parseJUnit(t *testing.T, b []byte) xmlTestSuites {
+	t.Helper()
+	var got xmlTestSuites
+	if err := xml.Unmarshal(b, &got); err != nil {
+		t.Fatalf("parsing emitted XML: %v\n--- output ---\n%s", err, string(b))
+	}
+	return got
+}
+
+// runWriteJUnit is a small helper to keep tests focused on assertions.
+func runWriteJUnit(t *testing.T, result eval.SuiteResult) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteJUnit(&buf, result); err != nil {
+		t.Fatalf("WriteJUnit: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestWriteJUnit_HeaderAndRoot(t *testing.T) {
+	result := eval.SuiteResult{SuiteID: "s1"}
+	out := runWriteJUnit(t, result)
+
+	if !bytes.HasPrefix(out, []byte(xml.Header)) {
+		preview := out
+		if len(preview) > 64 {
+			preview = preview[:64]
+		}
+		t.Fatalf("output should start with XML header %q, got %q", xml.Header, string(preview))
+	}
+
+	doc := parseJUnit(t, out)
+	if len(doc.TestSuites) != 1 {
+		t.Fatalf("want exactly 1 <testsuite>, got %d", len(doc.TestSuites))
+	}
+}
+
+func TestWriteJUnit_CountsAndAttributes(t *testing.T) {
+	started := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	completed := started.Add(2500 * time.Millisecond)
+
+	result := eval.SuiteResult{
+		SuiteID:     "demo",
+		StartedAt:   started,
+		CompletedAt: completed,
+		Tasks: []eval.TaskResult{
+			{TaskID: "p1", Outcome: "pass", DurationMs: 1234},
+			{TaskID: "p2", Outcome: "pass", DurationMs: 100},
+			{TaskID: "f1", Outcome: "fail", DurationMs: 500,
+				JudgeVerdict: eval.JudgeVerdict{Reason: "expected 200, got 500"}},
+			{TaskID: "e1", Outcome: "error", DurationMs: 50, Error: "harness crashed"},
+		},
+	}
+
+	out := runWriteJUnit(t, result)
+	doc := parseJUnit(t, out)
+	suite := doc.TestSuites[0]
+
+	if suite.Name != "demo" {
+		t.Errorf("name = %q, want %q", suite.Name, "demo")
+	}
+	if suite.Tests != 4 {
+		t.Errorf("tests = %d, want 4", suite.Tests)
+	}
+	if suite.Failures != 1 {
+		t.Errorf("failures = %d, want 1", suite.Failures)
+	}
+	if suite.Errors != 1 {
+		t.Errorf("errors = %d, want 1", suite.Errors)
+	}
+	if suite.Time != "2.500" {
+		t.Errorf("time = %q, want %q (3 d.p.)", suite.Time, "2.500")
+	}
+	if suite.Timestamp != "2026-05-09T12:00:00Z" {
+		t.Errorf("timestamp = %q, want RFC3339 UTC", suite.Timestamp)
+	}
+	if len(suite.TestCases) != 4 {
+		t.Fatalf("testcases = %d, want 4", len(suite.TestCases))
+	}
+}
+
+func TestWriteJUnit_TestCaseTimeIsSeconds(t *testing.T) {
+	result := eval.SuiteResult{
+		SuiteID: "s",
+		Tasks: []eval.TaskResult{
+			{TaskID: "t", Outcome: "pass", DurationMs: 1500},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	tc := doc.TestSuites[0].TestCases[0]
+	if tc.Time != "1.500" {
+		t.Errorf("time = %q, want %q", tc.Time, "1.500")
+	}
+	if tc.Classname != "s" {
+		t.Errorf("classname = %q, want suiteId %q", tc.Classname, "s")
+	}
+}
+
+func TestWriteJUnit_PassHasNoChildren(t *testing.T) {
+	result := eval.SuiteResult{
+		SuiteID: "s",
+		Tasks: []eval.TaskResult{
+			{TaskID: "p", Outcome: "pass", DurationMs: 10},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	tc := doc.TestSuites[0].TestCases[0]
+	if tc.Failure != nil {
+		t.Errorf("pass case should have no <failure>, got %+v", tc.Failure)
+	}
+	if tc.Error != nil {
+		t.Errorf("pass case should have no <error>, got %+v", tc.Error)
+	}
+}
+
+func TestWriteJUnit_FailEmitsFailure(t *testing.T) {
+	result := eval.SuiteResult{
+		SuiteID: "s",
+		Tasks: []eval.TaskResult{
+			{
+				TaskID:  "t",
+				Outcome: "fail",
+				JudgeVerdict: eval.JudgeVerdict{
+					Reason: "judge said no",
+					Details: []eval.JudgeDetail{
+						{Type: "test-command", Reason: "exit code 1"},
+						{Type: "file-exists", Reason: "missing /tmp/expected"},
+					},
+				},
+			},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	tc := doc.TestSuites[0].TestCases[0]
+	if tc.Failure == nil {
+		t.Fatal("fail case should have <failure>")
+	}
+	if tc.Error != nil {
+		t.Error("fail case should not have <error>")
+	}
+	if tc.Failure.Type != "EvalFailure" {
+		t.Errorf("failure type = %q, want %q", tc.Failure.Type, "EvalFailure")
+	}
+	if tc.Failure.Message != "judge said no" {
+		t.Errorf("failure message = %q, want judge reason", tc.Failure.Message)
+	}
+	body := tc.Failure.Body
+	if !strings.Contains(body, "judge said no") {
+		t.Errorf("failure body should contain reason; got %q", body)
+	}
+	if !strings.Contains(body, "test-command: exit code 1") {
+		t.Errorf("failure body should contain detail line %q; got %q",
+			"test-command: exit code 1", body)
+	}
+	if !strings.Contains(body, "file-exists: missing /tmp/expected") {
+		t.Errorf("failure body should contain second detail; got %q", body)
+	}
+}
+
+func TestWriteJUnit_ErrorEmitsError(t *testing.T) {
+	result := eval.SuiteResult{
+		SuiteID: "s",
+		Tasks: []eval.TaskResult{
+			{TaskID: "boom", Outcome: "error", Error: "exec: harness binary missing"},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	tc := doc.TestSuites[0].TestCases[0]
+	if tc.Error == nil {
+		t.Fatal("error case should have <error>")
+	}
+	if tc.Failure != nil {
+		t.Error("error case should not have <failure>")
+	}
+	if tc.Error.Type != "HarnessError" {
+		t.Errorf("error type = %q, want %q", tc.Error.Type, "HarnessError")
+	}
+	if tc.Error.Message != "exec: harness binary missing" {
+		t.Errorf("error message = %q, want task error", tc.Error.Message)
+	}
+}
+
+func TestWriteJUnit_EmptySuite(t *testing.T) {
+	result := eval.SuiteResult{SuiteID: "empty"}
+	out := runWriteJUnit(t, result)
+	doc := parseJUnit(t, out)
+	suite := doc.TestSuites[0]
+	if suite.Tests != 0 || suite.Failures != 0 || suite.Errors != 0 {
+		t.Errorf("empty suite counts: tests=%d failures=%d errors=%d, want 0/0/0",
+			suite.Tests, suite.Failures, suite.Errors)
+	}
+	if len(suite.TestCases) != 0 {
+		t.Errorf("empty suite should have no testcases, got %d", len(suite.TestCases))
+	}
+	if suite.Name != "empty" {
+		t.Errorf("name = %q, want %q", suite.Name, "empty")
+	}
+}
+
+// TestWriteJUnit_XMLEscaping pins that we delegate escaping to encoding/xml
+// rather than concatenating strings. Task IDs containing XML metacharacters
+// must round-trip unchanged through Unmarshal.
+func TestWriteJUnit_XMLEscaping(t *testing.T) {
+	weird := `<>&"'`
+	result := eval.SuiteResult{
+		SuiteID: weird,
+		Tasks: []eval.TaskResult{
+			{
+				TaskID:  weird,
+				Outcome: "fail",
+				JudgeVerdict: eval.JudgeVerdict{
+					Reason: "needs <escape> & \"quotes\"",
+				},
+			},
+		},
+	}
+	out := runWriteJUnit(t, result)
+	// Raw output must not contain unescaped attribute-breaking quotes.
+	if strings.Contains(string(out), `name="<>&"'"`) {
+		t.Fatalf("attribute quoting was not escaped:\n%s", string(out))
+	}
+	doc := parseJUnit(t, out)
+	tc := doc.TestSuites[0].TestCases[0]
+	if tc.Name != weird {
+		t.Errorf("task name round-trip mismatch: got %q, want %q", tc.Name, weird)
+	}
+	if doc.TestSuites[0].Name != weird {
+		t.Errorf("suite name round-trip mismatch: got %q, want %q", doc.TestSuites[0].Name, weird)
+	}
+	if tc.Failure == nil || !strings.Contains(tc.Failure.Body, `needs <escape> & "quotes"`) {
+		t.Errorf("failure body round-trip mismatch: %+v", tc.Failure)
+	}
+}
+
+func TestWriteJUnit_ProducesParseableXML(t *testing.T) {
+	// A coarse smoke test: feed mixed outcomes through WriteJUnit and confirm
+	// the output is well-formed by re-parsing into a generic map.
+	result := eval.SuiteResult{
+		SuiteID:     "smoke",
+		StartedAt:   time.Now().UTC(),
+		CompletedAt: time.Now().UTC().Add(time.Second),
+		Tasks: []eval.TaskResult{
+			{TaskID: "ok", Outcome: "pass", DurationMs: 10},
+			{TaskID: "bad", Outcome: "fail", DurationMs: 20,
+				JudgeVerdict: eval.JudgeVerdict{Reason: "no"}},
+			{TaskID: "boom", Outcome: "error", DurationMs: 30, Error: "x"},
+		},
+	}
+	out := runWriteJUnit(t, result)
+
+	// Round-trip via a token-walking decoder to ensure no malformed regions.
+	dec := xml.NewDecoder(bytes.NewReader(out))
+	for {
+		_, err := dec.Token()
+		if err != nil {
+			// We accept any error as termination here — io.EOF on
+			// success, anything else is a parser-detected malformation
+			// and the Unmarshal-based assertions in the other tests
+			// would have caught it; this is a coarse safety net.
+			break
+		}
+	}
+}

--- a/eval/reporter/junit_test.go
+++ b/eval/reporter/junit_test.go
@@ -3,6 +3,8 @@ package reporter
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +174,68 @@ func TestWriteJUnit_FailEmitsFailure(t *testing.T) {
 	}
 }
 
+// TestWriteJUnit_FailMessageFallback pins the I3 message-synthesis
+// behaviour: when the judge verdict has no top-level Reason but
+// carries sub-judge Details, the <failure message=...> attribute
+// must be populated from the first detail rather than left blank.
+// CI UIs (mikepenz/action-junit-report, Jenkins) render this
+// attribute as the failure headline.
+func TestWriteJUnit_FailMessageFallback(t *testing.T) {
+	result := eval.SuiteResult{
+		SuiteID: "s",
+		Tasks: []eval.TaskResult{
+			{
+				TaskID:  "composite-no-reason",
+				Outcome: "fail",
+				JudgeVerdict: eval.JudgeVerdict{
+					Reason: "", // intentionally empty
+					Details: []eval.JudgeDetail{
+						{Type: "test-command", Reason: "exit code 1"},
+						{Type: "file-exists", Reason: "missing /tmp/x"},
+					},
+				},
+			},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	tc := doc.TestSuites[0].TestCases[0]
+	if tc.Failure == nil {
+		t.Fatal("fail case should have <failure>")
+	}
+	if tc.Failure.Message != "exit code 1" {
+		t.Errorf("failure message = %q, want first detail reason %q", tc.Failure.Message, "exit code 1")
+	}
+}
+
+// TestWriteJUnit_UnknownOutcome pins the closed-set default branch:
+// an outcome value not in {"pass", "fail", "error"} must surface as
+// <error type="UnknownOutcome"> and increment the suite Errors count
+// so CI renderers don't silently inflate Tests against a placid 0/0
+// failures/errors total.
+func TestWriteJUnit_UnknownOutcome(t *testing.T) {
+	result := eval.SuiteResult{
+		SuiteID: "s",
+		Tasks: []eval.TaskResult{
+			{TaskID: "skipped-task", Outcome: "skipped"},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	suite := doc.TestSuites[0]
+	if suite.Errors != 1 {
+		t.Errorf("suite errors = %d, want 1", suite.Errors)
+	}
+	tc := suite.TestCases[0]
+	if tc.Error == nil {
+		t.Fatal("unknown outcome case should have <error>")
+	}
+	if tc.Error.Type != "UnknownOutcome" {
+		t.Errorf("error type = %q, want %q", tc.Error.Type, "UnknownOutcome")
+	}
+	if !strings.Contains(tc.Error.Message, "skipped") {
+		t.Errorf("error message = %q, want it to mention the unknown outcome value", tc.Error.Message)
+	}
+}
+
 func TestWriteJUnit_ErrorEmitsError(t *testing.T) {
 	result := eval.SuiteResult{
 		SuiteID: "s",
@@ -309,16 +373,19 @@ func TestWriteJUnit_ProducesParseableXML(t *testing.T) {
 	}
 	out := runWriteJUnit(t, result)
 
-	// Round-trip via a token-walking decoder to ensure no malformed regions.
+	// Round-trip via a token-walking decoder to ensure no malformed
+	// regions. EOF terminates the loop on success; any other error is
+	// a parser-detected malformation and must fail the test — the
+	// previous "break on any error" formulation made this assertion a
+	// no-op for the very class of bug it claimed to catch.
 	dec := xml.NewDecoder(bytes.NewReader(out))
 	for {
 		_, err := dec.Token()
-		if err != nil {
-			// We accept any error as termination here — io.EOF on
-			// success, anything else is a parser-detected malformation
-			// and the Unmarshal-based assertions in the other tests
-			// would have caught it; this is a coarse safety net.
+		if errors.Is(err, io.EOF) {
 			break
+		}
+		if err != nil {
+			t.Fatalf("malformed XML token: %v\n--- output ---\n%s", err, out)
 		}
 	}
 }

--- a/eval/reporter/junit_test.go
+++ b/eval/reporter/junit_test.go
@@ -247,6 +247,52 @@ func TestWriteJUnit_XMLEscaping(t *testing.T) {
 	}
 }
 
+// TestWriteJUnit_ZeroTimestampFallback pins the dry-run-shaped path
+// in buildTestSuite where StartedAt/CompletedAt are both zero (so
+// wall-clock subtraction would either be zero or panic-adjacent
+// nonsense): the suite's Time attribute must be the sum of the
+// per-task DurationMs values converted to seconds, and Timestamp
+// must be empty rather than the Go zero-time string.
+func TestWriteJUnit_ZeroTimestampFallback(t *testing.T) {
+	result := eval.SuiteResult{
+		SuiteID: "fallback",
+		// StartedAt and CompletedAt are intentionally zero.
+		Tasks: []eval.TaskResult{
+			{TaskID: "t1", Outcome: "pass", DurationMs: 1200},
+			{TaskID: "t2", Outcome: "pass", DurationMs: 300},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	suite := doc.TestSuites[0]
+	if suite.Time != "1.500" {
+		t.Errorf("time = %q, want %q (sum of DurationMs / 1000)", suite.Time, "1.500")
+	}
+	if suite.Timestamp != "" {
+		t.Errorf("timestamp = %q, want empty when StartedAt is zero", suite.Timestamp)
+	}
+}
+
+// TestWriteJUnit_BackwardTimestampFallback pins the second branch of
+// the fallback: when CompletedAt precedes StartedAt (clock skew, or a
+// recording deserialised with mismatched fields), we must not emit a
+// negative wall-clock duration. The DurationMs sum is used instead.
+func TestWriteJUnit_BackwardTimestampFallback(t *testing.T) {
+	started := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	result := eval.SuiteResult{
+		SuiteID:     "skewed",
+		StartedAt:   started,
+		CompletedAt: started.Add(-time.Second), // 1s before StartedAt
+		Tasks: []eval.TaskResult{
+			{TaskID: "t1", Outcome: "pass", DurationMs: 2000},
+		},
+	}
+	doc := parseJUnit(t, runWriteJUnit(t, result))
+	suite := doc.TestSuites[0]
+	if suite.Time != "2.000" {
+		t.Errorf("time = %q, want %q (DurationMs sum, not negative wall-clock)", suite.Time, "2.000")
+	}
+}
+
 func TestWriteJUnit_ProducesParseableXML(t *testing.T) {
 	// A coarse smoke test: feed mixed outcomes through WriteJUnit and confirm
 	// the output is well-formed by re-parsing into a generic map.


### PR DESCRIPTION
Closes #129.

## Summary

Implements JUnit XML output for `stirrup-eval` so eval-suite results can be ingested by the standard CI integrations (GitHub Actions, Buildkite, Jenkins, GitLab CI) for per-test history, flake detection, and PR annotations.

Two surfaces, both per the issue's "in-run + offline" recommendation:

- `stirrup-eval run --junit <path>` — writes `junit.xml` alongside `result.json` after a suite completes.
- `stirrup-eval convert --from <result.json> --to-junit <path>` — offline conversion of an existing `SuiteResult` JSON into JUnit XML.

The `eval-gate` CI job now passes `--junit eval/results/${name}/junit.xml`, picked up automatically by the existing `actions/upload-artifact@v7` step. Per the issue, wiring a JUnit rendering action (e.g. `mikepenz/action-junit-report`) is explicitly out of scope and left as a follow-up.

Stdlib `encoding/xml` only — no new dependencies on either module's `go.mod`.

## Type mapping

Per the issue spec:

| Source (eval/eval.go) | JUnit XML |
|---|---|
| `SuiteResult` | `<testsuites>` wrapping a single `<testsuite name=SuiteID tests=len(Tasks) failures=Σpass==fail errors=Σpass==error time=Δseconds timestamp=StartedAt(RFC3339)>` |
| `TaskResult` (`Outcome=="pass"`) | `<testcase>` with no children |
| `TaskResult` (`Outcome=="fail"`) | `<testcase>` with `<failure type="EvalFailure" message=Reason>` body listing JudgeVerdict.Reason and each Detail |
| `TaskResult` (`Outcome=="error"`) | `<testcase>` with `<error type="HarnessError" message=Error>` body |

`time` attributes use 3-decimal-place seconds (`strconv.FormatFloat(_, 'f', 3, 64)`). `<testsuite timestamp>` uses `StartedAt.UTC().Format(time.RFC3339)` for stability across CI runners. Body fields use `,chardata` so the encoder handles XML escaping for `<`/`>`/`&`/`"`.

## Implementation

Eight commits — three to land the feature, five to apply the post-review remediation pass.

**Feature** (`b6897df` `c163247` `ac6b77b`):
- `eval/reporter/junit.go` — `WriteJUnit(w io.Writer, result eval.SuiteResult) error`, plus unexported `xmlTestSuites`/`xmlTestSuite`/`xmlTestCase`/`xmlFailure`/`xmlError` and `buildTestSuite`/`buildTestCase` helpers.
- `eval/cmd/eval/main.go` — `--junit` flag on `cmdRun`; new `cmdConvert` registered as `convert` in the dispatch switch and listed in the `usage` banner.
- `.github/workflows/ci.yml` — eval-gate `--junit` argument.

**Remediation pass** (`3024509` `6319357` `560d4a7` `0ed1a90` `7fd7180`) — applied after a five-reviewer cycle (code, security, spec-compliance, test-coverage, api-design) was synthesised into a remediation brief:

- `3024509` `eval/cmd: surface writeJUnit close errors and pin 0o644 mode` — the deferred `_ = f.Close()` was discarding OS-level write errors that surface at `close(2)` (NFS, full disks, Docker overlay). Switched to explicit `OpenFile(O_WRONLY|O_CREATE|O_TRUNC, 0o644)` with explicit close-and-propagate; aligns mode with `writeJSON` regardless of umask.
- `6319357` `ci: protect eval artifacts from JUnit write failures` — `writeJUnit` failure in `cmdRun` is now a stderr warning rather than `log.Fatalf`, so a transient JUnit write failure no longer aborts a multi-suite eval-gate `for` loop and skips the `actions/upload-artifact` step. Added `if: always()` to the upload step plus an inline comment making the gating model explicit (compare-against-baseline gates; JUnit is artifact-only). `cmdConvert` keeps `log.Fatalf` — its sole job is the write.
- `560d4a7` `eval/reporter: cover zero and backward-timestamp fallback in JUnit` — pins the dry-run / non-monotonic-clock fallback path that sums `DurationMs` instead of using a negative wall-clock delta.
- `0ed1a90` `eval/cmd: cover convert dispatch and --junit flag through run()` — adds end-to-end coverage of the `run("convert", ...)` dispatch arm and the `--junit` flag path inside `cmdRun`. Uses a minimal `eval/cmd/eval/testdata/minimal_suite.hcl` fixture exercised in `--dry-run` mode so no harness binary is required at test time.
- `7fd7180` `eval/reporter: harden JUnit closed-set handling and message fallbacks` — adds a `default` branch in the outcome switches that emits an `<error type="UnknownOutcome">` so a future `"skipped"` outcome surfaces visibly rather than inflating `tests` while not incrementing `failures`/`errors`. Synthesises a `<failure message>` from the first detail when `JudgeVerdict.Reason == ""`. Promotes the placeholder parseability test to a real `t.Fatalf` on malformed XML, and covers the `loadResult` missing-file path.

## Review summary

| Reviewer | Findings | Resolution |
|---|---|---|
| code-reviewer | 2 BLOCKING, 4 IMPORTANT, 5 NIT | All blocking + important fixed; NITs deferred (cosmetic) |
| security-reviewer | 2 IMPORTANT, 1 NIT | Both important fixed (`writeJUnit` failure semantics, file mode); NIT deferred (`loadResult` size cap is pre-existing scope, filed for follow-up) |
| spec-compliance | COMPLIANT (1 IMPORTANT, 5 NIT) | Important is a project-wide `flag.ExitOnError` exit-2-vs-1 quirk, not in scope; NITs are spec-doc clarifications |
| test-coverage | reporter 96.0%, cmd/eval `cmdConvert` and `--junit` paths 0% | Both 0% paths now exercised through `run()` dispatch |
| api-design | 2 IMPORTANT (`--to-junit` vs `--format`/`--output`; `WriteJUnit` vs `FormatText` shape) | Decision: keep `--to-junit` for spec compliance and file a follow-up issue when a second format (TAP/SARIF) lands; the rename then becomes one motivated migration rather than two |

Synthesizer brief and individual reports are in `.coordinator-scratch/reviews-gh-129/` (not committed).

## Out of scope (filed for follow-up)

- Renaming `--to-junit` to `--format junit --output <path>` once a second format target appears.
- Migrating `reporter.FormatText` from `string`-returning to `WriteText(w io.Writer, ...) error` for package consistency.
- 64 MiB `io.LimitReader` cap on `loadResult` (pre-existing across `cmdCompare` etc.).
- `<properties>` block on `<testsuite>` carrying `RunID`/`PassRate` (insertion point is clean; no API change required when motivated).
- Wiring a JUnit-rendering action like `mikepenz/action-junit-report` — explicitly out of scope per #129.

## Test plan

- [x] `just test` clean (full workspace).
- [x] `just lint` introduces no new findings (12 pre-existing on `main`, all in `harness/`/`types/`; none in files this PR touches).
- [x] `eval/reporter` coverage is 96% of statements.
- [x] `eval/cmd/eval` `cmdConvert` and `--junit` flag paths covered via `run()` dispatch tests.
- [x] Round-trip XML escaping verified by `xml.Unmarshal`, not string-search.
- [x] Empty-suite, zero-timestamp, and backward-timestamp suite-duration paths exercised.
- [x] No new external dependencies (verified by inspecting both `go.mod` files; diff is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)