### PR TITLE
provider/openai-responses: keep required output key on empty tool results

### DIFF
--- a/eval/suites/openai-responses-empty-tool-output.hcl
+++ b/eval/suites/openai-responses-empty-tool-output.hcl
@@ -1,0 +1,104 @@
+# Live-API regression suite for issue #172 — the openai-responses
+# provider adapter dropped the required `output` key from
+# function_call_output wire items whenever a tool produced empty
+# stdout, causing the next turn to be rejected with HTTP 400
+# "Missing required parameter: 'input[N].output'".
+#
+# This suite is opt-in. It exercises a real round-trip against the
+# OpenAI Responses API and therefore requires:
+#
+#   - A real OpenAI API key set in the environment.
+#   - The harness binary configured with
+#     `--provider openai-responses --model <model>`.
+#
+# The unit-level marshal tests in
+# harness/internal/provider/openai_responses_test.go (covering
+# empty Content, error+empty content, and multiple empty results
+# in a row) are the per-PR gate for the fix. They cannot, however,
+# observe whether the OpenAI Responses API accepts the resulting
+# JSON — the harness's ReplayProvider sidesteps HTTP marshalling
+# entirely, and even a contract test against a recorded fixture
+# pins our serialisation, not OpenAI's parser. This suite is the
+# end-to-end pin: under the buggy adapter the run dies on turn 2
+# before the sentinel write happens, so the sentinel file is
+# absent and the task fails. Under the fix the run completes and
+# the sentinel is present.
+#
+# Not part of default CI: live provider calls are slow, flaky, and
+# spend real credits, and the per-PR signal is already provided by
+# the unit tests.
+#
+# Run with:
+#   OPENAI_KEY=... ./stirrup-eval run \
+#       --suite eval/suites/openai-responses-empty-tool-output.hcl \
+#       --output results/
+
+suite "openai-responses-empty-tool-output-regression" {
+  description = "Live-API regression for issue #172: the openai-responses adapter dropped the required `output` key from function_call_output items when a tool produced empty stdout, causing the next turn to be rejected with HTTP 400. Opt-in — requires a real OpenAI API key and the harness configured for --provider openai-responses; the unit tests in openai_responses_test.go are the per-PR gate, this suite is the end-to-end pin against the real Responses API."
+
+  task "empty-stdout-run-command-completes" {
+    description = "Drives the agent through at least one run_command whose stdout is empty (`true`), then a write_file that drops a sentinel. Under the buggy adapter, turn 2's request is rejected with HTTP 400 and `completed.txt` is never written. Under the fix, the sentinel is present with the literal text `ok`."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      Perform the following two steps exactly, in order, using the tools available to you. Do not run any other commands or write any other files.
+
+      Step 1: Run the shell command `true`. It will exit with status 0 and produce no output. That is expected.
+
+      Step 2: Write the literal text `ok` (two characters, lowercase, no newline, no quotes, no surrounding whitespace) to a file named `completed.txt` in the workspace root.
+
+      When both steps are done, stop.
+    EOT
+
+    judge {
+      type    = "composite"
+      require = "all"
+
+      judge {
+        type  = "file-exists"
+        paths = ["completed.txt"]
+      }
+
+      judge {
+        type    = "file-contains"
+        path    = "completed.txt"
+        pattern = "^ok$"
+      }
+    }
+  }
+
+  task "multiple-empty-stdout-run-commands-complete" {
+    description = "Same regression mechanic as the single-empty case, but exercises two empty-stdout tool results in a row before the sentinel write. The unit-level TestTranslateMessagesResponses_MultipleEmptyToolResultContents pins this path at the marshal layer; this task confirms the real Responses API also accepts repeated empty `output` values end-to-end. Sentinel file differs from the single-empty task so a partial pass is distinguishable in result.json."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      Perform the following three steps exactly, in order, using the tools available to you. Do not run any other commands or write any other files.
+
+      Step 1: Run the shell command `true`. It will exit with status 0 and produce no output. That is expected.
+
+      Step 2: Run the shell command `true` again. It will exit with status 0 and produce no output. That is expected.
+
+      Step 3: Write the literal text `ok` (two characters, lowercase, no newline, no quotes, no surrounding whitespace) to a file named `completed-multi.txt` in the workspace root.
+
+      When all three steps are done, stop.
+    EOT
+
+    judge {
+      type    = "composite"
+      require = "all"
+
+      judge {
+        type  = "file-exists"
+        paths = ["completed-multi.txt"]
+      }
+
+      judge {
+        type    = "file-contains"
+        path    = "completed-multi.txt"
+        pattern = "^ok$"
+      }
+    }
+  }
+}

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -112,12 +112,20 @@ type responsesRequest struct {
 // field selects which other fields are populated; this matches the
 // discriminated-union shape OpenAI publishes for typed input items.
 type responsesInput struct {
-	Type      string                  `json:"type"`                // "message" | "function_call" | "function_call_output"
-	Role      string                  `json:"role,omitempty"`      // for "message"
-	Content   []responsesContentBlock `json:"content,omitempty"`   // for "message"
-	Name      string                  `json:"name,omitempty"`      // for "function_call"
-	CallID    string                  `json:"call_id,omitempty"`   // for "function_call" / "function_call_output"
-	Arguments string                  `json:"arguments,omitempty"` // for "function_call" — JSON string
+	Type    string                  `json:"type"`              // "message" | "function_call" | "function_call_output"
+	Role    string                  `json:"role,omitempty"`    // for "message"
+	Content []responsesContentBlock `json:"content,omitempty"` // for "message"
+	Name    string                  `json:"name,omitempty"`    // for "function_call"
+	// CallID retains omitempty because the harness's construction path
+	// guarantees a non-empty ToolUseID on every tool_result block (so the
+	// key is always populated in practice). The Responses API treats
+	// call_id as required on function_call_output items, structurally
+	// parallel to the output field below — a future contributor relaxing
+	// the construction-side invariant would resurface #172 through this
+	// field. Splitting responsesInput into per-type structs is the long-term
+	// remedy; for now, the construction-path invariant carries it.
+	CallID    string `json:"call_id,omitempty"`   // for "function_call" / "function_call_output"
+	Arguments string `json:"arguments,omitempty"` // for "function_call" — JSON string
 	// Output has no omitempty: the Responses API rejects function_call_output
 	// items missing the "output" key with HTTP 400 (Missing required parameter:
 	// 'input[N].output'), even when the value is the empty string. See #172.
@@ -127,6 +135,11 @@ type responsesInput struct {
 // responsesContentBlock is one part inside a message item.
 // OpenAI uses "input_text" for user/system messages and "output_text" for
 // assistant messages — the asymmetry is part of their wire format.
+//
+// Text deliberately lacks omitempty: the Responses API requires the "text"
+// key on input_text / output_text content parts, even when the value is the
+// empty string. Structurally parallel to responsesInput.Output — see #172
+// for the analogous HTTP 400 that the missing-key surface produces.
 type responsesContentBlock struct {
 	Type string `json:"type"` // "input_text" | "output_text"
 	Text string `json:"text"`

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -118,7 +118,10 @@ type responsesInput struct {
 	Name      string                  `json:"name,omitempty"`      // for "function_call"
 	CallID    string                  `json:"call_id,omitempty"`   // for "function_call" / "function_call_output"
 	Arguments string                  `json:"arguments,omitempty"` // for "function_call" — JSON string
-	Output    string                  `json:"output,omitempty"`    // for "function_call_output"
+	// Output has no omitempty: the Responses API rejects function_call_output
+	// items missing the "output" key with HTTP 400 (Missing required parameter:
+	// 'input[N].output'), even when the value is the empty string. See #172.
+	Output string `json:"output"` // for "function_call_output" — required even when empty
 }
 
 // responsesContentBlock is one part inside a message item.

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -658,6 +658,55 @@ func TestOpenAIResponsesAdapter_RequestBody(t *testing.T) {
 	}
 }
 
+func TestOpenAIResponsesAdapter_RequestBody_EmptyToolResult(t *testing.T) {
+	// End-to-end pin for #172: drives Stream() with an empty tool_result
+	// block and asserts on the raw HTTP body the adapter actually sends.
+	// Catches any future regression where intermediate processing between
+	// translateMessagesResponses and json.Marshal silently elides the
+	// "output" key — a gap that unit tests on translateMessagesResponses
+	// alone would not surface.
+	var rawBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 1<<20)
+		n, _ := r.Body.Read(buf)
+		rawBody = buf[:n]
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`))
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model: "gpt-4.1",
+		Messages: []types.Message{
+			{
+				Role: "assistant",
+				Content: []types.ContentBlock{
+					{Type: "tool_use", ID: "call_1", Name: "noop", Input: json.RawMessage(`{}`)},
+				},
+			},
+			{
+				Role: "user",
+				Content: []types.ContentBlock{
+					{Type: "tool_result", ToolUseID: "call_1", Content: ""},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	for range ch {
+	}
+
+	if !bytes.Contains(rawBody, []byte(`"output":""`)) {
+		t.Errorf("request body missing empty 'output' key (the #172 wire-level pin): %s", rawBody)
+	}
+}
+
 func TestOpenAIResponsesAdapter_ContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -928,6 +977,77 @@ func TestTranslateMessagesResponses_EmptyToolResultContent(t *testing.T) {
 	}
 	if !bytes.Contains(raw, []byte(`"output":""`)) {
 		t.Errorf("marshalled JSON missing empty 'output' key: %s", raw)
+	}
+}
+
+func TestTranslateMessagesResponses_EmptyErrorToolResultContent(t *testing.T) {
+	// Pins the IsError + empty Content path: the "Error: " prefix produces
+	// a non-empty Output, so an omitempty regression on the Output field
+	// would NOT trip the marshal assertion in
+	// TestTranslateMessagesResponses_EmptyToolResultContent through this
+	// branch. The empty-Content error case is the structurally riskiest
+	// surface: a future contributor changing the prefix logic could land
+	// us back in the same HTTP 400 territory. See #172.
+	messages := []types.Message{
+		{Role: "user", Content: []types.ContentBlock{
+			{Type: "tool_result", ToolUseID: "call_1", Content: "", IsError: true},
+		}},
+	}
+	result := translateMessagesResponses(messages)
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].Type != "function_call_output" {
+		t.Errorf("Type = %q, want function_call_output", result[0].Type)
+	}
+	if result[0].Output != "Error: " {
+		t.Errorf("Output = %q, want %q", result[0].Output, "Error: ")
+	}
+	raw, err := json.Marshal(result[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"output":"Error: "`)) {
+		t.Errorf("marshalled JSON missing 'output':'Error: ' key/value: %s", raw)
+	}
+}
+
+func TestTranslateMessagesResponses_MultipleEmptyToolResultContents(t *testing.T) {
+	// Reproduces the realistic production scenario for #172: a single user
+	// message carrying multiple tool_result blocks where one or more have
+	// empty Content. The original HTTP 400 occurred during multi-tool turns
+	// — TestTranslateMessagesResponses_EmptyToolResultContent covers the
+	// single-block case, this covers the multi-block case where any one
+	// block silently dropping its "output" key would still trigger the bug.
+	messages := []types.Message{
+		{Role: "user", Content: []types.ContentBlock{
+			{Type: "tool_result", ToolUseID: "call_1", Content: ""},
+			{Type: "tool_result", ToolUseID: "call_2", Content: ""},
+		}},
+	}
+	result := translateMessagesResponses(messages)
+	if len(result) != 2 {
+		t.Fatalf("len(result) = %d, want 2", len(result))
+	}
+
+	wantIDs := []string{"call_1", "call_2"}
+	for i, item := range result {
+		if item.Type != "function_call_output" {
+			t.Errorf("result[%d].Type = %q, want function_call_output", i, item.Type)
+		}
+		if item.CallID != wantIDs[i] {
+			t.Errorf("result[%d].CallID = %q, want %q", i, item.CallID, wantIDs[i])
+		}
+		if item.Output != "" {
+			t.Errorf("result[%d].Output = %q, want empty string", i, item.Output)
+		}
+		raw, err := json.Marshal(item)
+		if err != nil {
+			t.Fatalf("marshal result[%d]: %v", i, err)
+		}
+		if !bytes.Contains(raw, []byte(`"output":""`)) {
+			t.Errorf("marshalled result[%d] missing empty 'output' key: %s", i, raw)
+		}
 	}
 }
 

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -853,6 +854,15 @@ func TestTranslateMessagesResponses(t *testing.T) {
 	if result[3].Type != "function_call_output" || result[3].CallID != "call_1" || result[3].Output != "package main" {
 		t.Errorf("result[3] = %+v, want function_call_output(call_1,package main)", result[3])
 	}
+	// Marshal-roundtrip check: a future omitempty regression on the Output
+	// field would be invisible to the struct comparison above. See #172.
+	raw, err := json.Marshal(result[3])
+	if err != nil {
+		t.Fatalf("marshal result[3]: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"output":"package main"`)) {
+		t.Errorf("marshalled result[3] missing populated output key: %s", raw)
+	}
 }
 
 func TestTranslateMessagesResponses_ErrorToolResult(t *testing.T) {
@@ -874,6 +884,50 @@ func TestTranslateMessagesResponses_ErrorToolResult(t *testing.T) {
 	}
 	if !strings.HasPrefix(result[0].Output, "Error: ") {
 		t.Errorf("expected error-prefixed output, got %q", result[0].Output)
+	}
+	// Marshal-roundtrip check: an omitempty regression on Output would not
+	// trip the struct assertions above for non-empty payloads, but the wire
+	// shape is what the API actually validates. See #172.
+	raw, err := json.Marshal(result[0])
+	if err != nil {
+		t.Fatalf("marshal result[0]: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"output":"Error: file not found"`)) {
+		t.Errorf("marshalled result[0] missing error-prefixed output: %s", raw)
+	}
+}
+
+func TestTranslateMessagesResponses_EmptyToolResultContent(t *testing.T) {
+	// Reproduces the wire-level failure where an empty tool_result content
+	// caused the openai-responses adapter to drop the required "output"
+	// field, yielding HTTP 400 from the Responses API. See #172.
+	messages := []types.Message{
+		{Role: "user", Content: []types.ContentBlock{
+			{Type: "tool_result", ToolUseID: "call_1", Content: ""},
+		}},
+	}
+	result := translateMessagesResponses(messages)
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].Type != "function_call_output" {
+		t.Errorf("Type = %q, want function_call_output", result[0].Type)
+	}
+	if result[0].CallID != "call_1" {
+		t.Errorf("CallID = %q, want call_1", result[0].CallID)
+	}
+	if result[0].Output != "" {
+		t.Errorf("Output = %q, want empty string", result[0].Output)
+	}
+	// The assertion that actually catches the bug: the marshalled JSON
+	// MUST include the "output" key even when its value is empty, because
+	// the Responses API rejects requests where the key is missing.
+	raw, err := json.Marshal(result[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"output":""`)) {
+		t.Errorf("marshalled JSON missing empty 'output' key: %s", raw)
 	}
 }
 


### PR DESCRIPTION
Closes #172.

## Summary

The OpenAI Responses API provider adapter dropped the `output` field from `function_call_output` items when the corresponding stirrup `tool_result` had an empty `Content` string, because the `responsesInput.Output` field carried a `json:"output,omitempty"` tag. OpenAI's Responses API requires `output` to be present unconditionally on every `function_call_output` item, so any run where a tool legitimately produced empty output (e.g. a `run_command` whose command writes nothing to stdout) crashed mid-run with HTTP 400:

```
provider stream failed ... openai responses API returned status 400:
  Missing required parameter: 'input[13].output'.
```

The fix is a one-character JSON struct-tag change — remove `omitempty` from `responsesInput.Output` — mirroring how the sibling OpenAI Chat Completions adapter handles empty tool-message content (`openaiMessage.Content`, no `omitempty`). The bug, root cause, and recommended fix are documented in detail in #172.

## Changes

- `harness/internal/provider/openai_responses.go`
  - **Fix (commit `d6268c1`):** drop `omitempty` from `Output` so `function_call_output` items always serialise the `output` key, even when the value is `""`. The original commit body cites the API failure mode and #172.
  - **Comment-only (commit `e041880`):** document adjacent required-key fields after a review found two structurally parallel surfaces — `CallID` (required on `function_call_output` per the API; harness construction already guarantees a non-empty `ToolUseID`, but the invariant is now stated inline) and `responsesContentBlock.Text` (deliberately lacks `omitempty` for the same reason as `Output`). No behavioural change.

- `harness/internal/provider/openai_responses_test.go`
  - **`TestTranslateMessagesResponses_EmptyToolResultContent`** (commit `d8133a4`) — the primary regression test for the bug. Marshal-roundtrip assertion that an empty `tool_result` Content still emits `"output":""` on the wire. Bite-checked: reintroducing `omitempty` makes the test fail with the exact JSON the bug produced.
  - **`TestTranslateMessagesResponses_EmptyErrorToolResultContent`** (commit `4e5f0a7`) — pins the `IsError: true` + empty Content path. The `"Error: " + content` prefix means this produces a non-empty Output (`"Error: "`), so a future `omitempty` re-introduction would survive undetected on this branch without an explicit test.
  - **`TestTranslateMessagesResponses_MultipleEmptyToolResultContents`** (commit `4e5f0a7`) — exercises the actual production scenario: two empty `tool_result` blocks in the same user message, which is what hit during real multi-tool turns.
  - **`TestOpenAIResponsesAdapter_RequestBody_EmptyToolResult`** (commit `4e5f0a7`) — end-to-end pin via `httptest.Server`: captures `rawBody` from `Stream()` and asserts the wire bytes contain `"output":""`. Closes the gap between unit-level `translateMessagesResponses` tests and the full request marshalling path.
  - **Marshal-roundtrip assertions** added to two existing tool-result tests (`TestTranslateMessagesResponses` and `TestTranslateMessagesResponses_ErrorToolResult`) so a future `omitempty` regression cannot slip through silently — struct equality on `Output == "..."` is invisible to field-level omitempty changes.

- `eval/suites/openai-responses-empty-tool-output.hcl` **(new, commit `cf51716`)** — a live-API regression suite for #172. Two tasks: a single-empty-stdout `run_command` followed by a sentinel write, and a two-empties-in-a-row variant matching the unit-level `TestTranslateMessagesResponses_MultipleEmptyToolResultContents`. Composite judge of `file-exists` + `file-contains` on the sentinel. Under the buggy adapter the run dies on turn 2 before the sentinel write happens and both tasks fail; under the fix both complete cleanly.
  - **Opt-in.** Requires a real OpenAI API key and a harness binary configured for `--provider openai-responses --model <model>`. The eval framework's `ReplayProvider` sidesteps HTTP marshalling, so this regression class is only catchable against a live provider. Not part of default CI — the unit-level marshal-roundtrip tests are the per-PR gate; this suite is the periodic end-to-end pin.
  - Follows the precedent of `eval/suites/guardrail.hcl` (also opt-in, also a real-provider dependency). Validated via `stirrup-eval run --dry-run`.

## Design decisions, with rationale

- **No `"(no output)"` sentinel.** The issue's recommended fix flagged a sentinel as a contingent fallback only if OpenAI also rejects `"output":""`. The actual API error names a missing *key*, not an invalid *value*; absent live-API evidence to the contrary, emitting the empty string is the minimum correct change and matches the Chat Completions sibling adapter's behaviour. The spec-compliance and api-design reviewers both concurred.
- **Single shared `responsesInput` struct retained.** Both the security and api-design reviewers noted that the discriminated-union struct now emits `"output":""` on all item types (not just `function_call_output`). Splitting into `responsesMessageInput` / `responsesCallInput` / `responsesCallOutputInput` is the clean long-term fix but is out-of-scope for a bug PR. Filed conceptually as a follow-up; the always-present-key pattern already exists for other union fields and OpenAI's API has not historically rejected unexpected zero-value fields on the other variants.
- **Sibling adapters not touched.** The issue's "Out of Scope" section lists why anthropic.go, openai.go (Chat Completions), bedrock.go, and gemini_request.go are unaffected. Verified during review; no churn there.
- **Eval suite is opt-in, not CI-gated.** The eval runner does not currently support per-task provider overrides (`eval/runner/runner.go:261` only forwards `--prompt`, `--mode`, `--workspace`, `--trace`, `--timeout`), so the suite relies on the operator configuring the harness binary externally. Adding a per-task provider field to the runner is a useful enhancement but belongs in its own change.

## Review cycle

This change went through code, security, spec-compliance, test-coverage, and API design review in parallel. The synthesis brief (preserved at `.reviews/gh-172/synthesis.md` locally; not committed) flagged two blocking test-coverage gaps (the `IsError: true` + empty content path, and the multi-empty-result scenario), both addressed in `4e5f0a7`. Three non-blocking improvements were also taken in `4e5f0a7` and `e041880`. Four reviewer concerns were assessed and dropped with rationale. The eval suite (`cf51716`) was added after review at the requester's prompt as defence-in-depth.

## Test plan

- [x] `just build` — passes
- [x] `just test` — passes (`harness/internal/provider` package and all dependents green)
- [x] `just lint` — clean on the three files touched (pre-existing diagnostics elsewhere in the tree are unrelated)
- [x] Bite-check: reintroducing `omitempty` on `Output` makes `TestTranslateMessagesResponses_EmptyToolResultContent`, `TestTranslateMessagesResponses_MultipleEmptyToolResultContents`, and `TestOpenAIResponsesAdapter_RequestBody_EmptyToolResult` fail at the marshal/rawBody assertions; `TestTranslateMessagesResponses_EmptyErrorToolResultContent` correctly does not fire under that mutation (it pins the `"Error: "` prefix shape, not the omitempty surface). Restored to fixed state.
- [x] `stirrup-eval run --suite eval/suites/openai-responses-empty-tool-output.hcl --dry-run` — passes (validates suite shape without API calls).
- [ ] Live-API regression check: not performed (no OpenAI key in CI). The reproduction in #172 used `gpt-5.4-nano` with an empty-stdout `run_command`; running the new eval suite with `OPENAI_KEY=... ./stirrup-eval run --suite eval/suites/openai-responses-empty-tool-output.hcl --output results/` against a harness configured for openai-responses would confirm end-to-end. The sentinel regex (`^ok$`) is anchored to defend against trailing-newline drift; if a real run shows the model adds a newline, relaxing to `(?m)^ok$` or `\bok\b` is a one-line follow-up after the first operator-curated baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)