### PR TITLE
ci/release: fix Direct WIF token-minting; document main-only smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,13 +178,49 @@ jobs:
       # action mints a Google access token from the GHA OIDC JWT and is
       # the trust hinge for GAR push — pinning to an immutable commit is
       # non-negotiable.
+      #
+      # `token_format` is intentionally omitted: Direct WIF (no
+      # intermediate service account) cannot synthesize an OAuth2 access
+      # token through this action's `access_token` output — that path
+      # requires SA impersonation. Instead, this step writes the
+      # federated `external_account` ADC credentials file, and the
+      # follow-up `gcloud auth print-access-token` step mints the bearer
+      # token via the STS exchange. See `docs/container-publishing.md`.
       - name: Authenticate to Google Cloud (Direct WIF)
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          token_format: access_token
+
+      # SHA-pinned to v3.0.1. Same pin as
+      # `smoke-gar-publish.yml::Set up gcloud CLI` — must move in
+      # lockstep. SHA verified via the GitHub API on 2026-05-10
+      # (`gh api repos/google-github-actions/setup-gcloud/git/refs/tags/v3.0.1`,
+      # which also matches the v3 floating tag's current target). The
+      # auth step only writes credentials; `gcloud` is needed on PATH so
+      # the next step can mint the GAR access token.
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      # `gcloud auth print-access-token` transparently performs the STS
+      # token-exchange against the federated principal and prints a
+      # Google access token usable by GAR. This is the canonical
+      # Direct-WIF pattern: the auth action's `access_token` output is
+      # unavailable without SA impersonation, but ADC + `gcloud` can
+      # still mint a bearer token from the federated credentials file.
+      #
+      # `::add-mask::` MUST run before the token is emitted to
+      # GITHUB_OUTPUT — masking applies to all subsequent log output, so
+      # any later step that accidentally echoes the token gets it
+      # redacted automatically.
+      - name: Mint GAR access token
+        id: gar-token
+        shell: bash
+        run: |
+          TOKEN=$(gcloud auth print-access-token)
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Google Artifact Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -195,7 +231,7 @@ jobs:
           # Substituting a service-account email here fails opaquely —
           # do not "fix" this to something more meaningful.
           username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
+          password: ${{ steps.gar-token.outputs.token }}
 
       # SHA-pinned to v6.0.0. SHA verified via the GitHub API on
       # 2026-05-10 (`gh api repos/docker/metadata-action/git/refs/tags/v6.0.0`,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,13 +325,49 @@ jobs:
       # action mints a Google access token from the GHA OIDC JWT and is
       # the trust hinge for GAR push — pinning to an immutable commit is
       # non-negotiable.
+      #
+      # `token_format` is intentionally omitted: Direct WIF (no
+      # intermediate service account) cannot synthesize an OAuth2 access
+      # token through this action's `access_token` output — that path
+      # requires SA impersonation. Instead, this step writes the
+      # federated `external_account` ADC credentials file, and the
+      # follow-up `gcloud auth print-access-token` step mints the bearer
+      # token via the STS exchange. See `docs/container-publishing.md`.
       - name: Authenticate to Google Cloud (Direct WIF)
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          token_format: access_token
+
+      # SHA-pinned to v3.0.1. Same pin as
+      # `smoke-gar-publish.yml::Set up gcloud CLI` — must move in
+      # lockstep. SHA verified via the GitHub API on 2026-05-10
+      # (`gh api repos/google-github-actions/setup-gcloud/git/refs/tags/v3.0.1`,
+      # which also matches the v3 floating tag's current target). The
+      # auth step only writes credentials; `gcloud` is needed on PATH so
+      # the next step can mint the GAR access token.
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      # `gcloud auth print-access-token` transparently performs the STS
+      # token-exchange against the federated principal and prints a
+      # Google access token usable by GAR. This is the canonical
+      # Direct-WIF pattern: the auth action's `access_token` output is
+      # unavailable without SA impersonation, but ADC + `gcloud` can
+      # still mint a bearer token from the federated credentials file.
+      #
+      # `::add-mask::` MUST run before the token is emitted to
+      # GITHUB_OUTPUT — masking applies to all subsequent log output, so
+      # any later step that accidentally echoes the token gets it
+      # redacted automatically.
+      - name: Mint GAR access token
+        id: gar-token
+        shell: bash
+        run: |
+          TOKEN=$(gcloud auth print-access-token)
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Google Artifact Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -342,7 +378,7 @@ jobs:
           # Substituting a service-account email here fails opaquely —
           # do not "fix" this to something more meaningful.
           username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
+          password: ${{ steps.gar-token.outputs.token }}
 
       # SHA-pinned to v6.0.0. SHA verified via the GitHub API on
       # 2026-05-10 (`gh api repos/docker/metadata-action/git/refs/tags/v6.0.0`,

--- a/.github/workflows/smoke-gar-publish.yml
+++ b/.github/workflows/smoke-gar-publish.yml
@@ -46,13 +46,20 @@ jobs:
       # `release.yml::publish-container` — must move in lockstep with
       # those workflows. SHA verified via the GitHub API on 2026-05-10
       # (`gh api repos/google-github-actions/auth/git/refs/tags/v3.0.0`).
+      #
+      # `token_format` is intentionally omitted: Direct WIF (no
+      # intermediate service account) cannot synthesize an OAuth2 access
+      # token through this action's `access_token` output — that path
+      # requires SA impersonation. The verification step below calls
+      # `gcloud auth print-access-token` instead, which performs the STS
+      # exchange against the federated credentials file written here.
+      # See `docs/container-publishing.md` for the full rationale.
       - name: Authenticate to Google Cloud (Direct WIF)
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          token_format: access_token
 
       # SHA-pinned to v3.0.1. SHA verified via the GitHub API on
       # 2026-05-10 (`gh api repos/google-github-actions/setup-gcloud/git/refs/tags/v3.0.1`,

--- a/.github/workflows/smoke-gar-publish.yml
+++ b/.github/workflows/smoke-gar-publish.yml
@@ -15,6 +15,19 @@ name: Smoke Test - GAR WIF Publish
 # Run via `gh workflow run smoke-gar-publish.yml` or the Actions UI.
 # Expected runtime ~30 seconds. Refs the dual-publish bootstrap in
 # `docs/container-publishing.md`.
+#
+# The workflow can only be successfully dispatched from `main` (or a
+# `v*` tag); the WIF provider's `attributeCondition` restricts token
+# issuance to those refs and rejects dispatches from feature branches
+# with `unauthorized_client: The given credential is rejected by the
+# attribute condition.`. This is intentional — the same condition
+# stops an attacker who lands a malicious workflow on a feature branch
+# from minting a token. To verify a change that touches the WIF auth
+# path (the `auth` / `setup-gcloud` / token-minting steps here or in
+# `ci.yml`/`release.yml`), merge fix-forward to `main` (failure mode
+# is fail-closed: the existing GHCR publish is unaffected by a broken
+# GAR auth step) and run `gh workflow run smoke-gar-publish.yml
+# --ref main` immediately as the first verification.
 
 on:
   workflow_dispatch:

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -238,6 +238,21 @@ the runner. Upstream reference:
 After the first `main` push merges with the new workflow, confirm the
 dual-publish worked end to end.
 
+### 0. (Optional) Run the smoke workflow on `main`
+
+The smoke workflow at `.github/workflows/smoke-gar-publish.yml` mints
+a federated access token and runs `gcloud artifacts repositories
+describe` against the target repo without pushing or pulling any
+image. Dispatch with `gh workflow run smoke-gar-publish.yml --ref
+main`. It is the fastest way to confirm the WIF provider, IAM
+bindings, and access-token minting path are healthy after a provider
+rotation, IAM rebind, or after editing the `auth` / `setup-gcloud` /
+token-minting steps in `ci.yml` / `release.yml`. Note that it can
+only be dispatched from main or a v* tag (the same WIF
+`attributeCondition` that gates the real publish path also gates the
+smoke). This is intentional, and means pre-merge verification of
+auth-surface changes on a feature branch is infeasible by design.
+
 ### 1. Confirm the image landed in GAR
 
 ```sh

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -213,6 +213,26 @@ that depend on them will fail at run time with a clear "registry
 hostname empty" or "workload identity provider empty" error — there
 is no silent fallback to a different identity.
 
+### Why we mint the access token via `gcloud` rather than the `auth` action's output
+
+The publish workflows do **not** use `google-github-actions/auth`'s
+`token_format: access_token` output to feed
+`docker/login-action`. Direct WIF deliberately has no intermediate
+service account, and the `access_token` output path requires SA
+impersonation — the action exits with "the GitHub Action workflow
+must specify a service_account to use when generating an OAuth 2.0
+Access Token" if you try. The federated `external_account` credentials
+file the action *does* write is sufficient for Google client libraries
+that consume Application Default Credentials, but `docker login`
+needs a literal bearer token. The canonical Direct-WIF pattern is
+therefore: run `auth` without `token_format`, then
+`setup-gcloud`, then `gcloud auth print-access-token` to transparently
+perform the STS exchange and emit a usable bearer token. The minting
+step pipes `::add-mask::` before writing the token to
+`GITHUB_OUTPUT` so any accidental log echo downstream is redacted by
+the runner. Upstream reference:
+[`google-github-actions/auth` — Direct Workload Identity Federation](https://github.com/google-github-actions/auth#direct-workload-identity-federation).
+
 ## Verification
 
 After the first `main` push merges with the new workflow, confirm the


### PR DESCRIPTION
## Summary

Follow-up fix to #163. The smoke workflow that landed in that PR did its job on the first run after merge — it caught a real bug in the Direct WIF auth path before any production push.

## What the smoke caught

```
google-github-actions/auth failed with: the GitHub Action workflow must specify
a "service_account" to use when generating an OAuth 2.0 Access Token.
```

(Run: https://github.com/rxbynerd/stirrup/actions/runs/25639141570)

**Root cause:** `google-github-actions/auth@v3` with `token_format: access_token` requires service-account impersonation. The Direct WIF model chosen for #159 deliberately omits the intermediate SA. The two are incompatible: Direct WIF can mint a federated identity but cannot synthesize an OAuth2 access token directly. `docker/login-action` needs a literal bearer token for GAR, so the original wiring couldn't work as written.

## The fix

For Direct WIF, the canonical pattern is:

1. `google-github-actions/auth` writes the federated credentials file only (no `token_format`).
2. `google-github-actions/setup-gcloud` puts `gcloud` on PATH.
3. `gcloud auth print-access-token` transparently performs the STS exchange against the federated principal and produces a Google access token usable by Artifact Registry.
4. `echo "::add-mask::$TOKEN"` keeps it out of logs before emitting it as a step output.
5. `docker/login-action` consumes the minted token as its `password:`.

Applied to all three workflows (`ci.yml`, `release.yml`, `smoke-gar-publish.yml`); doc subsection added explaining the why and linking to the [upstream Direct WIF reference](https://github.com/google-github-actions/auth#direct-workload-identity-federation).

## A second thing the smoke caught — by design

Attempting to verify the fix pre-merge by dispatching the smoke workflow against this branch hit:

```
unauthorized_client: The given credential is rejected by the attribute condition.
```

That's the WIF provider's `attributeCondition` (locked in #163 MF-1 to `refs/heads/main` and `refs/tags/v*`) correctly refusing to mint a token for a feature branch. **This is exactly the security boundary we wanted — but it also means the smoke workflow cannot be used to verify auth-path changes pre-merge.** The right pattern is fix-forward: merge this PR, then run `gh workflow run smoke-gar-publish.yml --ref main` as the first thing afterward. The failure mode is fail-closed (existing GHCR publish path is untouched) so merging is low-risk.

This tradeoff is now documented in the smoke workflow's top-of-file comment and in `docs/container-publishing.md`'s Verification section.

## Commits

- `f5d4fc0` — `ci/release/smoke: mint GAR access token via gcloud after Direct WIF auth`
- `bcbcf75` — `docs(container-publishing): document Direct-WIF access-token minting via gcloud`
- `f533584` — `docs/ci: note smoke-gar-publish.yml is dispatchable from main/v* only`

## Test plan

- [ ] Merge.
- [ ] `gh workflow run smoke-gar-publish.yml --ref main` — should now succeed end-to-end (token mint + GAR repo describe).
- [ ] Next `main` push should produce identical digests at `ghcr.io/rxbynerd/stirrup:latest` and `europe-west4-docker.pkg.dev/rubynerd-net/stirrup/stirrup:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
