### PR TITLE
ci/ops: migrate GAR auth to short-lived SA impersonation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,48 +179,23 @@ jobs:
       # the trust hinge for GAR push — pinning to an immutable commit is
       # non-negotiable.
       #
-      # `token_format` is intentionally omitted: Direct WIF (no
-      # intermediate service account) cannot synthesize an OAuth2 access
-      # token through this action's `access_token` output — that path
-      # requires SA impersonation. Instead, this step writes the
-      # federated `external_account` ADC credentials file, and the
-      # follow-up `gcloud auth print-access-token` step mints the bearer
-      # token via the STS exchange. See `docs/container-publishing.md`.
-      - name: Authenticate to Google Cloud (Direct WIF)
+      # `service_account` + `token_format: access_token` instructs the
+      # action to exchange the federated GHA OIDC JWT for a short-lived
+      # OAuth2 access token via service-account impersonation. The SA
+      # `vars.GAR_PUBLISHER_SA` holds the GAR-push role bindings; the
+      # GitHub principalSet only holds `roles/iam.workloadIdentityUser`
+      # on the SA (the impersonation grant). This is the canonical
+      # google-github-actions/auth pattern — see
+      # `docs/container-publishing.md` for the migration rationale
+      # (issue #167).
+      - name: Authenticate to Google Cloud (WIF + SA impersonation)
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
-      # SHA-pinned to v3.0.1. Same pin as
-      # `smoke-gar-publish.yml::Set up gcloud CLI` — must move in
-      # lockstep. SHA verified via the GitHub API on 2026-05-10
-      # (`gh api repos/google-github-actions/setup-gcloud/git/refs/tags/v3.0.1`,
-      # which also matches the v3 floating tag's current target). The
-      # auth step only writes credentials; `gcloud` is needed on PATH so
-      # the next step can mint the GAR access token.
-      - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-
-      # `gcloud auth print-access-token` transparently performs the STS
-      # token-exchange against the federated principal and prints a
-      # Google access token usable by GAR. This is the canonical
-      # Direct-WIF pattern: the auth action's `access_token` output is
-      # unavailable without SA impersonation, but ADC + `gcloud` can
-      # still mint a bearer token from the federated credentials file.
-      #
-      # `::add-mask::` MUST run before the token is emitted to
-      # GITHUB_OUTPUT — masking applies to all subsequent log output, so
-      # any later step that accidentally echoes the token gets it
-      # redacted automatically.
-      - name: Mint GAR access token
-        id: gar-token
-        shell: bash
-        run: |
-          TOKEN=$(gcloud auth print-access-token)
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+          service_account: ${{ vars.GAR_PUBLISHER_SA }}
+          token_format: access_token
 
       - name: Log in to Google Artifact Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -231,7 +206,7 @@ jobs:
           # Substituting a service-account email here fails opaquely —
           # do not "fix" this to something more meaningful.
           username: oauth2accesstoken
-          password: ${{ steps.gar-token.outputs.token }}
+          password: ${{ steps.gcp-auth.outputs.access_token }}
 
       # SHA-pinned to v6.0.0. SHA verified via the GitHub API on
       # 2026-05-10 (`gh api repos/docker/metadata-action/git/refs/tags/v6.0.0`,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,48 +326,23 @@ jobs:
       # the trust hinge for GAR push — pinning to an immutable commit is
       # non-negotiable.
       #
-      # `token_format` is intentionally omitted: Direct WIF (no
-      # intermediate service account) cannot synthesize an OAuth2 access
-      # token through this action's `access_token` output — that path
-      # requires SA impersonation. Instead, this step writes the
-      # federated `external_account` ADC credentials file, and the
-      # follow-up `gcloud auth print-access-token` step mints the bearer
-      # token via the STS exchange. See `docs/container-publishing.md`.
-      - name: Authenticate to Google Cloud (Direct WIF)
+      # `service_account` + `token_format: access_token` instructs the
+      # action to exchange the federated GHA OIDC JWT for a short-lived
+      # OAuth2 access token via service-account impersonation. The SA
+      # `vars.GAR_PUBLISHER_SA` holds the GAR-push role bindings; the
+      # GitHub principalSet only holds `roles/iam.workloadIdentityUser`
+      # on the SA (the impersonation grant). This is the canonical
+      # google-github-actions/auth pattern — see
+      # `docs/container-publishing.md` for the migration rationale
+      # (issue #167).
+      - name: Authenticate to Google Cloud (WIF + SA impersonation)
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
-      # SHA-pinned to v3.0.1. Same pin as
-      # `smoke-gar-publish.yml::Set up gcloud CLI` — must move in
-      # lockstep. SHA verified via the GitHub API on 2026-05-10
-      # (`gh api repos/google-github-actions/setup-gcloud/git/refs/tags/v3.0.1`,
-      # which also matches the v3 floating tag's current target). The
-      # auth step only writes credentials; `gcloud` is needed on PATH so
-      # the next step can mint the GAR access token.
-      - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-
-      # `gcloud auth print-access-token` transparently performs the STS
-      # token-exchange against the federated principal and prints a
-      # Google access token usable by GAR. This is the canonical
-      # Direct-WIF pattern: the auth action's `access_token` output is
-      # unavailable without SA impersonation, but ADC + `gcloud` can
-      # still mint a bearer token from the federated credentials file.
-      #
-      # `::add-mask::` MUST run before the token is emitted to
-      # GITHUB_OUTPUT — masking applies to all subsequent log output, so
-      # any later step that accidentally echoes the token gets it
-      # redacted automatically.
-      - name: Mint GAR access token
-        id: gar-token
-        shell: bash
-        run: |
-          TOKEN=$(gcloud auth print-access-token)
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+          service_account: ${{ vars.GAR_PUBLISHER_SA }}
+          token_format: access_token
 
       - name: Log in to Google Artifact Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -378,7 +353,7 @@ jobs:
           # Substituting a service-account email here fails opaquely —
           # do not "fix" this to something more meaningful.
           username: oauth2accesstoken
-          password: ${{ steps.gar-token.outputs.token }}
+          password: ${{ steps.gcp-auth.outputs.access_token }}
 
       # SHA-pinned to v6.0.0. SHA verified via the GitHub API on
       # 2026-05-10 (`gh api repos/docker/metadata-action/git/refs/tags/v6.0.0`,

--- a/.github/workflows/smoke-gar-publish.yml
+++ b/.github/workflows/smoke-gar-publish.yml
@@ -2,9 +2,10 @@ name: Smoke Test - GAR WIF Publish
 
 # Pre-merge / pre-release sanity check for the GCP Workload Identity
 # Federation + Google Artifact Registry plumbing. Exchanges the GitHub
-# Actions OIDC token via the configured WIF provider, confirms a Google
-# access token can be minted, and verifies the federated identity has
-# read access to the target Artifact Registry repository.
+# Actions OIDC token via the configured WIF provider, impersonates the
+# `vars.GAR_PUBLISHER_SA` service account to mint a short-lived OAuth2
+# access token, and verifies that identity has read access to the
+# target Artifact Registry repository.
 #
 # This workflow does NOT push (or pull) any container image. The actual
 # dual-publish path lives in `ci.yml::publish-container` (on main pushes)
@@ -23,11 +24,12 @@ name: Smoke Test - GAR WIF Publish
 # attribute condition.`. This is intentional — the same condition
 # stops an attacker who lands a malicious workflow on a feature branch
 # from minting a token. To verify a change that touches the WIF auth
-# path (the `auth` / `setup-gcloud` / token-minting steps here or in
-# `ci.yml`/`release.yml`), merge fix-forward to `main` (failure mode
-# is fail-closed: the existing GHCR publish is unaffected by a broken
-# GAR auth step) and run `gh workflow run smoke-gar-publish.yml
-# --ref main` immediately as the first verification.
+# path (the `auth` step here or in `ci.yml`/`release.yml`, or the
+# impersonation grant on `vars.GAR_PUBLISHER_SA`), merge fix-forward
+# to `main` (failure mode is fail-closed: the existing GHCR publish
+# is unaffected by a broken GAR auth step) and run `gh workflow run
+# smoke-gar-publish.yml --ref main` immediately as the first
+# verification.
 
 on:
   workflow_dispatch:
@@ -60,19 +62,21 @@ jobs:
       # those workflows. SHA verified via the GitHub API on 2026-05-10
       # (`gh api repos/google-github-actions/auth/git/refs/tags/v3.0.0`).
       #
-      # `token_format` is intentionally omitted: Direct WIF (no
-      # intermediate service account) cannot synthesize an OAuth2 access
-      # token through this action's `access_token` output — that path
-      # requires SA impersonation. The verification step below calls
-      # `gcloud auth print-access-token` instead, which performs the STS
-      # exchange against the federated credentials file written here.
-      # See `docs/container-publishing.md` for the full rationale.
-      - name: Authenticate to Google Cloud (Direct WIF)
+      # `service_account` + `token_format: access_token` exercises the
+      # same impersonation chain the publish workflows depend on: the
+      # GitHub principalSet impersonates `vars.GAR_PUBLISHER_SA`, which
+      # holds the GAR role bindings. A failure here surfaces a broken
+      # impersonation grant or a missing role binding before the next
+      # real publish run hits the same wall. See
+      # `docs/container-publishing.md` for the full rationale.
+      - name: Authenticate to Google Cloud (WIF + SA impersonation)
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GAR_PUBLISHER_SA }}
+          token_format: access_token
 
       # SHA-pinned to v3.0.1. SHA verified via the GitHub API on
       # 2026-05-10 (`gh api repos/google-github-actions/setup-gcloud/git/refs/tags/v3.0.1`,
@@ -92,9 +96,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "--- Confirming federated identity can mint an access token ---"
+          echo "--- Confirming federated identity can mint an access token via SA impersonation ---"
           gcloud auth print-access-token >/dev/null
-          echo "OK: WIF exchange succeeded; access token minted."
+          echo "OK: WIF + SA impersonation succeeded; access token minted."
 
           echo "--- Confirming the WIF identity can describe the GAR repository ---"
           # artifactregistry.repositories.get is a subset of the
@@ -129,8 +133,8 @@ jobs:
             echo ""
             echo "Verified:"
             echo ""
-            echo "- GitHub Actions OIDC → GCP access-token exchange via the configured WIF provider."
-            echo "- WIF identity has at least \`artifactregistry.repositories.get\` on the target repo (subset of \`roles/artifactregistry.writer\`)."
+            echo "- GitHub Actions OIDC → GCP access-token exchange via the configured WIF provider, impersonating \`vars.GAR_PUBLISHER_SA\`."
+            echo "- The SA has at least \`artifactregistry.repositories.get\` on the target repo (subset of \`roles/artifactregistry.writer\`)."
             echo ""
             echo "Deliberately NOT verified (covered by the real publish workflows):"
             echo ""

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -78,9 +78,11 @@ Final image path:
 ### 3. Create the Workload Identity Pool and Provider
 
 Use the [`google-github-actions/auth`](https://github.com/google-github-actions/auth)
-**Direct Workload Identity Federation** path: no intermediate service
-account, IAM roles bind to the external identity directly. This avoids
-the long-lived service-account-key foot-gun entirely.
+**Workload Identity Federation through a Service Account** path: the
+GitHub principalSet impersonates a short-lived service account that
+holds the GAR-push role bindings. There is no service-account JSON
+key file at any point — the SA exists purely as the actor whose roles
+the federated GitHub identity is authorised to assume.
 
 The provider's `attribute-condition` pins the GitHub repository so a
 token minted by any other repository — even one in the same
@@ -123,30 +125,49 @@ on this path — without it, any GitHub-hosted runner from any repo can
 exchange for an access token. Confirm the condition before binding
 IAM roles.
 
-### 4. Bind IAM roles to the external identity
+### 4. Create the publisher service account and bind IAM roles
 
-Direct WIF binds roles to the *principalSet* representing the GitHub
-OIDC subject — not to a service account.
+Create the dedicated publisher SA. It owns no key file, has no
+console login, and exists solely as the actor whose role bindings
+the GitHub principalSet is authorised to assume via WIF.
+
+```sh
+gcloud iam service-accounts create stirrup-publisher \
+  --display-name="Stirrup container publisher" \
+  --description="Impersonated by the rxbynerd/stirrup GitHub Actions WIF principal to push to GAR." \
+  --project=rubynerd-net
+```
+
+The full SA email is
+`stirrup-publisher@rubynerd-net.iam.gserviceaccount.com`. This value
+goes into GitHub as `vars.GAR_PUBLISHER_SA`.
+
+Grant the GitHub principalSet permission to impersonate the SA. This
+is the only binding the principalSet itself receives — every GAR /
+Artifact Analysis role binds to the SA, not to the principalSet.
 
 `<PROJECT_NUMBER>` is the numeric project number (not the project ID).
 Find it with `gcloud projects describe rubynerd-net --format='value(projectNumber)'`.
-The number itself does NOT need to be saved as a GitHub repository
-variable — only the fully-constructed `GCP_WORKLOAD_IDENTITY_PROVIDER`
-string (which embeds it) does.
 
 ```sh
 PRINCIPAL="principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/attribute.repository/rxbynerd/stirrup"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  stirrup-publisher@rubynerd-net.iam.gserviceaccount.com \
+  --role=roles/iam.workloadIdentityUser \
+  --member="$PRINCIPAL" \
+  --project=rubynerd-net
 ```
 
 #### Phase 1 (bind now)
 
-Phase 1 needs exactly one role on the WIF principal: the right to push
+Phase 1 needs exactly one role on the SA: the right to push
 container images.
 
 ```sh
 gcloud projects add-iam-policy-binding rubynerd-net \
   --role=roles/artifactregistry.writer \
-  --member="$PRINCIPAL"
+  --member="serviceAccount:stirrup-publisher@rubynerd-net.iam.gserviceaccount.com"
 ```
 
 | Role | Purpose | Phase |
@@ -173,7 +194,7 @@ for role in \
   roles/storage.objectAdmin; do
   gcloud projects add-iam-policy-binding rubynerd-net \
     --role="$role" \
-    --member="$PRINCIPAL"
+    --member="serviceAccount:stirrup-publisher@rubynerd-net.iam.gserviceaccount.com"
 done
 ```
 
@@ -191,6 +212,14 @@ project-scope binding is wider than strictly needed; a follow-up
 will narrow it to the Artifact Analysis bucket once that bucket's
 name is known.
 
+#### Transition note
+
+The original Phase 1 PR (#163) bound these roles directly to the
+principalSet. Issue #167 migrated to SA impersonation. Operators who
+ran the original bootstrap will have *both* sets of bindings in place
+during the transition; the follow-up cleanup PR revokes the
+principalSet bindings once the SA path is verified.
+
 ## GitHub-side configuration
 
 Set the following **repository variables** under
@@ -203,6 +232,7 @@ how `google-github-actions/auth` documents the pattern.
 |---|---|
 | `GCP_PROJECT_ID` | GCP project ID hosting the GAR repository (e.g. `rubynerd-net`). |
 | `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full resource path of the provider, e.g. `projects/<NUMBER>/locations/global/workloadIdentityPools/stirrup-gha/providers/stirrup-gha-provider`. The numeric project number is only needed to construct this string during bootstrap — it does not itself need to be stored as a separate repository variable. |
+| `GAR_PUBLISHER_SA` | Email of the publisher service account the GitHub principalSet impersonates (e.g. `stirrup-publisher@rubynerd-net.iam.gserviceaccount.com`). Holds all GAR / Artifact Analysis role bindings; the GitHub principalSet only holds `roles/iam.workloadIdentityUser` on this SA. |
 | `GAR_LOCATION` | Artifact Registry location, e.g. `europe-west4`. Determines the registry hostname `<location>-docker.pkg.dev`. |
 | `GAR_REPOSITORY` | Repository name within Artifact Registry (e.g. `stirrup`). |
 | `GAR_IMAGE` | Image name within the repository (e.g. `stirrup`). The final image path is `<GAR_LOCATION>-docker.pkg.dev/<GCP_PROJECT_ID>/<GAR_REPOSITORY>/<GAR_IMAGE>`. |
@@ -213,25 +243,25 @@ that depend on them will fail at run time with a clear "registry
 hostname empty" or "workload identity provider empty" error — there
 is no silent fallback to a different identity.
 
-### Why we mint the access token via `gcloud` rather than the `auth` action's output
+### Why short-lived service-account impersonation
 
-The publish workflows do **not** use `google-github-actions/auth`'s
-`token_format: access_token` output to feed
-`docker/login-action`. Direct WIF deliberately has no intermediate
-service account, and the `access_token` output path requires SA
-impersonation — the action exits with "the GitHub Action workflow
-must specify a service_account to use when generating an OAuth 2.0
-Access Token" if you try. The federated `external_account` credentials
-file the action *does* write is sufficient for Google client libraries
-that consume Application Default Credentials, but `docker login`
-needs a literal bearer token. The canonical Direct-WIF pattern is
-therefore: run `auth` without `token_format`, then
-`setup-gcloud`, then `gcloud auth print-access-token` to transparently
-perform the STS exchange and emit a usable bearer token. The minting
-step pipes `::add-mask::` before writing the token to
-`GITHUB_OUTPUT` so any accidental log echo downstream is redacted by
-the runner. Upstream reference:
-[`google-github-actions/auth` — Direct Workload Identity Federation](https://github.com/google-github-actions/auth#direct-workload-identity-federation).
+The publish workflows pass `service_account: ${{ vars.GAR_PUBLISHER_SA }}`
+and `token_format: access_token` to `google-github-actions/auth`. The
+action exchanges the GitHub OIDC JWT for STS-issued external-account
+credentials, then impersonates the SA to mint a short-lived OAuth2
+access token that `docker/login-action` consumes via
+`steps.gcp-auth.outputs.access_token`. No `gcloud` invocation, no
+`::add-mask::`, no extra step output — the canonical pattern. The
+predecessor design (PR #163, #166) used Direct WIF with no SA and
+piped `gcloud auth print-access-token` into a masked step output;
+issue #167 migrated to impersonation for parity with the upstream
+docs and to keep `gcloud`-based Phase 2 / Phase 3 work
+(SBOM upload, vulnerability gating) ergonomic. The blast radius is
+unchanged: an attacker who lands a malicious workflow on `main` or a
+`v*` tag still mints a token with the same five role grants — those
+roles now bind to the SA instead of the principalSet. Upstream
+reference:
+[`google-github-actions/auth` — Workload Identity Federation through a Service Account](https://github.com/google-github-actions/auth#workload-identity-federation-through-a-service-account).
 
 ## Verification
 
@@ -241,14 +271,16 @@ dual-publish worked end to end.
 ### 0. (Optional) Run the smoke workflow on `main`
 
 The smoke workflow at `.github/workflows/smoke-gar-publish.yml` mints
-a federated access token and runs `gcloud artifacts repositories
+a short-lived access token via the same WIF + SA-impersonation chain
+the publish workflows use, then runs `gcloud artifacts repositories
 describe` against the target repo without pushing or pulling any
 image. Dispatch with `gh workflow run smoke-gar-publish.yml --ref
-main`. It is the fastest way to confirm the WIF provider, IAM
-bindings, and access-token minting path are healthy after a provider
-rotation, IAM rebind, or after editing the `auth` / `setup-gcloud` /
-token-minting steps in `ci.yml` / `release.yml`. Note that it can
-only be dispatched from main or a v* tag (the same WIF
+main`. It is the fastest way to confirm the WIF provider, the
+`roles/iam.workloadIdentityUser` impersonation grant on
+`vars.GAR_PUBLISHER_SA`, and the SA's role bindings are healthy
+after a provider rotation, IAM rebind, or after editing the `auth`
+step in `ci.yml` / `release.yml`. Note that it can only be
+dispatched from main or a v* tag (the same WIF
 `attributeCondition` that gates the real publish path also gates the
 smoke). This is intentional, and means pre-merge verification of
 auth-surface changes on a feature branch is infeasible by design.


### PR DESCRIPTION
## Summary

Migrate the GAR auth path from "Direct WIF + gcloud-mediated token mint" (the pattern that landed in #163/#166) to "Direct WIF impersonating a short-lived service account." Done for customer-experience parity with the canonical `google-github-actions/auth` documentation — anyone copying this pattern into their own deployment now gets the well-trodden tutorial path instead of the `gcloud auth print-access-token` indirection.

Closes #167. Builds on #163 and #166.

## Why

PR #166 fixed a footgun: `google-github-actions/auth` cannot synthesize an OAuth2 access token without SA impersonation, so the Direct-WIF-without-SA path required `setup-gcloud` + `gcloud auth print-access-token` + `::add-mask::` + step output to feed `docker/login-action`. Functionally correct; experientially awkward. The "no intermediate SA" property of the original design is a security taste preference, not a meaningful risk reduction (the blast radius — the bound role set — is identical in either model).

See #167 for the full tradeoff table.

## Changes

### Workflow YAML

Auth step in `ci.yml`, `release.yml`, and `smoke-gar-publish.yml`:

```yaml
- name: Authenticate to Google Cloud (WIF + SA impersonation)
  id: gcp-auth
  uses: google-github-actions/auth@<SHA>  # v3.0.0
  with:
    project_id: ${{ vars.GCP_PROJECT_ID }}
    workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
    service_account: ${{ vars.GAR_PUBLISHER_SA }}
    token_format: access_token
```

`docker/login-action` now reads `steps.gcp-auth.outputs.access_token` directly. The `setup-gcloud` + "Mint GAR access token" steps were removed from `ci.yml::publish-container` and `release.yml::publish-container`. The smoke workflow keeps `setup-gcloud` because its verification step calls `gcloud artifacts repositories describe`.

### GCP-side (operator delta, already applied this session)

- Service account `stirrup-publisher@rubynerd-net.iam.gserviceaccount.com` created
- GH principalSet bound `roles/iam.workloadIdentityUser` on the SA (the impersonation grant)
- All five role bindings (`artifactregistry.writer` + 3x `containeranalysis.*` + `storage.objectAdmin`) mirrored onto the SA at the project level

**Importantly: the existing five principalSet bindings are NOT revoked yet.** They stay as a fallback during the transition. A follow-up PR will revoke them once the SA-impersonation path is verified working on `main`.

### Docs

`docs/container-publishing.md` rewritten so SA impersonation is the documented pattern from the top. The gcloud-mint subsection is gone. A transition note explains that operators who ran the original `#163` bootstrap will have both binding sets in place during the cutover. The repo-vars table now lists six values, with `GAR_PUBLISHER_SA` added.

### New GitHub repo var

`GAR_PUBLISHER_SA = stirrup-publisher@rubynerd-net.iam.gserviceaccount.com` (already set via `gh variable set` this session — no action needed from you).

## What does NOT change

- The WIF provider's `attributeCondition` (still locked to `main` + `v*` tags — the MF-1 security boundary is untouched)
- `id-token: write` permission scope
- Multi-arch build configuration
- Fork-safety guards
- Semver tag rules and the `release.needs: publish-container` dependency
- The other five `vars.*` (`GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GAR_LOCATION`, `GAR_REPOSITORY`, `GAR_IMAGE`)
- Any SHA-pinned action versions

## Test plan

- [ ] Merge.
- [ ] `gh workflow run smoke-gar-publish.yml --ref main` should succeed via the new SA-impersonation path.
- [ ] The next regular `main` push should publish identical digests to both registries.
- [ ] Once verified: follow-up PR will revoke the principalSet's five role bindings (leaving only the impersonation grant). I'll file that as a separate issue after the smoke confirms.

## Pre-merge smoke note

Same constraint as before: the `attributeCondition` prevents the smoke workflow from being dispatched against this branch (only `main` and `v*` tags can mint tokens). Fix-forward is the only verification path, but the failure mode remains fail-closed — if the new auth wiring is broken, GHCR publishing is unaffected and the fix is reverting these two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
