### PR TITLE
eval: wire full RunConfig surface through suite → task → harness invocation

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -209,12 +209,20 @@ accepts the full `types.RunConfig` shape:
 
 | Block               | Fields                                                                                                  |
 |---------------------|---------------------------------------------------------------------------------------------------------|
-| (top-level)         | `mode`, `max_turns`                                                                                     |
-| `provider`          | `type`, `api_key_ref`, `region`, `profile`, `base_url`, `api_key_header`, `query_params`, `gcp_project`, `gcp_location` |
+| (top-level)         | `max_turns`                                                                                             |
+| `provider`          | `type`, `api_key_ref`, `region`, `profile`, `base_url`, `api_key_header`, `query_params`, `gcp_project`, `gcp_location` (`gcp_credentials_file` is intentionally absent — file paths inline need file-relative resolution semantics; use `run_config_file` with a full JSON config when this field is needed) |
 | `model_router`      | `type`, `provider`, `model`, `mode_models`                                                              |
 | `context_strategy`  | `type`, `max_tokens`                                                                                    |
 | `edit_strategy`     | `type`, `fuzzy_threshold`                                                                               |
 | `verifier`          | `type`, `command`, `timeout`, `criteria`, `model`                                                       |
+
+Mode is controlled by the task-level `mode = "..."` attribute (or the
+suite-level `mode` baked into a `run_config_file`), not by a
+`mode = "..."` setting inside a `run_config { ... }` or
+`run_config_overrides { ... }` block. The runner forwards the task's
+`mode` to the harness via the `--mode` flag, which always wins over
+the merged `--config` payload, so surfacing `mode` inside the inline
+block would be an authoring trap.
 
 **Redaction.** When `--output` is set, the runner writes the redacted
 form of the merged config to `<output>/<suite>/<task>/run_config.redacted.json`

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -106,6 +106,133 @@ generate suites from a higher-level tool and emit the static HCL.
 Suite definitions live in `eval/suites/`. CI baselines live in
 `eval/baselines/`.
 
+### Pinning the harness configuration per suite
+
+Some regression suites are only meaningful against a specific harness
+configuration — a particular provider adapter, a specific credential
+federation mode, an executor with a particular network posture, a
+non-default verifier. Encoding that posture in the suite itself,
+rather than in operator memory or a wrapper script, keeps the suite
+self-describing and prevents silent skew between "what the author
+intended" and "what the runner actually passed on the command line".
+This is the surface introduced by issue #177.
+
+A suite can declare a `RunConfig` baseline in one of two
+mutually-exclusive forms, and each task can carry sparse overrides on
+top:
+
+```hcl
+suite "fix-nil-check-regressions" {
+  description = "..."
+
+  # Form A — external file. Path is resolved relative to the suite
+  # file's directory at load time, so authors can use intuitive
+  # relative paths (e.g. "configs/base.json" next to the suite).
+  run_config_file = "configs/openai-responses-base.json"
+
+  # Form B — inline. Mutually exclusive with run_config_file.
+  # run_config {
+  #   mode      = "execution"
+  #   max_turns = 10
+  #   provider {
+  #     type        = "openai-responses"
+  #     api_key_ref = "secret://OPENAI_KEY"
+  #   }
+  #   model_router {
+  #     type  = "static"
+  #     model = "gpt-4o-mini"
+  #   }
+  # }
+
+  task "task-001" {
+    description = "..."
+    mode        = "execution"
+    prompt      = "..."
+
+    # Per-task overrides apply on top of the suite baseline. Only set
+    # the fields that should differ for this task; nil/empty fields
+    # leave the baseline untouched.
+    run_config_overrides {
+      max_turns = 4
+      provider {
+        type        = "anthropic"
+        api_key_ref = "secret://ANTHROPIC_API_KEY"
+      }
+    }
+
+    judge { type = "file-exists" paths = ["done.txt"] }
+  }
+}
+```
+
+The carrier types are `EvalSuite.RunConfig` (`*RunConfigSource`) and
+`EvalTask.RunConfigOverrides` (`*RunConfigOverrides`) in
+[`types/eval.go`](../types/eval.go). The HCL grammar for both blocks
+lives in [`eval/spec/hcl.go`](../eval/spec/hcl.go); the runner merge
+and harness invocation live in
+[`eval/runner/runner.go`](../eval/runner/runner.go).
+
+**Precedence.** The runner merges in three layers, lowest to highest:
+
+1. The suite baseline (from `run_config_file` if set, else from the
+   inline `run_config { ... }` block).
+2. The per-task `run_config_overrides` block, applied as a sparse
+   patch on top of the baseline.
+3. The runner-supplied harness flags — `--prompt`, `--mode`,
+   `--workspace`, `--trace`, `--timeout` — passed explicitly when the
+   runner shells out to `stirrup harness`. These win over any value
+   carried by the merged RunConfig, matching the harness's documented
+   `--config` precedence (see the `--config` flag docstring in
+   [`harness/cmd/stirrup/cmd/harness.go`](../harness/cmd/stirrup/cmd/harness.go)).
+
+The merged config is written to `<task tmpDir>/run_config.json` and
+passed as `--config <path>` to the harness. Suites with neither
+`run_config_file` nor an inline `run_config` block, and tasks with no
+`run_config_overrides`, fall through to the legacy invocation — no
+`--config` flag, no merged artifact.
+
+**Path resolution.** `run_config_file` is resolved relative to the
+suite file's directory at load time; absolute paths are preserved
+verbatim. This keeps the runner pure: it never needs to know where the
+suite file was loaded from.
+
+**Mutual exclusion.** A suite that sets both `run_config_file` and an
+inline `run_config { ... }` block is rejected at load time. The merge
+order would otherwise be ambiguous.
+
+**Surfaced fields.** The HCL grammar currently surfaces the fields
+listed below. Operators who need a less-common field (Gemini safety
+settings, full credential federation blocks, dynamic-router cheap/
+expensive overrides, composite verifiers) should keep the baseline in
+a JSON file and reference it via `run_config_file` — the JSON loader
+accepts the full `types.RunConfig` shape:
+
+| Block               | Fields                                                                                                  |
+|---------------------|---------------------------------------------------------------------------------------------------------|
+| (top-level)         | `mode`, `max_turns`                                                                                     |
+| `provider`          | `type`, `api_key_ref`, `region`, `profile`, `base_url`, `api_key_header`, `query_params`, `gcp_project`, `gcp_location` |
+| `model_router`      | `type`, `provider`, `model`, `mode_models`                                                              |
+| `context_strategy`  | `type`, `max_tokens`                                                                                    |
+| `edit_strategy`     | `type`, `fuzzy_threshold`                                                                               |
+| `verifier`          | `type`, `command`, `timeout`, `criteria`, `model`                                                       |
+
+**Redaction.** When `--output` is set, the runner writes the redacted
+form of the merged config to `<output>/<suite>/<task>/run_config.redacted.json`
+alongside the trace. `secret://...` references are rewritten to
+`secret://[REDACTED]` by `RunConfig.Redact()`. This matches the
+project-wide invariant in [`CLAUDE.md`](../CLAUDE.md) that secrets
+never appear in `RunConfig` artifacts persisted alongside traces or
+recordings. Operators may safely audit, attach, and commit the
+redacted artifact.
+
+**Dry-run.** `eval run --dry-run` runs `types.ValidateRunConfig` on
+the merged config for every task. A task whose merged config fails
+validation surfaces as a failed `TaskResult` with the validation error
+in `Reason`; tasks whose merged config validates produce the synthetic
+all-pass `TaskResult` the dry-run path always emits. Suites without
+any RunConfig surface skip the validation step entirely and produce
+the same synthetic pass result as before.
+
 ### Judges
 
 A judge decides whether a task passed by inspecting the workspace

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -505,6 +505,17 @@ func dryRunSuite(suite types.EvalSuite, runID string, startedAt time.Time) eval.
 			passCount++
 			continue
 		}
+		// ValidateRunConfig requires Timeout to be set. The runner always
+		// passes --timeout 300 to the harness, and `timeout` is not
+		// surfaced in the HCL grammar (it is runner-owned), so the merged
+		// config built from an inline run_config block never carries one.
+		// Inject the runner's default before validating so dry-run does
+		// not falsely fail every suite that uses an inline block. A
+		// non-zero timeout already present in a JSON baseline survives.
+		if merged.Timeout == nil {
+			defaultTimeout := 300
+			merged.Timeout = &defaultTimeout
+		}
 		if err := types.ValidateRunConfig(merged); err != nil {
 			tasks[i] = eval.TaskResult{
 				TaskID:  t.ID,

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -633,6 +633,13 @@ func mergeRunConfig(suite types.EvalSuite, task types.EvalTask) (*types.RunConfi
 // baseline value. The semantics match the existing
 // types.RunConfigOverrides precedent used by experiments.
 func applyOverrides(cfg *types.RunConfig, ov *types.RunConfigOverrides) {
+	// Defensive nil guard: every current call site in mergeRunConfig
+	// already nil-checks ov, so this branch is unreachable today and
+	// shows up as the only uncovered line in this function. Kept on
+	// purpose — if a future call site forgets the check, applyOverrides
+	// would nil-deref on `ov.Mode`, and the failure mode would be
+	// nondeterministic rather than a clean no-op. Removing it would
+	// flip a clear contract ("safe to call with nil") into a sharp edge.
 	if ov == nil {
 		return
 	}

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -20,6 +20,16 @@ import (
 	"github.com/rxbynerd/stirrup/types"
 )
 
+// maxRunConfigFileBytes mirrors the harness's loadRunConfigFile cap
+// (harness/cmd/stirrup/cmd/harness.go ~ maxConfigFileBytes). A RunConfig
+// is at most a few KB; anything in the MB range is almost certainly a
+// mistake (a symlink to /dev/zero, a binary pasted into the path, etc.).
+// Kept in sync with the harness rather than factored out because
+// harness/cmd/... is internal to the stirrup binary and the helper has
+// no other consumers — duplicating ~25 lines keeps the cross-module
+// surface area smaller than exporting it would.
+const maxRunConfigFileBytes int64 = 1 << 20 // 1 MiB
+
 // RunConfig configures how the runner executes tasks.
 type RunConfig struct {
 	// HarnessPath is the path to the harness binary for live runs.
@@ -411,6 +421,111 @@ func errorResult(taskID string, start time.Time, err error) eval.TaskResult {
 		},
 		DurationMs: time.Since(start).Milliseconds(),
 	}
+}
+
+// mergeRunConfig resolves the *types.RunConfig the runner should hand
+// the harness for a given task by layering:
+//
+//  1. the suite-level baseline (loaded from `suite.RunConfig.File` if
+//     set, otherwise materialised from `suite.RunConfig.Inline`),
+//  2. any sparse `task.RunConfigOverrides` on top.
+//
+// It returns (nil, nil) when neither the suite nor the task supplies
+// any run-config surface — that case maps to the legacy invocation
+// path where the runner omits `--config` entirely. Returning a
+// pointer (rather than a value) lets the caller distinguish "no
+// merged config" from "merged config with all zero-value fields".
+func mergeRunConfig(suite types.EvalSuite, task types.EvalTask) (*types.RunConfig, error) {
+	if suite.RunConfig == nil && task.RunConfigOverrides == nil {
+		return nil, nil
+	}
+
+	var cfg types.RunConfig
+	if suite.RunConfig != nil {
+		switch {
+		case suite.RunConfig.File != "":
+			loaded, err := loadRunConfigFile(suite.RunConfig.File)
+			if err != nil {
+				return nil, fmt.Errorf("loading suite run-config file: %w", err)
+			}
+			cfg = *loaded
+		case suite.RunConfig.Inline != nil:
+			applyOverrides(&cfg, suite.RunConfig.Inline)
+		}
+	}
+
+	if task.RunConfigOverrides != nil {
+		applyOverrides(&cfg, task.RunConfigOverrides)
+	}
+
+	return &cfg, nil
+}
+
+// applyOverrides applies a sparse RunConfigOverrides on top of an
+// existing RunConfig. A nil pointer override means "do not touch this
+// field"; a non-nil pointer (or non-empty string) replaces the
+// baseline value. The semantics match the existing
+// types.RunConfigOverrides precedent used by experiments.
+func applyOverrides(cfg *types.RunConfig, ov *types.RunConfigOverrides) {
+	if ov == nil {
+		return
+	}
+	if ov.Mode != "" {
+		cfg.Mode = ov.Mode
+	}
+	if ov.Provider != nil {
+		cfg.Provider = *ov.Provider
+	}
+	if ov.ModelRouter != nil {
+		cfg.ModelRouter = *ov.ModelRouter
+	}
+	if ov.ContextStrategy != nil {
+		cfg.ContextStrategy = *ov.ContextStrategy
+	}
+	if ov.EditStrategy != nil {
+		cfg.EditStrategy = *ov.EditStrategy
+	}
+	if ov.Verifier != nil {
+		cfg.Verifier = *ov.Verifier
+	}
+	if ov.MaxTurns != nil {
+		cfg.MaxTurns = *ov.MaxTurns
+	}
+}
+
+// loadRunConfigFile reads a JSON RunConfig file at path with the same
+// guard rails as the harness's own loader: size capped at
+// maxRunConfigFileBytes, unknown fields rejected so config typos
+// surface immediately. Kept in sync by hand with
+// harness/cmd/stirrup/cmd/harness.go#loadRunConfigFile (the canonical
+// implementation); if that helper changes its cap or strictness, mirror
+// it here.
+func loadRunConfigFile(path string) (*types.RunConfig, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("reading config file %q: is a directory", path)
+	}
+	if info.Size() > maxRunConfigFileBytes {
+		return nil, fmt.Errorf("reading config file %q: %d bytes exceeds %d byte cap",
+			path, info.Size(), maxRunConfigFileBytes)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file %q: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("parsing config file %q: file is empty", path)
+	}
+	var cfg types.RunConfig
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file %q: %w", path, err)
+	}
+	return &cfg, nil
 }
 
 // buildResult constructs a TaskResult from a trace and verdict.

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -102,7 +102,7 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 		}, nil
 	}
 
-	results := runTasksConcurrently(ctx, suite.Tasks, cfg, suiteArtifactDir)
+	results := runTasksConcurrently(ctx, suite, cfg, suiteArtifactDir)
 
 	passCount := 0
 	for _, tr := range results {
@@ -131,7 +131,8 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 // len(tasks) so we never spawn idle workers; values <= 0 collapse to 1
 // (the historical sequential behaviour). Per-task errors do not abort
 // siblings — every task contributes a TaskResult.
-func runTasksConcurrently(ctx context.Context, tasks []types.EvalTask, cfg RunConfig, suiteArtifactDir string) []eval.TaskResult {
+func runTasksConcurrently(ctx context.Context, suite types.EvalSuite, cfg RunConfig, suiteArtifactDir string) []eval.TaskResult {
+	tasks := suite.Tasks
 	concurrency := cfg.Concurrency
 	if concurrency <= 0 {
 		concurrency = 1
@@ -154,7 +155,7 @@ func runTasksConcurrently(ctx context.Context, tasks []types.EvalTask, cfg RunCo
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
-				results[j.idx] = runTask(ctx, j.task, cfg, suiteArtifactDir)
+				results[j.idx] = runTask(ctx, suite, j.task, cfg, suiteArtifactDir)
 			}
 		}()
 	}
@@ -250,7 +251,7 @@ func validatePathSegment(label, id string) error {
 // suiteArtifactDir is non-empty, the task's trace and harness output streams
 // are copied into <suiteArtifactDir>/<taskID>/ before the temp workspace is
 // removed.
-func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtifactDir string) eval.TaskResult {
+func runTask(ctx context.Context, suite types.EvalSuite, task types.EvalTask, cfg RunConfig, suiteArtifactDir string) eval.TaskResult {
 	start := time.Now()
 
 	tmpDir, err := os.MkdirTemp("", "eval-task-"+task.ID+"-")
@@ -277,6 +278,28 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 		"--timeout", "300",
 	}
 
+	// Materialise the merged RunConfig (suite baseline + task overrides)
+	// into the task's tmpDir and hand it to the harness via --config. The
+	// harness's documented precedence rule keeps the runner's explicit
+	// flags (--prompt, --mode, --workspace, --trace, --timeout)
+	// authoritative even when --config is set. Cleanup rides on the
+	// existing tmpDir os.RemoveAll defer.
+	mergedCfg, mergeErr := mergeRunConfig(suite, task)
+	if mergeErr != nil {
+		return errorResult(task.ID, start, fmt.Errorf("merging run-config: %w", mergeErr))
+	}
+	if mergedCfg != nil {
+		cfgPath := filepath.Join(tmpDir, "run_config.json")
+		data, err := json.Marshal(mergedCfg)
+		if err != nil {
+			return errorResult(task.ID, start, fmt.Errorf("marshalling merged run-config: %w", err))
+		}
+		if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+			return errorResult(task.ID, start, fmt.Errorf("writing merged run-config: %w", err))
+		}
+		args = append(args, "--config", cfgPath)
+	}
+
 	cmd := exec.CommandContext(ctx, cfg.HarnessPath, args...)
 	cmd.Dir = workspaceDir
 
@@ -290,7 +313,7 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 	// when the harness exits non-zero. retainArtifacts is best-effort:
 	// retention failures must not mask the harness/judge result.
 	if suiteArtifactDir != "" {
-		retainArtifacts(suiteArtifactDir, task.ID, traceFile, stdoutBuf.Bytes(), stderrBuf.Bytes())
+		retainArtifacts(suiteArtifactDir, task.ID, traceFile, stdoutBuf.Bytes(), stderrBuf.Bytes(), mergedCfg)
 	}
 
 	if cmdErr != nil {
@@ -330,7 +353,13 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 // single-segment path. Retention errors are intentionally swallowed — they
 // must not mask the underlying TaskResult — but failures are still reported
 // via stderr so an operator can see when the artifact tree is incomplete.
-func retainArtifacts(suiteArtifactDir, taskID, traceFile string, stdout, stderr []byte) {
+//
+// When mergedCfg is non-nil the redacted form of the merged RunConfig is
+// also written as run_config.redacted.json so an operator can audit the
+// exact (post-`secret://` redaction) configuration the harness was
+// handed. Redact() is invariant in the codebase — chunk B re-uses it
+// rather than open-coding the secret-stripping rules.
+func retainArtifacts(suiteArtifactDir, taskID, traceFile string, stdout, stderr []byte, mergedCfg *types.RunConfig) {
 	taskDir := filepath.Join(suiteArtifactDir, taskID)
 	if err := os.MkdirAll(taskDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: mkdir: %v\n", taskID, err)
@@ -348,6 +377,17 @@ func retainArtifacts(suiteArtifactDir, taskID, traceFile string, stdout, stderr 
 	}
 	if err := os.WriteFile(filepath.Join(taskDir, "harness.stderr.txt"), stderr, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: stderr: %v\n", taskID, err)
+	}
+	if mergedCfg != nil {
+		redacted := mergedCfg.Redact()
+		data, err := json.MarshalIndent(redacted, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: run-config marshal: %v\n", taskID, err)
+			return
+		}
+		if err := os.WriteFile(filepath.Join(taskDir, "run_config.redacted.json"), data, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: run-config: %v\n", taskID, err)
+		}
 	}
 }
 

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -81,25 +81,7 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 	startedAt := time.Now()
 
 	if cfg.DryRun {
-		tasks := make([]eval.TaskResult, len(suite.Tasks))
-		for i, t := range suite.Tasks {
-			tasks[i] = eval.TaskResult{
-				TaskID:  t.ID,
-				Outcome: "pass",
-				JudgeVerdict: eval.JudgeVerdict{
-					Passed: true,
-					Reason: "dry run — skipped",
-				},
-			}
-		}
-		return eval.SuiteResult{
-			SuiteID:     suite.ID,
-			RunID:       runID,
-			StartedAt:   startedAt,
-			CompletedAt: time.Now(),
-			Tasks:       tasks,
-			PassRate:    1.0,
-		}, nil
+		return dryRunSuite(suite, runID, startedAt), nil
 	}
 
 	results := runTasksConcurrently(ctx, suite, cfg, suiteArtifactDir)
@@ -460,6 +442,103 @@ func errorResult(taskID string, start time.Time, err error) eval.TaskResult {
 			Reason: err.Error(),
 		},
 		DurationMs: time.Since(start).Milliseconds(),
+	}
+}
+
+// dryRunSuite materialises the dry-run SuiteResult: for suites with no
+// run-config surface every task is recorded as a vacuous pass (today's
+// behaviour); for suites that supply a baseline or per-task overrides
+// the merged RunConfig for each task is run through ValidateRunConfig
+// and any validation error is surfaced per-task. The dry-run path
+// never invokes the harness binary.
+func dryRunSuite(suite types.EvalSuite, runID string, startedAt time.Time) eval.SuiteResult {
+	hasConfigSurface := suite.RunConfig != nil
+	if !hasConfigSurface {
+		for _, t := range suite.Tasks {
+			if t.RunConfigOverrides != nil {
+				hasConfigSurface = true
+				break
+			}
+		}
+	}
+
+	tasks := make([]eval.TaskResult, len(suite.Tasks))
+	passCount := 0
+	for i, t := range suite.Tasks {
+		if !hasConfigSurface {
+			tasks[i] = eval.TaskResult{
+				TaskID:  t.ID,
+				Outcome: "pass",
+				JudgeVerdict: eval.JudgeVerdict{
+					Passed: true,
+					Reason: "dry run — skipped",
+				},
+			}
+			passCount++
+			continue
+		}
+
+		merged, mergeErr := mergeRunConfig(suite, t)
+		if mergeErr != nil {
+			tasks[i] = eval.TaskResult{
+				TaskID:  t.ID,
+				Outcome: "error",
+				Error:   mergeErr.Error(),
+				JudgeVerdict: eval.JudgeVerdict{
+					Passed: false,
+					Reason: fmt.Sprintf("dry run — merging run-config: %v", mergeErr),
+				},
+			}
+			continue
+		}
+		if merged == nil {
+			// hasConfigSurface implies at least one task had overrides; tasks
+			// without their own overrides + no suite baseline still take this
+			// branch. Treat them as vacuous-pass: there's nothing to validate.
+			tasks[i] = eval.TaskResult{
+				TaskID:  t.ID,
+				Outcome: "pass",
+				JudgeVerdict: eval.JudgeVerdict{
+					Passed: true,
+					Reason: "dry run — skipped (no merged config)",
+				},
+			}
+			passCount++
+			continue
+		}
+		if err := types.ValidateRunConfig(merged); err != nil {
+			tasks[i] = eval.TaskResult{
+				TaskID:  t.ID,
+				Outcome: "fail",
+				JudgeVerdict: eval.JudgeVerdict{
+					Passed: false,
+					Reason: fmt.Sprintf("dry run — RunConfig validation failed: %v", err),
+				},
+			}
+			continue
+		}
+		tasks[i] = eval.TaskResult{
+			TaskID:  t.ID,
+			Outcome: "pass",
+			JudgeVerdict: eval.JudgeVerdict{
+				Passed: true,
+				Reason: "dry run — RunConfig validated",
+			},
+		}
+		passCount++
+	}
+
+	passRate := float64(0)
+	if len(tasks) > 0 {
+		passRate = float64(passCount) / float64(len(tasks))
+	}
+	return eval.SuiteResult{
+		SuiteID:     suite.ID,
+		RunID:       runID,
+		StartedAt:   startedAt,
+		CompletedAt: time.Now(),
+		Tasks:       tasks,
+		PassRate:    passRate,
 	}
 }
 

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -368,15 +368,52 @@ func retainArtifacts(suiteArtifactDir, taskID, traceFile string, stdout, stderr 
 		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: stderr: %v\n", taskID, err)
 	}
 	if mergedCfg != nil {
+		// Belt-and-braces: parse-time and validate-time both reject raw
+		// credentials in api_key_ref, but if a misconfiguration ever
+		// slipped through, Redact() would quietly rewrite it to the
+		// sentinel and the redacted artifact would hide the bad config
+		// from audit. Emit a warning to stderr before redacting so an
+		// operator inspecting the artifact tree sees the misconfiguration.
+		warnIfRawAPIKeyRef(taskID, mergedCfg)
 		redacted := mergedCfg.Redact()
 		data, err := json.MarshalIndent(redacted, "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: run-config marshal: %v\n", taskID, err)
 			return
 		}
-		if err := os.WriteFile(filepath.Join(taskDir, "run_config.redacted.json"), data, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(taskDir, "run_config.redacted.json"), data, 0o640); err != nil {
 			fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: run-config: %v\n", taskID, err)
 		}
+	}
+}
+
+// warnIfRawAPIKeyRef emits a stderr warning when the merged config
+// carries an apiKeyRef that does not use the secret:// scheme. The
+// invariant is enforced at parse and validate time; this is a
+// last-line safeguard so that if a regression ever lets a raw value
+// through, an operator inspecting the audit artifact sees the
+// misconfiguration instead of a silently-redacted line.
+func warnIfRawAPIKeyRef(taskID string, cfg *types.RunConfig) {
+	if cfg == nil {
+		return
+	}
+	check := func(path, ref string) {
+		if ref == "" || strings.HasPrefix(ref, "secret://") {
+			return
+		}
+		fmt.Fprintf(os.Stderr,
+			"eval: task %q: %s is a raw value (not a secret:// reference); it should have been rejected at parse/validate time — redacting in artifact but the harness will refuse this configuration\n",
+			taskID, path)
+	}
+	check("provider.apiKeyRef", cfg.Provider.APIKeyRef)
+	for name, p := range cfg.Providers {
+		check(fmt.Sprintf("providers[%s].apiKeyRef", name), p.APIKeyRef)
+	}
+	if cfg.Executor.VcsBackend != nil {
+		check("executor.vcsBackend.apiKeyRef", cfg.Executor.VcsBackend.APIKeyRef)
+	}
+	for i, server := range cfg.Tools.MCPServers {
+		check(fmt.Sprintf("tools.mcpServers[%d].apiKeyRef", i), server.APIKeyRef)
 	}
 }
 

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -254,10 +254,17 @@ func runTask(ctx context.Context, suite types.EvalSuite, task types.EvalTask, cf
 	args := []string{
 		"harness",
 		"--prompt", task.Prompt,
-		"--mode", taskMode(task),
 		"--workspace", workspaceDir,
 		"--trace", traceFile,
 		"--timeout", "300",
+	}
+	// Only forward --mode when the task explicitly pins one at the task
+	// level. Suite-level baseline mode (or any merged-config mode) comes
+	// through --config; the harness's applyOverrides treats every flag
+	// present on the command line as authoritative, so passing a default
+	// here would silently shadow a suite-level run_config { mode = "..." }.
+	if task.Mode != "" {
+		args = append(args, "--mode", task.Mode)
 	}
 
 	// Materialise the merged RunConfig (suite baseline + task overrides)
@@ -421,14 +428,6 @@ func parseTraceFile(path string) (*types.RunTrace, error) {
 	}
 
 	return &trace, nil
-}
-
-// taskMode returns the mode for a task, defaulting to "execution".
-func taskMode(task types.EvalTask) string {
-	if task.Mode != "" {
-		return task.Mode
-	}
-	return "execution"
 }
 
 // errorResult builds a TaskResult with outcome "error".

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -1247,6 +1247,53 @@ func TestRunSuite_DryRunValidatesMergedConfig(t *testing.T) {
 	}
 }
 
+// TestRunSuite_DryRunInlineConfigWithNoTimeout pins the contract that
+// an inline run_config block — which cannot carry a timeout (the field
+// is intentionally not surfaced in the HCL grammar) — validates
+// successfully under --dry-run. The runner injects its own default
+// timeout before validation so suites that don't express a timeout
+// (i.e. every inline-block suite) don't falsely fail dry-run.
+func TestRunSuite_DryRunInlineConfigWithNoTimeout(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "dry-run-no-timeout-suite",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				// Mode is set via the carrier here for the programmatic
+				// test; the HCL grammar no longer surfaces it (B-1).
+				Mode: "execution",
+				Provider: &types.ProviderConfig{
+					Type:      "anthropic",
+					APIKeyRef: "secret://K",
+				},
+				MaxTurns: intPtr(4),
+			},
+		},
+		Tasks: []types.EvalTask{
+			{
+				ID:     "t1",
+				Mode:   "execution",
+				Prompt: "p",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+			},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	tr := result.Tasks[0]
+	if tr.Outcome != "pass" {
+		t.Errorf("Outcome = %q, want %q (dry-run must inject default timeout)", tr.Outcome, "pass")
+	}
+	if !strings.Contains(tr.JudgeVerdict.Reason, "RunConfig validated") {
+		t.Errorf("Reason = %q, want it to mention RunConfig validated", tr.JudgeVerdict.Reason)
+	}
+}
+
 // TestRunSuite_DryRunNoConfigStillSkipsAsPass pins today's behaviour for
 // suites that have no run-config surface — dry-run must remain a vacuous
 // pass for every task so existing CI invocations keep their semantics.

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -1688,6 +1688,140 @@ func TestMergeRunConfig_FileBaselineRejectsUnknownFields(t *testing.T) {
 	}
 }
 
+// TestMergeRunConfig_FileBaselineWithTaskOverrides exercises the
+// "load from file + apply task overrides" combination, which neither
+// the file-only round-trip nor the inline-baseline override tests
+// reach by themselves. A regression in either applyOverrides or the
+// loadRunConfigFile baseline path would surface here.
+func TestMergeRunConfig_FileBaselineWithTaskOverrides(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "base.json")
+	timeout := 90
+	baseline := types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://K"},
+		MaxTurns: 10,
+		Timeout:  &timeout,
+	}
+	data, _ := json.Marshal(baseline)
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	suite := types.EvalSuite{
+		ID:        "s",
+		RunConfig: &types.RunConfigSource{File: cfgPath},
+		Tasks: []types.EvalTask{
+			{
+				ID: "t1",
+				// Task only tweaks MaxTurns; the rest of the file baseline
+				// must survive untouched.
+				RunConfigOverrides: &types.RunConfigOverrides{
+					MaxTurns: intPtr(3),
+				},
+			},
+		},
+	}
+	got, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want populated merged config")
+	}
+	if got.Mode != "execution" {
+		t.Errorf("Mode = %q, want execution (file baseline)", got.Mode)
+	}
+	if got.Provider.Type != "anthropic" || got.Provider.APIKeyRef != "secret://K" {
+		t.Errorf("Provider = %#v, want anthropic baseline preserved", got.Provider)
+	}
+	if got.MaxTurns != 3 {
+		t.Errorf("MaxTurns = %d, want 3 (task override wins over file's 10)", got.MaxTurns)
+	}
+	if got.Timeout == nil || *got.Timeout != 90 {
+		t.Errorf("Timeout = %v, want *90 (file baseline timeout preserved)", got.Timeout)
+	}
+}
+
+// TestMergeRunConfig_FileBaselineIsDirectory pins the documented
+// safety rail: loadRunConfigFile rejects a directory path with a
+// clear "is a directory" error rather than failing later inside the
+// JSON decoder.
+func TestMergeRunConfig_FileBaselineIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	suite := types.EvalSuite{
+		ID:        "s",
+		RunConfig: &types.RunConfigSource{File: dir},
+		Tasks:     []types.EvalTask{{ID: "t1"}},
+	}
+	_, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err == nil {
+		t.Fatal("expected error for directory path")
+	}
+	if !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("error = %q, want it to mention 'is a directory'", err.Error())
+	}
+}
+
+// TestMergeRunConfig_FileBaselineExceedsSizeCap pins the
+// maxRunConfigFileBytes guard. A multi-MB config file is almost
+// always a misconfiguration (symlink to /dev/zero, binary pasted
+// into the path) and the runner must reject it before the
+// JSON decoder allocates a huge buffer.
+func TestMergeRunConfig_FileBaselineExceedsSizeCap(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "huge.json")
+	// One byte past the cap is enough to trip the guard.
+	huge := make([]byte, maxRunConfigFileBytes+1)
+	// Make the payload valid-ish JSON so a regression that skipped the
+	// size check would still need to fail on something else; we want a
+	// clean signal that the cap is what fires.
+	huge[0] = '{'
+	for i := 1; i < len(huge)-1; i++ {
+		huge[i] = ' '
+	}
+	huge[len(huge)-1] = '}'
+	if err := os.WriteFile(cfgPath, huge, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	suite := types.EvalSuite{
+		ID:        "s",
+		RunConfig: &types.RunConfigSource{File: cfgPath},
+		Tasks:     []types.EvalTask{{ID: "t1"}},
+	}
+	_, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err == nil {
+		t.Fatal("expected error for oversized config file")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %q, want it to mention 'exceeds'", err.Error())
+	}
+}
+
+// TestMergeRunConfig_FileBaselineEmptyFile pins the explicit empty-
+// file check: a zero-byte JSON file would decode to a zero-value
+// RunConfig (legal Go but a silently-broken config), so the loader
+// rejects it loudly instead.
+func TestMergeRunConfig_FileBaselineEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(cfgPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	suite := types.EvalSuite{
+		ID:        "s",
+		RunConfig: &types.RunConfigSource{File: cfgPath},
+		Tasks:     []types.EvalTask{{ID: "t1"}},
+	}
+	_, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err == nil {
+		t.Fatal("expected error for empty config file")
+	}
+	if !strings.Contains(err.Error(), "file is empty") {
+		t.Errorf("error = %q, want it to mention 'file is empty'", err.Error())
+	}
+}
+
 // TestMergeRunConfig_TaskOverridesOnlyNoBaseline asserts that a task
 // with overrides but no suite-level baseline still produces a non-nil
 // merged config built from a zero-value RunConfig.

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -780,3 +780,553 @@ func collectOutcomes(results []eval.TaskResult) []string {
 	}
 	return out
 }
+
+// configRecordingHarness writes a fake harness that records the
+// `--config` path it was invoked with into argsLog and copies the
+// config file's bytes into a parallel file at configLog so tests can
+// inspect what the runner handed the binary. The harness still writes
+// a minimal trace file so the judge has something to chew on.
+func configRecordingHarness(t *testing.T, argsLog, configLog string) string {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+CONFIG=""
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --config) CONFIG="$2"; echo "config=$2" >> %q; shift 2 ;;
+    --trace)  TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]; then
+  cat "$CONFIG" > %q
+fi
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`, argsLog, configLog)
+	return writeFakeHarness(t, script)
+}
+
+func intPtr(v int) *int { return &v }
+
+// TestRunSuite_MergedConfigPassedToHarness verifies that a suite with an
+// inline RunConfig baseline plus a task override produces a per-task
+// JSON config file at a path the runner hands the harness via --config,
+// and that the file deserialises into the expected merged shape (task
+// override layered on top of the suite baseline).
+func TestRunSuite_MergedConfigPassedToHarness(t *testing.T) {
+	logDir := t.TempDir()
+	argsLog := filepath.Join(logDir, "args.log")
+	configLog := filepath.Join(logDir, "config.json")
+	harness := configRecordingHarness(t, argsLog, configLog)
+
+	suite := types.EvalSuite{
+		ID: "merged-config-suite",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				Mode: "execution",
+				Provider: &types.ProviderConfig{
+					Type:      "openai-responses",
+					APIKeyRef: "secret://OPENAI_KEY",
+				},
+				MaxTurns: intPtr(8),
+			},
+		},
+		Tasks: []types.EvalTask{
+			{
+				ID:     "t1",
+				Prompt: "do thing",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+				RunConfigOverrides: &types.RunConfigOverrides{
+					MaxTurns: intPtr(4),
+				},
+			},
+		},
+	}
+
+	_, err := RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsContent, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("reading args log: %v", err)
+	}
+	if !strings.Contains(string(argsContent), "config=") {
+		t.Fatalf("args log did not record --config invocation: %q", string(argsContent))
+	}
+
+	configContent, err := os.ReadFile(configLog)
+	if err != nil {
+		t.Fatalf("reading config log: %v", err)
+	}
+	var got types.RunConfig
+	if err := json.Unmarshal(configContent, &got); err != nil {
+		t.Fatalf("config JSON not deserialisable: %v\n%s", err, string(configContent))
+	}
+	if got.Mode != "execution" {
+		t.Errorf("Mode = %q, want %q", got.Mode, "execution")
+	}
+	if got.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q, want %q", got.Provider.Type, "openai-responses")
+	}
+	if got.Provider.APIKeyRef != "secret://OPENAI_KEY" {
+		t.Errorf("Provider.APIKeyRef = %q, want %q", got.Provider.APIKeyRef, "secret://OPENAI_KEY")
+	}
+	// Task override must win over the suite baseline (4 over 8).
+	if got.MaxTurns != 4 {
+		t.Errorf("MaxTurns = %d, want 4 (task override should win)", got.MaxTurns)
+	}
+}
+
+// TestRunSuite_FileBaselineLoaded verifies the suite.RunConfig.File
+// path is read by the runner, parsed as JSON, and used as the merged
+// config baseline. Without task overrides the merged config must equal
+// the file's contents verbatim.
+func TestRunSuite_FileBaselineLoaded(t *testing.T) {
+	logDir := t.TempDir()
+	argsLog := filepath.Join(logDir, "args.log")
+	configLog := filepath.Join(logDir, "config.json")
+	harness := configRecordingHarness(t, argsLog, configLog)
+
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "base.json")
+	timeout := 120
+	baseline := types.RunConfig{
+		Mode: "execution",
+		Provider: types.ProviderConfig{
+			Type:      "anthropic",
+			APIKeyRef: "secret://ANTHROPIC_KEY",
+		},
+		MaxTurns: 6,
+		Timeout:  &timeout,
+	}
+	data, err := json.Marshal(baseline)
+	if err != nil {
+		t.Fatalf("marshalling baseline: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatalf("writing baseline file: %v", err)
+	}
+
+	suite := types.EvalSuite{
+		ID:        "file-baseline-suite",
+		RunConfig: &types.RunConfigSource{File: cfgPath},
+		Tasks: []types.EvalTask{
+			{
+				ID:     "t1",
+				Prompt: "p",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+			},
+		},
+	}
+
+	_, err = RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	configContent, err := os.ReadFile(configLog)
+	if err != nil {
+		t.Fatalf("reading config log: %v", err)
+	}
+	var got types.RunConfig
+	if err := json.Unmarshal(configContent, &got); err != nil {
+		t.Fatalf("config JSON not deserialisable: %v", err)
+	}
+	if got.Mode != "execution" || got.Provider.Type != "anthropic" || got.MaxTurns != 6 {
+		t.Errorf("file-baseline merge did not survive round-trip: %#v", got)
+	}
+}
+
+// TestRunSuite_NoConfigSurfaceLegacyInvocation pins the backwards-compat
+// contract: a suite with no RunConfig and no per-task overrides must NOT
+// add --config to the args slice, and no run_config.redacted.json
+// artifact may appear under OutputDir.
+func TestRunSuite_NoConfigSurfaceLegacyInvocation(t *testing.T) {
+	logDir := t.TempDir()
+	argsLog := filepath.Join(logDir, "args.log")
+	// Capture ALL args, not just --config, so we can assert --config is absent.
+	script := fmt.Sprintf(`#!/bin/sh
+echo "args:" >> %q
+for a in "$@"; do echo "  $a" >> %q; done
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`, argsLog, argsLog)
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "legacy-suite",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	out := t.TempDir()
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		OutputDir:   out,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("reading args log: %v", err)
+	}
+	if strings.Contains(string(logBytes), "--config") {
+		t.Errorf("args log contains --config for a no-config-surface suite: %q", string(logBytes))
+	}
+
+	// No artifact may exist on disk.
+	artifact := filepath.Join(out, "legacy-suite", "t1", "run_config.redacted.json")
+	if _, err := os.Stat(artifact); err == nil {
+		t.Errorf("run_config.redacted.json should not exist for a no-config-surface suite (found at %s)", artifact)
+	}
+}
+
+// TestRunSuite_RetainedArtifactRedacted pins the redaction guarantee:
+// the persisted run_config.redacted.json must NOT contain the literal
+// secret reference value and MUST contain the redaction sentinel.
+func TestRunSuite_RetainedArtifactRedacted(t *testing.T) {
+	logDir := t.TempDir()
+	argsLog := filepath.Join(logDir, "args.log")
+	configLog := filepath.Join(logDir, "config.json")
+	harness := configRecordingHarness(t, argsLog, configLog)
+
+	const realKeyRef = "secret://REAL_KEY_PLAINTEXT"
+	suite := types.EvalSuite{
+		ID: "redacted-suite",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				Mode: "execution",
+				Provider: &types.ProviderConfig{
+					Type:      "openai-responses",
+					APIKeyRef: realKeyRef,
+				},
+			},
+		},
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	out := t.TempDir()
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		OutputDir:   out,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	artifact := filepath.Join(out, "redacted-suite", "t1", "run_config.redacted.json")
+	content, err := os.ReadFile(artifact)
+	if err != nil {
+		t.Fatalf("reading redacted artifact: %v", err)
+	}
+	if strings.Contains(string(content), "REAL_KEY_PLAINTEXT") {
+		t.Errorf("redacted artifact leaked secret reference value:\n%s", string(content))
+	}
+	if !strings.Contains(string(content), "secret://[REDACTED]") {
+		t.Errorf("redacted artifact missing redaction sentinel:\n%s", string(content))
+	}
+}
+
+// TestRunSuite_DryRunValidatesMergedConfig asserts that --dry-run runs
+// ValidateRunConfig on the merged config and surfaces validator errors
+// per task. We use a read-only mode paired with an allow-all permission
+// policy, which ValidateRunConfig rejects.
+func TestRunSuite_DryRunValidatesMergedConfig(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "dry-run-invalid-suite",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				Mode: "planning",
+				Provider: &types.ProviderConfig{
+					Type:      "anthropic",
+					APIKeyRef: "secret://K",
+				},
+			},
+		},
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	tr := result.Tasks[0]
+	if tr.Outcome == "pass" {
+		t.Errorf("task outcome = pass, want a non-pass for an invalid merged config")
+	}
+	if !strings.Contains(tr.JudgeVerdict.Reason, "RunConfig validation failed") {
+		t.Errorf("reason = %q, want it to mention RunConfig validation", tr.JudgeVerdict.Reason)
+	}
+}
+
+// TestRunSuite_DryRunNoConfigStillSkipsAsPass pins today's behaviour for
+// suites that have no run-config surface — dry-run must remain a vacuous
+// pass for every task so existing CI invocations keep their semantics.
+func TestRunSuite_DryRunNoConfigStillSkipsAsPass(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "dry-run-legacy",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p"},
+			{ID: "t2", Prompt: "p"},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, tr := range result.Tasks {
+		if tr.Outcome != "pass" {
+			t.Errorf("task %s: outcome = %q, want pass (no-config-surface dry-run regression)", tr.TaskID, tr.Outcome)
+		}
+		if !strings.Contains(tr.JudgeVerdict.Reason, "skipped") {
+			t.Errorf("task %s: reason = %q, want it to mention skipped", tr.TaskID, tr.JudgeVerdict.Reason)
+		}
+	}
+	if result.PassRate != 1.0 {
+		t.Errorf("PassRate = %f, want 1.0", result.PassRate)
+	}
+}
+
+// TestMergeRunConfig_NoSurfaceReturnsNil pins the (nil, nil) contract:
+// the runner uses that signal to skip --config entirely and preserve
+// backwards compat with pre-#177 suites.
+func TestMergeRunConfig_NoSurfaceReturnsNil(t *testing.T) {
+	suite := types.EvalSuite{ID: "s", Tasks: []types.EvalTask{{ID: "t1"}}}
+	got, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %#v, want nil", got)
+	}
+}
+
+// TestMergeRunConfig_InlineBaseline asserts that the suite-level
+// inline overrides materialise into a non-nil merged config with all
+// sparse fields populated (provider, model router, context strategy,
+// edit strategy, verifier, mode, max-turns).
+func TestMergeRunConfig_InlineBaseline(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "s",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				Mode:            "execution",
+				Provider:        &types.ProviderConfig{Type: "openai-responses", APIKeyRef: "secret://K"},
+				ModelRouter:     &types.ModelRouterConfig{Type: "static", Model: "gpt-5.4-nano"},
+				ContextStrategy: &types.ContextStrategyConfig{Type: "full-history"},
+				EditStrategy:    &types.EditStrategyConfig{Type: "string-replace"},
+				Verifier:        &types.VerifierConfig{Type: "noop"},
+				MaxTurns:        intPtr(12),
+			},
+		},
+		Tasks: []types.EvalTask{{ID: "t1"}},
+	}
+	got, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want a populated merged config")
+	}
+	if got.Mode != "execution" {
+		t.Errorf("Mode = %q", got.Mode)
+	}
+	if got.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q", got.Provider.Type)
+	}
+	if got.ModelRouter.Model != "gpt-5.4-nano" {
+		t.Errorf("ModelRouter.Model = %q", got.ModelRouter.Model)
+	}
+	if got.ContextStrategy.Type != "full-history" {
+		t.Errorf("ContextStrategy.Type = %q", got.ContextStrategy.Type)
+	}
+	if got.EditStrategy.Type != "string-replace" {
+		t.Errorf("EditStrategy.Type = %q", got.EditStrategy.Type)
+	}
+	if got.Verifier.Type != "noop" {
+		t.Errorf("Verifier.Type = %q", got.Verifier.Type)
+	}
+	if got.MaxTurns != 12 {
+		t.Errorf("MaxTurns = %d, want 12", got.MaxTurns)
+	}
+}
+
+// TestMergeRunConfig_TaskOverridesPreserveBaseline asserts that a task
+// that sets only one field leaves the suite's other baseline fields
+// intact — sparse semantics, not whole-record replacement.
+func TestMergeRunConfig_TaskOverridesPreserveBaseline(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "s",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				Mode:     "execution",
+				Provider: &types.ProviderConfig{Type: "openai-responses", APIKeyRef: "secret://K"},
+				MaxTurns: intPtr(10),
+			},
+		},
+		Tasks: []types.EvalTask{
+			{
+				ID: "t1",
+				RunConfigOverrides: &types.RunConfigOverrides{
+					MaxTurns: intPtr(3),
+				},
+			},
+		},
+	}
+	got, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Mode != "execution" {
+		t.Errorf("Mode = %q, want baseline preserved", got.Mode)
+	}
+	if got.Provider.Type != "openai-responses" {
+		t.Errorf("Provider = %#v, want baseline preserved", got.Provider)
+	}
+	if got.MaxTurns != 3 {
+		t.Errorf("MaxTurns = %d, want task override 3", got.MaxTurns)
+	}
+}
+
+// TestMergeRunConfig_NilOverridesPreserveBaseline pins the sparse
+// semantics for nil-pointer fields: a task override with all-nil
+// pointer fields must not zero out the suite baseline.
+func TestMergeRunConfig_NilOverridesPreserveBaseline(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "s",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				Mode:     "execution",
+				Provider: &types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://K"},
+				MaxTurns: intPtr(7),
+			},
+		},
+		Tasks: []types.EvalTask{
+			{ID: "t1", RunConfigOverrides: &types.RunConfigOverrides{}}, // empty; all nil
+		},
+	}
+	got, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Mode != "execution" || got.Provider.Type != "anthropic" || got.MaxTurns != 7 {
+		t.Errorf("baseline not preserved: %#v", got)
+	}
+}
+
+// TestMergeRunConfig_FileBaselineRoundTrip asserts that a JSON file
+// referenced by suite.RunConfig.File is read and parsed verbatim.
+func TestMergeRunConfig_FileBaselineRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "base.json")
+	timeout := 60
+	baseline := types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "gemini", APIKeyRef: "secret://G"},
+		MaxTurns: 5,
+		Timeout:  &timeout,
+	}
+	data, _ := json.Marshal(baseline)
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	suite := types.EvalSuite{
+		ID:        "s",
+		RunConfig: &types.RunConfigSource{File: cfgPath},
+		Tasks:     []types.EvalTask{{ID: "t1"}},
+	}
+	got, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Mode != "execution" || got.Provider.Type != "gemini" || got.MaxTurns != 5 {
+		t.Errorf("file baseline not round-tripped: %#v", got)
+	}
+}
+
+// TestMergeRunConfig_FileBaselineMissingFile surfaces a clear error
+// when the file referenced by suite.RunConfig.File cannot be opened.
+func TestMergeRunConfig_FileBaselineMissingFile(t *testing.T) {
+	suite := types.EvalSuite{
+		ID:        "s",
+		RunConfig: &types.RunConfigSource{File: filepath.Join(t.TempDir(), "missing.json")},
+		Tasks:     []types.EvalTask{{ID: "t1"}},
+	}
+	_, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "loading suite run-config file") {
+		t.Errorf("error = %q, want it to mention loading", err.Error())
+	}
+}
+
+// TestMergeRunConfig_FileBaselineRejectsUnknownFields ensures we keep
+// the harness's strict-decoding contract: a typo in the config file
+// surfaces as an error rather than being silently dropped.
+func TestMergeRunConfig_FileBaselineRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "bogus.json")
+	// `runId` is a valid field, but `runIdTypo` is not.
+	if err := os.WriteFile(cfgPath, []byte(`{"mode":"execution","runIdTypo":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	suite := types.EvalSuite{
+		ID:        "s",
+		RunConfig: &types.RunConfigSource{File: cfgPath},
+		Tasks:     []types.EvalTask{{ID: "t1"}},
+	}
+	_, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err == nil {
+		t.Fatal("expected error for unknown field in config JSON")
+	}
+}
+
+// TestMergeRunConfig_TaskOverridesOnlyNoBaseline asserts that a task
+// with overrides but no suite-level baseline still produces a non-nil
+// merged config built from a zero-value RunConfig.
+func TestMergeRunConfig_TaskOverridesOnlyNoBaseline(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "s",
+		Tasks: []types.EvalTask{
+			{
+				ID: "t1",
+				RunConfigOverrides: &types.RunConfigOverrides{
+					Mode:     "execution",
+					Provider: &types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://K"},
+					MaxTurns: intPtr(2),
+				},
+			},
+		},
+	}
+	got, err := mergeRunConfig(suite, suite.Tasks[0])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want a populated merged config from task-only overrides")
+	}
+	if got.Mode != "execution" || got.Provider.Type != "anthropic" || got.MaxTurns != 2 {
+		t.Errorf("task-only overrides not materialised: %#v", got)
+	}
+}

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -879,6 +879,176 @@ func TestRunSuite_MergedConfigPassedToHarness(t *testing.T) {
 	}
 }
 
+// TestRunSuite_SuiteLevelModePinned pins the precedence contract for
+// mode: a suite that bakes mode into a file-based RunConfig baseline
+// must not have it silently shadowed by a default --mode flag injected
+// by the runner. The harness's applyOverrides treats any flag set on
+// the command line as authoritative, so passing --mode unconditionally
+// would defeat the suite-level baseline. The fix is to only forward
+// --mode when the task pins its own Mode.
+func TestRunSuite_SuiteLevelModePinned(t *testing.T) {
+	logDir := t.TempDir()
+	argsLog := filepath.Join(logDir, "args.log")
+	configLog := filepath.Join(logDir, "config.json")
+	harness := configRecordingHarness(t, argsLog, configLog)
+
+	// Use a file-based baseline so the merged config carries Mode =
+	// "planning" before validation. Inline run_config { mode = ... } is
+	// no longer surfaced in the HCL grammar (B-1 fix).
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "base.json")
+	timeout := 120
+	baseline := types.RunConfig{
+		Mode: "planning",
+		Provider: types.ProviderConfig{
+			Type:      "anthropic",
+			APIKeyRef: "secret://K",
+		},
+		MaxTurns: 4,
+		Timeout:  &timeout,
+	}
+	data, err := json.Marshal(baseline)
+	if err != nil {
+		t.Fatalf("marshalling baseline: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatalf("writing baseline file: %v", err)
+	}
+
+	suite := types.EvalSuite{
+		ID:        "mode-pinned-suite",
+		RunConfig: &types.RunConfigSource{File: cfgPath},
+		Tasks: []types.EvalTask{
+			// Task has NO Mode set; the suite-level baseline must win.
+			{
+				ID:     "t1",
+				Prompt: "p",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+			},
+		},
+	}
+
+	_, err = RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The fake harness in configRecordingHarness only records --config.
+	// To verify --mode is absent we re-run the assertion with a wider
+	// recorder. Instead, read the config the runner wrote: it should
+	// carry Mode = "planning". And separately, assert by reading the
+	// args log that we *do* see --config (so the path was set) without
+	// any --mode pair.
+	argsContent, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("reading args log: %v", err)
+	}
+	if !strings.Contains(string(argsContent), "config=") {
+		t.Fatalf("args log did not record --config invocation: %q", string(argsContent))
+	}
+
+	configContent, err := os.ReadFile(configLog)
+	if err != nil {
+		t.Fatalf("reading config log: %v", err)
+	}
+	var got types.RunConfig
+	if err := json.Unmarshal(configContent, &got); err != nil {
+		t.Fatalf("config JSON not deserialisable: %v\n%s", err, string(configContent))
+	}
+	if got.Mode != "planning" {
+		t.Errorf("Mode = %q, want %q (suite baseline must reach harness)", got.Mode, "planning")
+	}
+
+	// Verify --mode is absent from the args. Use a wider-recording
+	// harness this time that captures every arg.
+	wideArgs := filepath.Join(logDir, "wide-args.log")
+	wideScript := fmt.Sprintf(`#!/bin/sh
+for a in "$@"; do echo "$a" >> %q; done
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`, wideArgs)
+	wideHarness := writeFakeHarness(t, wideScript)
+	_, err = RunSuite(context.Background(), suite, RunConfig{HarnessPath: wideHarness})
+	if err != nil {
+		t.Fatalf("unexpected error (wide harness): %v", err)
+	}
+	wideContent, err := os.ReadFile(wideArgs)
+	if err != nil {
+		t.Fatalf("reading wide args log: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(wideContent)), "\n") {
+		if strings.TrimSpace(line) == "--mode" {
+			t.Errorf("--mode flag must not appear when task has no explicit Mode; full args:\n%s", string(wideContent))
+		}
+	}
+}
+
+// TestRunSuite_TaskLevelModeForwarded asserts the inverse of
+// TestRunSuite_SuiteLevelModePinned: a task with an explicit Mode
+// still has --mode forwarded so per-task overrides keep working.
+func TestRunSuite_TaskLevelModeForwarded(t *testing.T) {
+	logDir := t.TempDir()
+	argsLog := filepath.Join(logDir, "args.log")
+	script := fmt.Sprintf(`#!/bin/sh
+for a in "$@"; do echo "$a" >> %q; done
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`, argsLog)
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "task-mode-suite",
+		Tasks: []types.EvalTask{
+			{
+				ID:     "t1",
+				Mode:   "review",
+				Prompt: "p",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+			},
+		},
+	}
+	_, err := RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	content, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("reading args log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	sawMode := false
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "--mode" {
+			sawMode = true
+			if i+1 >= len(lines) || strings.TrimSpace(lines[i+1]) != "review" {
+				t.Errorf("--mode value = %q, want %q; full args:\n%s",
+					func() string {
+						if i+1 < len(lines) {
+							return lines[i+1]
+						}
+						return "<missing>"
+					}(),
+					"review", string(content))
+			}
+		}
+	}
+	if !sawMode {
+		t.Errorf("--mode flag must appear when task pins Mode; full args:\n%s", string(content))
+	}
+}
+
 // TestRunSuite_FileBaselineLoaded verifies the suite.RunConfig.File
 // path is read by the runner, parsed as JSON, and used as the merged
 // config baseline. Without task overrides the merged config must equal

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -1208,6 +1208,36 @@ func TestRunSuite_RetainedArtifactRedacted(t *testing.T) {
 	if !strings.Contains(string(content), "secret://[REDACTED]") {
 		t.Errorf("redacted artifact missing redaction sentinel:\n%s", string(content))
 	}
+
+	// Belt-and-braces: the artifact is redacted, but the file the
+	// harness actually received via --config must still carry the
+	// original reference. A regression that fed the redacted form to
+	// the harness would break startup at the SecretStore (the
+	// SECRET://[REDACTED] env var would fail to resolve). The
+	// configRecordingHarness copies the --config file's bytes into
+	// configLog while the runner's tmpDir is still alive.
+	handed, err := os.ReadFile(configLog)
+	if err != nil {
+		t.Fatalf("reading config handed to harness: %v", err)
+	}
+	var handedCfg types.RunConfig
+	if err := json.Unmarshal(handed, &handedCfg); err != nil {
+		t.Fatalf("config handed to harness is not valid JSON: %v\n%s", err, string(handed))
+	}
+	if handedCfg.Provider.APIKeyRef != realKeyRef {
+		t.Errorf("harness --config Provider.APIKeyRef = %q, want %q (un-redacted reference)",
+			handedCfg.Provider.APIKeyRef, realKeyRef)
+	}
+
+	// Also pin the audit artifact's permission bits (B-4): owner rw,
+	// group r, world none.
+	info, err := os.Stat(artifact)
+	if err != nil {
+		t.Fatalf("stat redacted artifact: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o640); got != want {
+		t.Errorf("redacted artifact mode = %#o, want %#o", got, want)
+	}
 }
 
 // TestRunSuite_DryRunValidatesMergedConfig asserts that --dry-run runs
@@ -1239,11 +1269,15 @@ func TestRunSuite_DryRunValidatesMergedConfig(t *testing.T) {
 		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
 	}
 	tr := result.Tasks[0]
-	if tr.Outcome == "pass" {
-		t.Errorf("task outcome = pass, want a non-pass for an invalid merged config")
+	// Pin the exact outcome: "fail" is the validation-failure branch
+	// (versus "error" for a merge failure). A regression that
+	// conflated the two would silently break operator-facing
+	// reporting; `!= "pass"` is too permissive to catch that.
+	if tr.Outcome != "fail" {
+		t.Errorf("Outcome = %q, want %q", tr.Outcome, "fail")
 	}
 	if !strings.Contains(tr.JudgeVerdict.Reason, "RunConfig validation failed") {
-		t.Errorf("reason = %q, want it to mention RunConfig validation", tr.JudgeVerdict.Reason)
+		t.Errorf("reason = %q, want it to mention RunConfig validation failed", tr.JudgeVerdict.Reason)
 	}
 }
 

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -1247,6 +1247,141 @@ func TestRunSuite_DryRunValidatesMergedConfig(t *testing.T) {
 	}
 }
 
+// TestRunSuite_DryRunValidatesAndPasses pins the dry-run success
+// outcome: a suite whose merged config validates cleanly produces a
+// "pass" outcome with the dry-run reason. This is the most common
+// production case for --dry-run; the existing dry-run tests only
+// covered the no-config-surface and validation-failure paths.
+func TestRunSuite_DryRunValidatesAndPasses(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "dry-run-valid-suite",
+		RunConfig: &types.RunConfigSource{
+			Inline: &types.RunConfigOverrides{
+				Mode: "execution",
+				Provider: &types.ProviderConfig{
+					Type:      "openai-responses",
+					APIKeyRef: "secret://OPENAI_KEY",
+				},
+				MaxTurns: intPtr(6),
+			},
+		},
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	tr := result.Tasks[0]
+	if tr.Outcome != "pass" {
+		t.Errorf("Outcome = %q, want %q", tr.Outcome, "pass")
+	}
+	if !strings.Contains(tr.JudgeVerdict.Reason, "RunConfig validated") {
+		t.Errorf("Reason = %q, want it to mention RunConfig validated", tr.JudgeVerdict.Reason)
+	}
+	if result.PassRate != 1.0 {
+		t.Errorf("PassRate = %f, want 1.0", result.PassRate)
+	}
+}
+
+// TestRunSuite_DryRunMergeErrorSurfacedPerTask pins the dry-run
+// "merge failed" branch: when mergeRunConfig itself returns an error
+// (e.g. RunConfigSource.File points at a nonexistent file), the task
+// outcome must be "error" with the merge failure surfaced as the
+// judge reason. The branch was reachable but had no test.
+func TestRunSuite_DryRunMergeErrorSurfacedPerTask(t *testing.T) {
+	suite := types.EvalSuite{
+		ID:        "dry-run-merge-err-suite",
+		RunConfig: &types.RunConfigSource{File: filepath.Join(t.TempDir(), "does-not-exist.json")},
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	tr := result.Tasks[0]
+	if tr.Outcome != "error" {
+		t.Errorf("Outcome = %q, want %q", tr.Outcome, "error")
+	}
+	if !strings.Contains(tr.JudgeVerdict.Reason, "merging run-config") {
+		t.Errorf("Reason = %q, want it to mention merging run-config", tr.JudgeVerdict.Reason)
+	}
+}
+
+// TestRunSuite_DryRunMixedTaskConfigSurface pins the "merged == nil"
+// vacuous-pass branch: when the suite has no suite-level RunConfig,
+// task-1 has RunConfigOverrides, and task-2 has none, task-2's
+// merge returns (nil, nil) and the dry-run path emits a vacuous
+// pass with the "skipped (no merged config)" reason. The branch was
+// reachable but untested.
+func TestRunSuite_DryRunMixedTaskConfigSurface(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "dry-run-mixed-suite",
+		// No suite-level RunConfig — hasConfigSurface is driven by task-1.
+		Tasks: []types.EvalTask{
+			{
+				ID:     "t1",
+				Prompt: "p",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+				RunConfigOverrides: &types.RunConfigOverrides{
+					Mode:     "execution",
+					Provider: &types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://K"},
+					MaxTurns: intPtr(4),
+				},
+			},
+			{
+				ID:     "t2",
+				Prompt: "p",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+				// No RunConfigOverrides; merged will be (nil, nil).
+			},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2", len(result.Tasks))
+	}
+
+	// task-1: merged config validates, outcome pass with "RunConfig validated".
+	t1 := result.Tasks[0]
+	if t1.TaskID != "t1" {
+		t.Fatalf("Tasks[0].TaskID = %q, want t1", t1.TaskID)
+	}
+	if t1.Outcome != "pass" {
+		t.Errorf("t1.Outcome = %q, want pass", t1.Outcome)
+	}
+	if !strings.Contains(t1.JudgeVerdict.Reason, "RunConfig validated") {
+		t.Errorf("t1.Reason = %q, want it to mention RunConfig validated", t1.JudgeVerdict.Reason)
+	}
+
+	// task-2: no overrides, merged nil, vacuous pass with "skipped".
+	t2 := result.Tasks[1]
+	if t2.TaskID != "t2" {
+		t.Fatalf("Tasks[1].TaskID = %q, want t2", t2.TaskID)
+	}
+	if t2.Outcome != "pass" {
+		t.Errorf("t2.Outcome = %q, want pass", t2.Outcome)
+	}
+	if !strings.Contains(t2.JudgeVerdict.Reason, "skipped") {
+		t.Errorf("t2.Reason = %q, want it to mention skipped", t2.JudgeVerdict.Reason)
+	}
+}
+
 // TestRunSuite_DryRunInlineConfigWithNoTimeout pins the contract that
 // an inline run_config block — which cannot carry a timeout (the field
 // is intentionally not surfaced in the HCL grammar) — validates

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -119,19 +119,22 @@ type rootSpec struct {
 }
 
 type suiteSpec struct {
-	ID          string     `hcl:"id,label"`
-	Description string     `hcl:"description,optional"`
-	Tasks       []taskSpec `hcl:"task,block"`
+	ID             string                    `hcl:"id,label"`
+	Description    string                    `hcl:"description,optional"`
+	RunConfigFile  *string                   `hcl:"run_config_file,optional"`
+	RunConfig      *runConfigOverridesSpec   `hcl:"run_config,block"`
+	Tasks          []taskSpec                `hcl:"task,block"`
 }
 
 type taskSpec struct {
-	ID          string    `hcl:"id,label"`
-	Description string    `hcl:"description,optional"`
-	Repo        string    `hcl:"repo,optional"`
-	Ref         string    `hcl:"ref,optional"`
-	Mode        string    `hcl:"mode,optional"`
-	Prompt      string    `hcl:"prompt,optional"`
-	Judge       judgeSpec `hcl:"judge,block"`
+	ID                 string                  `hcl:"id,label"`
+	Description        string                  `hcl:"description,optional"`
+	Repo               string                  `hcl:"repo,optional"`
+	Ref                string                  `hcl:"ref,optional"`
+	Mode               string                  `hcl:"mode,optional"`
+	Prompt             string                  `hcl:"prompt,optional"`
+	RunConfigOverrides *runConfigOverridesSpec `hcl:"run_config_overrides,block"`
+	Judge              judgeSpec               `hcl:"judge,block"`
 }
 
 type judgeSpec struct {
@@ -143,6 +146,74 @@ type judgeSpec struct {
 	Criteria string      `hcl:"criteria,optional"`
 	Require  string      `hcl:"require,optional"`
 	Judges   []judgeSpec `hcl:"judge,block"`
+}
+
+// runConfigOverridesSpec is the HCL shape of types.RunConfigOverrides.
+// Used for both the suite-level inline `run_config` block and the
+// per-task `run_config_overrides` block — both produce a
+// *types.RunConfigOverrides.
+//
+// The HCL field naming is snake_case throughout to match the rest of
+// the suite grammar (`paths`, `pattern`, `command`); each block maps to
+// the corresponding JSON field on types.RunConfigOverrides and its
+// nested structs in types/runconfig.go.
+//
+// Surfaced fields (chunk A): every field on types.RunConfigOverrides
+// (Mode, Provider, ModelRouter, ContextStrategy, EditStrategy,
+// Verifier, MaxTurns) plus the commonly-set sub-fields of their
+// nested configs. Less-common sub-fields (e.g. Gemini safety
+// settings, dynamic-router thresholds, composite verifier children)
+// can be added in follow-ups without changing the carrier shape.
+type runConfigOverridesSpec struct {
+	Mode            string                   `hcl:"mode,optional"`
+	MaxTurns        *int                     `hcl:"max_turns,optional"`
+	Provider        *providerConfigSpec      `hcl:"provider,block"`
+	ModelRouter     *modelRouterConfigSpec   `hcl:"model_router,block"`
+	ContextStrategy *contextStrategyConfigSpec `hcl:"context_strategy,block"`
+	EditStrategy    *editStrategyConfigSpec  `hcl:"edit_strategy,block"`
+	Verifier        *verifierConfigSpec      `hcl:"verifier,block"`
+}
+
+// providerConfigSpec covers the most-common ProviderConfig fields.
+// Credential federation, Gemini safety settings, and per-vendor
+// extensions can be added in follow-ups; this set is enough to
+// distinguish provider type + auth + endpoint, which is what eval
+// suites today need to enforce.
+type providerConfigSpec struct {
+	Type         string            `hcl:"type"`
+	APIKeyRef    string            `hcl:"api_key_ref,optional"`
+	Region       string            `hcl:"region,optional"`
+	Profile      string            `hcl:"profile,optional"`
+	BaseURL      string            `hcl:"base_url,optional"`
+	APIKeyHeader string            `hcl:"api_key_header,optional"`
+	QueryParams  map[string]string `hcl:"query_params,optional"`
+	GCPProject   string            `hcl:"gcp_project,optional"`
+	GCPLocation  string            `hcl:"gcp_location,optional"`
+}
+
+type modelRouterConfigSpec struct {
+	Type       string            `hcl:"type"`
+	Provider   string            `hcl:"provider,optional"`
+	Model      string            `hcl:"model,optional"`
+	ModeModels map[string]string `hcl:"mode_models,optional"`
+}
+
+type contextStrategyConfigSpec struct {
+	Type      string `hcl:"type"`
+	MaxTokens *int   `hcl:"max_tokens,optional"`
+}
+
+type editStrategyConfigSpec struct {
+	Type           string   `hcl:"type"`
+	FuzzyThreshold *float64 `hcl:"fuzzy_threshold,optional"`
+}
+
+type verifierConfigSpec struct {
+	Type     string `hcl:"type"`
+	Command  string `hcl:"command,optional"`
+	Timeout  *int   `hcl:"timeout,optional"`
+	Criteria string `hcl:"criteria,optional"`
+	Model    string `hcl:"model,optional"`
 }
 
 // rejectUnsupportedTopLevel inspects the file body and returns a clear
@@ -255,6 +326,25 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 		return types.EvalSuite{}, fmt.Errorf("suite %q must contain at least one task", s.ID)
 	}
 
+	// Suite-level run-config baseline: file path and inline block are
+	// mutually exclusive — a suite that sets both leaves the merge order
+	// genuinely ambiguous, so reject loudly rather than silently picking
+	// a winner.
+	var runCfgSource *types.RunConfigSource
+	if s.RunConfigFile != nil && s.RunConfig != nil {
+		return types.EvalSuite{}, fmt.Errorf(
+			"suite %q: run_config_file and run_config block are mutually exclusive — set only one",
+			s.ID,
+		)
+	}
+	switch {
+	case s.RunConfigFile != nil:
+		runCfgSource = &types.RunConfigSource{File: *s.RunConfigFile}
+	case s.RunConfig != nil:
+		inline := convertRunConfigOverrides(s.RunConfig)
+		runCfgSource = &types.RunConfigSource{Inline: inline}
+	}
+
 	tasks := make([]types.EvalTask, 0, len(s.Tasks))
 	for i, t := range s.Tasks {
 		if t.ID == "" {
@@ -265,13 +355,14 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 			return types.EvalSuite{}, err
 		}
 		tasks = append(tasks, types.EvalTask{
-			ID:          t.ID,
-			Description: t.Description,
-			Repo:        t.Repo,
-			Ref:         t.Ref,
-			Prompt:      t.Prompt,
-			Mode:        t.Mode,
-			Judge:       j,
+			ID:                 t.ID,
+			Description:        t.Description,
+			Repo:               t.Repo,
+			Ref:                t.Ref,
+			Prompt:             t.Prompt,
+			Mode:               t.Mode,
+			Judge:              j,
+			RunConfigOverrides: convertRunConfigOverrides(t.RunConfigOverrides),
 		})
 	}
 
@@ -279,7 +370,69 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 		ID:          s.ID,
 		Description: s.Description,
 		Tasks:       tasks,
+		RunConfig:   runCfgSource,
 	}, nil
+}
+
+// convertRunConfigOverrides walks a parsed runConfigOverridesSpec into
+// a *types.RunConfigOverrides. Returns nil when src is nil so callers
+// can distinguish "no override block was authored" from "override
+// block was authored but every field happened to be a zero value".
+func convertRunConfigOverrides(src *runConfigOverridesSpec) *types.RunConfigOverrides {
+	if src == nil {
+		return nil
+	}
+	out := &types.RunConfigOverrides{
+		Mode:     src.Mode,
+		MaxTurns: src.MaxTurns,
+	}
+	if src.Provider != nil {
+		out.Provider = &types.ProviderConfig{
+			Type:         src.Provider.Type,
+			APIKeyRef:    src.Provider.APIKeyRef,
+			Region:       src.Provider.Region,
+			Profile:      src.Provider.Profile,
+			BaseURL:      src.Provider.BaseURL,
+			APIKeyHeader: src.Provider.APIKeyHeader,
+			QueryParams:  src.Provider.QueryParams,
+			GCPProject:   src.Provider.GCPProject,
+			GCPLocation:  src.Provider.GCPLocation,
+		}
+	}
+	if src.ModelRouter != nil {
+		out.ModelRouter = &types.ModelRouterConfig{
+			Type:       src.ModelRouter.Type,
+			Provider:   src.ModelRouter.Provider,
+			Model:      src.ModelRouter.Model,
+			ModeModels: src.ModelRouter.ModeModels,
+		}
+	}
+	if src.ContextStrategy != nil {
+		cs := &types.ContextStrategyConfig{Type: src.ContextStrategy.Type}
+		if src.ContextStrategy.MaxTokens != nil {
+			cs.MaxTokens = *src.ContextStrategy.MaxTokens
+		}
+		out.ContextStrategy = cs
+	}
+	if src.EditStrategy != nil {
+		out.EditStrategy = &types.EditStrategyConfig{
+			Type:           src.EditStrategy.Type,
+			FuzzyThreshold: src.EditStrategy.FuzzyThreshold,
+		}
+	}
+	if src.Verifier != nil {
+		v := &types.VerifierConfig{
+			Type:     src.Verifier.Type,
+			Command:  src.Verifier.Command,
+			Criteria: src.Verifier.Criteria,
+			Model:    src.Verifier.Model,
+		}
+		if src.Verifier.Timeout != nil {
+			v.Timeout = *src.Verifier.Timeout
+		}
+		out.Verifier = v
+	}
+	return out
 }
 
 // convertJudge recursively translates a judgeSpec into types.EvalJudge,

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -364,7 +364,10 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 	case s.RunConfigFile != nil:
 		runCfgSource = &types.RunConfigSource{File: *s.RunConfigFile}
 	case s.RunConfig != nil:
-		inline := convertRunConfigOverrides(s.RunConfig)
+		inline, err := convertRunConfigOverrides(s.RunConfig)
+		if err != nil {
+			return types.EvalSuite{}, fmt.Errorf("suite %q: %w", s.ID, err)
+		}
 		runCfgSource = &types.RunConfigSource{Inline: inline}
 	}
 
@@ -377,6 +380,10 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 		if err != nil {
 			return types.EvalSuite{}, err
 		}
+		taskOverrides, err := convertRunConfigOverrides(t.RunConfigOverrides)
+		if err != nil {
+			return types.EvalSuite{}, fmt.Errorf("task %q: %w", t.ID, err)
+		}
 		tasks = append(tasks, types.EvalTask{
 			ID:                 t.ID,
 			Description:        t.Description,
@@ -385,7 +392,7 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 			Prompt:             t.Prompt,
 			Mode:               t.Mode,
 			Judge:              j,
-			RunConfigOverrides: convertRunConfigOverrides(t.RunConfigOverrides),
+			RunConfigOverrides: taskOverrides,
 		})
 	}
 
@@ -397,13 +404,43 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 	}, nil
 }
 
+// requireSecretSchemeIfSet returns an error when ref is non-empty and
+// does not start with "secret://". The eval HCL surface accepts only
+// references resolved by the harness SecretStore; a raw credential
+// authored inline would otherwise sit on disk in the merged run-config
+// (admittedly at 0600) and be silently hidden by Redact() when the
+// retained artifact is written, masking the misconfiguration from
+// audit. The check mirrors CLAUDE.md's "secrets never as raw values in
+// RunConfig" invariant at parse time so authors see a clear error
+// where they wrote the value, not deep inside the harness boot path.
+func requireSecretSchemeIfSet(field, ref string) error {
+	if ref == "" {
+		return nil
+	}
+	if !strings.HasPrefix(ref, "secret://") {
+		return fmt.Errorf(
+			"%s %q: raw credentials are not permitted; use a secret:// reference",
+			field, ref,
+		)
+	}
+	return nil
+}
+
 // convertRunConfigOverrides walks a parsed runConfigOverridesSpec into
 // a *types.RunConfigOverrides. Returns nil when src is nil so callers
 // can distinguish "no override block was authored" from "override
 // block was authored but every field happened to be a zero value".
-func convertRunConfigOverrides(src *runConfigOverridesSpec) *types.RunConfigOverrides {
+//
+// Returns an error when a surfaced api_key_ref does not use the
+// "secret://" scheme. Authoring a raw credential inline is rejected
+// at parse time so it never reaches the merged run_config.json the
+// runner hands the harness, where it would otherwise sit on disk
+// (admittedly with 0600 perms, but the redacted artifact would also
+// quietly hide the misconfiguration). Defense-in-depth is also
+// enforced by types.ValidateRunConfig.
+func convertRunConfigOverrides(src *runConfigOverridesSpec) (*types.RunConfigOverrides, error) {
 	if src == nil {
-		return nil
+		return nil, nil
 	}
 	// Mode is not surfaced in the HCL grammar (see runConfigOverridesSpec
 	// doc-comment); the runner reads task.Mode directly via the task-level
@@ -414,6 +451,9 @@ func convertRunConfigOverrides(src *runConfigOverridesSpec) *types.RunConfigOver
 		MaxTurns: src.MaxTurns,
 	}
 	if src.Provider != nil {
+		if err := requireSecretSchemeIfSet("provider.api_key_ref", src.Provider.APIKeyRef); err != nil {
+			return nil, err
+		}
 		out.Provider = &types.ProviderConfig{
 			Type:         src.Provider.Type,
 			APIKeyRef:    src.Provider.APIKeyRef,
@@ -459,7 +499,7 @@ func convertRunConfigOverrides(src *runConfigOverridesSpec) *types.RunConfigOver
 		}
 		out.Verifier = v
 	}
-	return out
+	return out, nil
 }
 
 // convertJudge recursively translates a judgeSpec into types.EvalJudge,

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -119,11 +119,11 @@ type rootSpec struct {
 }
 
 type suiteSpec struct {
-	ID             string                    `hcl:"id,label"`
-	Description    string                    `hcl:"description,optional"`
-	RunConfigFile  *string                   `hcl:"run_config_file,optional"`
-	RunConfig      *runConfigOverridesSpec   `hcl:"run_config,block"`
-	Tasks          []taskSpec                `hcl:"task,block"`
+	ID            string                  `hcl:"id,label"`
+	Description   string                  `hcl:"description,optional"`
+	RunConfigFile *string                 `hcl:"run_config_file,optional"`
+	RunConfig     *runConfigOverridesSpec `hcl:"run_config,block"`
+	Tasks         []taskSpec              `hcl:"task,block"`
 }
 
 type taskSpec struct {
@@ -165,13 +165,13 @@ type judgeSpec struct {
 // settings, dynamic-router thresholds, composite verifier children)
 // can be added in follow-ups without changing the carrier shape.
 type runConfigOverridesSpec struct {
-	Mode            string                   `hcl:"mode,optional"`
-	MaxTurns        *int                     `hcl:"max_turns,optional"`
-	Provider        *providerConfigSpec      `hcl:"provider,block"`
-	ModelRouter     *modelRouterConfigSpec   `hcl:"model_router,block"`
+	Mode            string                     `hcl:"mode,optional"`
+	MaxTurns        *int                       `hcl:"max_turns,optional"`
+	Provider        *providerConfigSpec        `hcl:"provider,block"`
+	ModelRouter     *modelRouterConfigSpec     `hcl:"model_router,block"`
 	ContextStrategy *contextStrategyConfigSpec `hcl:"context_strategy,block"`
-	EditStrategy    *editStrategyConfigSpec  `hcl:"edit_strategy,block"`
-	Verifier        *verifierConfigSpec      `hcl:"verifier,block"`
+	EditStrategy    *editStrategyConfigSpec    `hcl:"edit_strategy,block"`
+	Verifier        *verifierConfigSpec        `hcl:"verifier,block"`
 }
 
 // providerConfigSpec covers the most-common ProviderConfig fields.

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -173,13 +173,22 @@ type judgeSpec struct {
 // nested structs in types/runconfig.go.
 //
 // Surfaced fields (chunk A): every field on types.RunConfigOverrides
-// (Mode, Provider, ModelRouter, ContextStrategy, EditStrategy,
-// Verifier, MaxTurns) plus the commonly-set sub-fields of their
-// nested configs. Less-common sub-fields (e.g. Gemini safety
-// settings, dynamic-router thresholds, composite verifier children)
-// can be added in follow-ups without changing the carrier shape.
+// (Provider, ModelRouter, ContextStrategy, EditStrategy, Verifier,
+// MaxTurns) plus the commonly-set sub-fields of their nested configs.
+// Less-common sub-fields (e.g. Gemini safety settings, dynamic-router
+// thresholds, composite verifier children) can be added in follow-ups
+// without changing the carrier shape.
+//
+// Mode is intentionally absent from the HCL grammar even though the
+// Go type types.RunConfigOverrides.Mode exists. The runner forwards
+// task.Mode through the harness's --mode flag, which always wins over
+// the --config payload; exposing `mode = "..."` inside a run_config
+// block would be an authoring trap (parsed and either silently
+// ignored at the task level, or only effective at the suite level
+// when no task pins its own Mode). Authors set mode at the task or
+// suite level via the existing `mode = "..."` attribute. Experiments
+// that consume RunConfigOverrides directly still use the Go field.
 type runConfigOverridesSpec struct {
-	Mode            string                     `hcl:"mode,optional"`
 	MaxTurns        *int                       `hcl:"max_turns,optional"`
 	Provider        *providerConfigSpec        `hcl:"provider,block"`
 	ModelRouter     *modelRouterConfigSpec     `hcl:"model_router,block"`
@@ -396,8 +405,12 @@ func convertRunConfigOverrides(src *runConfigOverridesSpec) *types.RunConfigOver
 	if src == nil {
 		return nil
 	}
+	// Mode is not surfaced in the HCL grammar (see runConfigOverridesSpec
+	// doc-comment); the runner reads task.Mode directly via the task-level
+	// `mode = "..."` attribute. Leaving Mode at its zero value here keeps
+	// the merged RunConfig the runner builds free of a phantom mode that
+	// would silently shadow the task-level value.
 	out := &types.RunConfigOverrides{
-		Mode:     src.Mode,
 		MaxTurns: src.MaxTurns,
 	}
 	if src.Provider != nil {

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -212,6 +212,13 @@ type providerConfigSpec struct {
 	QueryParams  map[string]string `hcl:"query_params,optional"`
 	GCPProject   string            `hcl:"gcp_project,optional"`
 	GCPLocation  string            `hcl:"gcp_location,optional"`
+	// GCPCredentialsFile is intentionally absent: a file path inline
+	// requires the same relative-path resolution treatment as
+	// run_config_file itself (resolve against the suite file's
+	// directory, validate the file exists, enforce a size cap). The
+	// equivalent surface for authors who need GCP service-account
+	// auth is to keep the full RunConfig in JSON and reference it via
+	// run_config_file. See docs/eval.md for the rationale.
 }
 
 type modelRouterConfigSpec struct {

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -110,7 +111,20 @@ func LoadSuiteHCL(path string) (types.EvalSuite, error) {
 		return types.EvalSuite{}, fmt.Errorf("expected exactly one suite block, found %d", len(root.Suites))
 	}
 
-	return convertSuite(root.Suites[0])
+	suite, err := convertSuite(root.Suites[0])
+	if err != nil {
+		return types.EvalSuite{}, err
+	}
+	// Resolve a suite-level `run_config_file` reference relative to the
+	// suite file's directory so authors can use intuitive relative paths
+	// (e.g. `configs/base.json` next to the suite). Absolute paths are
+	// preserved verbatim. Doing the resolution here keeps the runner
+	// pure: it never needs to know where the suite file lived.
+	if suite.RunConfig != nil && suite.RunConfig.File != "" && !filepath.IsAbs(suite.RunConfig.File) {
+		base := filepath.Dir(path)
+		suite.RunConfig.File = filepath.Join(base, suite.RunConfig.File)
+	}
+	return suite, nil
 }
 
 // rootSpec is the top level of the HCL grammar.

--- a/eval/spec/hcl_test.go
+++ b/eval/spec/hcl_test.go
@@ -723,6 +723,181 @@ suite "s" {
 	}
 }
 
+// TestLoadSuiteHCL_RunConfigInlineBlock_AllSubFields exercises every
+// HCL-surfaced field on the runConfigOverridesSpec and its three
+// sub-block types (ContextStrategy, EditStrategy, Verifier) plus the
+// less-frequently-set provider sub-fields (api_key_header,
+// query_params, region, gcp_project, gcp_location) and the
+// model_router fields (provider, mode_models). A typo in any HCL
+// tag or a wrong pointer dereference in convertRunConfigOverrides
+// would surface here.
+func TestLoadSuiteHCL_RunConfigInlineBlock_AllSubFields(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    max_turns = 12
+
+    context_strategy {
+      type       = "full-history"
+      max_tokens = 4096
+    }
+
+    edit_strategy {
+      type            = "search-replace"
+      fuzzy_threshold = 0.8
+    }
+
+    verifier {
+      type     = "test-command"
+      command  = "make test"
+      timeout  = 60
+      criteria = "exit-zero"
+      model    = "gpt-4o-mini"
+    }
+
+    provider {
+      type           = "openai-responses"
+      api_key_ref    = "secret://OPENAI_KEY"
+      api_key_header = "Authorization"
+      region         = "us-east-1"
+      profile        = "dev"
+      base_url       = "https://example.com/v1"
+      gcp_project    = "my-gcp-project"
+      gcp_location   = "us-central1"
+      query_params   = { "api-version" = "2025-01" }
+    }
+
+    model_router {
+      type     = "static"
+      model    = "gpt-4o"
+      provider = "openai-responses"
+      mode_models = {
+        "planning"  = "gpt-4o-mini"
+        "execution" = "gpt-4o"
+      }
+    }
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "run-config-all-subfields.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig == nil || got.RunConfig.Inline == nil {
+		t.Fatalf("expected inline RunConfig, got %#v", got.RunConfig)
+	}
+	in := got.RunConfig.Inline
+
+	// Top-level
+	if in.MaxTurns == nil || *in.MaxTurns != 12 {
+		t.Errorf("MaxTurns = %v, want *12", in.MaxTurns)
+	}
+
+	// ContextStrategy
+	if in.ContextStrategy == nil {
+		t.Fatal("ContextStrategy = nil, want populated")
+	}
+	if in.ContextStrategy.Type != "full-history" {
+		t.Errorf("ContextStrategy.Type = %q, want %q", in.ContextStrategy.Type, "full-history")
+	}
+	if in.ContextStrategy.MaxTokens != 4096 {
+		t.Errorf("ContextStrategy.MaxTokens = %d, want 4096", in.ContextStrategy.MaxTokens)
+	}
+
+	// EditStrategy
+	if in.EditStrategy == nil {
+		t.Fatal("EditStrategy = nil, want populated")
+	}
+	if in.EditStrategy.Type != "search-replace" {
+		t.Errorf("EditStrategy.Type = %q, want %q", in.EditStrategy.Type, "search-replace")
+	}
+	if in.EditStrategy.FuzzyThreshold == nil || *in.EditStrategy.FuzzyThreshold != 0.8 {
+		t.Errorf("EditStrategy.FuzzyThreshold = %v, want *0.8", in.EditStrategy.FuzzyThreshold)
+	}
+
+	// Verifier
+	if in.Verifier == nil {
+		t.Fatal("Verifier = nil, want populated")
+	}
+	if in.Verifier.Type != "test-command" {
+		t.Errorf("Verifier.Type = %q, want %q", in.Verifier.Type, "test-command")
+	}
+	if in.Verifier.Command != "make test" {
+		t.Errorf("Verifier.Command = %q, want %q", in.Verifier.Command, "make test")
+	}
+	if in.Verifier.Timeout != 60 {
+		t.Errorf("Verifier.Timeout = %d, want 60", in.Verifier.Timeout)
+	}
+	if in.Verifier.Criteria != "exit-zero" {
+		t.Errorf("Verifier.Criteria = %q, want %q", in.Verifier.Criteria, "exit-zero")
+	}
+	if in.Verifier.Model != "gpt-4o-mini" {
+		t.Errorf("Verifier.Model = %q, want %q", in.Verifier.Model, "gpt-4o-mini")
+	}
+
+	// Provider — every surfaced sub-field.
+	if in.Provider == nil {
+		t.Fatal("Provider = nil, want populated")
+	}
+	if in.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q, want %q", in.Provider.Type, "openai-responses")
+	}
+	if in.Provider.APIKeyRef != "secret://OPENAI_KEY" {
+		t.Errorf("Provider.APIKeyRef = %q, want %q", in.Provider.APIKeyRef, "secret://OPENAI_KEY")
+	}
+	if in.Provider.APIKeyHeader != "Authorization" {
+		t.Errorf("Provider.APIKeyHeader = %q, want %q", in.Provider.APIKeyHeader, "Authorization")
+	}
+	if in.Provider.Region != "us-east-1" {
+		t.Errorf("Provider.Region = %q, want %q", in.Provider.Region, "us-east-1")
+	}
+	if in.Provider.Profile != "dev" {
+		t.Errorf("Provider.Profile = %q, want %q", in.Provider.Profile, "dev")
+	}
+	if in.Provider.BaseURL != "https://example.com/v1" {
+		t.Errorf("Provider.BaseURL = %q, want %q", in.Provider.BaseURL, "https://example.com/v1")
+	}
+	if in.Provider.GCPProject != "my-gcp-project" {
+		t.Errorf("Provider.GCPProject = %q, want %q", in.Provider.GCPProject, "my-gcp-project")
+	}
+	if in.Provider.GCPLocation != "us-central1" {
+		t.Errorf("Provider.GCPLocation = %q, want %q", in.Provider.GCPLocation, "us-central1")
+	}
+	if got, want := in.Provider.QueryParams["api-version"], "2025-01"; got != want {
+		t.Errorf("Provider.QueryParams[api-version] = %q, want %q", got, want)
+	}
+
+	// ModelRouter — every surfaced sub-field.
+	if in.ModelRouter == nil {
+		t.Fatal("ModelRouter = nil, want populated")
+	}
+	if in.ModelRouter.Type != "static" {
+		t.Errorf("ModelRouter.Type = %q, want %q", in.ModelRouter.Type, "static")
+	}
+	if in.ModelRouter.Model != "gpt-4o" {
+		t.Errorf("ModelRouter.Model = %q, want %q", in.ModelRouter.Model, "gpt-4o")
+	}
+	if in.ModelRouter.Provider != "openai-responses" {
+		t.Errorf("ModelRouter.Provider = %q, want %q", in.ModelRouter.Provider, "openai-responses")
+	}
+	if got, want := in.ModelRouter.ModeModels["planning"], "gpt-4o-mini"; got != want {
+		t.Errorf("ModelRouter.ModeModels[planning] = %q, want %q", got, want)
+	}
+	if got, want := in.ModelRouter.ModeModels["execution"], "gpt-4o"; got != want {
+		t.Errorf("ModelRouter.ModeModels[execution] = %q, want %q", got, want)
+	}
+}
+
 // TestLoadSuiteHCL_RunConfigOverridesPerTask asserts the per-task
 // override block decodes into EvalTask.RunConfigOverrides with the
 // fields the author set, and is independent of the suite-level

--- a/eval/spec/hcl_test.go
+++ b/eval/spec/hcl_test.go
@@ -577,6 +577,249 @@ func TestLoadSuiteHCL_SuiteBlockMissingLabel(t *testing.T) {
 	}
 }
 
+// TestLoadSuiteHCL_RunConfigFile asserts that a suite-level
+// `run_config_file` attribute populates EvalSuite.RunConfig with the
+// path as the File field, and leaves Inline nil. The runner (chunk B)
+// is responsible for resolving the path; the loader stays purely
+// syntactic.
+func TestLoadSuiteHCL_RunConfigFile(t *testing.T) {
+	src := `
+suite "s" {
+  run_config_file = "configs/base.json"
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "run-config-file.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig == nil {
+		t.Fatal("expected suite RunConfig to be populated")
+	}
+	if got.RunConfig.File != "configs/base.json" {
+		t.Errorf("RunConfig.File = %q, want %q", got.RunConfig.File, "configs/base.json")
+	}
+	if got.RunConfig.Inline != nil {
+		t.Errorf("RunConfig.Inline = %#v, want nil", got.RunConfig.Inline)
+	}
+	if got.Tasks[0].RunConfigOverrides != nil {
+		t.Errorf("Tasks[0].RunConfigOverrides = %#v, want nil", got.Tasks[0].RunConfigOverrides)
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigInlineBlock asserts that an inline
+// suite-level `run_config { ... }` block decodes into
+// EvalSuite.RunConfig.Inline with the field set the author specified.
+// File is left empty because the inline path is the one that was
+// taken.
+func TestLoadSuiteHCL_RunConfigInlineBlock(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    mode      = "execution"
+    max_turns = 10
+
+    provider {
+      type        = "openai-responses"
+      api_key_ref = "secret://OPENAI_KEY"
+      base_url    = "https://example/v1"
+    }
+
+    model_router {
+      type     = "static"
+      provider = "openai-responses"
+      model    = "gpt-5.4-nano"
+    }
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "run-config-inline.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig == nil || got.RunConfig.Inline == nil {
+		t.Fatalf("expected inline run-config, got %#v", got.RunConfig)
+	}
+	if got.RunConfig.File != "" {
+		t.Errorf("RunConfig.File = %q, want empty", got.RunConfig.File)
+	}
+	in := got.RunConfig.Inline
+	if in.Mode != "execution" {
+		t.Errorf("Mode = %q, want %q", in.Mode, "execution")
+	}
+	if in.MaxTurns == nil || *in.MaxTurns != 10 {
+		t.Errorf("MaxTurns = %v, want *10", in.MaxTurns)
+	}
+	if in.Provider == nil {
+		t.Fatal("expected Provider to be set")
+	}
+	if in.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q, want %q", in.Provider.Type, "openai-responses")
+	}
+	if in.Provider.APIKeyRef != "secret://OPENAI_KEY" {
+		t.Errorf("Provider.APIKeyRef = %q, want %q", in.Provider.APIKeyRef, "secret://OPENAI_KEY")
+	}
+	if in.Provider.BaseURL != "https://example/v1" {
+		t.Errorf("Provider.BaseURL = %q, want %q", in.Provider.BaseURL, "https://example/v1")
+	}
+	if in.ModelRouter == nil {
+		t.Fatal("expected ModelRouter to be set")
+	}
+	if in.ModelRouter.Type != "static" || in.ModelRouter.Model != "gpt-5.4-nano" {
+		t.Errorf("ModelRouter = %#v, want type=static model=gpt-5.4-nano", in.ModelRouter)
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigOverridesPerTask asserts the per-task
+// override block decodes into EvalTask.RunConfigOverrides with the
+// fields the author set, and is independent of the suite-level
+// baseline (the merging is the runner's responsibility in chunk B).
+func TestLoadSuiteHCL_RunConfigOverridesPerTask(t *testing.T) {
+	src := `
+suite "s" {
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    run_config_overrides {
+      max_turns = 4
+      provider {
+        type        = "anthropic"
+        api_key_ref = "secret://ANTHROPIC_KEY"
+      }
+    }
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "task-overrides.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig != nil {
+		t.Errorf("suite RunConfig = %#v, want nil", got.RunConfig)
+	}
+	tov := got.Tasks[0].RunConfigOverrides
+	if tov == nil {
+		t.Fatal("expected per-task RunConfigOverrides to be set")
+	}
+	if tov.MaxTurns == nil || *tov.MaxTurns != 4 {
+		t.Errorf("MaxTurns = %v, want *4", tov.MaxTurns)
+	}
+	if tov.Provider == nil {
+		t.Fatal("expected Provider override")
+	}
+	if tov.Provider.Type != "anthropic" {
+		t.Errorf("Provider.Type = %q, want %q", tov.Provider.Type, "anthropic")
+	}
+	if tov.Provider.APIKeyRef != "secret://ANTHROPIC_KEY" {
+		t.Errorf("Provider.APIKeyRef = %q, want %q", tov.Provider.APIKeyRef, "secret://ANTHROPIC_KEY")
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigSourcesMutuallyExclusive pins the contract
+// that a suite cannot set both `run_config_file` and a `run_config {}`
+// block. The error must name both sources so authors can find the
+// conflict without re-reading the docs.
+func TestLoadSuiteHCL_RunConfigSourcesMutuallyExclusive(t *testing.T) {
+	src := `
+suite "s" {
+  run_config_file = "configs/base.json"
+  run_config {
+    mode = "execution"
+  }
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "both-sources.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive run-config sources")
+	}
+	for _, frag := range []string{"run_config_file", "run_config block", "mutually exclusive"} {
+		if !strings.Contains(err.Error(), frag) {
+			t.Fatalf("error = %q, want it to mention %q", err.Error(), frag)
+		}
+	}
+}
+
+// TestLoadSuiteHCL_BackwardsCompatNoRunConfig confirms that a suite
+// authored before this issue (no run_config_* fields anywhere) decodes
+// with RunConfig == nil at the suite level and on every task. This is
+// the contract that lets existing suites continue to work unchanged.
+func TestLoadSuiteHCL_BackwardsCompatNoRunConfig(t *testing.T) {
+	hclPath := filepath.Join("testdata", "sample.hcl")
+	got, err := LoadSuiteHCL(hclPath)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig != nil {
+		t.Errorf("RunConfig = %#v, want nil for legacy suite", got.RunConfig)
+	}
+	for _, task := range got.Tasks {
+		if task.RunConfigOverrides != nil {
+			t.Errorf("task %q RunConfigOverrides = %#v, want nil", task.ID, task.RunConfigOverrides)
+		}
+	}
+}
+
+// TestLoadSuiteHCL_ExistingSuitesStillParse exercises the production
+// suites checked in under eval/suites/ to confirm the grammar
+// extension hasn't regressed their loadability. Neither suite uses
+// the new run-config surface yet, so this is a pure backwards-compat
+// pin.
+func TestLoadSuiteHCL_ExistingSuitesStillParse(t *testing.T) {
+	cases := []string{
+		"../suites/guardrail.hcl",
+		"../suites/openai-responses-empty-tool-output.hcl",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			if _, err := os.Stat(p); err != nil {
+				t.Skipf("suite %s not present: %v", p, err)
+			}
+			suite, err := LoadSuiteHCL(p)
+			if err != nil {
+				t.Fatalf("LoadSuiteHCL(%s): %v", p, err)
+			}
+			if suite.ID == "" {
+				t.Fatalf("LoadSuiteHCL(%s) returned suite with empty ID", p)
+			}
+			if suite.RunConfig != nil {
+				t.Errorf("suite %s RunConfig = %#v, want nil (legacy)", p, suite.RunConfig)
+			}
+		})
+	}
+}
+
 func writeTemp(t *testing.T, name, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/eval/spec/hcl_test.go
+++ b/eval/spec/hcl_test.go
@@ -806,6 +806,113 @@ suite "s" {
 	}
 }
 
+// TestLoadSuiteHCL_RawAPIKeyRefRejected pins the parse-time invariant
+// that provider.api_key_ref must use the secret:// scheme. A raw
+// credential authored inline would otherwise sit on disk in the
+// merged run-config the runner hands the harness (at 0600, but
+// silently) and Redact() would hide the misconfiguration from the
+// audit artifact. The check fires on both suite-level inline
+// run_config blocks and per-task run_config_overrides blocks.
+func TestLoadSuiteHCL_RawAPIKeyRefRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "suite-level inline run_config",
+			src: `
+suite "s" {
+  run_config {
+    provider {
+      type        = "anthropic"
+      api_key_ref = "sk-raw-bad-key"
+    }
+  }
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`,
+		},
+		{
+			name: "per-task run_config_overrides",
+			src: `
+suite "s" {
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    run_config_overrides {
+      provider {
+        type        = "anthropic"
+        api_key_ref = "literal-key-value"
+      }
+    }
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTemp(t, "raw-key.hcl", tc.src)
+			_, err := LoadSuiteHCL(path)
+			if err == nil {
+				t.Fatal("expected error for raw api_key_ref")
+			}
+			for _, frag := range []string{"raw credentials", "secret://"} {
+				if !strings.Contains(err.Error(), frag) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), frag)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadSuiteHCL_SecretSchemedAPIKeyRefAccepted is the positive twin
+// of TestLoadSuiteHCL_RawAPIKeyRefRejected: a properly schemed
+// reference still parses.
+func TestLoadSuiteHCL_SecretSchemedAPIKeyRefAccepted(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    provider {
+      type        = "anthropic"
+      api_key_ref = "secret://ANTHROPIC_KEY"
+    }
+  }
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "schemed-key.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RunConfig == nil || got.RunConfig.Inline == nil || got.RunConfig.Inline.Provider == nil {
+		t.Fatalf("expected populated provider, got %#v", got.RunConfig)
+	}
+	if got.RunConfig.Inline.Provider.APIKeyRef != "secret://ANTHROPIC_KEY" {
+		t.Errorf("APIKeyRef = %q, want %q",
+			got.RunConfig.Inline.Provider.APIKeyRef, "secret://ANTHROPIC_KEY")
+	}
+}
+
 // TestLoadSuiteHCL_BackwardsCompatNoRunConfig confirms that a suite
 // authored before this issue (no run_config_* fields anywhere) decodes
 // with RunConfig == nil at the suite level and on every task. This is

--- a/eval/spec/hcl_test.go
+++ b/eval/spec/hcl_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -604,14 +605,46 @@ suite "s" {
 	if got.RunConfig == nil {
 		t.Fatal("expected suite RunConfig to be populated")
 	}
-	if got.RunConfig.File != "configs/base.json" {
-		t.Errorf("RunConfig.File = %q, want %q", got.RunConfig.File, "configs/base.json")
+	// The loader resolves a relative `run_config_file` against the suite
+	// file's directory so the runner can open it without further plumbing.
+	wantFile := filepath.Join(filepath.Dir(path), "configs/base.json")
+	if got.RunConfig.File != wantFile {
+		t.Errorf("RunConfig.File = %q, want %q", got.RunConfig.File, wantFile)
 	}
 	if got.RunConfig.Inline != nil {
 		t.Errorf("RunConfig.Inline = %#v, want nil", got.RunConfig.Inline)
 	}
 	if got.Tasks[0].RunConfigOverrides != nil {
 		t.Errorf("Tasks[0].RunConfigOverrides = %#v, want nil", got.Tasks[0].RunConfigOverrides)
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigFileAbsolutePreserved asserts that an
+// absolute path in `run_config_file` is preserved verbatim by the
+// loader rather than being re-rooted under the suite's directory.
+func TestLoadSuiteHCL_RunConfigFileAbsolutePreserved(t *testing.T) {
+	absPath := "/absolute/path/to/configs/base.json"
+	src := fmt.Sprintf(`
+suite "s" {
+  run_config_file = %q
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`, absPath)
+	path := writeTemp(t, "run-config-file-abs.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig == nil || got.RunConfig.File != absPath {
+		t.Errorf("RunConfig.File = %q, want absolute path %q (unchanged)",
+			got.RunConfig.File, absPath)
 	}
 }
 

--- a/eval/spec/hcl_test.go
+++ b/eval/spec/hcl_test.go
@@ -826,28 +826,55 @@ func TestLoadSuiteHCL_BackwardsCompatNoRunConfig(t *testing.T) {
 
 // TestLoadSuiteHCL_ExistingSuitesStillParse exercises the production
 // suites checked in under eval/suites/ to confirm the grammar
-// extension hasn't regressed their loadability. Neither suite uses
-// the new run-config surface yet, so this is a pure backwards-compat
-// pin.
+// extension hasn't regressed their loadability. The openai-responses
+// regression suite pins its own provider posture inline (issue #177),
+// so its RunConfig is expected to be populated; guardrail.hcl remains
+// on the legacy path.
 func TestLoadSuiteHCL_ExistingSuitesStillParse(t *testing.T) {
-	cases := []string{
-		"../suites/guardrail.hcl",
-		"../suites/openai-responses-empty-tool-output.hcl",
+	cases := []struct {
+		path           string
+		wantRunConfig  bool
+		wantProvider   string
+		wantModel      string
+	}{
+		{
+			path:          "../suites/guardrail.hcl",
+			wantRunConfig: false,
+		},
+		{
+			path:          "../suites/openai-responses-empty-tool-output.hcl",
+			wantRunConfig: true,
+			wantProvider:  "openai-responses",
+			wantModel:     "gpt-4o-mini",
+		},
 	}
-	for _, p := range cases {
-		t.Run(p, func(t *testing.T) {
-			if _, err := os.Stat(p); err != nil {
-				t.Skipf("suite %s not present: %v", p, err)
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			if _, err := os.Stat(c.path); err != nil {
+				t.Skipf("suite %s not present: %v", c.path, err)
 			}
-			suite, err := LoadSuiteHCL(p)
+			suite, err := LoadSuiteHCL(c.path)
 			if err != nil {
-				t.Fatalf("LoadSuiteHCL(%s): %v", p, err)
+				t.Fatalf("LoadSuiteHCL(%s): %v", c.path, err)
 			}
 			if suite.ID == "" {
-				t.Fatalf("LoadSuiteHCL(%s) returned suite with empty ID", p)
+				t.Fatalf("LoadSuiteHCL(%s) returned suite with empty ID", c.path)
 			}
-			if suite.RunConfig != nil {
-				t.Errorf("suite %s RunConfig = %#v, want nil (legacy)", p, suite.RunConfig)
+			switch {
+			case !c.wantRunConfig && suite.RunConfig != nil:
+				t.Errorf("suite %s RunConfig = %#v, want nil (legacy)", c.path, suite.RunConfig)
+			case c.wantRunConfig && suite.RunConfig == nil:
+				t.Fatalf("suite %s RunConfig = nil, want pinned baseline", c.path)
+			case c.wantRunConfig:
+				if suite.RunConfig.Inline == nil {
+					t.Fatalf("suite %s RunConfig.Inline = nil, want inline baseline", c.path)
+				}
+				if got := suite.RunConfig.Inline.Provider; got == nil || got.Type != c.wantProvider {
+					t.Errorf("suite %s provider = %#v, want type %q", c.path, got, c.wantProvider)
+				}
+				if got := suite.RunConfig.Inline.ModelRouter; got == nil || got.Model != c.wantModel {
+					t.Errorf("suite %s model = %#v, want model %q", c.path, got, c.wantModel)
+				}
 			}
 		})
 	}

--- a/eval/spec/hcl_test.go
+++ b/eval/spec/hcl_test.go
@@ -657,7 +657,6 @@ func TestLoadSuiteHCL_RunConfigInlineBlock(t *testing.T) {
 	src := `
 suite "s" {
   run_config {
-    mode      = "execution"
     max_turns = 10
 
     provider {
@@ -695,8 +694,11 @@ suite "s" {
 		t.Errorf("RunConfig.File = %q, want empty", got.RunConfig.File)
 	}
 	in := got.RunConfig.Inline
-	if in.Mode != "execution" {
-		t.Errorf("Mode = %q, want %q", in.Mode, "execution")
+	// Mode is not surfaced in the HCL run_config grammar; the runner
+	// reads mode from the task-level attribute. The inline carrier's
+	// Mode field stays at its zero value regardless of authoring.
+	if in.Mode != "" {
+		t.Errorf("Mode = %q, want empty (mode not surfaced in run_config block)", in.Mode)
 	}
 	if in.MaxTurns == nil || *in.MaxTurns != 10 {
 		t.Errorf("MaxTurns = %v, want *10", in.MaxTurns)
@@ -780,7 +782,7 @@ func TestLoadSuiteHCL_RunConfigSourcesMutuallyExclusive(t *testing.T) {
 suite "s" {
   run_config_file = "configs/base.json"
   run_config {
-    mode = "execution"
+    max_turns = 5
   }
   task "t1" {
     mode   = "execution"

--- a/eval/suites/openai-responses-empty-tool-output.hcl
+++ b/eval/suites/openai-responses-empty-tool-output.hcl
@@ -7,22 +7,28 @@
 # This suite is opt-in. It exercises a real round-trip against the
 # OpenAI Responses API and therefore requires:
 #
-#   - A real OpenAI API key set in the environment.
-#   - The harness binary configured with
-#     `--provider openai-responses --model <model>`.
+#   - A real OpenAI API key resolvable through the harness's
+#     SecretStore at the reference `secret://OPENAI_KEY` (mirrors
+#     the convention used for `secret://ANTHROPIC_API_KEY`).
+#
+# The suite pins its own provider posture via the inline
+# `run_config` block below: callers no longer need to remember to
+# pass `--provider openai-responses --model <model>` on the
+# command line, the suite carries that information itself
+# (issue #177).
 #
 # The unit-level marshal tests in
 # harness/internal/provider/openai_responses_test.go (covering
 # empty Content, error+empty content, and multiple empty results
-# in a row) are the per-PR gate for the fix. They cannot, however,
-# observe whether the OpenAI Responses API accepts the resulting
-# JSON — the harness's ReplayProvider sidesteps HTTP marshalling
-# entirely, and even a contract test against a recorded fixture
-# pins our serialisation, not OpenAI's parser. This suite is the
-# end-to-end pin: under the buggy adapter the run dies on turn 2
-# before the sentinel write happens, so the sentinel file is
-# absent and the task fails. Under the fix the run completes and
-# the sentinel is present.
+# in a row) remain the per-PR gate for the fix. They cannot,
+# however, observe whether the OpenAI Responses API accepts the
+# resulting JSON — the harness's ReplayProvider sidesteps HTTP
+# marshalling entirely, and even a contract test against a
+# recorded fixture pins our serialisation, not OpenAI's parser.
+# This suite is the end-to-end pin: under the buggy adapter the
+# run dies on turn 2 before the sentinel write happens, so the
+# sentinel file is absent and the task fails. Under the fix the
+# run completes and the sentinel is present.
 #
 # Not part of default CI: live provider calls are slow, flaky, and
 # spend real credits, and the per-PR signal is already provided by
@@ -34,7 +40,25 @@
 #       --output results/
 
 suite "openai-responses-empty-tool-output-regression" {
-  description = "Live-API regression for issue #172: the openai-responses adapter dropped the required `output` key from function_call_output items when a tool produced empty stdout, causing the next turn to be rejected with HTTP 400. Opt-in — requires a real OpenAI API key and the harness configured for --provider openai-responses; the unit tests in openai_responses_test.go are the per-PR gate, this suite is the end-to-end pin against the real Responses API."
+  description = "Live-API regression for issue #172: the openai-responses adapter dropped the required `output` key from function_call_output items when a tool produced empty stdout, causing the next turn to be rejected with HTTP 400. Opt-in — requires a real OpenAI API key resolvable as `secret://OPENAI_KEY`; the suite pins its own provider posture so no `--provider` / `--model` flags are needed. The unit tests in openai_responses_test.go are the per-PR gate; this suite is the end-to-end pin against the real Responses API."
+
+  # The provider posture this regression depends on is encoded in
+  # the suite itself rather than left to the caller's command line.
+  # Operators only need the OPENAI_KEY secret in the environment.
+  # max_turns is capped tight: each task expects a short, scripted
+  # tool sequence, so a high cap would only hide failures behind
+  # unrelated wandering.
+  run_config {
+    max_turns = 6
+    provider {
+      type        = "openai-responses"
+      api_key_ref = "secret://OPENAI_KEY"
+    }
+    model_router {
+      type  = "static"
+      model = "gpt-4o-mini"
+    }
+  }
 
   task "empty-stdout-run-command-completes" {
     description = "Drives the agent through at least one run_command whose stdout is empty (`true`), then a write_file that drops a sentinel. Under the buggy adapter, turn 2's request is rejected with HTTP 400 and `completed.txt` is never written. Under the fix, the sentinel is present with the literal text `ok`."

--- a/types/eval.go
+++ b/types/eval.go
@@ -6,6 +6,14 @@ type EvalSuite struct {
 	ID          string     `json:"id"`
 	Description string     `json:"description"`
 	Tasks       []EvalTask `json:"tasks"`
+
+	// RunConfig carries an optional suite-level RunConfig baseline that
+	// every task inherits. The runner merges per-task RunConfigOverrides
+	// on top of it before invoking `stirrup harness --config`. Nil means
+	// "no suite-level baseline configured", which preserves the legacy
+	// runner behaviour of relying entirely on the harness binary's own
+	// defaults / flags.
+	RunConfig *RunConfigSource `json:"runConfig,omitempty"`
 }
 
 // EvalTask describes a single evaluation task.
@@ -17,6 +25,30 @@ type EvalTask struct {
 	Prompt      string    `json:"prompt"`
 	Mode        string    `json:"mode"`
 	Judge       EvalJudge `json:"judge"`
+
+	// RunConfigOverrides carries optional sparse RunConfig overrides
+	// applied on top of the suite-level baseline (if any) when the
+	// runner materialises the per-task RunConfig. Nil means "no per-task
+	// overrides", in which case the suite-level baseline (if any) is
+	// used as-is.
+	RunConfigOverrides *RunConfigOverrides `json:"runConfigOverrides,omitempty"`
+}
+
+// RunConfigSource describes where a suite's RunConfig baseline comes
+// from. Exactly one of File or Inline is expected to be set; the spec
+// loader enforces mutual exclusion at parse time. The carrier itself
+// keeps both fields so downstream consumers can branch on whichever is
+// populated without a second tagged enum.
+type RunConfigSource struct {
+	// File is a filesystem path to a RunConfig JSON document of the same
+	// shape consumed by `stirrup harness --config`. Resolved relative to
+	// the suite file's directory by the loader.
+	File string `json:"file,omitempty"`
+
+	// Inline is a sparse, parsed RunConfig baseline expressed inline in
+	// the suite definition. Same shape as a per-task RunConfigOverrides
+	// — only the fields the suite cares about need to be set.
+	Inline *RunConfigOverrides `json:"inline,omitempty"`
 }
 
 // EvalJudge describes how to judge a run's outcome.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1181,6 +1181,15 @@ func ValidateRunConfig(config *RunConfig) error {
 	for name, prov := range config.Providers {
 		validateCredentialConfig(prov.Credential, fmt.Sprintf("providers[%s].credential", name), &errs)
 	}
+	// MCP servers and the VCS backend each carry their own apiKeyRef
+	// that Redact() rewrites; reject raw values here to match the
+	// provider-level invariant.
+	if config.Executor.VcsBackend != nil {
+		validateAPIKeyRef("executor.vcsBackend.apiKeyRef", config.Executor.VcsBackend.APIKeyRef, &errs)
+	}
+	for i, server := range config.Tools.MCPServers {
+		validateAPIKeyRef(fmt.Sprintf("tools.mcpServers[%d].apiKeyRef", i), server.APIKeyRef, &errs)
+	}
 
 	// Read-only modes must use deny-side-effects or ask-upstream
 	if readOnlyModes[config.Mode] && config.PermissionPolicy.Type == "allow-all" {
@@ -1505,11 +1514,32 @@ func validateVerifierConfig(cfg VerifierConfig, path string, errs *[]string) {
 	}
 }
 
+// validateAPIKeyRef enforces the "no raw credentials" invariant: any
+// non-empty APIKeyRef must use the "secret://" scheme so the harness
+// SecretStore resolves it at runtime. A raw value would otherwise
+// flow into a persisted run-config (e.g. the eval runner's
+// run_config.json hand-off) and be silently hidden by Redact() in
+// the audit artifact. Mirrors CLAUDE.md's "secrets never as raw
+// values in RunConfig" invariant inside the validator so the same
+// bad config is rejected whether it arrives via HCL, JSON, or a
+// programmatic API.
+func validateAPIKeyRef(path, ref string, errs *[]string) {
+	if ref == "" {
+		return
+	}
+	if !strings.HasPrefix(ref, "secret://") {
+		*errs = append(*errs, fmt.Sprintf(
+			"%s %q does not use the secret:// scheme; raw credentials are not permitted in RunConfig",
+			path, ref))
+	}
+}
+
 func validateProviderConfigs(config *RunConfig, errs *[]string) {
 	knownProviders := map[string]bool{}
 	if config.Provider.Type != "" {
 		knownProviders[config.Provider.Type] = true
 	}
+	validateAPIKeyRef("provider.apiKeyRef", config.Provider.APIKeyRef, errs)
 	validateOpenAIAuthFields("provider", config.Provider, errs)
 	validateGeminiProviderFields("provider", config.Provider, errs)
 	validateAnthropicProviderFields("provider", config.Provider, errs)
@@ -1526,6 +1556,7 @@ func validateProviderConfigs(config *RunConfig, errs *[]string) {
 		knownProviders[name] = true
 		path := fmt.Sprintf("providers[%s]", name)
 		validateRequiredType(path, provider.Type, validProviderTypes, errs)
+		validateAPIKeyRef(fmt.Sprintf("%s.apiKeyRef", path), provider.APIKeyRef, errs)
 		validateOpenAIAuthFields(path, provider, errs)
 		validateGeminiProviderFields(path, provider, errs)
 		validateAnthropicProviderFields(path, provider, errs)

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -151,6 +151,81 @@ func validConfig() *RunConfig {
 	}
 }
 
+// TestValidateRunConfig_RawAPIKeyRefRejected pins the "no raw
+// credentials" invariant at the validator level so the same bad
+// config is rejected regardless of how it arrived (HCL, JSON file,
+// programmatic API). Without this, a raw key would silently flow to
+// disk in the eval runner's merged config artifact and be hidden by
+// Redact() in the audit copy.
+func TestValidateRunConfig_RawAPIKeyRefRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*RunConfig)
+		wantSub string
+	}{
+		{
+			name: "provider.apiKeyRef raw",
+			mutate: func(c *RunConfig) {
+				c.Provider.APIKeyRef = "sk-raw-bad"
+			},
+			wantSub: "provider.apiKeyRef",
+		},
+		{
+			name: "named provider.apiKeyRef raw",
+			mutate: func(c *RunConfig) {
+				c.Provider.Type = ""
+				c.Providers = map[string]ProviderConfig{
+					"primary": {Type: "anthropic", APIKeyRef: "literal-key"},
+				}
+			},
+			wantSub: "providers[primary].apiKeyRef",
+		},
+		{
+			name: "vcsBackend.apiKeyRef raw",
+			mutate: func(c *RunConfig) {
+				c.Executor.VcsBackend = &VcsBackendConfig{APIKeyRef: "ghp_raw_bad"}
+			},
+			wantSub: "executor.vcsBackend.apiKeyRef",
+		},
+		{
+			name: "mcpServers[].apiKeyRef raw",
+			mutate: func(c *RunConfig) {
+				c.Tools.MCPServers = []MCPServerConfig{{Name: "x", URI: "https://example", APIKeyRef: "raw-mcp-key"}}
+			},
+			wantSub: "tools.mcpServers[0].apiKeyRef",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validConfig()
+			tc.mutate(cfg)
+			err := ValidateRunConfig(cfg)
+			if err == nil {
+				t.Fatal("expected error for raw apiKeyRef")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), "raw credentials are not permitted") {
+				t.Errorf("error = %q, want it to mention 'raw credentials are not permitted'", err.Error())
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_SecretSchemedAPIKeyRefAccepted is the
+// positive twin: secret:// references must pass validation in every
+// surface that carries an apiKeyRef.
+func TestValidateRunConfig_SecretSchemedAPIKeyRefAccepted(t *testing.T) {
+	cfg := validConfig()
+	cfg.Provider.APIKeyRef = "secret://ANTHROPIC_KEY"
+	cfg.Executor.VcsBackend = &VcsBackendConfig{APIKeyRef: "secret://GH_TOKEN"}
+	cfg.Tools.MCPServers = []MCPServerConfig{{Name: "x", URI: "https://example", APIKeyRef: "secret://MCP"}}
+	if err := ValidateRunConfig(cfg); err != nil {
+		t.Fatalf("expected nil error for secret://-schemed refs, got: %v", err)
+	}
+}
+
 func TestValidateRunConfig_Valid(t *testing.T) {
 	if err := ValidateRunConfig(validConfig()); err != nil {
 		t.Fatalf("expected nil error for valid config, got: %v", err)


### PR DESCRIPTION
## Summary

Closes #177.

`stirrup-eval` previously shelled out to `stirrup harness` with exactly five flags (`--prompt`, `--mode`, `--workspace`, `--trace`, `--timeout`). Provider type, model, credential federation, executor, edit strategy, verifier, code scanner, guardrail, observability, max-turns, transport — every other RunConfig field had to come from the harness binary's defaults or the operator's external environment. A suite could *describe* a regression scenario but couldn't *enforce* the configuration that made the scenario meaningful (this surfaced concretely while writing the regression suite for #172).

This PR wires the full `types.RunConfig` surface through the eval framework so suites can pin their required harness posture inline.

## What landed

Three layers of authoring surface, all optional and backwards-compatible:

1. **Suite-level external baseline** — `run_config_file = "path/to/runconfig.json"`. Loads a JSON `RunConfig` of the same shape consumed by `stirrup harness --config`. Resolved relative to the suite file's directory at load time.
2. **Suite-level inline baseline** — `run_config { ... }` HCL block, mutually exclusive with `run_config_file`. Sparse subset of `RunConfig` surfaced: `mode` (suite-level only — see Design notes), `provider { type, api_key_ref, base_url, api_key_header, query_params, region, profile, gcp_project, gcp_location }`, `model_router { type, provider, model, mode_models }`, `context_strategy { type, max_tokens }`, `edit_strategy { type, fuzzy_threshold }`, `verifier { type, command, timeout, criteria, model }`, `max_turns`.
3. **Per-task sparse overrides** — `run_config_overrides { ... }` inside a task, same shape as the inline `run_config` baseline (minus `mode`, see Design notes). Applied on top of the suite-level baseline.

The runner:

- Loads the suite baseline (file or inline) into a `types.RunConfig`.
- Applies the task's `RunConfigOverrides` on top.
- Writes the merged config to `<tmpDir>/run_config.json` (`0o600`).
- Invokes `stirrup harness --config <path> --prompt … --workspace … --trace … --timeout …`. Per the harness's documented `--config` precedence, the runner's explicit flags stay authoritative.
- When `--output` is set, persists `<output>/<suite>/<task>/run_config.redacted.json` (`0o640`) via `RunConfig.Redact()`.
- Under `--dry-run`, injects the runner's default timeout and calls `types.ValidateRunConfig` on the merged config per task, surfacing failures as failed `TaskResult`s.

A suite with no `RunConfig` and no per-task `RunConfigOverrides` falls through to today's invocation unchanged (no `--config`, no redacted artifact, no behavioural change).

## Demo

`eval/suites/openai-responses-empty-tool-output.hcl` now inlines its provider posture:

```hcl
run_config {
  provider {
    type        = "openai-responses"
    api_key_ref = "secret://OPENAI_KEY"
  }
  model_router { model = "gpt-4o-mini" }
}
```

The suite's docstring previously said *"the harness binary configured with `--provider openai-responses --model <model>`"* — that gap is exactly what #177 closes.

## Acceptance criteria mapping

All ten acceptance criteria from #177 are met (spec-compliance review found 10/10 met, evidence cited per criterion):

- [x] `eval/spec/hcl.go` parses `run_config_file`, `run_config { ... }`, `run_config_overrides { ... }`.
- [x] Mutual exclusion of `run_config_file` and `run_config` enforced at parse time.
- [x] `types.EvalSuite` and `types.EvalTask` carry the new fields; new `RunConfigSource` wrapper.
- [x] `eval/runner/runner.go` resolves the merged RunConfig per task, writes the temp config, invokes `--config`.
- [x] Retained artifacts include `run_config.redacted.json` per task.
- [x] `--dry-run` runs `ValidateRunConfig` per task and surfaces failures.
- [x] `guardrail.hcl` parses unchanged; `openai-responses-empty-tool-output.hcl` updated as the demo.
- [x] `docs/eval.md` updated with the new authoring surface.
- [x] `openai-responses-empty-tool-output.hcl` demonstrates the new flow end-to-end.
- [x] Tests cover: file ref, inline block, per-task overrides, mutual-exclusion validation, redaction in retained artifacts.

## Design notes

- **`mode` at the task-override layer is intentionally not surfaced in HCL.** The runner forwards `--mode <task.Mode>` only when the task carries an explicit top-level `mode` attribute. `RunConfigOverrides.Mode` on the Go type remains for the experiment runner (`types.Experiment.BaseConfig`). The asymmetry avoids a parse-time silent-no-op trap: a `mode` written inside an HCL overrides block would have been silently ignored at runtime under the existing harness flag-precedence rule. The doc's *Surfaced fields* table calls this out explicitly.
- **`api_key_ref` values must use the `secret://` scheme.** Validated at three layers: HCL parse (immediate, clearest error message), `ValidateRunConfig` (defense-in-depth, also catches programmatic callers), and `retainArtifacts` (stderr warning at the marshal site if either earlier gate is bypassed). Enforces the existing project invariant *"secrets never as raw values in RunConfig"* (see `CLAUDE.md`).
- **`gcp_credentials_file` deliberately not surfaced inline.** Inline file paths would need the same relative-resolution treatment as `run_config_file` itself; rather than build a second resolution path, suites needing this can use `run_config_file` pointing at a JSON config. Documented in `eval.md` and in a comment on `providerConfigSpec`.
- **`loadRunConfigFile` is duplicated from `harness/cmd/stirrup/cmd/harness.go` rather than factored.** The harness command package is binary-private. Exporting it (or inventing a new shared file-I/O helper in `types/`) would expand the public API more than the ~25-line duplication justifies. A pin-test (`TestMergeRunConfig_FileBaselineRejectsUnknownFields`) keeps the cross-module contract honest. A follow-up issue will be filed.
- **`run_config_file` is resolved relative to the suite file's directory in the spec loader.** Absolute paths pass through unchanged. The runner is pure with respect to filesystem layout — it never needs to know where the suite file lived.

## Test plan

- [x] `just build` — clean.
- [x] `just test` — all packages green. 17 new tests in `eval/runner` (38 total), 11 new tests in `eval/spec` (27 total), 2 new tests in `types`.
- [x] `just lint` — 12 diagnostics, all pre-existing on `main`. Zero new diagnostics introduced.
- [x] Existing suites (`guardrail.hcl` and the live regression suite) continue to parse and round-trip.
- [x] Per-task merge semantics covered: nil source, file-only baseline, inline-only baseline, inline + task overrides, file + task overrides, every sparse field on `RunConfigOverrides`.
- [x] Redaction guarantee covered: artifact contains `secret://[REDACTED]`, NOT the original `secret://REAL_KEY` reference; harness subprocess receives the un-redacted form.
- [x] Dry-run validation covered: validates merged config per task, surfaces failures as `fail`/`error` outcomes, preserves vacuous-pass when no RunConfig surface is set, injects default timeout so inline configs don't false-fail.
- [x] Backwards compat: a suite with no RunConfig surface produces no `--config` flag, no redacted artifact, identical behaviour to before this PR.

## Review cycle

Five reviewers ran in parallel (code, security, spec-compliance, test-coverage, api-design) and the synthesizer consolidated into a 10-blocker + 4-important remediation brief. All blockers and important findings are resolved in this PR:

| Finding | Fix |
|---|---|
| B-1 `--mode` precedence bug | Runner only forwards `--mode` when the task carries an explicit top-level `mode`; HCL grammar drops `mode` from `run_config_overrides`. |
| B-2 raw `api_key_ref` accepted | Three-layer validation (parse, validate, warn-at-marshal) requiring `secret://` scheme. |
| B-3 dry-run false-negatives on inline configs | Inject runner's default timeout before `ValidateRunConfig` (the runner's `--timeout` flag would have overridden it at runtime). |
| B-4 artifact world-readable | `run_config.redacted.json` mode tightened from `0o644` to `0o640`. |
| B-5/6/7 dry-run branch coverage | New tests for the validate-pass, merge-error, and mixed-task-config dry-run paths. |
| B-8 sub-block round-trip coverage | New test covers every nested HCL field on `runConfigOverridesSpec`. |
| B-9/10 weak test assertions | Strengthened to assert exact outcomes and to verify the harness received un-redacted input. |
| I-1 `GCPCredentialsFile` ergonomics | Documented as file-only in `eval.md` and as a code comment on `providerConfigSpec`. |
| I-2 file-baseline + task-overrides | New `TestMergeRunConfig_FileBaselineWithTaskOverrides`. |
| I-3 `loadRunConfigFile` guards | New tests pin the is-directory, size-cap, and empty-file branches. |
| I-4 `applyOverrides` nil-guard | Documented with a comment at the guard explaining the defensive contract. |

Ten lower-priority findings (mostly pre-existing concerns the review surfaced — `loadRunConfigFile` duplication consolidation, `secret://file:///` scheme allowlist, stale doc concurrency statements, `hcl.Diagnostic` error ergonomics, etc.) are intentionally deferred to follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)