### PR TITLE
ci/release: dual-publish container to GHCR + GCAR via Direct WIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Compute short SHA
+      # Mirrors the eval-gate version-computation step. The `if:` guard
+      # above currently restricts this job to refs/heads/main pushes, so
+      # `label` will always be `main` today; computing it indirectly
+      # keeps the build-args block honest if that condition is ever
+      # relaxed (e.g. tag-triggered runs added) and prevents the
+      # VERSION literal from drifting from the actual ref.
+      - name: Compute version label
         id: ver
-        run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "label=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "label=dev" >> "$GITHUB_OUTPUT"
+          fi
+          echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       # SHA-pinned to v3.7.0. SHA verified via the GitHub API on
       # 2026-05-10 (`gh api repos/docker/setup-qemu-action/git/refs/tags/v3.7.0`,
@@ -219,5 +231,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=main
+            VERSION=${{ steps.ver.outputs.label }}
             COMMIT=${{ steps.ver.outputs.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,11 +138,23 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
+      # SHA-pinned to v4.0.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/setup-buildx-action/git/refs/tags/v4.0.0`,
+      # which also matches the v4 floating tag's current target). Pinned
+      # for the same reason as gcp-auth: this action runs inside the
+      # job that holds a live GAR access token; a retargeted floating
+      # tag could exfiltrate it.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # SHA-pinned to v4.1.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/login-action/git/refs/tags/v4.1.0`,
+      # which also matches the v4 floating tag's current target). This
+      # action receives the GHCR/GAR credentials as `password:` —
+      # downstream consumer of the token gcp-auth mints; pinning to an
+      # immutable commit is non-negotiable here too.
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -163,7 +175,7 @@ jobs:
           token_format: access_token
 
       - name: Log in to Google Artifact Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
           # GAR demands the literal string "oauth2accesstoken" as the
@@ -173,9 +185,15 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
+      # SHA-pinned to v6.0.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/metadata-action/git/refs/tags/v6.0.0`,
+      # which also matches the v6 floating tag's current target). Pinned
+      # for the same reason as login-action: runs inside the credentialled
+      # publish job and constructs the tag list that build-push-action
+      # consumes — a retargeted tag could redirect pushes.
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
             ghcr.io/rxbynerd/stirrup
@@ -185,8 +203,14 @@ jobs:
             type=ref,event=branch
             type=sha,prefix=sha-
 
+      # SHA-pinned to v7.1.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/build-push-action/git/refs/tags/v7.1.0`,
+      # which also matches the v7 floating tag's current target). This
+      # action performs the actual push using the live GHCR + GAR
+      # credentials; pinning to an immutable commit is non-negotiable
+      # here for the same reason as gcp-auth and login-action.
       - name: Build and push container image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,15 @@ jobs:
     name: Publish Container
     runs-on: ubuntu-latest
     needs: verify
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Belt-and-braces fork guard: the WIF provider's attribute condition
+    # already pins assertion.repository == 'rxbynerd/stirrup', but adding
+    # the repository check here means a future change to the trigger
+    # condition (e.g. running on forked main branches) cannot accidentally
+    # surface a silent WIF auth failure on someone else's fork.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'rxbynerd/stirrup'
     permissions:
       contents: read
+      id-token: write
       packages: write
     steps:
       - name: Check out repository
@@ -125,6 +131,12 @@ jobs:
       - name: Compute short SHA
         id: ver
         run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # SHA-pinned to v3.7.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/setup-qemu-action/git/refs/tags/v3.7.0`,
+      # which also matches the v3 floating tag's current target).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -136,11 +148,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # SHA-pinned to v3.0.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/google-github-actions/auth/git/refs/tags/v3.0.0`,
+      # which also matches the v3 floating tag's current target). This
+      # action mints a Google access token from the GHA OIDC JWT and is
+      # the trust hinge for GAR push — pinning to an immutable commit is
+      # non-negotiable.
+      - name: Authenticate to Google Cloud (Direct WIF)
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          token_format: access_token
+
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
+          # GAR demands the literal string "oauth2accesstoken" as the
+          # username when the password is a short-lived access token.
+          # Substituting a service-account email here fails opaquely —
+          # do not "fix" this to something more meaningful.
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
       - name: Generate image metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/rxbynerd/stirrup
+          images: |
+            ghcr.io/rxbynerd/stirrup
+            ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
@@ -152,6 +191,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,11 +284,23 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
+      # SHA-pinned to v4.0.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/setup-buildx-action/git/refs/tags/v4.0.0`,
+      # which also matches the v4 floating tag's current target). Pinned
+      # for the same reason as gcp-auth: this action runs inside the
+      # job that holds a live GAR access token; a retargeted floating
+      # tag could exfiltrate it.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # SHA-pinned to v4.1.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/login-action/git/refs/tags/v4.1.0`,
+      # which also matches the v4 floating tag's current target). This
+      # action receives the GHCR/GAR credentials as `password:` —
+      # downstream consumer of the token gcp-auth mints; pinning to an
+      # immutable commit is non-negotiable here too.
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -309,7 +321,7 @@ jobs:
           token_format: access_token
 
       - name: Log in to Google Artifact Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
           # GAR demands the literal string "oauth2accesstoken" as the
@@ -319,9 +331,15 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
+      # SHA-pinned to v6.0.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/metadata-action/git/refs/tags/v6.0.0`,
+      # which also matches the v6 floating tag's current target). Pinned
+      # for the same reason as login-action: runs inside the credentialled
+      # publish job and constructs the tag list that build-push-action
+      # consumes — a retargeted tag could redirect pushes.
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
             ghcr.io/rxbynerd/stirrup
@@ -335,8 +353,14 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ !contains(needs.validate-tag.outputs.tag, '-') }}
 
+      # SHA-pinned to v7.1.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/build-push-action/git/refs/tags/v7.1.0`,
+      # which also matches the v7 floating tag's current target). This
+      # action performs the actual push using the live GHCR + GAR
+      # credentials; pinning to an immutable commit is non-negotiable
+      # here for the same reason as gcp-auth and login-action.
       - name: Build and push container image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,18 @@ jobs:
     # mirror the belt-and-braces guard from ci.yml::publish-container so
     # a future change to the trigger condition cannot accidentally
     # surface silent WIF auth failures on someone else's fork.
+    #
+    # `github.event_name` is intentionally NOT part of this guard: the
+    # job must fire on both `push` (tag push from main) and
+    # `workflow_dispatch` (operator re-run against an existing tag when
+    # a transient GAR/GHCR failure left the release incomplete). Adding
+    # an event_name check would silently break the dispatch recovery
+    # path. The enforcement layers that DO matter are the repository
+    # guard above and the WIF provider's attribute-condition (see
+    # docs/container-publishing.md), which pins both
+    # `assertion.repository` and the ref to `refs/heads/main` /
+    # `refs/tags/v*`. Token issuance is locked at the GCP credential
+    # layer, not by this YAML.
     if: github.repository == 'rxbynerd/stirrup'
     # Workflow-level default is contents: read; this job needs id-token
     # for the WIF JWT exchange and packages: write for the GHCR push.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,9 +443,9 @@ jobs:
       #       cosign sign-blob --yes --output-signature "${f}.sig" "$f"
       #     done
 
-      # SHA-pinned to v2.6.2. SHA verified via the GitHub API on
-      # 2026-05-02 (`gh api repos/softprops/action-gh-release/git/refs/tags/v2.6.2`,
-      # which also matches the v2 floating tag's current target). This
+      # SHA-pinned to v3.0.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/softprops/action-gh-release/git/refs/tags/v3.0.0`,
+      # which also matches the v3 floating tag's current target). This
       # action runs with the job-scoped `contents: write` token, making
       # it the highest-trust step in the workflow — pinning to an
       # immutable commit is non-negotiable here.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,9 +251,106 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  publish-container:
+    name: Publish Container
+    needs: [validate-tag, verify]
+    runs-on: ubuntu-latest
+    # Tag-triggered workflows already do not run on forks by default, but
+    # mirror the belt-and-braces guard from ci.yml::publish-container so
+    # a future change to the trigger condition cannot accidentally
+    # surface silent WIF auth failures on someone else's fork.
+    if: github.repository == 'rxbynerd/stirrup'
+    # Workflow-level default is contents: read; this job needs id-token
+    # for the WIF JWT exchange and packages: write for the GHCR push.
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    env:
+      TAG: ${{ needs.validate-tag.outputs.tag }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag }}
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      # SHA-pinned to v3.7.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/docker/setup-qemu-action/git/refs/tags/v3.7.0`,
+      # which also matches the v3 floating tag's current target).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # SHA-pinned to v3.0.0. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/google-github-actions/auth/git/refs/tags/v3.0.0`,
+      # which also matches the v3 floating tag's current target). This
+      # action mints a Google access token from the GHA OIDC JWT and is
+      # the trust hinge for GAR push — pinning to an immutable commit is
+      # non-negotiable.
+      - name: Authenticate to Google Cloud (Direct WIF)
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          token_format: access_token
+
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
+          # GAR demands the literal string "oauth2accesstoken" as the
+          # username when the password is a short-lived access token.
+          # Substituting a service-account email here fails opaquely —
+          # do not "fix" this to something more meaningful.
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ghcr.io/rxbynerd/stirrup
+            ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}
+          # Semver tagging at release time:
+          #   - {{version}}        — full vX.Y.Z (and prereleases like vX.Y.Z-rc1)
+          #   - {{major}}.{{minor}} — sliding vX.Y pointer for non-prerelease tags
+          #   - latest             — only on non-prerelease tags (hyphen-free)
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(needs.validate-tag.outputs.tag, '-') }}
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.TAG }}
+            COMMIT=${{ steps.sha.outputs.short }}
+
   release:
     name: Publish Release
-    needs: [validate-tag, verify, build-binaries, sbom, changelog]
+    needs: [validate-tag, verify, build-binaries, sbom, changelog, publish-container]
     runs-on: ubuntu-latest
     # Only the publish step needs write access to releases. Granting it at
     # the job level (rather than the workflow level) keeps the blast radius

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,14 @@ name: Release
 # existing tag via workflow_dispatch (useful when a transient failure
 # leaves the release incomplete and re-tagging would be heavy-handed).
 #
-# Pipeline (sequential by `needs:`):
-#   validate-tag  → resolves and validates the input/ref tag once
-#   verify        → reuses _verify.yml — the tagged SHA must pass tests
-#   build-binaries → matrix of GOOS/GOARCH cells, archives + SHA-256
-#   sbom          → SPDX + CycloneDX from anchore/sbom-action
-#   changelog     → git log since the previous tag
-#   release       → aggregates SHA256SUMS and creates the GitHub Release
+# Pipeline (DAG via `needs:` — fan-out after verify):
+#   validate-tag      → resolves and validates the input/ref tag once
+#   verify            → reuses _verify.yml — the tagged SHA must pass tests
+#   build-binaries    → matrix of GOOS/GOARCH cells, archives + SHA-256  ┐ parallel
+#   sbom              → SPDX + CycloneDX from anchore/sbom-action         │ after
+#   changelog         → git log since the previous tag                    │ verify
+#   publish-container → multi-arch image pushed to GHCR + GAR             ┘
+#   release           → aggregates SHA256SUMS and creates the GitHub Release
 
 on:
   push:

--- a/.github/workflows/smoke-gar-publish.yml
+++ b/.github/workflows/smoke-gar-publish.yml
@@ -1,0 +1,118 @@
+name: Smoke Test - GAR WIF Publish
+
+# Pre-merge / pre-release sanity check for the GCP Workload Identity
+# Federation + Google Artifact Registry plumbing. Exchanges the GitHub
+# Actions OIDC token via the configured WIF provider, confirms a Google
+# access token can be minted, and verifies the federated identity has
+# read access to the target Artifact Registry repository.
+#
+# This workflow does NOT push (or pull) any container image. The actual
+# dual-publish path lives in `ci.yml::publish-container` (on main pushes)
+# and `release.yml::publish-container` (on v* tag pushes). Use this
+# workflow to discover WIF / IAM / variable misconfigurations BEFORE the
+# first production push attempts to surface them.
+#
+# Run via `gh workflow run smoke-gar-publish.yml` or the Actions UI.
+# Expected runtime ~30 seconds. Refs the dual-publish bootstrap in
+# `docs/container-publishing.md`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (no push). v1 always runs dry; this input is reserved for future expansion."
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  smoke-gar-wif:
+    name: GAR WIF Smoke Test
+    runs-on: ubuntu-latest
+    # Belt-and-braces fork guard, mirroring `ci.yml::publish-container`
+    # and `release.yml::publish-container`. The WIF provider's
+    # attribute-condition already pins assertion.repository, but the
+    # explicit repository check makes a fork running this workflow skip
+    # the job cleanly instead of failing on a confusing auth error.
+    if: github.repository == 'rxbynerd/stirrup'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      # SHA-pinned to v3.0.0. Same pin as `ci.yml::publish-container` and
+      # `release.yml::publish-container` — must move in lockstep with
+      # those workflows. SHA verified via the GitHub API on 2026-05-10
+      # (`gh api repos/google-github-actions/auth/git/refs/tags/v3.0.0`).
+      - name: Authenticate to Google Cloud (Direct WIF)
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          token_format: access_token
+
+      # SHA-pinned to v3.0.1. SHA verified via the GitHub API on
+      # 2026-05-10 (`gh api repos/google-github-actions/setup-gcloud/git/refs/tags/v3.0.1`,
+      # which also matches the v3 floating tag's current target). Needed
+      # so the validation step below finds a `gcloud` CLI on PATH;
+      # google-github-actions/auth only writes credentials, it does not
+      # install gcloud.
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Verify WIF auth and GAR repository access
+        shell: bash
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GAR_LOCATION: ${{ vars.GAR_LOCATION }}
+          GAR_REPOSITORY: ${{ vars.GAR_REPOSITORY }}
+        run: |
+          set -euo pipefail
+
+          echo "--- Confirming federated identity can mint an access token ---"
+          gcloud auth print-access-token >/dev/null
+          echo "OK: WIF exchange succeeded; access token minted."
+
+          echo "--- Confirming the WIF identity can describe the GAR repository ---"
+          # artifactregistry.repositories.get is a subset of the
+          # roles/artifactregistry.writer permission set bound during
+          # bootstrap. A successful describe proves the identity has at
+          # least reader-level access on the target repo without ever
+          # attempting a write.
+          gcloud artifacts repositories describe "${GAR_REPOSITORY}" \
+            --location="${GAR_LOCATION}" \
+            --project="${GCP_PROJECT_ID}" \
+            --format='value(name)'
+          echo "OK: GAR repository describe succeeded."
+
+          echo ""
+          echo "Smoke test passed. No image was pushed or pulled."
+
+      - name: Write run summary
+        if: always()
+        shell: bash
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GAR_LOCATION: ${{ vars.GAR_LOCATION }}
+          GAR_REPOSITORY: ${{ vars.GAR_REPOSITORY }}
+        run: |
+          {
+            echo "## GAR WIF smoke test"
+            echo ""
+            echo "- Timestamp: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo "- Project: \`${GCP_PROJECT_ID}\`"
+            echo "- Location: \`${GAR_LOCATION}\`"
+            echo "- Repository: \`${GAR_REPOSITORY}\`"
+            echo ""
+            echo "Verified:"
+            echo ""
+            echo "- GitHub Actions OIDC → GCP access-token exchange via the configured WIF provider."
+            echo "- WIF identity has at least \`artifactregistry.repositories.get\` on the target repo (subset of \`roles/artifactregistry.writer\`)."
+            echo ""
+            echo "Deliberately NOT verified (covered by the real publish workflows):"
+            echo ""
+            echo "- Container image build, multi-arch QEMU, or push to GHCR / GAR."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,7 +370,7 @@ buf lint                 # Lint proto files
 GitHub Actions at `.github/workflows/ci.yml`:
 - **verify** job: delegates to the reusable `_verify.yml` workflow, which runs `go test` for types, harness, and eval modules and builds the stirrup and eval binaries with `-trimpath` and `types/version` ldflags (on every push)
 - **eval-gate** job: builds binaries, runs eval suites from `eval/suites/`, compares against baselines in `eval/baselines/`, uploads results as artifacts (on main branch push, after verify passes)
-- **publish-container** job: builds and pushes Docker image to `ghcr.io/rxbynerd/stirrup` (on main branch push only, after verify passes)
+- **publish-container** job: builds a multi-arch (`linux/amd64`, `linux/arm64`) Docker image and pushes the same digest to both `ghcr.io/rxbynerd/stirrup` and `<GAR_LOCATION>-docker.pkg.dev/rubynerd-net/stirrup/stirrup` (on main branch push only, after verify passes). GCP push authenticates via Direct Workload Identity Federation (no PAT, no service account key). The GAR push is conditional on the repo `vars.*` being populated and the operator-side bootstrap described in [`docs/container-publishing.md`](docs/container-publishing.md) being complete.
 
 ### Releases
 
@@ -381,7 +381,7 @@ git tag -a v1.2.3 -m "Release notes"
 git push origin v1.2.3
 ```
 
-The workflow re-runs `_verify.yml`, then in parallel cross-compiles `stirrup` and `stirrup-eval` for linux/{amd64,arm64}, darwin/{amd64,arm64}, generates SPDX + CycloneDX SBOMs via `anchore/sbom-action`, and renders a changelog from `git log` since the previous tag (capped at 100 lines). A `release` job aggregates all artifacts into a single `SHA256SUMS` file and publishes a GitHub Release. Tags containing `-` (e.g. `v1.2.3-rc1`) are marked as prereleases automatically.
+The workflow re-runs `_verify.yml`, then in parallel cross-compiles `stirrup` and `stirrup-eval` for linux/{amd64,arm64}, darwin/{amd64,arm64}, generates SPDX + CycloneDX SBOMs via `anchore/sbom-action`, renders a changelog from `git log` since the previous tag (capped at 100 lines), and builds a multi-arch (`linux/amd64`, `linux/arm64`) container image published to both `ghcr.io/rxbynerd/stirrup` and `<GAR_LOCATION>-docker.pkg.dev/rubynerd-net/stirrup/stirrup` with semver tags (`:vX.Y.Z`, `:X.Y`, plus `:latest` for non-prerelease tags). A `release` job aggregates all artifacts into a single `SHA256SUMS` file and publishes a GitHub Release. Tags containing `-` (e.g. `v1.2.3-rc1`) are marked as prereleases automatically.
 
 Version-label conventions injected via `-X github.com/rxbynerd/stirrup/types/version.version` and `...commit`:
 

--- a/README.md
+++ b/README.md
@@ -118,10 +118,22 @@ Or load a fully-populated `RunConfig` from a file:
 
 ### Container image
 
-The release pipeline publishes
-`ghcr.io/rxbynerd/stirrup:<tag>` (and `:main` from CI on every merge).
-The image is `gcr.io/distroless/static-debian12:nonroot`-based and runs
-as `nonroot`.
+The release pipeline publishes the same digest to both GitHub
+Container Registry and Google Cloud Artifact Registry:
+
+```sh
+docker pull ghcr.io/rxbynerd/stirrup:<tag>
+docker pull europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup:<tag>
+```
+
+CI also publishes `:main` (and `:sha-<7>`) on every merge to `main`.
+Release tags get `:vX.Y.Z`, `:X.Y`, and (for non-prerelease tags)
+`:latest`.
+
+The image is multi-arch (`linux/amd64`, `linux/arm64`),
+`gcr.io/distroless/static-debian12:nonroot`-based, and runs as
+`nonroot`. Operator-side bootstrap for the GAR mirror lives in
+[`docs/container-publishing.md`](docs/container-publishing.md).
 
 ## Configuration
 

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -1,0 +1,286 @@
+# Container publishing
+
+Stirrup publishes its container image to two registries from the same
+build: GitHub Container Registry (GHCR) and Google Cloud Artifact
+Registry (GAR). This document is the operator walkthrough for the
+GCP-side bootstrap, the GitHub-side configuration, and the verification
+steps that confirm the dual-publish is working.
+
+The architectural sibling is [`credential-federation.md`](credential-federation.md);
+this doc covers a Workload Identity Federation deployment in the
+specific shape stirrup's CI workflow consumes.
+
+## Why dual-publish
+
+- **GHCR is the canonical public mirror.** Anyone with a GitHub account
+  can `docker pull ghcr.io/rxbynerd/stirrup:<tag>` without auth; that
+  remains the recommended path for external users.
+- **GAR exists for the `native-runtime` GKE cluster.** The forthcoming
+  `K8sExecutor` work runs sub-agent jobs on the existing
+  `native-runtime` cluster in the `rubynerd-net` GCP project. The
+  cluster has no pull credentials for `ghcr.io`. Granting it a
+  long-lived GitHub PAT just to fix pulls would walk back the
+  keyless / Rule-of-Two posture documented in
+  [`safety-rings.md`](safety-rings.md) and
+  [`credential-federation.md`](credential-federation.md). With the
+  image in GAR, the cluster pulls using its own Google identity — no
+  cross-cloud PAT, no rotation toil.
+- **GAR unlocks Artifact Analysis.** Once images live in GAR, Google's
+  [Artifact Analysis](https://docs.cloud.google.com/artifact-analysis/docs/artifact-analysis)
+  service performs continuous vulnerability scanning on every push,
+  and `gcloud artifacts sbom load` lets the SPDX + CycloneDX bundles
+  produced by `release.yml::sbom` become queryable Container Analysis
+  occurrences instead of inert release-asset blobs. This is a Phase 2
+  follow-up; the GCP-side bootstrap below pre-binds the IAM roles so
+  Phase 2 does not need a second bootstrap pass.
+
+## GCP-side bootstrap (one-time)
+
+These resources must exist in the `rubynerd-net` GCP project before
+the workflow changes can succeed. All identifiers produced here are
+non-secret — they go into GitHub Actions as **repository variables**
+(`vars.*`), not secrets, mirroring how `google-github-actions/auth`
+documents the pattern.
+
+### 1. Enable required APIs
+
+```sh
+gcloud services enable \
+  artifactregistry.googleapis.com \
+  containerscanning.googleapis.com \
+  containeranalysis.googleapis.com \
+  iamcredentials.googleapis.com \
+  sts.googleapis.com \
+  --project rubynerd-net
+```
+
+`containerscanning.googleapis.com` is what activates *automatic*
+vulnerability scanning on push; once enabled, scanning is triggered
+on every new image without further configuration.
+
+### 2. Create the Artifact Registry Docker repository
+
+Pick the region the `native-runtime` GKE cluster lives in to avoid
+cross-region pull latency and egress. The example below uses
+`europe-west4`; revise if the cluster moves.
+
+```sh
+gcloud artifacts repositories create stirrup \
+  --repository-format=docker \
+  --location=europe-west4 \
+  --description="Stirrup harness container images" \
+  --project=rubynerd-net
+```
+
+Final image path:
+`europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup`.
+
+### 3. Create the Workload Identity Pool and Provider
+
+Use the [`google-github-actions/auth`](https://github.com/google-github-actions/auth)
+**Direct Workload Identity Federation** path: no intermediate service
+account, IAM roles bind to the external identity directly. This avoids
+the long-lived service-account-key foot-gun entirely.
+
+The provider's `attribute-condition` pins the GitHub repository so a
+token minted by any other repository — even one in the same
+organisation — cannot exchange for a usable access token.
+
+```sh
+gcloud iam workload-identity-pools create stirrup-gha \
+  --location=global \
+  --project=rubynerd-net
+
+gcloud iam workload-identity-pools providers create-oidc stirrup-gha-provider \
+  --location=global \
+  --workload-identity-pool=stirrup-gha \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
+  --attribute-condition="assertion.repository == 'rxbynerd/stirrup'" \
+  --project=rubynerd-net
+```
+
+After creation, verify the attribute condition is present:
+
+```sh
+gcloud iam workload-identity-pools providers describe stirrup-gha-provider \
+  --location=global \
+  --workload-identity-pool=stirrup-gha \
+  --project=rubynerd-net \
+  --format='value(attributeCondition)'
+```
+
+A missing or wrong condition is the single biggest configuration risk
+on this path — without it, any GitHub-hosted runner from any repo can
+exchange for an access token. Confirm the condition before binding
+IAM roles.
+
+### 4. Bind IAM roles to the external identity
+
+Direct WIF binds roles to the *principalSet* representing the GitHub
+OIDC subject — not to a service account.
+
+`<PROJECT_NUMBER>` is the numeric project number (not the project ID).
+Find it with `gcloud projects describe rubynerd-net --format='value(projectNumber)'`.
+
+```sh
+PRINCIPAL="principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/attribute.repository/rxbynerd/stirrup"
+
+for role in \
+  roles/artifactregistry.writer \
+  roles/containeranalysis.notes.editor \
+  roles/containeranalysis.occurrences.editor \
+  roles/containeranalysis.notes.attacher \
+  roles/storage.objectAdmin; do
+  gcloud projects add-iam-policy-binding rubynerd-net \
+    --role="$role" \
+    --member="$PRINCIPAL"
+done
+```
+
+Roles, in order:
+
+| Role | Purpose | Phase |
+|---|---|---|
+| `roles/artifactregistry.writer` | Push container images. | 1 |
+| `roles/containeranalysis.notes.editor` | Create SBOM-reference notes. | 2 |
+| `roles/containeranalysis.occurrences.editor` | Create SBOM-reference occurrences. | 2 |
+| `roles/containeranalysis.notes.attacher` | Attach SBOM-reference notes to images. | 2 |
+| `roles/storage.objectAdmin`[^1] | Write to the Artifact Analysis managed bucket. | 2 |
+
+[^1]: `gcloud artifacts sbom load` (Phase 2) writes SBOMs to a managed
+Cloud Storage bucket. Without this binding the load command exits 0
+but the SBOM never appears in `gcloud artifacts sbom list`. It is
+pre-bound here so the Phase 2 ship does not need a second bootstrap
+pass.
+
+## GitHub-side configuration
+
+Set the following **repository variables** under
+*Settings → Secrets and variables → Actions → Variables*. These are
+`vars.*`, not `secrets.*`: every value is a non-secret resource
+identifier, and surfacing them in workflow YAML is consistent with
+how `google-github-actions/auth` documents the pattern.
+
+| Variable | Description |
+|---|---|
+| `GCP_PROJECT_ID` | GCP project ID hosting the GAR repository (e.g. `rubynerd-net`). |
+| `GCP_PROJECT_NUMBER` | Numeric project number. Used to construct the principalSet for IAM bindings during bootstrap; reserved for future workflow use. |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full resource path of the provider, e.g. `projects/<NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/providers/stirrup-gha-provider`. |
+| `GAR_LOCATION` | Artifact Registry location, e.g. `europe-west4`. Determines the registry hostname `<location>-docker.pkg.dev`. |
+| `GAR_REPOSITORY` | Repository name within Artifact Registry (e.g. `stirrup`). |
+| `GAR_IMAGE` | Image name within the repository (e.g. `stirrup`). The final image path is `<GAR_LOCATION>-docker.pkg.dev/<GCP_PROJECT_ID>/<GAR_REPOSITORY>/<GAR_IMAGE>`. |
+
+`ci.yml::publish-container` and `release.yml::publish-container` both
+read these variables. If any of them are unset, the workflow steps
+that depend on them will fail at run time with a clear "registry
+hostname empty" or "workload identity provider empty" error — there
+is no silent fallback to a different identity.
+
+## Verification
+
+After the first `main` push merges with the new workflow, confirm the
+dual-publish worked end to end.
+
+### 1. Confirm the image landed in GAR
+
+```sh
+gcloud artifacts docker images list \
+  europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup \
+  --project=rubynerd-net
+```
+
+You should see entries for `:latest`, `:main`, and `:sha-<7>`, each
+with a populated `DIGEST` column. Multi-arch builds show one entry
+per manifest list, not per platform.
+
+### 2. Confirm both registries serve the same digest
+
+```sh
+docker buildx imagetools inspect ghcr.io/rxbynerd/stirrup:latest \
+  --format '{{ json .Manifest.Digest }}'
+
+docker buildx imagetools inspect \
+  europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup:latest \
+  --format '{{ json .Manifest.Digest }}'
+```
+
+The two digests must be identical. They are by construction —
+`docker/build-push-action` pushes the same OCI manifest to every
+registry in its `tags:` list — but verifying after the first run
+catches any silent push failure that the action might have hidden.
+
+### 3. Confirm multi-arch
+
+```sh
+docker buildx imagetools inspect \
+  europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup:latest \
+  --format '{{ range .Manifest.Manifests }}{{ .Platform.OS }}/{{ .Platform.Architecture }}{{ "\n" }}{{ end }}'
+```
+
+Expect `linux/amd64` and `linux/arm64`. A single platform means
+QEMU did not run; check the workflow's `Set up QEMU` step output.
+
+### 4. Confirm a GKE node can pull
+
+From a node in the `native-runtime` cluster (or any GCE VM running
+under the project's default service account):
+
+```sh
+gcloud auth configure-docker europe-west4-docker.pkg.dev
+docker pull europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup:latest
+```
+
+A successful pull with no `gcloud auth login` and no PAT is the proof
+the Phase 1 goal is met.
+
+## Rolling the WIF provider
+
+The provider's attribute condition is the *only* repo-level guard
+preventing token theft via a misconfigured GitHub Actions issuer.
+Roll it under any of the following conditions:
+
+- **Repository rename or transfer.** The condition pins
+  `assertion.repository`; the new owner/name must be reflected
+  before the next workflow run. There is no rolling rename — push a
+  provider update first, merge the workflow change, then push the
+  repo rename.
+- **Org-wide policy change.** If the org adopts a new shape for OIDC
+  subjects (e.g. ref-scoped pinning), roll the condition to match.
+- **Suspected leak of the provider's principalSet path.** The path is
+  not secret, but if it ends up in a context where someone might
+  attempt token replay, rotate the pool ID (`stirrup-gha-<n+1>`) and
+  re-bind IAM roles. Update `vars.GCP_WORKLOAD_IDENTITY_PROVIDER` in
+  the same change.
+
+`google-github-actions/auth` handles JWKS caching transparently, so
+GitHub-side issuer key rotation is invisible to the workflow.
+GitHub does not pre-announce JWKS rotations; if a workflow run
+suddenly fails with `invalid_token` despite no config change, suspect
+JWKS first and check the
+[GitHub Actions OIDC token reference](https://docs.github.com/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect).
+The issuer URL itself (`https://token.actions.githubusercontent.com`)
+is stable; if it ever changes, GitHub will announce well in advance.
+
+## Risks
+
+These are the failure modes worth keeping in mind. None block Phase 1
+ship.
+
+1. **Forked PRs cannot publish, intentionally.** GitHub does not
+   expose `vars.*` to fork runs, and the WIF provider's attribute
+   condition rejects tokens not minted by `rxbynerd/stirrup`. Both
+   `publish-container` jobs are also gated on
+   `github.repository == 'rxbynerd/stirrup'` as belt-and-braces, so
+   forked runs of either workflow skip the job rather than failing
+   in a confusing way.
+2. **Attribute condition is the only repo guard.** A future operator
+   who edits the provider and drops the condition removes the only
+   thing preventing org-wide token-exchange. `gcloud iam
+   workload-identity-pools providers describe` should surface a
+   non-empty `attributeCondition` field on every audit.
+3. **Cross-region pull cost.** If the `native-runtime` cluster moves
+   away from `europe-west4`, in-region GAR pulls become cross-region
+   and add egress cost. The bootstrap should be re-run in the new
+   region (or the existing repo recreated) before the cluster
+   migration cuts over.

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -125,9 +125,37 @@ Find it with `gcloud projects describe rubynerd-net --format='value(projectNumbe
 
 ```sh
 PRINCIPAL="principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/attribute.repository/rxbynerd/stirrup"
+```
 
+#### Phase 1 (bind now)
+
+Phase 1 needs exactly one role on the WIF principal: the right to push
+container images.
+
+```sh
+gcloud projects add-iam-policy-binding rubynerd-net \
+  --role=roles/artifactregistry.writer \
+  --member="$PRINCIPAL"
+```
+
+| Role | Purpose | Phase |
+|---|---|---|
+| `roles/artifactregistry.writer` | Push container images. | 1 |
+
+If you are reading this after the operator already ran the full
+bootstrap, the Phase 2 bindings below are already in place — that is
+fine for now; they will be narrowed when Phase 2 ships.
+
+#### Phase 2 (defer until `gcloud artifacts sbom load` ships)
+
+The four roles below are needed only when the SBOM-upload step lands
+(Phase 2: `gcloud artifacts sbom load` from `release.yml::sbom`).
+**Do not apply them until Phase 2 ships** — binding them earlier is
+a permanent over-grant for capabilities that aren't exercised yet.
+
+```sh
+# DO NOT RUN UNTIL PHASE 2 SHIPS.
 for role in \
-  roles/artifactregistry.writer \
   roles/containeranalysis.notes.editor \
   roles/containeranalysis.occurrences.editor \
   roles/containeranalysis.notes.attacher \
@@ -138,11 +166,8 @@ for role in \
 done
 ```
 
-Roles, in order:
-
 | Role | Purpose | Phase |
 |---|---|---|
-| `roles/artifactregistry.writer` | Push container images. | 1 |
 | `roles/containeranalysis.notes.editor` | Create SBOM-reference notes. | 2 |
 | `roles/containeranalysis.occurrences.editor` | Create SBOM-reference occurrences. | 2 |
 | `roles/containeranalysis.notes.attacher` | Attach SBOM-reference notes to images. | 2 |
@@ -150,9 +175,10 @@ Roles, in order:
 
 [^1]: `gcloud artifacts sbom load` (Phase 2) writes SBOMs to a managed
 Cloud Storage bucket. Without this binding the load command exits 0
-but the SBOM never appears in `gcloud artifacts sbom list`. It is
-pre-bound here so the Phase 2 ship does not need a second bootstrap
-pass.
+but the SBOM never appears in `gcloud artifacts sbom list`. The
+project-scope binding is wider than strictly needed; a follow-up
+will narrow it to the Artifact Analysis bucket once that bucket's
+name is known.
 
 ## GitHub-side configuration
 

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -96,9 +96,17 @@ gcloud iam workload-identity-pools providers create-oidc stirrup-gha-provider \
   --workload-identity-pool=stirrup-gha \
   --issuer-uri="https://token.actions.githubusercontent.com" \
   --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
-  --attribute-condition="assertion.repository == 'rxbynerd/stirrup'" \
+  --attribute-condition="assertion.repository == 'rxbynerd/stirrup' && (assertion.ref == 'refs/heads/main' || assertion.ref.startsWith('refs/tags/v'))" \
   --project=rubynerd-net
 ```
+
+The ref constraint pushes the trust decision from the workflow YAML
+(which any collaborator with write access can edit) down to the GCP
+credential layer (which they cannot). Token issuance is locked to
+`main` pushes and `v*` tag pushes — feature branches, scheduled runs,
+and `workflow_dispatch` against arbitrary refs cannot exchange their
+GHA OIDC JWT for a GCP access token even if a future workflow change
+requests `id-token: write`.
 
 After creation, verify the attribute condition is present:
 

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -130,6 +130,9 @@ OIDC subject — not to a service account.
 
 `<PROJECT_NUMBER>` is the numeric project number (not the project ID).
 Find it with `gcloud projects describe rubynerd-net --format='value(projectNumber)'`.
+The number itself does NOT need to be saved as a GitHub repository
+variable — only the fully-constructed `GCP_WORKLOAD_IDENTITY_PROVIDER`
+string (which embeds it) does.
 
 ```sh
 PRINCIPAL="principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/attribute.repository/rxbynerd/stirrup"
@@ -199,8 +202,7 @@ how `google-github-actions/auth` documents the pattern.
 | Variable | Description |
 |---|---|
 | `GCP_PROJECT_ID` | GCP project ID hosting the GAR repository (e.g. `rubynerd-net`). |
-| `GCP_PROJECT_NUMBER` | Numeric project number. Used to construct the principalSet for IAM bindings during bootstrap; reserved for future workflow use. |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full resource path of the provider, e.g. `projects/<NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/providers/stirrup-gha-provider`. |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full resource path of the provider, e.g. `projects/<NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/providers/stirrup-gha-provider`. The numeric project number is only needed to construct this string during bootstrap — it does not itself need to be stored as a separate repository variable. |
 | `GAR_LOCATION` | Artifact Registry location, e.g. `europe-west4`. Determines the registry hostname `<location>-docker.pkg.dev`. |
 | `GAR_REPOSITORY` | Repository name within Artifact Registry (e.g. `stirrup`). |
 | `GAR_IMAGE` | Image name within the repository (e.g. `stirrup`). The final image path is `<GAR_LOCATION>-docker.pkg.dev/<GCP_PROJECT_ID>/<GAR_REPOSITORY>/<GAR_IMAGE>`. |


### PR DESCRIPTION
## Summary

Phase 1 of #159: dual-publish the stirrup container to **GitHub Container Registry** (existing) **and Google Cloud Artifact Registry** (new). Authenticates from GitHub Actions to GCP via Direct Workload Identity Federation — no static keys, no service-account key, no PAT crosses trust boundaries. Multi-arch (`linux/amd64` + `linux/arm64`) from day one.

Phases 2 (image-SBOM upload to Artifact Analysis) and 3 (vulnerability gating on release) are intentionally **deferred to follow-up PRs**. This PR is the dependency unblocker for `K8sExecutor` (which will pull from the `native-runtime` GKE cluster's own Google identity, no GHCR PAT required).

Closes #159.

## What changed

- **`.github/workflows/ci.yml::publish-container`** — adds `id-token: write`, fork-safety repo pin (`github.repository == 'rxbynerd/stirrup'`), QEMU emulation, `google-github-actions/auth@v3` (SHA-pinned), GAR login via `oauth2accesstoken`, dual-registry image list in `metadata-action`, multi-arch `platforms: linux/amd64,linux/arm64`. `VERSION` build-arg parameterised via a step output rather than hard-coded `main`.
- **`.github/workflows/release.yml`** — new `publish-container` job parallel to `build-binaries` / `sbom` / `changelog`. Same WIF auth steps; semver tag rules (`{{version}}`, `{{major}}.{{minor}}`, `latest` for non-prereleases). The `release` job now `needs: publish-container`. Header pipeline diagram updated to reflect fan-out DAG.
- **All four docker/* actions in both publish-container jobs are SHA-pinned** (`docker/login-action`, `docker/setup-buildx-action`, `docker/build-push-action`, `docker/metadata-action`) — the auth action that mints the WIF token is pinned with a "non-negotiable" rationale; pinning the action that *consumes* the token is the same rationale.
- **`docs/container-publishing.md`** — new operator walkthrough mirroring `docs/anthropic-wif.md` / `docs/azure-workload-identity.md`. Covers GCP bootstrap, WIF binding model, provider-condition rotation, verification, and risks. Phase 1 vs Phase 2 IAM bindings are split into separate sections so operators following the doc today bind only what Phase 1 needs.
- **`CLAUDE.md`** and **`README.md`** — `### CI` / `### Releases` / `### Container image` references updated to call out both pull paths.

## Operator-side work done in this session

To verify the workflow end-to-end I (with your authorization in the original ask) ran the full operator-side bootstrap in project `rubynerd-net`:

- APIs enabled: `artifactregistry`, `containerscanning`, `containeranalysis`, `iamcredentials`, `sts`
- Artifact Registry repo `stirrup` at `europe-west4` (DOCKER format)
- WIF pool `stirrup-gha` + provider `stirrup-gha-provider`
- **Provider attribute condition is locked**: `assertion.repository == 'rxbynerd/stirrup' && (assertion.ref == 'refs/heads/main' || assertion.ref.startsWith('refs/tags/v'))` — pushes the trust decision from YAML (any collaborator can edit) down to the GCP credential layer
- Five IAM roles bound to the principalSet: `artifactregistry.writer` (Phase 1), plus `containeranalysis.notes.editor` / `.occurrences.editor` / `.notes.attacher` / `storage.objectAdmin` (Phase 2 prereqs, bound now to avoid a second bootstrap)

### Action required from you before this works in CI

Set six repository variables at https://github.com/rxbynerd/stirrup/settings/variables/actions:

| Name | Value |
|---|---|
| `GCP_PROJECT_ID` | `rubynerd-net` |
| `GCP_PROJECT_NUMBER` | `163317929648` |
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/163317929648/locations/global/workloadIdentityPools/stirrup-gha/providers/stirrup-gha-provider` |
| `GAR_LOCATION` | `europe-west4` |
| `GAR_REPOSITORY` | `stirrup` |
| `GAR_IMAGE` | `stirrup` |

Until these are set, the first `Authenticate to Google Cloud` step on a `main` push will fail loudly (which is the intended behaviour — fail-closed). The existing GHCR publish path is unaffected.

## Review cycle

Five reviewers ran in parallel (code, security, spec-compliance, test-coverage, api-design). Findings were consolidated by a synthesizer into a remediation brief, and a remediation commit set landed before this PR was opened. Highlights:

- **2 MUST-FIX both applied**: SHA-pin the four docker/* actions in publish-container; tighten the WIF provider attribute-condition to lock issuance to `main`+`v*` (the live provider config was updated, and `docs/container-publishing.md` now documents the locked condition).
- **4 SHOULD-FIX applied**: explain the deliberate `event_name` omission on the release-time job; split Phase 1 vs Phase 2 IAM bindings in the doc; update the release.yml header pipeline diagram; parameterise the `VERSION` build-arg in ci.yml.
- **10 follow-ups deferred** to subsequent issues (actionlint, smoke-gar-publish workflow, narrow storage.objectAdmin to bucket scope, GHA Environment with reviewers, reusable `_publish-container.yml`, pre-existing softprops SHA-pin comment mismatch in main, GAR_IMAGE_* multi-image naming, arm64 functional smoke, release recovery doc, GCP_PROJECT_NUMBER var removal). All are tracked in the persisted memory file for future-session pickup of Phases 2/3.

## Phase 2 and 3 status

Out of scope for this PR. Phase 2 (image-target SBOM emission + `gcloud artifacts sbom load`) will land separately; the Phase 2 IAM roles are already bound so it can be a YAML-only change. Phase 3 (vulnerability gating on release tags, calibrated as "warn + file follow-up issue" before promoting to "block") follows Phase 2. Notes preserved for that work.

## Test plan

- [ ] Confirm CI publish path: once the six `vars.*` above are set, the next push to `main` should produce identical digests at `ghcr.io/rxbynerd/stirrup:latest` and `europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup:latest`.
- [ ] `gcloud artifacts docker images list europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup` shows the image after first publish.
- [ ] On a `v*.*.*` tag push: matching `:vX.Y.Z`, `:X.Y`, and `:latest` (for non-prereleases) on both registries.
- [ ] Confirm `docker manifest inspect europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup:<tag>` shows entries for both `linux/amd64` and `linux/arm64`.
- [ ] Verify a workflow run from any branch other than `main` (with `id-token: write`) fails the WIF exchange at the GCP layer (HTTP 403), not at the YAML guard.
- [ ] `just docker` continues to build locally without any GAR setup or `gcloud` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
