### PR TITLE
eval: wire full RunConfig surface through suite → task → harness invocation

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -106,6 +106,123 @@ generate suites from a higher-level tool and emit the static HCL.
 Suite definitions live in `eval/suites/`. CI baselines live in
 `eval/baselines/`.
 
+### Suite-level RunConfig surface
+
+A suite can pin the harness configuration it expects to run against,
+so the regression scenario it describes cannot be silently nullified
+by the operator's environment. Three authoring constructs cover the
+suite → task layering:
+
+| Construct | Scope | Shape | Mutual exclusion |
+|---|---|---|---|
+| `run_config_file = "path.json"` | suite | Path to a `RunConfig` JSON file matching what `stirrup harness --config` already consumes. | Cannot coexist with inline `run_config`. |
+| `run_config { ... }` | suite | Inline `RunConfig` baseline. | Cannot coexist with `run_config_file`. |
+| `run_config_overrides { ... }` | per task | Sparse overlay applied on top of the suite baseline. | n/a |
+
+Per-task `run_config_overrides` follows the existing
+`types.RunConfigOverrides` shape and currently surfaces `mode`,
+`provider`, `model_router`, `context_strategy`, `edit_strategy`,
+`verifier`, and `max_turns`. Only fields explicitly set on the
+overlay take effect; everything else passes the baseline through
+unchanged.
+
+```hcl
+suite "openai-responses-empty-tool-output-regression" {
+  description = "..."
+
+  run_config {
+    provider {
+      type        = "openai-responses"
+      api_key_ref = "secret://OPENAI_KEY"
+    }
+
+    model_router {
+      type     = "static"
+      provider = "openai-responses"
+      model    = "gpt-5.4-nano"
+    }
+  }
+
+  task "empty-stdout-run-command-completes" {
+    description = "..."
+    prompt      = "..."
+
+    # Optional sparse overlay (not used by this regression task).
+    # run_config_overrides {
+    #   max_turns = 4
+    # }
+
+    judge { ... }
+  }
+}
+```
+
+The live example is at
+[`eval/suites/openai-responses-empty-tool-output.hcl`](../eval/suites/openai-responses-empty-tool-output.hcl).
+
+**Precedence.** Explicit runner-managed flags
+(`--workspace`, `--trace`, `--timeout`, `--prompt`, `--mode`) always
+override the merged config. The runner sets them on every harness
+invocation because they are scoped to the per-task temp workspace
+and trace file the runner manages; the merged `--config` carries
+everything else (provider, model_router, executor, permission
+policy, guard rail, code scanner, observability, max_turns, …).
+This matches the precedence rule the harness's `--config` flag
+already documents.
+
+**Retention.** When `--output` is set, each retained task
+directory carries a `run_config.redacted.json` companion next to
+`trace.jsonl`, `harness.stdout.txt`, and `harness.stderr.txt`. The
+redaction guarantee matches `RunConfig.Redact()`: every
+`secret://` reference is rewritten to `secret://[REDACTED]`
+before the file lands on disk, so a retained artifact never
+carries a resolved secret out of the process. The reference
+itself never leaves the suite — only its redacted form is
+persisted.
+
+**Dry-run validation.** `stirrup-eval run --dry-run` builds the
+merged config for each task and feeds it to
+`types.ValidateRunConfig`. Validation errors are surfaced
+per task in the resulting `SuiteResult` (outcome `"error"`, the
+validator's message in `JudgeVerdict.Reason`) without aborting
+the suite; sibling tasks are still validated and reported. A
+suite with no `run_config_file` and no inline `run_config`
+preserves the legacy dry-run shape: every task is reported as a
+synthetic `"pass"` with reason `"dry run — skipped"`.
+
+**Replay-mode caveat.** `ReplayProvider` re-emits recorded
+`TurnRecord.ModelOutput` entries and never speaks HTTP. A suite
+that pins `provider` under a replay-mode invocation produces a
+configuration whose provider field has no effect: the replay
+provider is selected ahead of any wire-format adapter. The
+provider pin is still useful as documentation of the original
+recording's posture, but it does not gate the run.
+
+**Backwards compatibility.** A suite with no `run_config_file`,
+no inline `run_config`, and no per-task `run_config_overrides`
+behaves exactly as before — the runner falls back to the
+five-flag invocation (`--prompt`, `--mode`, `--workspace`,
+`--trace`, `--timeout`) and writes no `run_config.redacted.json`.
+The new fields are purely additive.
+
+**Currently unsupported.** The inline `run_config` block decodes
+most of `types.RunConfig` but defers a small number of fields
+whose HCL representation is awkward under gohcl's attribute
+model. These must be authored via `run_config_file` (which is
+parsed as JSON, where they are straightforward) until the parser
+grows dedicated handling:
+
+- `providers` (named multi-provider lineup, `map[string]ProviderConfig`)
+- `dynamic_context` (`map[string]DynamicContextValue`)
+- `guard_rail.custom_criteria` (`map[string]string`)
+- `trace_emitter.headers` (`map[string]string`)
+- `tools.mcp_servers` (slice of structs)
+- `transport` (the eval runner is stdio-only)
+
+Setting these via `run_config_file` is the recommended escape
+hatch; the suite still benefits from inline `run_config_overrides`
+for the supported subset.
+
 ### Judges
 
 A judge decides whether a task passed by inspecting the workspace
@@ -176,13 +293,21 @@ each task's judge to the workspace. Writes a `result.json`
 (`eval.SuiteResult`) into `--output`. Errors per-task are captured in
 `TaskResult.Error` without halting the suite.
 
+When the suite declares a baseline (`run_config_file` or inline
+`run_config`), the runner merges the per-task
+`run_config_overrides` overlay, writes the result to a per-task
+temp file, and invokes `stirrup harness --config <merged>.json`
+alongside the five workspace-scoped flags. The retained artifact
+tree gains a `run_config.redacted.json` per task. See
+[Suite-level RunConfig surface](#suite-level-runconfig-surface).
+
 | Flag             | Default          | Description                                                  |
 |------------------|------------------|--------------------------------------------------------------|
 | `--suite`        | required         | Path to `EvalSuite` HCL file (`.hcl`).                       |
 | `--output`       | current dir      | Directory for `result.json` and per-task artifacts.          |
 | `--harness`      | `stirrup` on PATH| Harness binary to invoke for live runs.                      |
 | `--concurrency`  | `1`              | Requested parallelism. Honoured as `1` until concurrency lands. |
-| `--dry-run`      | `false`          | Validate the suite and emit a synthetic all-pass result.     |
+| `--dry-run`      | `false`          | Validate the suite (and, when present, the merged per-task RunConfig via `ValidateRunConfig`) and emit a synthetic result. |
 
 Exit code is `0` regardless of pass rate — use `compare` to gate CI.
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -168,15 +168,36 @@ suite "openai-responses-empty-tool-output-regression" {
 The live example is at
 [`eval/suites/openai-responses-empty-tool-output.hcl`](../eval/suites/openai-responses-empty-tool-output.hcl).
 
-**Precedence.** Explicit runner-managed flags
-(`--workspace`, `--trace`, `--timeout`, `--prompt`, `--mode`) always
-override the merged config. The runner sets them on every harness
-invocation because they are scoped to the per-task temp workspace
-and trace file the runner manages; the merged `--config` carries
-everything else (provider, model_router, executor, permission
-policy, guard rail, code scanner, observability, max_turns, …).
-This matches the precedence rule the harness's `--config` flag
-already documents.
+**Precedence.** When a merged config is in use the runner passes
+only the flags it actually needs to manage:
+
+- `--workspace` — always passed (the per-task tmpdir has no
+  in-config equivalent the suite could supply).
+- `--trace` — not passed; the trace path is injected into the
+  merged config's `trace_emitter.file_path` so the harness picks
+  it up without triggering the flag's emitter-type coercion.
+- `--prompt` — passed only when the task has a non-empty `prompt`
+  attribute.
+- `--mode` — passed only when the task has a non-empty `mode`
+  attribute. A suite-level `run_config { mode = "..." }` rides in
+  the merged config and is honoured when the task itself does not
+  override.
+- `--timeout` — not passed; the merged config carries it.
+
+The legacy invocation path (a suite with no `run_config_file` and
+no inline `run_config`) keeps passing the historic five flags
+verbatim, so existing suites are unchanged.
+
+**`run_config_file` path resolution.** The path stored in
+`run_config_file` is used verbatim by the runner; relative paths
+resolve against the working directory of the `stirrup-eval`
+invocation, not the directory containing the suite file. For a
+suite checked into a repository, the recommendation is to use an
+absolute path or to invoke the runner from a stable working
+directory. Authors who want a suite-relative path can compose one
+explicitly in their CI script (e.g.
+`stirrup-eval run --suite "$REPO/eval/suites/foo.hcl"` after `cd`
+into the repo root).
 
 **Retention.** When `--output` is set, each retained task
 directory carries a `run_config.redacted.json` companion next to
@@ -208,10 +229,10 @@ recording's posture, but it does not gate the run.
 
 **Backwards compatibility.** A suite with no `run_config_file`,
 no inline `run_config`, and no per-task `run_config_overrides`
-behaves exactly as before — the runner falls back to the
-five-flag invocation (`--prompt`, `--mode`, `--workspace`,
-`--trace`, `--timeout`) and writes no `run_config.redacted.json`.
-The new fields are purely additive.
+behaves exactly as before — the runner falls back to the legacy
+invocation (`--prompt`, `--mode`, `--workspace`, `--trace`,
+`--timeout`) and writes no `run_config.redacted.json`. The new
+fields are purely additive.
 
 **Currently unsupported.** The inline `run_config` block decodes
 most of `types.RunConfig` but defers a small number of fields

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -120,11 +120,19 @@ suite → task layering:
 | `run_config_overrides { ... }` | per task | Sparse overlay applied on top of the suite baseline. | n/a |
 
 Per-task `run_config_overrides` follows the existing
-`types.RunConfigOverrides` shape and currently surfaces `mode`,
-`provider`, `model_router`, `context_strategy`, `edit_strategy`,
-`verifier`, and `max_turns`. Only fields explicitly set on the
-overlay take effect; everything else passes the baseline through
-unchanged.
+`types.RunConfigOverrides` shape and currently surfaces `provider`,
+`model_router`, `context_strategy`, `edit_strategy`, `verifier`,
+and `max_turns`. Only fields explicitly set on the overlay take
+effect; everything else passes the baseline through unchanged.
+
+Per-task mode is set via the task block's `mode` attribute, not
+`run_config_overrides`. The runner always passes the task's mode
+as the harness's `--mode` flag, which would otherwise silently
+override anything written in the overlay; the HCL surface omits
+`mode` from `run_config_overrides` so the conflict cannot arise.
+A suite-level `run_config { mode = "..." }` is still effective —
+it rides in the merged config file and is honoured by the
+harness unless the task itself sets a `mode` attribute.
 
 ```hcl
 suite "openai-responses-empty-tool-output-regression" {
@@ -215,7 +223,6 @@ grows dedicated handling:
 - `providers` (named multi-provider lineup, `map[string]ProviderConfig`)
 - `dynamic_context` (`map[string]DynamicContextValue`)
 - `guard_rail.custom_criteria` (`map[string]string`)
-- `trace_emitter.headers` (`map[string]string`)
 - `tools.mcp_servers` (slice of structs)
 - `transport` (the eval runner is stdio-only)
 

--- a/eval/runner/merge.go
+++ b/eval/runner/merge.go
@@ -1,0 +1,126 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// maxRunConfigFileBytes caps the size of a suite-level RunConfig JSON file
+// the runner will read. Mirrors the harness's loadRunConfigFile cap so a
+// suite cannot smuggle a multi-megabyte file past the runner that the
+// harness would reject anyway.
+const maxRunConfigFileBytes int64 = 1 << 20 // 1 MiB
+
+// loadRunConfigFile reads a JSON file at path and unmarshals it into a
+// RunConfig. Unknown fields are rejected so typos in a suite's baseline
+// config fail loudly rather than being silently dropped.
+//
+// This is intentionally a copy of the harness's loader rather than a shared
+// helper: keeping it inside the runner package preserves the eval module's
+// existing dependency direction (eval → types, never eval → harness).
+func loadRunConfigFile(path string) (*types.RunConfig, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading run_config_file %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("reading run_config_file %q: is a directory", path)
+	}
+	if info.Size() > maxRunConfigFileBytes {
+		return nil, fmt.Errorf("reading run_config_file %q: %d bytes exceeds %d byte cap", path, info.Size(), maxRunConfigFileBytes)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading run_config_file %q: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("parsing run_config_file %q: file is empty", path)
+	}
+	var cfg types.RunConfig
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing run_config_file %q: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// resolveBaseline produces the suite-level baseline RunConfig for a task,
+// or nil if the suite declares neither a file nor inline block (i.e. the
+// legacy five-flag invocation path). The returned config is always a fresh
+// allocation safe for the caller to mutate.
+func resolveBaseline(suite types.EvalSuite) (*types.RunConfig, error) {
+	switch {
+	case suite.RunConfigFile != "":
+		return loadRunConfigFile(suite.RunConfigFile)
+	case suite.RunConfig != nil:
+		// Deep-copy via JSON round-trip so the per-task merge does not
+		// mutate the shared suite spec. The cost is negligible (RunConfig
+		// is at most a few KB) and this avoids hand-maintaining a clone
+		// helper that would silently miss new fields as the type grows.
+		data, err := json.Marshal(suite.RunConfig)
+		if err != nil {
+			return nil, fmt.Errorf("cloning inline run_config baseline: %w", err)
+		}
+		var clone types.RunConfig
+		if err := json.Unmarshal(data, &clone); err != nil {
+			return nil, fmt.Errorf("cloning inline run_config baseline: %w", err)
+		}
+		return &clone, nil
+	default:
+		return nil, nil
+	}
+}
+
+// mergeOverrides applies a sparse RunConfigOverrides overlay on top of a
+// baseline RunConfig. Only non-zero / non-nil fields on the overlay take
+// effect; everything else passes the baseline through unchanged.
+//
+// The baseline pointer is mutated in place and also returned for chaining.
+// A nil overlay is a no-op (the baseline is returned unchanged). A nil
+// baseline is an error: an overlay with nothing to apply against is a
+// programming bug, surfaced loudly rather than silently producing a
+// half-formed config.
+//
+// Pointer-typed override fields (Provider, ModelRouter, ContextStrategy,
+// EditStrategy, Verifier, MaxTurns) are treated as "set if non-nil".
+// Scalar fields (Mode) are treated as "set if non-zero". This mirrors the
+// RunConfigOverrides shape: pointer fields exist so the caller can leave
+// them out, and the string Mode uses "" as the sentinel for "unset" since
+// it is also the zero value of a valid RunConfig.
+func mergeOverrides(baseline *types.RunConfig, overlay *types.RunConfigOverrides) *types.RunConfig {
+	if baseline == nil {
+		return nil
+	}
+	if overlay == nil {
+		return baseline
+	}
+
+	if overlay.Mode != "" {
+		baseline.Mode = overlay.Mode
+	}
+	if overlay.Provider != nil {
+		baseline.Provider = *overlay.Provider
+	}
+	if overlay.ModelRouter != nil {
+		baseline.ModelRouter = *overlay.ModelRouter
+	}
+	if overlay.ContextStrategy != nil {
+		baseline.ContextStrategy = *overlay.ContextStrategy
+	}
+	if overlay.EditStrategy != nil {
+		baseline.EditStrategy = *overlay.EditStrategy
+	}
+	if overlay.Verifier != nil {
+		baseline.Verifier = *overlay.Verifier
+	}
+	if overlay.MaxTurns != nil {
+		baseline.MaxTurns = *overlay.MaxTurns
+	}
+
+	return baseline
+}

--- a/eval/runner/merge.go
+++ b/eval/runner/merge.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"syscall"
 
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -19,23 +21,54 @@ const maxRunConfigFileBytes int64 = 1 << 20 // 1 MiB
 // RunConfig. Unknown fields are rejected so typos in a suite's baseline
 // config fail loudly rather than being silently dropped.
 //
+// The file must be a regular file: FIFOs, sockets, and device files are
+// rejected before the read. Without that guard a worker pool entering
+// loadRunConfigFile on a path like `/tmp/evil-fifo` would block
+// indefinitely on os.ReadFile, deadlocking RunSuite for the duration
+// of the worker pool's lifetime. The size cap and io.LimitReader give a
+// second layer of defence in case a regular file's reported size is
+// raced after the fstat (small TOCTOU window — the loader is still
+// authoritative on the bytes it actually consumed).
+//
 // This is intentionally a copy of the harness's loader rather than a shared
 // helper: keeping it inside the runner package preserves the eval module's
-// existing dependency direction (eval → types, never eval → harness).
+// existing dependency direction (eval → types, never eval → harness). The
+// harness copy still uses the two-syscall Stat+ReadFile shape; tracked as
+// a separate hardening pass under issue #177 follow-ups.
 func loadRunConfigFile(path string) (*types.RunConfig, error) {
-	info, err := os.Stat(path)
+	// O_NONBLOCK is the load-bearing flag: on POSIX, opening a FIFO
+	// for read without a connected writer blocks indefinitely. With
+	// O_NONBLOCK the open returns immediately for any path type, so
+	// the worker pool cannot be parked by a hostile or accidental
+	// FIFO at the configured run_config_file path. Regular files
+	// ignore O_NONBLOCK.
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		return nil, fmt.Errorf("reading run_config_file %q: %w", path, err)
 	}
-	if info.IsDir() {
-		return nil, fmt.Errorf("reading run_config_file %q: is a directory", path)
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("reading run_config_file %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("reading run_config_file %q: not a regular file (mode %s)", path, info.Mode())
 	}
 	if info.Size() > maxRunConfigFileBytes {
 		return nil, fmt.Errorf("reading run_config_file %q: %d bytes exceeds %d byte cap", path, info.Size(), maxRunConfigFileBytes)
 	}
-	data, err := os.ReadFile(path)
+
+	// io.LimitReader bounds the read regardless of what fstat reported —
+	// a file that grew between stat and read still cannot smuggle a
+	// multi-MiB blob through this loader. Read one byte past the cap so
+	// we can distinguish "exactly cap bytes" from "exceeded cap".
+	data, err := io.ReadAll(io.LimitReader(f, maxRunConfigFileBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading run_config_file %q: %w", path, err)
+	}
+	if int64(len(data)) > maxRunConfigFileBytes {
+		return nil, fmt.Errorf("reading run_config_file %q: exceeds %d byte cap", path, maxRunConfigFileBytes)
 	}
 	if len(data) == 0 {
 		return nil, fmt.Errorf("parsing run_config_file %q: file is empty", path)
@@ -53,7 +86,16 @@ func loadRunConfigFile(path string) (*types.RunConfig, error) {
 // or nil if the suite declares neither a file nor inline block (i.e. the
 // legacy five-flag invocation path). The returned config is always a fresh
 // allocation safe for the caller to mutate.
+//
+// Mutual exclusion is enforced at HCL parse time, but a Go caller
+// constructing EvalSuite directly (integration tests, the experiment
+// runner, future callers) can still set both fields. resolveBaseline
+// surfaces that as an error so the inline block is never silently
+// discarded in favour of the file.
 func resolveBaseline(suite types.EvalSuite) (*types.RunConfig, error) {
+	if suite.RunConfigFile != "" && suite.RunConfig != nil {
+		return nil, fmt.Errorf("suite %q: run_config_file and run_config are mutually exclusive", suite.ID)
+	}
 	switch {
 	case suite.RunConfigFile != "":
 		return loadRunConfigFile(suite.RunConfigFile)
@@ -82,9 +124,11 @@ func resolveBaseline(suite types.EvalSuite) (*types.RunConfig, error) {
 //
 // The baseline pointer is mutated in place and also returned for chaining.
 // A nil overlay is a no-op (the baseline is returned unchanged). A nil
-// baseline is an error: an overlay with nothing to apply against is a
-// programming bug, surfaced loudly rather than silently producing a
-// half-formed config.
+// baseline returns nil: the legacy invocation path (no suite-level
+// baseline) has nothing for the overlay to land on, and the caller is
+// expected to treat (nil, _) as "no merged config — fall back to the
+// five-flag harness invocation". The runner already enforces that
+// contract in buildMergedConfig.
 //
 // Pointer-typed override fields (Provider, ModelRouter, ContextStrategy,
 // EditStrategy, Verifier, MaxTurns) are treated as "set if non-nil".

--- a/eval/runner/merge_test.go
+++ b/eval/runner/merge_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -625,30 +626,36 @@ done
 
 // TestRunSuite_WithBaselineWritesConfigAndRedactedArtifact covers the
 // new invocation path: when the suite declares a baseline, the runner
-// must (a) invoke the harness with --config <path>, (b) write the
-// merged config to that path, and (c) retain a run_config.redacted.json
-// alongside the trace artifacts. The redacted artifact must contain the
-// secret:// reference unchanged — the reference is not a resolved
-// value, so Redact() does not rewrite plain secret:// references on
-// fields like Provider.APIKeyRef (which it does redact to
-// "secret://[REDACTED]" — the test checks for the redaction marker).
+// must (a) invoke the harness with --config <path> and no shadowing
+// flags (no --mode, no --timeout, no --trace — those land in the
+// merged config or in the per-task tmpdir), (b) write the merged
+// config to that path with TraceEmitter.FilePath set to the runner's
+// trace path, and (c) retain a run_config.redacted.json alongside
+// the trace artifacts.
 func TestRunSuite_WithBaselineWritesConfigAndRedactedArtifact(t *testing.T) {
 	logDir := t.TempDir()
 	argLog := filepath.Join(logDir, "args.log")
 	configCapture := filepath.Join(logDir, "config-capture.json")
+	// The fake harness no longer receives --trace on the merged-config
+	// path. Read the trace path out of the merged config instead, so a
+	// successful trace artifact is still produced for parseTraceFile to
+	// consume in runTask.
 	script := fmt.Sprintf(`#!/bin/sh
-TRACE=""
 CONFIG=""
 echo "$@" >> %q
 while [ $# -gt 0 ]; do
   case "$1" in
-    --trace)  TRACE="$2";  shift 2 ;;
     --config) CONFIG="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
-[ -n "$CONFIG" ] && cp "$CONFIG" %q
-[ -n "$TRACE" ]  && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+if [ -n "$CONFIG" ]; then
+  cp "$CONFIG" %q
+  # Extract trace_emitter.file_path with a sed grep (the merged
+  # config is single-line JSON). Tolerant of leading/trailing whitespace.
+  TRACE=$(sed -n 's/.*"filePath":"\([^"]*\)".*/\1/p' "$CONFIG")
+  [ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+fi
 `, argLog, configCapture)
 	harness := writeFakeHarness(t, script)
 
@@ -676,16 +683,23 @@ done
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// (a) --config was passed.
+	// (a) --config was passed, and the shadowing flags were not.
 	logData, err := os.ReadFile(argLog)
 	if err != nil {
 		t.Fatalf("reading arg log: %v", err)
 	}
-	if !strings.Contains(string(logData), "--config") {
-		t.Errorf("expected --config in harness args; got %q", string(logData))
+	logStr := string(logData)
+	if !strings.Contains(logStr, "--config") {
+		t.Errorf("expected --config in harness args; got %q", logStr)
+	}
+	for _, banned := range []string{"--timeout", "--mode", "--trace"} {
+		if strings.Contains(logStr, banned) {
+			t.Errorf("merged-config invocation must not pass %s; got args: %q", banned, logStr)
+		}
 	}
 
-	// (b) Captured config decodes back to the same RunConfig shape.
+	// (b) Captured config decodes back to the same RunConfig shape,
+	// with TraceEmitter.FilePath populated by the runner.
 	captured, err := os.ReadFile(configCapture)
 	if err != nil {
 		t.Fatalf("reading captured config: %v", err)
@@ -699,6 +713,12 @@ done
 	}
 	if got.Provider.APIKeyRef != "secret://OPENAI_KEY" {
 		t.Errorf("captured config APIKeyRef = %q, want %q (must be the unredacted reference — the harness needs it to resolve)", got.Provider.APIKeyRef, "secret://OPENAI_KEY")
+	}
+	if got.TraceEmitter.FilePath == "" {
+		t.Errorf("captured config TraceEmitter.FilePath is empty; runner must inject the per-task trace path")
+	}
+	if !strings.HasSuffix(got.TraceEmitter.FilePath, "trace.jsonl") {
+		t.Errorf("captured config TraceEmitter.FilePath = %q, want a path ending in trace.jsonl", got.TraceEmitter.FilePath)
 	}
 
 	// (c) Redacted artifact exists and has the reference scrubbed.
@@ -720,6 +740,270 @@ done
 	if !strings.Contains(string(redactedData), "secret://[REDACTED]") {
 		t.Errorf("redacted artifact missing redaction marker; data: %q", string(redactedData))
 	}
+
+	// (d) S1: retained redacted config must be mode 0o600 — it carries
+	// operator posture (provider type/model/network allowlists) and
+	// must not be world-readable on shared CI runners.
+	info, err := os.Stat(redactedPath)
+	if err != nil {
+		t.Fatalf("stat redacted artifact: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("redacted artifact perm = %o, want 0600", perm)
+	}
+}
+
+// TestRunSuite_HarnessFailWithTracePreservesVerdict covers the
+// runTask branch where the harness exits non-zero but still leaves a
+// usable trace behind. The runner must consult the judge and return
+// a real outcome (pass/fail) rather than discarding the trace and
+// reporting "error".
+func TestRunSuite_HarnessFailWithTracePreservesVerdict(t *testing.T) {
+	script := `#!/bin/sh
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+# Harness reports a non-zero exit despite emitting a trace — e.g. a
+# tool exited 1 but the agent loop closed cleanly. The runner should
+# still consult the judge.
+exit 1
+`
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "harness-fail-with-trace",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"definitely-not-created.txt"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("RunSuite error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	// Judge looks for a missing file → fail, not error. The trace
+	// was preserved so the outcome reflects the judge's verdict.
+	if result.Tasks[0].Outcome != "fail" {
+		t.Errorf("outcome = %q, want fail (judge rejected, trace consumed)", result.Tasks[0].Outcome)
+	}
+}
+
+// TestRunSuite_CloneRepoFailureSurfacedAsError exercises the
+// runTask repo-clone error path. A nonexistent remote URL makes
+// `git clone` fail quickly and the runner must report the task as
+// "error" without spawning the harness.
+func TestRunSuite_CloneRepoFailureSurfacedAsError(t *testing.T) {
+	// git may not be installed in some sandboxed CI environments. If
+	// the binary is missing the test skips — cloneRepo's error path
+	// is still exercised below via the unreachable-remote URL on
+	// systems that do have git.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+	script := `#!/bin/sh
+echo "should not be invoked" >&2
+exit 99
+`
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "clone-fail",
+		Tasks: []types.EvalTask{
+			{
+				ID:     "t1",
+				Prompt: "p",
+				Repo:   "https://invalid.localhost.invalid/does-not-exist.git",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}},
+			},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("RunSuite error: %v", err)
+	}
+	if result.Tasks[0].Outcome != "error" {
+		t.Errorf("outcome = %q, want error", result.Tasks[0].Outcome)
+	}
+	if !strings.Contains(result.Tasks[0].Error, "cloning repo") {
+		t.Errorf("error = %q, want it to mention cloning repo", result.Tasks[0].Error)
+	}
+}
+
+// TestRunSuite_HarnessFailWithoutTraceErrors covers the runTask
+// branch where the harness exits non-zero AND fails to leave a
+// usable trace. The outcome must be "error" and the surfaced error
+// must include the harness's stderr so the operator can diagnose.
+func TestRunSuite_HarnessFailWithoutTraceErrors(t *testing.T) {
+	script := `#!/bin/sh
+echo "harness boot failure" >&2
+exit 2
+`
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "harness-fail-no-trace",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("RunSuite error: %v", err)
+	}
+	if result.Tasks[0].Outcome != "error" {
+		t.Errorf("outcome = %q, want error", result.Tasks[0].Outcome)
+	}
+	if !strings.Contains(result.Tasks[0].Error, "harness boot failure") {
+		t.Errorf("error = %q, want it to include harness stderr", result.Tasks[0].Error)
+	}
+}
+
+// TestRunSuite_HarnessSuccessWithoutTraceErrors covers the
+// parse-trace error path after a clean harness exit. Without this,
+// a harness that exits 0 but emits no trace would silently produce
+// an undefined outcome.
+func TestRunSuite_HarnessSuccessWithoutTraceErrors(t *testing.T) {
+	script := `#!/bin/sh
+exit 0
+`
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "harness-noop",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("RunSuite error: %v", err)
+	}
+	if result.Tasks[0].Outcome != "error" {
+		t.Errorf("outcome = %q, want error", result.Tasks[0].Outcome)
+	}
+	if !strings.Contains(result.Tasks[0].Error, "parsing trace") {
+		t.Errorf("error = %q, want it to mention parsing trace", result.Tasks[0].Error)
+	}
+}
+
+// TestBuildMergedConfig_NilBaseline pins the legacy-invocation
+// contract on the merge helper: a nil baseline returns (nil, nil)
+// so runTask falls through to the legacy flag-only path.
+func TestBuildMergedConfig_NilBaseline(t *testing.T) {
+	four := 4
+	merged, err := buildMergedConfig(nil, &types.RunConfigOverrides{MaxTurns: &four})
+	if err != nil {
+		t.Fatalf("buildMergedConfig: %v", err)
+	}
+	if merged != nil {
+		t.Errorf("expected nil merged config for nil baseline, got %#v", merged)
+	}
+}
+
+// TestRunSuite_FailOutcomeOnJudgeReject covers the buildResult
+// fail-outcome branch: the harness succeeds and writes a trace, but
+// the judge's verdict is Passed=false. The outcome must be "fail",
+// not "error" — the harness ran cleanly; the run simply did not
+// meet the suite's criteria.
+func TestRunSuite_FailOutcomeOnJudgeReject(t *testing.T) {
+	script := `#!/bin/sh
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`
+	harness := writeFakeHarness(t, script)
+
+	// file-exists judge with a path that the harness will never
+	// create — the harness ran but the judge rejects.
+	suite := types.EvalSuite{
+		ID: "legacy-fail",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"definitely-not-created.txt"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{HarnessPath: harness})
+	if err != nil {
+		t.Fatalf("RunSuite error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	if result.Tasks[0].Outcome != "fail" {
+		t.Errorf("outcome = %q, want fail", result.Tasks[0].Outcome)
+	}
+}
+
+// TestRunTask_RejectsInvalidMergedConfigBeforeSubprocess covers B6:
+// when the merged RunConfig fails ValidateRunConfig the runner must
+// surface a per-task "error" outcome without launching the harness.
+// The fake harness records every invocation in argLog; the test
+// asserts that file stays empty.
+func TestRunTask_RejectsInvalidMergedConfigBeforeSubprocess(t *testing.T) {
+	logDir := t.TempDir()
+	argLog := filepath.Join(logDir, "args.log")
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %q
+`, argLog)
+	harness := writeFakeHarness(t, script)
+
+	timeout := 300
+	// Review mode requires a restrictive permission policy; allow-all
+	// trips the read-only-mode invariant in ValidateRunConfig before
+	// any tools.builtIn check kicks in. The baseline is otherwise
+	// well-formed.
+	bad := &types.RunConfig{
+		Mode:             "review",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_KEY"},
+		MaxTurns:         10,
+		Timeout:          &timeout,
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"read_file"}},
+	}
+	suite := types.EvalSuite{
+		ID:        "ro-suite",
+		RunConfig: bad,
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+	})
+	if err != nil {
+		t.Fatalf("RunSuite error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	if result.Tasks[0].Outcome != "error" {
+		t.Errorf("outcome = %q, want error", result.Tasks[0].Outcome)
+	}
+	if !strings.Contains(result.Tasks[0].Error, "review") {
+		t.Errorf("error = %q, want it to name the offending mode", result.Tasks[0].Error)
+	}
+
+	// Subprocess must not have launched.
+	if _, err := os.Stat(argLog); err == nil {
+		t.Errorf("harness was invoked despite validation failure; arg log %s exists", argLog)
+	}
 }
 
 // TestRunSuite_WithBaselineRetainedArtifactOmitsResolvedSecrets is the
@@ -730,15 +1014,21 @@ done
 // path, this test should catch it via a substring check for plausible
 // secret-shaped values that should not appear in a redacted file.
 func TestRunSuite_WithBaselineRetainedArtifactOmitsResolvedSecrets(t *testing.T) {
+	// The runner no longer passes --trace when --config is in use; the
+	// trace path rides in TraceEmitter.FilePath inside the merged
+	// config. Extract it from the JSON to produce a valid trace.
 	script := `#!/bin/sh
-TRACE=""
+CONFIG=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --trace) TRACE="$2"; shift 2 ;;
+    --config) CONFIG="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
-[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+if [ -n "$CONFIG" ]; then
+  TRACE=$(sed -n 's/.*"filePath":"\([^"]*\)".*/\1/p' "$CONFIG")
+  [ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+fi
 `
 	harness := writeFakeHarness(t, script)
 

--- a/eval/runner/merge_test.go
+++ b/eval/runner/merge_test.go
@@ -456,6 +456,89 @@ func TestBuildMergedConfig_FileBaselineWithTaskOverride(t *testing.T) {
 	}
 }
 
+// TestBuildMergedConfig_InjectsDefaultTimeoutWhenAbsent pins the
+// timeout-injection contract introduced for the suite-level inline
+// run_config flow. The HCL grammar does not surface `timeout` (it is
+// runner-owned), so a merged config originating from an inline block
+// arrives with Timeout == nil. ValidateRunConfig requires a positive
+// timeout, so without the injection both dry-run and live-run would
+// false-fail every suite using the inline shape.
+func TestBuildMergedConfig_InjectsDefaultTimeoutWhenAbsent(t *testing.T) {
+	baseline := &types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		MaxTurns: 10,
+		// Timeout intentionally left nil — emulates an inline run_config
+		// block where the HCL grammar does not expose `timeout`.
+	}
+	merged, err := buildMergedConfig(baseline, nil)
+	if err != nil {
+		t.Fatalf("buildMergedConfig: %v", err)
+	}
+	if merged == nil {
+		t.Fatal("expected non-nil merged config")
+	}
+	if merged.Timeout == nil {
+		t.Fatal("expected default Timeout to be injected, got nil")
+	}
+	if *merged.Timeout != defaultTaskTimeoutSeconds {
+		t.Errorf("Timeout = %d, want %d (default)", *merged.Timeout, defaultTaskTimeoutSeconds)
+	}
+}
+
+// TestBuildMergedConfig_PreservesExplicitTimeout confirms that a
+// Timeout already pinned by the baseline (e.g. a JSON config loaded
+// via run_config_file) survives the merge unchanged. Injecting the
+// default unconditionally would silently override a JSON baseline's
+// explicit longer timeout — exactly the kind of authoring trap the
+// new RunConfig surface is meant to close.
+func TestBuildMergedConfig_PreservesExplicitTimeout(t *testing.T) {
+	explicit := 900
+	baseline := &types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		MaxTurns: 10,
+		Timeout:  &explicit,
+	}
+	merged, err := buildMergedConfig(baseline, nil)
+	if err != nil {
+		t.Fatalf("buildMergedConfig: %v", err)
+	}
+	if merged.Timeout == nil || *merged.Timeout != 900 {
+		t.Errorf("Timeout = %v, want pointer to 900 (baseline value preserved)", merged.Timeout)
+	}
+}
+
+// TestDryRun_InlineConfigWithoutTimeoutPasses guards against the false-
+// failure regression: a suite with an inline run_config block that
+// does not set `timeout` must still pass dry-run validation. Before
+// the timeout-injection fix, ValidateRunConfig would reject every such
+// suite with "timeout is required" — the most common authoring shape
+// failing dry-run.
+func TestDryRun_InlineConfigWithoutTimeoutPasses(t *testing.T) {
+	baseline := &types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		MaxTurns: 10,
+	}
+	suite := types.EvalSuite{
+		ID:        "inline-no-timeout",
+		Tasks:     []types.EvalTask{{ID: "t1", Prompt: "p"}},
+		RunConfig: baseline,
+	}
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(result.Tasks))
+	}
+	if result.Tasks[0].Outcome != "pass" {
+		t.Errorf("outcome = %q (error %q), want pass — inline configs without timeout should pass dry-run after injection",
+			result.Tasks[0].Outcome, result.Tasks[0].Error)
+	}
+}
+
 // TestDryRun_NoBaselineIsNoOp pins the backwards-compat contract: a
 // suite with no run_config block must still dry-run as "pass" for every
 // task, exactly as it did before this chunk.

--- a/eval/runner/merge_test.go
+++ b/eval/runner/merge_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1153,4 +1154,86 @@ fi
 	if !strings.Contains(body, "secret://[REDACTED]") {
 		t.Errorf("redacted artifact missing redaction marker; data: %q", body)
 	}
+}
+
+// TestWarnIfRawAPIKeyRef pins the defense-in-depth warning: if a raw
+// api_key_ref ever reaches the retain-artifact path (meaning both the
+// parse-time and validate-time gates were bypassed), the warning must
+// fire for every secret-bearing field on the merged config so an
+// operator inspecting the artifact tree sees the bypass. Without this
+// signal, Redact() would quietly rewrite the raw value to the
+// sentinel and the misconfiguration would be invisible.
+func TestWarnIfRawAPIKeyRef(t *testing.T) {
+	cfg := &types.RunConfig{
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "sk-ant-raw"},
+		Executor: types.ExecutorConfig{
+			VcsBackend: &types.VcsBackendConfig{Type: "github", APIKeyRef: "ghp_rawvalue"},
+		},
+		Providers: map[string]types.ProviderConfig{
+			"backup": {Type: "openai", APIKeyRef: "sk-openai-raw"},
+		},
+		Tools: types.ToolsConfig{
+			MCPServers: []types.MCPServerConfig{
+				{Name: "test", URI: "stdio:///test", APIKeyRef: "raw-mcp-key"},
+			},
+		},
+	}
+
+	stderr := captureStderr(t, func() { warnIfRawAPIKeyRef("t1", cfg) })
+
+	for _, want := range []string{
+		"provider.apiKeyRef",
+		"executor.vcsBackend.apiKeyRef",
+		"providers[backup].apiKeyRef",
+		"tools.mcpServers[0].apiKeyRef",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr %q does not warn about %s", stderr, want)
+		}
+	}
+}
+
+// TestWarnIfRawAPIKeyRef_AllSecretRefsStaysSilent confirms the warning
+// only fires for raw values. A merged config where every apiKeyRef
+// uses the secret:// scheme must produce no stderr output — the warn
+// path is a regression alarm, not a chatty diagnostic.
+func TestWarnIfRawAPIKeyRef_AllSecretRefsStaysSilent(t *testing.T) {
+	cfg := &types.RunConfig{
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_KEY"},
+		Executor: types.ExecutorConfig{
+			VcsBackend: &types.VcsBackendConfig{Type: "github", APIKeyRef: "secret://GITHUB_TOKEN"},
+		},
+	}
+	stderr := captureStderr(t, func() { warnIfRawAPIKeyRef("t1", cfg) })
+	if stderr != "" {
+		t.Errorf("expected no warnings for all-secret refs; got %q", stderr)
+	}
+}
+
+// captureStderr replaces os.Stderr with a pipe for the duration of fn
+// and returns whatever fn wrote. Closes over the pipe so each invocation
+// is self-contained — concurrent tests must not run this helper in
+// parallel since os.Stderr is process-global.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = origStderr
+	<-done
+	_ = r.Close()
+	return buf.String()
 }

--- a/eval/runner/merge_test.go
+++ b/eval/runner/merge_test.go
@@ -1,12 +1,15 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/types"
@@ -211,7 +214,10 @@ func TestResolveBaseline_FileErrors(t *testing.T) {
 				}
 				return p
 			},
-			want: "is a directory",
+			// After the open-then-fstat rewrite, the directory case
+			// surfaces via the "not a regular file" guard, which is
+			// the same path that catches FIFOs and device files.
+			want: "not a regular file",
 		},
 		{
 			name: "empty file",
@@ -235,6 +241,22 @@ func TestResolveBaseline_FileErrors(t *testing.T) {
 			},
 			want: "parsing run_config_file",
 		},
+		{
+			// Guards against a regression where a future change could
+			// drop the size cap. The file is one byte over the cap.
+			name: "oversize",
+			setup: func(t *testing.T) string {
+				p := filepath.Join(dir, "oversize.json")
+				// JSON parseability is irrelevant: the size guard fires
+				// before json.Decode runs.
+				big := bytes.Repeat([]byte("x"), int(maxRunConfigFileBytes)+1)
+				if err := os.WriteFile(p, big, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return p
+			},
+			want: "exceeds",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -248,6 +270,188 @@ func TestResolveBaseline_FileErrors(t *testing.T) {
 				t.Errorf("error = %q, want substring %q", err.Error(), tc.want)
 			}
 		})
+	}
+}
+
+// TestResolveBaseline_RejectsFIFO is the regression guard for the
+// worker-pool DoS vector: a named pipe at run_config_file would block
+// os.ReadFile indefinitely under the old two-syscall Stat+ReadFile
+// shape, deadlocking every worker that hit the path. The
+// IsRegular() check in loadRunConfigFile rejects it before the read
+// blocks.
+//
+// FIFOs are a POSIX construct; the test skips on non-unix platforms
+// (Windows has no equivalent in syscall.Mkfifo).
+func TestResolveBaseline_RejectsFIFO(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs unsupported on Windows")
+	}
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "evil-fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported on this platform: %v", err)
+	}
+
+	suite := types.EvalSuite{ID: "s", Tasks: []types.EvalTask{{ID: "t1"}}, RunConfigFile: fifo}
+	_, err := resolveBaseline(suite)
+	if err == nil {
+		t.Fatal("expected error opening a FIFO, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "not a regular file")
+	}
+}
+
+// TestResolveBaseline_RejectsBothFileAndInlineBlock pins the
+// mutual-exclusion guard for Go callers. The HCL parser already
+// rejects suites that set both fields, but integration tests and
+// the experiment runner construct EvalSuite directly. The runner
+// must surface a clear error rather than silently preferring the
+// file and discarding the inline block.
+func TestResolveBaseline_RejectsBothFileAndInlineBlock(t *testing.T) {
+	suite := types.EvalSuite{
+		ID:            "dual",
+		Tasks:         []types.EvalTask{{ID: "t1"}},
+		RunConfigFile: "/tmp/whatever.json",
+		RunConfig:     baselineRunConfig(),
+	}
+	_, err := resolveBaseline(suite)
+	if err == nil {
+		t.Fatal("expected error when both run_config_file and run_config are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "mutually exclusive")
+	}
+	if !strings.Contains(err.Error(), "dual") {
+		t.Errorf("error = %q, want it to name the suite ID", err.Error())
+	}
+}
+
+// TestMergeOverrides_AllOverlayFields fans the merge contract over
+// every pointer-typed overlay field. Without this, a regression that
+// drops one of ModelRouter / ContextStrategy / EditStrategy / Verifier
+// / MaxTurns from mergeOverrides would not be caught by the existing
+// "Mode + Provider" coverage.
+func TestMergeOverrides_AllOverlayFields(t *testing.T) {
+	t.Run("ModelRouter", func(t *testing.T) {
+		baseline := baselineRunConfig()
+		overlay := &types.RunConfigOverrides{
+			ModelRouter: &types.ModelRouterConfig{Type: "static", Model: "claude-haiku-4-5"},
+		}
+		got := mergeOverrides(baseline, overlay)
+		if got.ModelRouter.Type != "static" || got.ModelRouter.Model != "claude-haiku-4-5" {
+			t.Errorf("ModelRouter = %#v, want {Type:static Model:claude-haiku-4-5}", got.ModelRouter)
+		}
+	})
+
+	t.Run("ContextStrategy", func(t *testing.T) {
+		baseline := baselineRunConfig()
+		overlay := &types.RunConfigOverrides{
+			ContextStrategy: &types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 12000},
+		}
+		got := mergeOverrides(baseline, overlay)
+		if got.ContextStrategy.Type != "sliding-window" || got.ContextStrategy.MaxTokens != 12000 {
+			t.Errorf("ContextStrategy = %#v, want {Type:sliding-window MaxTokens:12000}", got.ContextStrategy)
+		}
+	})
+
+	t.Run("EditStrategy", func(t *testing.T) {
+		baseline := baselineRunConfig()
+		threshold := 0.7
+		overlay := &types.RunConfigOverrides{
+			EditStrategy: &types.EditStrategyConfig{Type: "multi", FuzzyThreshold: &threshold},
+		}
+		got := mergeOverrides(baseline, overlay)
+		if got.EditStrategy.Type != "multi" {
+			t.Errorf("EditStrategy.Type = %q, want multi", got.EditStrategy.Type)
+		}
+		if got.EditStrategy.FuzzyThreshold == nil || *got.EditStrategy.FuzzyThreshold != 0.7 {
+			t.Errorf("EditStrategy.FuzzyThreshold = %v, want pointer to 0.7", got.EditStrategy.FuzzyThreshold)
+		}
+	})
+
+	t.Run("Verifier", func(t *testing.T) {
+		baseline := baselineRunConfig()
+		overlay := &types.RunConfigOverrides{
+			Verifier: &types.VerifierConfig{Type: "test-runner", Command: "go test ./..."},
+		}
+		got := mergeOverrides(baseline, overlay)
+		if got.Verifier.Type != "test-runner" || got.Verifier.Command != "go test ./..." {
+			t.Errorf("Verifier = %#v, want {Type:test-runner Command:go test ./...}", got.Verifier)
+		}
+	})
+
+	t.Run("MaxTurns", func(t *testing.T) {
+		baseline := baselineRunConfig()
+		six := 6
+		overlay := &types.RunConfigOverrides{MaxTurns: &six}
+		got := mergeOverrides(baseline, overlay)
+		if got.MaxTurns != 6 {
+			t.Errorf("MaxTurns = %d, want 6", got.MaxTurns)
+		}
+	})
+}
+
+// TestMergeOverrides_ZeroModeDoesNotOverwrite confirms the Mode
+// sentinel contract: the empty string on the overlay means "unset"
+// and must not clobber a baseline that already carries a concrete
+// mode. Without this, an overlay constructed with only pointer-typed
+// fields would zero the baseline's Mode.
+func TestMergeOverrides_ZeroModeDoesNotOverwrite(t *testing.T) {
+	baseline := baselineRunConfig() // Mode = "execution"
+	four := 4
+	overlay := &types.RunConfigOverrides{MaxTurns: &four}
+
+	got := mergeOverrides(baseline, overlay)
+	if got.Mode != "execution" {
+		t.Errorf("Mode = %q, want execution (unchanged by zero-value overlay)", got.Mode)
+	}
+}
+
+// TestBuildMergedConfig_FileBaselineWithTaskOverride covers the
+// combined path: the suite carries a file-based baseline AND the
+// task carries a sparse overlay. The merged config must reflect
+// both — the baseline's provider/timeout and the overlay's
+// MaxTurns. Without this, the file path could drift apart from the
+// inline path silently.
+func TestBuildMergedConfig_FileBaselineWithTaskOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.json")
+	data, err := json.Marshal(baselineRunConfig())
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+
+	suite := types.EvalSuite{
+		ID:            "s",
+		Tasks:         []types.EvalTask{{ID: "t1"}},
+		RunConfigFile: path,
+	}
+	baseline, err := resolveBaseline(suite)
+	if err != nil {
+		t.Fatalf("resolveBaseline: %v", err)
+	}
+
+	six := 6
+	overlay := &types.RunConfigOverrides{
+		MaxTurns: &six,
+		Provider: &types.ProviderConfig{Type: "openai-responses", APIKeyRef: "secret://OPENAI_KEY"},
+	}
+	merged, err := buildMergedConfig(baseline, overlay)
+	if err != nil {
+		t.Fatalf("buildMergedConfig: %v", err)
+	}
+	if merged.MaxTurns != 6 {
+		t.Errorf("MaxTurns = %d, want 6 (overlay)", merged.MaxTurns)
+	}
+	if merged.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q, want openai-responses (overlay)", merged.Provider.Type)
+	}
+	if merged.Timeout == nil || *merged.Timeout != 300 {
+		t.Errorf("Timeout = %v, want pointer to 300 (baseline)", merged.Timeout)
 	}
 }
 

--- a/eval/runner/merge_test.go
+++ b/eval/runner/merge_test.go
@@ -1,0 +1,579 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// baselineRunConfig builds a valid RunConfig that satisfies
+// types.ValidateRunConfig (execution mode, anthropic provider, max_turns
+// + timeout set). Tests that exercise merge / redaction / dry-run start
+// from this so they only have to vary the fields under test.
+func baselineRunConfig() *types.RunConfig {
+	timeout := 300
+	return &types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		MaxTurns: 10,
+		Timeout:  &timeout,
+	}
+}
+
+// TestMergeOverrides_NoOverlay confirms a nil overlay leaves the baseline
+// untouched. mergeOverrides has to be safe to call with no per-task
+// overrides — that is the suite-baseline-only path.
+func TestMergeOverrides_NoOverlay(t *testing.T) {
+	baseline := baselineRunConfig()
+	got := mergeOverrides(baseline, nil)
+	if got == nil {
+		t.Fatal("expected non-nil merged config")
+	}
+	if got.MaxTurns != 10 || got.Mode != "execution" {
+		t.Errorf("baseline mutated unexpectedly: %+v", got)
+	}
+}
+
+// TestMergeOverrides_SparseField asserts a sparse overlay only changes
+// the named field; every other baseline field passes through unchanged.
+// This is the core "sparse overlay" contract for per-task overrides.
+func TestMergeOverrides_SparseField(t *testing.T) {
+	baseline := baselineRunConfig()
+	four := 4
+	overlay := &types.RunConfigOverrides{MaxTurns: &four}
+
+	got := mergeOverrides(baseline, overlay)
+	if got.MaxTurns != 4 {
+		t.Errorf("MaxTurns = %d, want 4", got.MaxTurns)
+	}
+	if got.Mode != "execution" {
+		t.Errorf("Mode = %q, want %q (unchanged)", got.Mode, "execution")
+	}
+	if got.Provider.Type != "anthropic" {
+		t.Errorf("Provider.Type = %q, want %q (unchanged)", got.Provider.Type, "anthropic")
+	}
+}
+
+// TestMergeOverrides_MultipleFields covers the case where an overlay
+// touches a pointer field (Provider) and a scalar field (Mode) at the
+// same time. Both should land; pointer copies are deref'd so the merged
+// config does not alias overlay-owned memory.
+func TestMergeOverrides_MultipleFields(t *testing.T) {
+	baseline := baselineRunConfig()
+	overlay := &types.RunConfigOverrides{
+		Mode:     "planning",
+		Provider: &types.ProviderConfig{Type: "openai-responses", APIKeyRef: "secret://OPENAI_KEY"},
+	}
+
+	got := mergeOverrides(baseline, overlay)
+	if got.Mode != "planning" {
+		t.Errorf("Mode = %q, want %q", got.Mode, "planning")
+	}
+	if got.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q, want %q", got.Provider.Type, "openai-responses")
+	}
+	// Pointer dereference, not alias: mutating the overlay's Provider
+	// must not be observable on the merged result.
+	overlay.Provider.Type = "mutated"
+	if got.Provider.Type == "mutated" {
+		t.Error("merged Provider aliases overlay-owned memory; expected dereference")
+	}
+}
+
+// TestMergeOverrides_NilBaseline asserts the explicit nil-baseline guard.
+// A merge with no baseline is a programming bug (the caller should never
+// produce overrides without a base), and the helper returns nil rather
+// than fabricating a half-formed config.
+func TestMergeOverrides_NilBaseline(t *testing.T) {
+	four := 4
+	got := mergeOverrides(nil, &types.RunConfigOverrides{MaxTurns: &four})
+	if got != nil {
+		t.Errorf("nil baseline must return nil, got %+v", got)
+	}
+}
+
+// TestBuildMergedConfig_FromInlineBaseline exercises the suite-inline
+// baseline path end-to-end: clone the baseline, apply overrides, return
+// a fresh allocation. Mutating the result must not be observable on the
+// suite's original RunConfig pointer.
+func TestBuildMergedConfig_FromInlineBaseline(t *testing.T) {
+	suite := types.EvalSuite{
+		ID:        "s",
+		Tasks:     []types.EvalTask{{ID: "t1"}},
+		RunConfig: baselineRunConfig(),
+	}
+	baseline, err := resolveBaseline(suite)
+	if err != nil {
+		t.Fatalf("resolveBaseline: %v", err)
+	}
+	if baseline == nil {
+		t.Fatal("expected non-nil baseline for inline run_config")
+	}
+
+	four := 4
+	merged, err := buildMergedConfig(baseline, &types.RunConfigOverrides{MaxTurns: &four})
+	if err != nil {
+		t.Fatalf("buildMergedConfig: %v", err)
+	}
+	if merged.MaxTurns != 4 {
+		t.Errorf("merged MaxTurns = %d, want 4", merged.MaxTurns)
+	}
+	// Mutating the merged result must not touch the suite spec pointer.
+	merged.MaxTurns = 99
+	if suite.RunConfig.MaxTurns == 99 {
+		t.Error("merged config aliases suite.RunConfig — clone must be a deep copy")
+	}
+}
+
+// TestBuildMergedConfig_FromFileBaseline asserts the run_config_file
+// path reads the JSON, decodes a RunConfig, and applies overrides
+// identically to the inline path.
+func TestBuildMergedConfig_FromFileBaseline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.json")
+	data, err := json.Marshal(baselineRunConfig())
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+
+	suite := types.EvalSuite{
+		ID:            "s",
+		Tasks:         []types.EvalTask{{ID: "t1"}},
+		RunConfigFile: path,
+	}
+	baseline, err := resolveBaseline(suite)
+	if err != nil {
+		t.Fatalf("resolveBaseline: %v", err)
+	}
+	if baseline == nil {
+		t.Fatal("expected non-nil baseline for run_config_file")
+	}
+	if baseline.Provider.Type != "anthropic" {
+		t.Errorf("Provider.Type = %q, want %q", baseline.Provider.Type, "anthropic")
+	}
+
+	four := 4
+	merged, err := buildMergedConfig(baseline, &types.RunConfigOverrides{MaxTurns: &four})
+	if err != nil {
+		t.Fatalf("buildMergedConfig: %v", err)
+	}
+	if merged.MaxTurns != 4 {
+		t.Errorf("merged MaxTurns = %d, want 4", merged.MaxTurns)
+	}
+}
+
+// TestResolveBaseline_None pins the legacy path: a suite with neither a
+// file nor an inline block returns (nil, nil) so the runner skips the
+// --config wire entirely.
+func TestResolveBaseline_None(t *testing.T) {
+	suite := types.EvalSuite{ID: "s", Tasks: []types.EvalTask{{ID: "t1"}}}
+	baseline, err := resolveBaseline(suite)
+	if err != nil {
+		t.Fatalf("resolveBaseline: %v", err)
+	}
+	if baseline != nil {
+		t.Errorf("expected nil baseline for legacy suite, got %+v", baseline)
+	}
+}
+
+// TestResolveBaseline_FileErrors covers the failure modes of the file
+// loader: missing path, directory, oversized payload, empty file,
+// unknown JSON fields. Each must surface a non-nil error rather than
+// silently producing a partial baseline.
+func TestResolveBaseline_FileErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name  string
+		setup func(t *testing.T) string
+		want  string
+	}{
+		{
+			name:  "missing file",
+			setup: func(*testing.T) string { return filepath.Join(dir, "nope.json") },
+			want:  "reading run_config_file",
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T) string {
+				p := filepath.Join(dir, "dir")
+				if err := os.Mkdir(p, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return p
+			},
+			want: "is a directory",
+		},
+		{
+			name: "empty file",
+			setup: func(t *testing.T) string {
+				p := filepath.Join(dir, "empty.json")
+				if err := os.WriteFile(p, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return p
+			},
+			want: "file is empty",
+		},
+		{
+			name: "unknown field",
+			setup: func(t *testing.T) string {
+				p := filepath.Join(dir, "bad.json")
+				if err := os.WriteFile(p, []byte(`{"thisFieldDoesNotExist":true}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return p
+			},
+			want: "parsing run_config_file",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := tc.setup(t)
+			suite := types.EvalSuite{ID: "s", Tasks: []types.EvalTask{{ID: "t1"}}, RunConfigFile: path}
+			_, err := resolveBaseline(suite)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestDryRun_NoBaselineIsNoOp pins the backwards-compat contract: a
+// suite with no run_config block must still dry-run as "pass" for every
+// task, exactly as it did before this chunk.
+func TestDryRun_NoBaselineIsNoOp(t *testing.T) {
+	suite := types.EvalSuite{
+		ID: "legacy-suite",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p"},
+			{ID: "t2", Prompt: "p"},
+		},
+	}
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2", len(result.Tasks))
+	}
+	for _, tr := range result.Tasks {
+		if tr.Outcome != "pass" {
+			t.Errorf("task %s: outcome = %q, want pass", tr.TaskID, tr.Outcome)
+		}
+	}
+	if result.PassRate != 1.0 {
+		t.Errorf("PassRate = %f, want 1.0", result.PassRate)
+	}
+}
+
+// TestDryRun_InvalidMergedConfig surfaces a ValidateRunConfig failure as
+// a per-task "error" outcome without aborting siblings. The invalid
+// shape is the canonical read-only-mode invariant called out in
+// CLAUDE.md: planning mode plus a write tool in tools.builtIn.
+func TestDryRun_InvalidMergedConfig(t *testing.T) {
+	timeout := 300
+	bad := &types.RunConfig{
+		Mode:             "planning",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		MaxTurns:         10,
+		Timeout:          &timeout,
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"read_file", "write_file"}},
+	}
+	suite := types.EvalSuite{
+		ID:        "ro-suite",
+		Tasks:     []types.EvalTask{{ID: "bad", Prompt: "p"}, {ID: "ok", Prompt: "p"}},
+		RunConfig: bad,
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2", len(result.Tasks))
+	}
+	// Every task in this suite inherits the same broken baseline, so
+	// every task should surface the same validation error rather than
+	// pass. The point of this test is to confirm the per-task wiring is
+	// in place — sibling-isolation is exercised by the per-task overlay
+	// test below.
+	for _, tr := range result.Tasks {
+		if tr.Outcome != "error" {
+			t.Errorf("task %s: outcome = %q, want error", tr.TaskID, tr.Outcome)
+		}
+		if !strings.Contains(tr.Error, "write tool") {
+			t.Errorf("task %s: error = %q, want substring about write tool", tr.TaskID, tr.Error)
+		}
+	}
+}
+
+// TestDryRun_PerTaskOverrideInvalidatesOnlyThatTask asserts the
+// sibling-isolation property: when only one task's overlay produces an
+// invalid merged config, the other tasks still pass.
+func TestDryRun_PerTaskOverrideInvalidatesOnlyThatTask(t *testing.T) {
+	timeout := 300
+	baseline := &types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		MaxTurns: 10,
+		Timeout:  &timeout,
+	}
+	// An override that flips the mode to planning without supplying a
+	// compatible tools.builtIn list triggers the "read-only mode requires
+	// an explicit tools.builtIn list" rule. The other task uses no
+	// override so the baseline stays valid.
+	suite := types.EvalSuite{
+		ID:        "mixed-suite",
+		RunConfig: baseline,
+		Tasks: []types.EvalTask{
+			{ID: "ok-task", Prompt: "p"},
+			{ID: "bad-task", Prompt: "p", RunConfigOverrides: &types.RunConfigOverrides{Mode: "planning"}},
+		},
+	}
+
+	result, err := RunSuite(context.Background(), suite, RunConfig{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2", len(result.Tasks))
+	}
+	got := map[string]string{
+		result.Tasks[0].TaskID: result.Tasks[0].Outcome,
+		result.Tasks[1].TaskID: result.Tasks[1].Outcome,
+	}
+	if got["ok-task"] != "pass" {
+		t.Errorf("ok-task outcome = %q, want pass", got["ok-task"])
+	}
+	if got["bad-task"] != "error" {
+		t.Errorf("bad-task outcome = %q, want error", got["bad-task"])
+	}
+}
+
+// TestRunSuite_NoBaselineUsesLegacyInvocation verifies the
+// backwards-compat invariant from the issue: a suite with no
+// run_config_file / run_config block must invoke the harness with the
+// legacy five flags only — no --config wire, no redacted artifact.
+//
+// The fake harness writes its argv to a sidecar file so the test can
+// inspect what the runner actually passed; the assertion is that
+// "--config" is not among the args.
+func TestRunSuite_NoBaselineUsesLegacyInvocation(t *testing.T) {
+	logDir := t.TempDir()
+	argLog := filepath.Join(logDir, "args.log")
+	script := fmt.Sprintf(`#!/bin/sh
+TRACE=""
+echo "$@" >> %q
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`, argLog)
+	harness := writeFakeHarness(t, script)
+
+	suite := types.EvalSuite{
+		ID: "legacy",
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	out := t.TempDir()
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		OutputDir:   out,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logData, err := os.ReadFile(argLog)
+	if err != nil {
+		t.Fatalf("reading arg log: %v", err)
+	}
+	if strings.Contains(string(logData), "--config") {
+		t.Errorf("legacy invocation must not pass --config; got args: %q", string(logData))
+	}
+
+	// No baseline → no redacted artifact retained.
+	redactedPath := filepath.Join(out, "legacy", "t1", "run_config.redacted.json")
+	if _, err := os.Stat(redactedPath); !os.IsNotExist(err) {
+		t.Errorf("legacy invocation must not write %s; stat err = %v", redactedPath, err)
+	}
+}
+
+// TestRunSuite_WithBaselineWritesConfigAndRedactedArtifact covers the
+// new invocation path: when the suite declares a baseline, the runner
+// must (a) invoke the harness with --config <path>, (b) write the
+// merged config to that path, and (c) retain a run_config.redacted.json
+// alongside the trace artifacts. The redacted artifact must contain the
+// secret:// reference unchanged — the reference is not a resolved
+// value, so Redact() does not rewrite plain secret:// references on
+// fields like Provider.APIKeyRef (which it does redact to
+// "secret://[REDACTED]" — the test checks for the redaction marker).
+func TestRunSuite_WithBaselineWritesConfigAndRedactedArtifact(t *testing.T) {
+	logDir := t.TempDir()
+	argLog := filepath.Join(logDir, "args.log")
+	configCapture := filepath.Join(logDir, "config-capture.json")
+	script := fmt.Sprintf(`#!/bin/sh
+TRACE=""
+CONFIG=""
+echo "$@" >> %q
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace)  TRACE="$2";  shift 2 ;;
+    --config) CONFIG="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$CONFIG" ] && cp "$CONFIG" %q
+[ -n "$TRACE" ]  && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`, argLog, configCapture)
+	harness := writeFakeHarness(t, script)
+
+	timeout := 300
+	baseline := &types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "openai-responses", APIKeyRef: "secret://OPENAI_KEY"},
+		MaxTurns: 10,
+		Timeout:  &timeout,
+	}
+	suite := types.EvalSuite{
+		ID:        "wired",
+		RunConfig: baseline,
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	out := t.TempDir()
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		OutputDir:   out,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// (a) --config was passed.
+	logData, err := os.ReadFile(argLog)
+	if err != nil {
+		t.Fatalf("reading arg log: %v", err)
+	}
+	if !strings.Contains(string(logData), "--config") {
+		t.Errorf("expected --config in harness args; got %q", string(logData))
+	}
+
+	// (b) Captured config decodes back to the same RunConfig shape.
+	captured, err := os.ReadFile(configCapture)
+	if err != nil {
+		t.Fatalf("reading captured config: %v", err)
+	}
+	var got types.RunConfig
+	if err := json.Unmarshal(captured, &got); err != nil {
+		t.Fatalf("unmarshal captured config: %v", err)
+	}
+	if got.Provider.Type != "openai-responses" {
+		t.Errorf("captured config Provider.Type = %q, want %q", got.Provider.Type, "openai-responses")
+	}
+	if got.Provider.APIKeyRef != "secret://OPENAI_KEY" {
+		t.Errorf("captured config APIKeyRef = %q, want %q (must be the unredacted reference — the harness needs it to resolve)", got.Provider.APIKeyRef, "secret://OPENAI_KEY")
+	}
+
+	// (c) Redacted artifact exists and has the reference scrubbed.
+	redactedPath := filepath.Join(out, "wired", "t1", "run_config.redacted.json")
+	redactedData, err := os.ReadFile(redactedPath)
+	if err != nil {
+		t.Fatalf("reading redacted artifact: %v", err)
+	}
+	var redacted types.RunConfig
+	if err := json.Unmarshal(redactedData, &redacted); err != nil {
+		t.Fatalf("unmarshal redacted artifact: %v", err)
+	}
+	if redacted.Provider.APIKeyRef != "secret://[REDACTED]" {
+		t.Errorf("redacted artifact APIKeyRef = %q, want %q", redacted.Provider.APIKeyRef, "secret://[REDACTED]")
+	}
+	// The redacted artifact must never carry a resolved secret. It is
+	// only a reference, so the on-disk JSON must contain only the
+	// redaction marker — never a plaintext token.
+	if !strings.Contains(string(redactedData), "secret://[REDACTED]") {
+		t.Errorf("redacted artifact missing redaction marker; data: %q", string(redactedData))
+	}
+}
+
+// TestRunSuite_WithBaselineRetainedArtifactOmitsResolvedSecrets is the
+// belt-and-braces guard for the invariant in CLAUDE.md: the retained
+// run_config.redacted.json must never contain a resolved secret, only
+// references. Today Redact() handles every secret-bearing field on
+// RunConfig; if a future field is added without an accompanying Redact
+// path, this test should catch it via a substring check for plausible
+// secret-shaped values that should not appear in a redacted file.
+func TestRunSuite_WithBaselineRetainedArtifactOmitsResolvedSecrets(t *testing.T) {
+	script := `#!/bin/sh
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$TRACE" ] && echo '{"id":"t","turns":1,"outcome":"success"}' > "$TRACE"
+`
+	harness := writeFakeHarness(t, script)
+
+	timeout := 300
+	baseline := &types.RunConfig{
+		Mode:     "execution",
+		Provider: types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		MaxTurns: 10,
+		Timeout:  &timeout,
+	}
+	suite := types.EvalSuite{
+		ID:        "redact-suite",
+		RunConfig: baseline,
+		Tasks: []types.EvalTask{
+			{ID: "t1", Prompt: "p", Judge: types.EvalJudge{Type: "file-exists", Paths: []string{"placeholder"}}},
+		},
+	}
+
+	out := t.TempDir()
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harness,
+		OutputDir:   out,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	redactedPath := filepath.Join(out, "redact-suite", "t1", "run_config.redacted.json")
+	data, err := os.ReadFile(redactedPath)
+	if err != nil {
+		t.Fatalf("reading redacted artifact: %v", err)
+	}
+	// The reference must be redacted; the bare secret:// scheme outside
+	// a [REDACTED] context is the failure mode to guard against.
+	body := string(data)
+	if strings.Contains(body, "secret://ANTHROPIC_API_KEY") {
+		t.Errorf("redacted artifact still contains the original secret reference; data: %q", body)
+	}
+	if !strings.Contains(body, "secret://[REDACTED]") {
+		t.Errorf("redacted artifact missing redaction marker; data: %q", body)
+	}
+}

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -570,7 +570,17 @@ func writeMergedConfig(path string, cfg *types.RunConfig) error {
 // disk so a retained artifact never carries a resolved secret out of the
 // process. Retention errors are reported on stderr to match retainArtifacts
 // but never mask the TaskResult.
+//
+// A stderr warning fires for any apiKeyRef that does not use the
+// secret:// scheme. The invariant is already enforced at HCL parse time
+// (eval/spec.validateInlineAPIKeyRefs) and again by
+// types.ValidateRunConfig before the harness is spawned, but the warning
+// here is the third defensive layer: if a regression ever lets a raw
+// value through both prior gates, Redact() will quietly rewrite it to
+// the sentinel — masking the misconfiguration from anyone inspecting the
+// artifact tree. The warning makes the bypass visible.
 func retainRedactedConfig(suiteArtifactDir, taskID string, cfg *types.RunConfig) {
+	warnIfRawAPIKeyRef(taskID, cfg)
 	redacted := cfg.Redact()
 	data, err := json.MarshalIndent(redacted, "", "  ")
 	if err != nil {
@@ -589,6 +599,44 @@ func retainRedactedConfig(suiteArtifactDir, taskID string, cfg *types.RunConfig)
 	// 0o600 narrows that exposure.
 	if err := os.WriteFile(filepath.Join(taskDir, "run_config.redacted.json"), data, 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: redacted config write: %v\n", taskID, err)
+	}
+}
+
+// warnIfRawAPIKeyRef emits a stderr warning for any apiKeyRef field in
+// the merged config that does not use the secret:// scheme. The
+// invariant is enforced at HCL parse time and again by
+// types.ValidateRunConfig before the harness is spawned, so reaching
+// this code with a raw value means both prior gates were bypassed —
+// likely a regression in either layer. Without this warning, Redact()
+// would silently rewrite the raw value to "[REDACTED]" in the audit
+// artifact and an operator inspecting the artifact tree would have no
+// signal that the configuration was rejected for that reason.
+//
+// The field list here must stay in lockstep with the redactor in
+// types.RunConfig.Redact() and with eval/spec.validateInlineAPIKeyRefs.
+// A new secret-bearing field added to RunConfig without extending this
+// helper would create a defense-in-depth hole.
+func warnIfRawAPIKeyRef(taskID string, cfg *types.RunConfig) {
+	if cfg == nil {
+		return
+	}
+	check := func(path, ref string) {
+		if ref == "" || strings.HasPrefix(ref, "secret://") {
+			return
+		}
+		fmt.Fprintf(os.Stderr,
+			"eval: task %q: %s is a raw value (not a secret:// reference); it should have been rejected at parse/validate time — redacting in artifact but the harness will refuse this configuration\n",
+			taskID, path)
+	}
+	check("provider.apiKeyRef", cfg.Provider.APIKeyRef)
+	for name, p := range cfg.Providers {
+		check(fmt.Sprintf("providers[%s].apiKeyRef", name), p.APIKeyRef)
+	}
+	if cfg.Executor.VcsBackend != nil {
+		check("executor.vcsBackend.apiKeyRef", cfg.Executor.VcsBackend.APIKeyRef)
+	}
+	for i, server := range cfg.Tools.MCPServers {
+		check(fmt.Sprintf("tools.mcpServers[%d].apiKeyRef", i), server.APIKeyRef)
 	}
 }
 

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -70,17 +70,28 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 	runID := fmt.Sprintf("eval-%d", time.Now().UnixMilli())
 	startedAt := time.Now()
 
+	// Load the suite-level RunConfig baseline once; per-task overlays are
+	// applied against a fresh clone inside runTask / dry-run validation.
+	// A nil baseline preserves the legacy five-flag invocation path.
+	baseline, baselineErr := resolveBaseline(suite)
+	if baselineErr != nil {
+		return eval.SuiteResult{}, baselineErr
+	}
+
 	if cfg.DryRun {
 		tasks := make([]eval.TaskResult, len(suite.Tasks))
 		for i, t := range suite.Tasks {
-			tasks[i] = eval.TaskResult{
-				TaskID:  t.ID,
-				Outcome: "pass",
-				JudgeVerdict: eval.JudgeVerdict{
-					Passed: true,
-					Reason: "dry run — skipped",
-				},
+			tasks[i] = dryRunTask(t, baseline)
+		}
+		passCount := 0
+		for _, tr := range tasks {
+			if tr.Outcome == "pass" {
+				passCount++
 			}
+		}
+		passRate := float64(0)
+		if len(tasks) > 0 {
+			passRate = float64(passCount) / float64(len(tasks))
 		}
 		return eval.SuiteResult{
 			SuiteID:     suite.ID,
@@ -88,11 +99,11 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 			StartedAt:   startedAt,
 			CompletedAt: time.Now(),
 			Tasks:       tasks,
-			PassRate:    1.0,
+			PassRate:    passRate,
 		}, nil
 	}
 
-	results := runTasksConcurrently(ctx, suite.Tasks, cfg, suiteArtifactDir)
+	results := runTasksConcurrently(ctx, suite.Tasks, cfg, suiteArtifactDir, baseline)
 
 	passCount := 0
 	for _, tr := range results {
@@ -121,7 +132,7 @@ func RunSuite(ctx context.Context, suite types.EvalSuite, cfg RunConfig) (eval.S
 // len(tasks) so we never spawn idle workers; values <= 0 collapse to 1
 // (the historical sequential behaviour). Per-task errors do not abort
 // siblings — every task contributes a TaskResult.
-func runTasksConcurrently(ctx context.Context, tasks []types.EvalTask, cfg RunConfig, suiteArtifactDir string) []eval.TaskResult {
+func runTasksConcurrently(ctx context.Context, tasks []types.EvalTask, cfg RunConfig, suiteArtifactDir string, baseline *types.RunConfig) []eval.TaskResult {
 	concurrency := cfg.Concurrency
 	if concurrency <= 0 {
 		concurrency = 1
@@ -144,7 +155,7 @@ func runTasksConcurrently(ctx context.Context, tasks []types.EvalTask, cfg RunCo
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
-				results[j.idx] = runTask(ctx, j.task, cfg, suiteArtifactDir)
+				results[j.idx] = runTask(ctx, j.task, cfg, suiteArtifactDir, baseline)
 			}
 		}()
 	}
@@ -239,8 +250,11 @@ func validatePathSegment(label, id string) error {
 // runTask executes a single eval task and returns the result. If
 // suiteArtifactDir is non-empty, the task's trace and harness output streams
 // are copied into <suiteArtifactDir>/<taskID>/ before the temp workspace is
-// removed.
-func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtifactDir string) eval.TaskResult {
+// removed. When baseline is non-nil, the runner merges the task's
+// RunConfigOverrides on top, writes the result to a per-task temp file,
+// invokes the harness with --config, and retains a redacted copy under
+// <suiteArtifactDir>/<taskID>/run_config.redacted.json.
+func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtifactDir string, baseline *types.RunConfig) eval.TaskResult {
 	start := time.Now()
 
 	tmpDir, err := os.MkdirTemp("", "eval-task-"+task.ID+"-")
@@ -258,14 +272,34 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 
 	traceFile := filepath.Join(tmpDir, "trace.jsonl")
 
-	args := []string{
-		"harness",
+	// Merge baseline + per-task overrides into a fresh RunConfig and
+	// write it next to the workspace. A nil baseline (suite declared no
+	// run_config_file / run_config block) preserves the legacy
+	// five-flag invocation: no --config arg, no redacted artifact.
+	merged, mergeErr := buildMergedConfig(baseline, task.RunConfigOverrides)
+	if mergeErr != nil {
+		return errorResult(task.ID, start, mergeErr)
+	}
+
+	configPath := ""
+	if merged != nil {
+		configPath = filepath.Join(tmpDir, "runconfig.json")
+		if err := writeMergedConfig(configPath, merged); err != nil {
+			return errorResult(task.ID, start, err)
+		}
+	}
+
+	args := []string{"harness"}
+	if configPath != "" {
+		args = append(args, "--config", configPath)
+	}
+	args = append(args,
 		"--prompt", task.Prompt,
 		"--mode", taskMode(task),
 		"--workspace", workspaceDir,
 		"--trace", traceFile,
 		"--timeout", "300",
-	}
+	)
 
 	cmd := exec.CommandContext(ctx, cfg.HarnessPath, args...)
 	cmd.Dir = workspaceDir
@@ -281,6 +315,9 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 	// retention failures must not mask the harness/judge result.
 	if suiteArtifactDir != "" {
 		retainArtifacts(suiteArtifactDir, task.ID, traceFile, stdoutBuf.Bytes(), stderrBuf.Bytes())
+		if merged != nil {
+			retainRedactedConfig(suiteArtifactDir, task.ID, merged)
+		}
 	}
 
 	if cmdErr != nil {
@@ -410,6 +447,112 @@ func errorResult(taskID string, start time.Time, err error) eval.TaskResult {
 			Reason: err.Error(),
 		},
 		DurationMs: time.Since(start).Milliseconds(),
+	}
+}
+
+// buildMergedConfig produces a per-task RunConfig from the suite baseline
+// and per-task overlay. A nil baseline returns (nil, nil): the suite has
+// not opted into the RunConfig surface, so the legacy invocation path
+// stays in effect. The baseline argument is cloned before the overlay is
+// applied so callers can reuse it across tasks.
+func buildMergedConfig(baseline *types.RunConfig, overlay *types.RunConfigOverrides) (*types.RunConfig, error) {
+	if baseline == nil {
+		return nil, nil
+	}
+	// JSON round-trip clones every field, including pointer-typed
+	// sub-structs. Cheap enough for RunConfig-sized blobs and avoids
+	// hand-maintaining a deep copier that would silently miss new fields.
+	data, err := json.Marshal(baseline)
+	if err != nil {
+		return nil, fmt.Errorf("cloning suite baseline RunConfig: %w", err)
+	}
+	clone := &types.RunConfig{}
+	if err := json.Unmarshal(data, clone); err != nil {
+		return nil, fmt.Errorf("cloning suite baseline RunConfig: %w", err)
+	}
+	return mergeOverrides(clone, overlay), nil
+}
+
+// writeMergedConfig marshals the merged RunConfig to path. The file is
+// created inside the per-task tmpdir and is removed with the rest of the
+// workspace via the caller's defer os.RemoveAll. Permissions are 0o600 —
+// although secret values are not present (only secret:// references), the
+// file still carries the operator's chosen run posture and should not be
+// world-readable on shared CI runners.
+func writeMergedConfig(path string, cfg *types.RunConfig) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshalling merged RunConfig: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing merged RunConfig: %w", err)
+	}
+	return nil
+}
+
+// retainRedactedConfig writes the redacted form of the merged RunConfig
+// alongside the trace and harness output streams. Redact() rewrites every
+// secret:// reference to "secret://[REDACTED]" before the file lands on
+// disk so a retained artifact never carries a resolved secret out of the
+// process. Retention errors are reported on stderr to match retainArtifacts
+// but never mask the TaskResult.
+func retainRedactedConfig(suiteArtifactDir, taskID string, cfg *types.RunConfig) {
+	redacted := cfg.Redact()
+	data, err := json.MarshalIndent(redacted, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: redacted config marshal: %v\n", taskID, err)
+		return
+	}
+	taskDir := filepath.Join(suiteArtifactDir, taskID)
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: mkdir: %v\n", taskID, err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "run_config.redacted.json"), data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: redacted config write: %v\n", taskID, err)
+	}
+}
+
+// dryRunTask produces a TaskResult for a single task during a --dry-run
+// invocation. With a nil baseline the task behaves as it does today
+// (pass, "dry run — skipped"). With a baseline, the runner builds the
+// merged RunConfig and calls ValidateRunConfig; a validation failure
+// flips the outcome to "error" and surfaces the validator's message.
+// Other tasks in the same dry-run pass are unaffected (each task is
+// validated independently).
+func dryRunTask(task types.EvalTask, baseline *types.RunConfig) eval.TaskResult {
+	merged, err := buildMergedConfig(baseline, task.RunConfigOverrides)
+	if err != nil {
+		return eval.TaskResult{
+			TaskID:  task.ID,
+			Outcome: "error",
+			Error:   err.Error(),
+			JudgeVerdict: eval.JudgeVerdict{
+				Passed: false,
+				Reason: err.Error(),
+			},
+		}
+	}
+	if merged != nil {
+		if vErr := types.ValidateRunConfig(merged); vErr != nil {
+			return eval.TaskResult{
+				TaskID:  task.ID,
+				Outcome: "error",
+				Error:   vErr.Error(),
+				JudgeVerdict: eval.JudgeVerdict{
+					Passed: false,
+					Reason: vErr.Error(),
+				},
+			}
+		}
+	}
+	return eval.TaskResult{
+		TaskID:  task.ID,
+		Outcome: "pass",
+		JudgeVerdict: eval.JudgeVerdict{
+			Passed: true,
+			Reason: "dry run — skipped",
+		},
 	}
 }
 

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -238,6 +238,15 @@ func validatePathSegment(label, id string) error {
 	if strings.ContainsAny(id, "/\\") {
 		return fmt.Errorf("%s %q must not contain path separators", label, id)
 	}
+	if strings.ContainsRune(id, '\x00') {
+		// A NUL inside a filename is rejected by every supported
+		// filesystem, but the validator is the single place that
+		// documents what the runner will accept as a directory name;
+		// reject it here so the error surfaces against the operator's
+		// suite ID rather than later as an obscure filesystem syscall
+		// error. Cheap to check, hard to silently let through.
+		return fmt.Errorf("%s %q must not contain a null byte", label, id)
+	}
 	if id == "." || id == ".." {
 		return fmt.Errorf("%s %q is a reserved path segment", label, id)
 	}
@@ -283,23 +292,67 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 
 	configPath := ""
 	if merged != nil {
+		// Route the runner-managed trace path through the merged
+		// config so --trace never has to appear on the command line
+		// when --config is in use. The harness's applyOverrides
+		// coerces TraceEmitter.Type to "jsonl" whenever --trace is
+		// passed and --trace-emitter is not, which would silently
+		// reset a suite's intentional otel emitter to jsonl. Setting
+		// FilePath in the merged config lets the harness pick up the
+		// per-task trace path without that coercion side-effect.
+		merged.TraceEmitter.FilePath = traceFile
+
+		// Validate the merged config before spawning the harness so a
+		// structural error (e.g. a read-only mode paired with an
+		// allow-all permission policy, or a write-tool entry under
+		// planning mode) becomes a per-task "error" outcome instead
+		// of a wasted subprocess launch followed by a harness boot
+		// failure. dryRunTask already runs this check; keeping the
+		// live path in sync prevents the two from drifting.
+		if vErr := types.ValidateRunConfig(merged); vErr != nil {
+			return errorResult(task.ID, start, vErr)
+		}
+
 		configPath = filepath.Join(tmpDir, "runconfig.json")
 		if err := writeMergedConfig(configPath, merged); err != nil {
 			return errorResult(task.ID, start, err)
 		}
 	}
 
+	// --workspace is always needed: the runner manages the per-task
+	// tmpdir and the harness has no way to discover it otherwise.
+	// --trace is conditional: when a merged config is in use, the
+	// runner already injected the trace path into TraceEmitter.FilePath
+	// above, and passing --trace as well would trigger the harness's
+	// applyOverrides path that coerces TraceEmitter.Type to "jsonl"
+	// (silently clobbering a suite's intentional otel emitter).
+	// --prompt and --mode are passed only when the task supplies a
+	// non-zero value, so the merged config's prompt/mode is honoured
+	// when the task itself does not override. --timeout is never
+	// passed alongside --config — the merged config carries it.
 	args := []string{"harness"}
 	if configPath != "" {
 		args = append(args, "--config", configPath)
 	}
-	args = append(args,
-		"--prompt", task.Prompt,
-		"--mode", taskMode(task),
-		"--workspace", workspaceDir,
-		"--trace", traceFile,
-		"--timeout", "300",
-	)
+	args = append(args, "--workspace", workspaceDir)
+	if configPath == "" {
+		args = append(args, "--trace", traceFile)
+	}
+	if task.Prompt != "" {
+		args = append(args, "--prompt", task.Prompt)
+	}
+	if task.Mode != "" {
+		args = append(args, "--mode", task.Mode)
+	}
+	if configPath == "" {
+		// Legacy invocation has no in-config carrier for these two —
+		// fall back to the historic defaults so behaviour for suites
+		// that have not opted into the RunConfig surface is unchanged.
+		if task.Mode == "" {
+			args = append(args, "--mode", "execution")
+		}
+		args = append(args, "--timeout", "300")
+	}
 
 	cmd := exec.CommandContext(ctx, cfg.HarnessPath, args...)
 	cmd.Dir = workspaceDir
@@ -407,6 +460,13 @@ func parseTraceFile(path string) (*types.RunTrace, error) {
 
 	var lastLine string
 	scanner := bufio.NewScanner(f)
+	// bufio.Scanner's default 64 KiB line limit is too small for traces
+	// that carry a large tool output in a single JSONL record. A
+	// correct harness run with a multi-hundred-KiB grep result would
+	// otherwise surface as "bufio.Scanner: token too long" and the
+	// task would land as an "error" outcome rather than a real fail.
+	// 4 MiB matches the trace-emitter's own per-record cap.
+	scanner.Buffer(make([]byte, 0, 256*1024), 4*1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line != "" {
@@ -426,14 +486,6 @@ func parseTraceFile(path string) (*types.RunTrace, error) {
 	}
 
 	return &trace, nil
-}
-
-// taskMode returns the mode for a task, defaulting to "execution".
-func taskMode(task types.EvalTask) string {
-	if task.Mode != "" {
-		return task.Mode
-	}
-	return "execution"
 }
 
 // errorResult builds a TaskResult with outcome "error".
@@ -508,7 +560,12 @@ func retainRedactedConfig(suiteArtifactDir, taskID string, cfg *types.RunConfig)
 		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: mkdir: %v\n", taskID, err)
 		return
 	}
-	if err := os.WriteFile(filepath.Join(taskDir, "run_config.redacted.json"), data, 0o644); err != nil {
+	// 0o600 matches the on-disk live config: although Redact() strips
+	// secrets, the file still carries operational posture (provider
+	// type, model, network allowlists, permission policy). On shared
+	// CI runners the artifact tree may be inspectable by other jobs;
+	// 0o600 narrows that exposure.
+	if err := os.WriteFile(filepath.Join(taskDir, "run_config.redacted.json"), data, 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "eval: artifact retention failed for task %q: redacted config write: %v\n", taskID, err)
 	}
 }

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -20,6 +20,13 @@ import (
 	"github.com/rxbynerd/stirrup/types"
 )
 
+// defaultTaskTimeoutSeconds is the per-task timeout the runner falls back
+// to when the merged RunConfig does not pin one and on the legacy
+// invocation path. It matches the historic `--timeout 300` value the
+// runner has always supplied so suites that opt into the RunConfig
+// surface without setting `timeout = ...` keep behaving the same.
+const defaultTaskTimeoutSeconds = 300
+
 // RunConfig configures how the runner executes tasks.
 type RunConfig struct {
 	// HarnessPath is the path to the harness binary for live runs.
@@ -351,7 +358,7 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 		if task.Mode == "" {
 			args = append(args, "--mode", "execution")
 		}
-		args = append(args, "--timeout", "300")
+		args = append(args, "--timeout", fmt.Sprintf("%d", defaultTaskTimeoutSeconds))
 	}
 
 	cmd := exec.CommandContext(ctx, cfg.HarnessPath, args...)
@@ -507,6 +514,16 @@ func errorResult(taskID string, start time.Time, err error) eval.TaskResult {
 // not opted into the RunConfig surface, so the legacy invocation path
 // stays in effect. The baseline argument is cloned before the overlay is
 // applied so callers can reuse it across tasks.
+//
+// types.ValidateRunConfig requires Timeout to be set and positive, but
+// `timeout` is not surfaced in the HCL grammar (it is runner-owned at
+// the eval layer). Without an injection here, every suite whose merged
+// config originates from an inline run_config block — the common case
+// — would false-fail both dry-run validation and the live-run pre-
+// flight check with a misleading "timeout is required" error. Inject
+// the runner's default Timeout when the merged config does not already
+// pin one; a value already present in a JSON baseline (loaded via
+// run_config_file) or set by an overlay survives unchanged.
 func buildMergedConfig(baseline *types.RunConfig, overlay *types.RunConfigOverrides) (*types.RunConfig, error) {
 	if baseline == nil {
 		return nil, nil
@@ -522,7 +539,12 @@ func buildMergedConfig(baseline *types.RunConfig, overlay *types.RunConfigOverri
 	if err := json.Unmarshal(data, clone); err != nil {
 		return nil, fmt.Errorf("cloning suite baseline RunConfig: %w", err)
 	}
-	return mergeOverrides(clone, overlay), nil
+	merged := mergeOverrides(clone, overlay)
+	if merged != nil && merged.Timeout == nil {
+		t := defaultTaskTimeoutSeconds
+		merged.Timeout = &t
+	}
+	return merged, nil
 }
 
 // writeMergedConfig marshals the merged RunConfig to path. The file is

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -119,19 +119,22 @@ type rootSpec struct {
 }
 
 type suiteSpec struct {
-	ID          string     `hcl:"id,label"`
-	Description string     `hcl:"description,optional"`
-	Tasks       []taskSpec `hcl:"task,block"`
+	ID            string         `hcl:"id,label"`
+	Description   string         `hcl:"description,optional"`
+	RunConfigFile string         `hcl:"run_config_file,optional"`
+	RunConfig     *runConfigSpec `hcl:"run_config,block"`
+	Tasks         []taskSpec     `hcl:"task,block"`
 }
 
 type taskSpec struct {
-	ID          string    `hcl:"id,label"`
-	Description string    `hcl:"description,optional"`
-	Repo        string    `hcl:"repo,optional"`
-	Ref         string    `hcl:"ref,optional"`
-	Mode        string    `hcl:"mode,optional"`
-	Prompt      string    `hcl:"prompt,optional"`
-	Judge       judgeSpec `hcl:"judge,block"`
+	ID                 string                  `hcl:"id,label"`
+	Description        string                  `hcl:"description,optional"`
+	Repo               string                  `hcl:"repo,optional"`
+	Ref                string                  `hcl:"ref,optional"`
+	Mode               string                  `hcl:"mode,optional"`
+	Prompt             string                  `hcl:"prompt,optional"`
+	RunConfigOverrides *runConfigOverridesSpec `hcl:"run_config_overrides,block"`
+	Judge              judgeSpec               `hcl:"judge,block"`
 }
 
 type judgeSpec struct {
@@ -254,6 +257,12 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 	if len(s.Tasks) == 0 {
 		return types.EvalSuite{}, fmt.Errorf("suite %q must contain at least one task", s.ID)
 	}
+	if s.RunConfigFile != "" && s.RunConfig != nil {
+		return types.EvalSuite{}, fmt.Errorf(
+			"suite %q sets both `run_config_file` and `run_config` block; these are mutually exclusive — pick one",
+			s.ID,
+		)
+	}
 
 	tasks := make([]types.EvalTask, 0, len(s.Tasks))
 	for i, t := range s.Tasks {
@@ -265,20 +274,23 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 			return types.EvalSuite{}, err
 		}
 		tasks = append(tasks, types.EvalTask{
-			ID:          t.ID,
-			Description: t.Description,
-			Repo:        t.Repo,
-			Ref:         t.Ref,
-			Prompt:      t.Prompt,
-			Mode:        t.Mode,
-			Judge:       j,
+			ID:                 t.ID,
+			Description:        t.Description,
+			Repo:               t.Repo,
+			Ref:                t.Ref,
+			Prompt:             t.Prompt,
+			Mode:               t.Mode,
+			Judge:              j,
+			RunConfigOverrides: runConfigOverridesSpecToType(t.RunConfigOverrides),
 		})
 	}
 
 	return types.EvalSuite{
-		ID:          s.ID,
-		Description: s.Description,
-		Tasks:       tasks,
+		ID:            s.ID,
+		Description:   s.Description,
+		Tasks:         tasks,
+		RunConfigFile: s.RunConfigFile,
+		RunConfig:     runConfigSpecToType(s.RunConfig),
 	}, nil
 }
 

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -278,6 +278,11 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 		)
 	}
 
+	suiteRunConfig := runConfigSpecToType(s.RunConfig)
+	if err := validateInlineAPIKeyRefs(suiteRunConfig, nil); err != nil {
+		return types.EvalSuite{}, fmt.Errorf("suite %q: %w", s.ID, err)
+	}
+
 	tasks := make([]types.EvalTask, 0, len(s.Tasks))
 	for i, t := range s.Tasks {
 		if t.ID == "" {
@@ -287,6 +292,10 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 		if err != nil {
 			return types.EvalSuite{}, err
 		}
+		taskOverrides := runConfigOverridesSpecToType(t.RunConfigOverrides)
+		if err := validateInlineAPIKeyRefs(nil, taskOverrides); err != nil {
+			return types.EvalSuite{}, fmt.Errorf("task %q: %w", t.ID, err)
+		}
 		tasks = append(tasks, types.EvalTask{
 			ID:                 t.ID,
 			Description:        t.Description,
@@ -295,7 +304,7 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 			Prompt:             t.Prompt,
 			Mode:               t.Mode,
 			Judge:              j,
-			RunConfigOverrides: runConfigOverridesSpecToType(t.RunConfigOverrides),
+			RunConfigOverrides: taskOverrides,
 		})
 	}
 
@@ -304,7 +313,7 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 		Description:   s.Description,
 		Tasks:         tasks,
 		RunConfigFile: s.RunConfigFile,
-		RunConfig:     runConfigSpecToType(s.RunConfig),
+		RunConfig:     suiteRunConfig,
 	}, nil
 }
 

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -110,7 +111,20 @@ func LoadSuiteHCL(path string) (types.EvalSuite, error) {
 		return types.EvalSuite{}, fmt.Errorf("expected exactly one suite block, found %d", len(root.Suites))
 	}
 
-	return convertSuite(root.Suites[0])
+	suite, err := convertSuite(root.Suites[0])
+	if err != nil {
+		return types.EvalSuite{}, err
+	}
+	// Resolve a suite-level run_config_file relative to the suite file's
+	// directory so authors can write intuitive relative paths
+	// (`configs/base.json` next to the suite) without depending on the
+	// caller's working directory. Absolute paths pass through unchanged.
+	// Done here rather than in the runner so the runner stays pure with
+	// respect to filesystem layout.
+	if suite.RunConfigFile != "" && !filepath.IsAbs(suite.RunConfigFile) {
+		suite.RunConfigFile = filepath.Join(filepath.Dir(path), suite.RunConfigFile)
+	}
+	return suite, nil
 }
 
 // rootSpec is the top level of the HCL grammar.

--- a/eval/spec/runconfig.go
+++ b/eval/spec/runconfig.go
@@ -1,0 +1,533 @@
+package spec
+
+import (
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// runConfigSpec mirrors types.RunConfig for HCL decoding. Field names
+// here use snake_case to match the codebase's convention; tag-based
+// gohcl decoding rejects unknown attributes so typos surface at parse
+// time rather than as silent zero values.
+//
+// Not every RunConfig field is exposed yet. The following are
+// deliberately omitted from chunk 2 and tracked for follow-up:
+//
+//   - Providers map[string]ProviderConfig (named multi-provider lineup)
+//   - DynamicContext map[string]DynamicContextValue
+//   - GuardRailConfig.CustomCriteria map[string]string
+//   - TraceEmitterConfig.Headers map[string]string
+//   - TransportConfig (the eval runner is stdio-only)
+//   - ToolsConfig.MCPServers (slice of structs)
+//
+// Maps-of-structs and slices-of-structs are awkward to express in
+// gohcl's attribute model; they need either an hcl block or a
+// dedicated cty path. Adding them is purely additive.
+type runConfigSpec struct {
+	RunID                string                `hcl:"run_id,optional"`
+	Mode                 string                `hcl:"mode,optional"`
+	SessionName          string                `hcl:"session_name,optional"`
+	Prompt               string                `hcl:"prompt,optional"`
+	MaxTurns             *int                  `hcl:"max_turns,optional"`
+	MaxTokenBudget       *int                  `hcl:"max_token_budget,optional"`
+	MaxCostBudget        *float64              `hcl:"max_cost_budget,optional"`
+	Timeout              *int                  `hcl:"timeout,optional"`
+	FollowUpGrace        *int                  `hcl:"follow_up_grace,optional"`
+	LogLevel             string                `hcl:"log_level,optional"`
+	SystemPromptOverride string                `hcl:"system_prompt_override,optional"`
+	SensitiveData        *bool                 `hcl:"sensitive_data,optional"`
+	Provider             *providerSpec         `hcl:"provider,block"`
+	ModelRouter          *modelRouterSpec      `hcl:"model_router,block"`
+	PromptBuilder        *promptBuilderSpec    `hcl:"prompt_builder,block"`
+	ContextStrategy      *contextStrategySpec  `hcl:"context_strategy,block"`
+	Executor             *executorSpec         `hcl:"executor,block"`
+	EditStrategy         *editStrategySpec     `hcl:"edit_strategy,block"`
+	Verifier             *verifierSpec         `hcl:"verifier,block"`
+	PermissionPolicy     *permissionPolicySpec `hcl:"permission_policy,block"`
+	GitStrategy          *gitStrategySpec      `hcl:"git_strategy,block"`
+	Transport            *transportSpec        `hcl:"transport,block"`
+	TraceEmitter         *traceEmitterSpec     `hcl:"trace_emitter,block"`
+	Tools                *toolsSpec            `hcl:"tools,block"`
+	RuleOfTwo            *ruleOfTwoSpec        `hcl:"rule_of_two,block"`
+	CodeScanner          *codeScannerSpec      `hcl:"code_scanner,block"`
+	GuardRail            *guardRailSpec        `hcl:"guard_rail,block"`
+	Observability        *observabilitySpec    `hcl:"observability,block"`
+}
+
+// runConfigOverridesSpec mirrors types.RunConfigOverrides. Every field
+// is a pointer / optional so a sparse overlay is the natural shape.
+type runConfigOverridesSpec struct {
+	Mode            string               `hcl:"mode,optional"`
+	MaxTurns        *int                 `hcl:"max_turns,optional"`
+	Provider        *providerSpec        `hcl:"provider,block"`
+	ModelRouter     *modelRouterSpec     `hcl:"model_router,block"`
+	ContextStrategy *contextStrategySpec `hcl:"context_strategy,block"`
+	EditStrategy    *editStrategySpec    `hcl:"edit_strategy,block"`
+	Verifier        *verifierSpec        `hcl:"verifier,block"`
+}
+
+type providerSpec struct {
+	Type                 string                    `hcl:"type"`
+	APIKeyRef            string                    `hcl:"api_key_ref,optional"`
+	Region               string                    `hcl:"region,optional"`
+	Profile              string                    `hcl:"profile,optional"`
+	BaseURL              string                    `hcl:"base_url,optional"`
+	APIKeyHeader         string                    `hcl:"api_key_header,optional"`
+	QueryParams          map[string]string         `hcl:"query_params,optional"`
+	GCPProject           string                    `hcl:"gcp_project,optional"`
+	GCPLocation          string                    `hcl:"gcp_location,optional"`
+	GCPCredentialsFile   string                    `hcl:"gcp_credentials_file,optional"`
+	Credential           *credentialSpec           `hcl:"credential,block"`
+	GeminiSafetySettings []geminiSafetySettingSpec `hcl:"gemini_safety_setting,block"`
+}
+
+type credentialSpec struct {
+	Type             string           `hcl:"type"`
+	RoleARN          string           `hcl:"role_arn,optional"`
+	SessionName      string           `hcl:"session_name,optional"`
+	Audience         string           `hcl:"audience,optional"`
+	ServiceAccount   string           `hcl:"service_account,optional"`
+	FederationRuleID string           `hcl:"federation_rule_id,optional"`
+	OrganizationID   string           `hcl:"organization_id,optional"`
+	ServiceAccountID string           `hcl:"service_account_id,optional"`
+	WorkspaceID      string           `hcl:"workspace_id,optional"`
+	AzureTenantID    string           `hcl:"azure_tenant_id,optional"`
+	AzureClientID    string           `hcl:"azure_client_id,optional"`
+	AzureScope       string           `hcl:"azure_scope,optional"`
+	AzureTokenURL    string           `hcl:"azure_token_url,optional"`
+	TokenSource      *tokenSourceSpec `hcl:"token_source,block"`
+}
+
+type tokenSourceSpec struct {
+	Type     string `hcl:"type"`
+	Audience string `hcl:"audience,optional"`
+	Path     string `hcl:"path,optional"`
+	EnvVar   string `hcl:"env_var,optional"`
+	Resource string `hcl:"resource,optional"`
+	ClientID string `hcl:"client_id,optional"`
+}
+
+type geminiSafetySettingSpec struct {
+	Category  string `hcl:"category"`
+	Threshold string `hcl:"threshold"`
+}
+
+type modelRouterSpec struct {
+	Type                    string            `hcl:"type,optional"`
+	Provider                string            `hcl:"provider,optional"`
+	Model                   string            `hcl:"model,optional"`
+	ModeModels              map[string]string `hcl:"mode_models,optional"`
+	CheapProvider           string            `hcl:"cheap_provider,optional"`
+	CheapModel              string            `hcl:"cheap_model,optional"`
+	ExpensiveProvider       string            `hcl:"expensive_provider,optional"`
+	ExpensiveModel          string            `hcl:"expensive_model,optional"`
+	ExpensiveTurnThreshold  int               `hcl:"expensive_turn_threshold,optional"`
+	ExpensiveTokenThreshold int               `hcl:"expensive_token_threshold,optional"`
+	CheapStopReasons        []string          `hcl:"cheap_stop_reasons,optional"`
+}
+
+type promptBuilderSpec struct {
+	Type     string `hcl:"type"`
+	Template string `hcl:"template,optional"`
+}
+
+type contextStrategySpec struct {
+	Type      string `hcl:"type"`
+	MaxTokens int    `hcl:"max_tokens,optional"`
+}
+
+type executorSpec struct {
+	Type       string              `hcl:"type"`
+	Workspace  string              `hcl:"workspace,optional"`
+	Image      string              `hcl:"image,optional"`
+	Proxy      string              `hcl:"proxy,optional"`
+	Runtime    string              `hcl:"runtime,optional"`
+	VcsBackend *vcsBackendSpec     `hcl:"vcs_backend,block"`
+	Network    *networkSpec        `hcl:"network,block"`
+	Resources  *resourceLimitsSpec `hcl:"resources,block"`
+}
+
+type vcsBackendSpec struct {
+	Type      string `hcl:"type"`
+	APIKeyRef string `hcl:"api_key_ref,optional"`
+	Repo      string `hcl:"repo,optional"`
+	Ref       string `hcl:"ref,optional"`
+}
+
+type networkSpec struct {
+	Mode      string   `hcl:"mode"`
+	Allowlist []string `hcl:"allowlist,optional"`
+}
+
+type resourceLimitsSpec struct {
+	CPUs     float64 `hcl:"cpus"`
+	MemoryMB int     `hcl:"memory_mb"`
+	DiskMB   int     `hcl:"disk_mb"`
+	PIDs     int     `hcl:"pids"`
+}
+
+type editStrategySpec struct {
+	Type           string   `hcl:"type"`
+	FuzzyThreshold *float64 `hcl:"fuzzy_threshold,optional"`
+}
+
+type verifierSpec struct {
+	Type      string         `hcl:"type"`
+	Command   string         `hcl:"command,optional"`
+	Timeout   int            `hcl:"timeout,optional"`
+	Criteria  string         `hcl:"criteria,optional"`
+	Model     string         `hcl:"model,optional"`
+	Verifiers []verifierSpec `hcl:"verifier,block"`
+}
+
+type permissionPolicySpec struct {
+	Type       string `hcl:"type"`
+	Timeout    int    `hcl:"timeout,optional"`
+	PolicyFile string `hcl:"policy_file,optional"`
+	Fallback   string `hcl:"fallback,optional"`
+}
+
+type gitStrategySpec struct {
+	Type string `hcl:"type"`
+}
+
+type transportSpec struct {
+	Type    string `hcl:"type"`
+	Address string `hcl:"address,optional"`
+}
+
+type traceEmitterSpec struct {
+	Type            string `hcl:"type"`
+	FilePath        string `hcl:"file_path,optional"`
+	Endpoint        string `hcl:"endpoint,optional"`
+	MetricsEndpoint string `hcl:"metrics_endpoint,optional"`
+	Protocol        string `hcl:"protocol,optional"`
+}
+
+type toolsSpec struct {
+	BuiltIn []string `hcl:"built_in,optional"`
+}
+
+type ruleOfTwoSpec struct {
+	Enforce *bool `hcl:"enforce,optional"`
+}
+
+type codeScannerSpec struct {
+	Type              string   `hcl:"type"`
+	Scanners          []string `hcl:"scanners,optional"`
+	BlockOnWarn       bool     `hcl:"block_on_warn,optional"`
+	SemgrepConfigPath string   `hcl:"semgrep_config_path,optional"`
+}
+
+type guardRailSpec struct {
+	Type          string          `hcl:"type"`
+	Phases        []string        `hcl:"phases,optional"`
+	Endpoint      string          `hcl:"endpoint,optional"`
+	Model         string          `hcl:"model,optional"`
+	Threshold     float64         `hcl:"threshold,optional"`
+	Criteria      []string        `hcl:"criteria,optional"`
+	Think         *bool           `hcl:"think,optional"`
+	TimeoutMs     int             `hcl:"timeout_ms,optional"`
+	FailOpen      bool            `hcl:"fail_open,optional"`
+	MinChunkChars int             `hcl:"min_chunk_chars,optional"`
+	Stages        []guardRailSpec `hcl:"stage,block"`
+}
+
+type observabilitySpec struct {
+	Environment      string `hcl:"environment,optional"`
+	ServiceNamespace string `hcl:"service_namespace,optional"`
+}
+
+// runConfigSpecToType materialises a parsed runConfigSpec into a
+// *types.RunConfig. Nil input returns nil so callers can treat
+// "absent" and "present-but-empty" identically.
+func runConfigSpecToType(s *runConfigSpec) *types.RunConfig {
+	if s == nil {
+		return nil
+	}
+	out := &types.RunConfig{
+		RunID:                s.RunID,
+		Mode:                 s.Mode,
+		SessionName:          s.SessionName,
+		Prompt:               s.Prompt,
+		LogLevel:             s.LogLevel,
+		SystemPromptOverride: s.SystemPromptOverride,
+		MaxTokenBudget:       s.MaxTokenBudget,
+		MaxCostBudget:        s.MaxCostBudget,
+		Timeout:              s.Timeout,
+		FollowUpGrace:        s.FollowUpGrace,
+		SensitiveData:        s.SensitiveData,
+	}
+	if s.MaxTurns != nil {
+		out.MaxTurns = *s.MaxTurns
+	}
+	if s.Provider != nil {
+		out.Provider = providerSpecToType(s.Provider)
+	}
+	if s.ModelRouter != nil {
+		out.ModelRouter = modelRouterSpecToType(s.ModelRouter)
+	}
+	if s.PromptBuilder != nil {
+		out.PromptBuilder = promptBuilderSpecToType(s.PromptBuilder)
+	}
+	if s.ContextStrategy != nil {
+		out.ContextStrategy = contextStrategySpecToType(s.ContextStrategy)
+	}
+	if s.Executor != nil {
+		out.Executor = executorSpecToType(s.Executor)
+	}
+	if s.EditStrategy != nil {
+		out.EditStrategy = editStrategySpecToType(s.EditStrategy)
+	}
+	if s.Verifier != nil {
+		out.Verifier = verifierSpecToType(s.Verifier)
+	}
+	if s.PermissionPolicy != nil {
+		out.PermissionPolicy = permissionPolicySpecToType(s.PermissionPolicy)
+	}
+	if s.GitStrategy != nil {
+		out.GitStrategy = types.GitStrategyConfig{Type: s.GitStrategy.Type}
+	}
+	if s.Transport != nil {
+		out.Transport = types.TransportConfig{Type: s.Transport.Type, Address: s.Transport.Address}
+	}
+	if s.TraceEmitter != nil {
+		out.TraceEmitter = traceEmitterSpecToType(s.TraceEmitter)
+	}
+	if s.Tools != nil {
+		out.Tools = types.ToolsConfig{BuiltIn: s.Tools.BuiltIn}
+	}
+	if s.RuleOfTwo != nil {
+		out.RuleOfTwo = &types.RuleOfTwoConfig{Enforce: s.RuleOfTwo.Enforce}
+	}
+	if s.CodeScanner != nil {
+		out.CodeScanner = &types.CodeScannerConfig{
+			Type:              s.CodeScanner.Type,
+			Scanners:          s.CodeScanner.Scanners,
+			BlockOnWarn:       s.CodeScanner.BlockOnWarn,
+			SemgrepConfigPath: s.CodeScanner.SemgrepConfigPath,
+		}
+	}
+	if s.GuardRail != nil {
+		gr := guardRailSpecToType(*s.GuardRail)
+		out.GuardRail = &gr
+	}
+	if s.Observability != nil {
+		out.Observability = types.ObservabilityConfig{
+			Environment:      s.Observability.Environment,
+			ServiceNamespace: s.Observability.ServiceNamespace,
+		}
+	}
+	return out
+}
+
+// runConfigOverridesSpecToType materialises a parsed runConfigOverridesSpec
+// into a *types.RunConfigOverrides. Nil input returns nil.
+func runConfigOverridesSpecToType(s *runConfigOverridesSpec) *types.RunConfigOverrides {
+	if s == nil {
+		return nil
+	}
+	out := &types.RunConfigOverrides{
+		Mode:     s.Mode,
+		MaxTurns: s.MaxTurns,
+	}
+	if s.Provider != nil {
+		p := providerSpecToType(s.Provider)
+		out.Provider = &p
+	}
+	if s.ModelRouter != nil {
+		mr := modelRouterSpecToType(s.ModelRouter)
+		out.ModelRouter = &mr
+	}
+	if s.ContextStrategy != nil {
+		cs := contextStrategySpecToType(s.ContextStrategy)
+		out.ContextStrategy = &cs
+	}
+	if s.EditStrategy != nil {
+		es := editStrategySpecToType(s.EditStrategy)
+		out.EditStrategy = &es
+	}
+	if s.Verifier != nil {
+		v := verifierSpecToType(s.Verifier)
+		out.Verifier = &v
+	}
+	return out
+}
+
+func providerSpecToType(s *providerSpec) types.ProviderConfig {
+	out := types.ProviderConfig{
+		Type:               s.Type,
+		APIKeyRef:          s.APIKeyRef,
+		Region:             s.Region,
+		Profile:            s.Profile,
+		BaseURL:            s.BaseURL,
+		APIKeyHeader:       s.APIKeyHeader,
+		QueryParams:        s.QueryParams,
+		GCPProject:         s.GCPProject,
+		GCPLocation:        s.GCPLocation,
+		GCPCredentialsFile: s.GCPCredentialsFile,
+	}
+	if s.Credential != nil {
+		c := credentialSpecToType(*s.Credential)
+		out.Credential = &c
+	}
+	if len(s.GeminiSafetySettings) > 0 {
+		settings := make([]types.GeminiSafetySetting, 0, len(s.GeminiSafetySettings))
+		for _, gs := range s.GeminiSafetySettings {
+			settings = append(settings, types.GeminiSafetySetting{
+				Category:  gs.Category,
+				Threshold: gs.Threshold,
+			})
+		}
+		out.GeminiSafetySettings = settings
+	}
+	return out
+}
+
+func credentialSpecToType(s credentialSpec) types.CredentialConfig {
+	out := types.CredentialConfig{
+		Type:             s.Type,
+		RoleARN:          s.RoleARN,
+		SessionName:      s.SessionName,
+		Audience:         s.Audience,
+		ServiceAccount:   s.ServiceAccount,
+		FederationRuleID: s.FederationRuleID,
+		OrganizationID:   s.OrganizationID,
+		ServiceAccountID: s.ServiceAccountID,
+		WorkspaceID:      s.WorkspaceID,
+		AzureTenantID:    s.AzureTenantID,
+		AzureClientID:    s.AzureClientID,
+		AzureScope:       s.AzureScope,
+		AzureTokenURL:    s.AzureTokenURL,
+	}
+	if s.TokenSource != nil {
+		out.TokenSource = &types.TokenSourceConfig{
+			Type:     s.TokenSource.Type,
+			Audience: s.TokenSource.Audience,
+			Path:     s.TokenSource.Path,
+			EnvVar:   s.TokenSource.EnvVar,
+			Resource: s.TokenSource.Resource,
+			ClientID: s.TokenSource.ClientID,
+		}
+	}
+	return out
+}
+
+func modelRouterSpecToType(s *modelRouterSpec) types.ModelRouterConfig {
+	return types.ModelRouterConfig{
+		Type:                    s.Type,
+		Provider:                s.Provider,
+		Model:                   s.Model,
+		ModeModels:              s.ModeModels,
+		CheapProvider:           s.CheapProvider,
+		CheapModel:              s.CheapModel,
+		ExpensiveProvider:       s.ExpensiveProvider,
+		ExpensiveModel:          s.ExpensiveModel,
+		ExpensiveTurnThreshold:  s.ExpensiveTurnThreshold,
+		ExpensiveTokenThreshold: s.ExpensiveTokenThreshold,
+		CheapStopReasons:        s.CheapStopReasons,
+	}
+}
+
+func promptBuilderSpecToType(s *promptBuilderSpec) types.PromptBuilderConfig {
+	return types.PromptBuilderConfig{Type: s.Type, Template: s.Template}
+}
+
+func contextStrategySpecToType(s *contextStrategySpec) types.ContextStrategyConfig {
+	return types.ContextStrategyConfig{Type: s.Type, MaxTokens: s.MaxTokens}
+}
+
+func executorSpecToType(s *executorSpec) types.ExecutorConfig {
+	out := types.ExecutorConfig{
+		Type:      s.Type,
+		Workspace: s.Workspace,
+		Image:     s.Image,
+		Proxy:     s.Proxy,
+		Runtime:   s.Runtime,
+	}
+	if s.VcsBackend != nil {
+		out.VcsBackend = &types.VcsBackendConfig{
+			Type:      s.VcsBackend.Type,
+			APIKeyRef: s.VcsBackend.APIKeyRef,
+			Repo:      s.VcsBackend.Repo,
+			Ref:       s.VcsBackend.Ref,
+		}
+	}
+	if s.Network != nil {
+		out.Network = &types.NetworkConfig{
+			Mode:      s.Network.Mode,
+			Allowlist: s.Network.Allowlist,
+		}
+	}
+	if s.Resources != nil {
+		out.Resources = &types.ResourceLimits{
+			CPUs:     s.Resources.CPUs,
+			MemoryMB: s.Resources.MemoryMB,
+			DiskMB:   s.Resources.DiskMB,
+			PIDs:     s.Resources.PIDs,
+		}
+	}
+	return out
+}
+
+func editStrategySpecToType(s *editStrategySpec) types.EditStrategyConfig {
+	return types.EditStrategyConfig{Type: s.Type, FuzzyThreshold: s.FuzzyThreshold}
+}
+
+func verifierSpecToType(s *verifierSpec) types.VerifierConfig {
+	out := types.VerifierConfig{
+		Type:     s.Type,
+		Command:  s.Command,
+		Timeout:  s.Timeout,
+		Criteria: s.Criteria,
+		Model:    s.Model,
+	}
+	if len(s.Verifiers) > 0 {
+		out.Verifiers = make([]types.VerifierConfig, 0, len(s.Verifiers))
+		for _, v := range s.Verifiers {
+			vv := v
+			out.Verifiers = append(out.Verifiers, verifierSpecToType(&vv))
+		}
+	}
+	return out
+}
+
+func permissionPolicySpecToType(s *permissionPolicySpec) types.PermissionPolicyConfig {
+	return types.PermissionPolicyConfig{
+		Type:       s.Type,
+		Timeout:    s.Timeout,
+		PolicyFile: s.PolicyFile,
+		Fallback:   s.Fallback,
+	}
+}
+
+func traceEmitterSpecToType(s *traceEmitterSpec) types.TraceEmitterConfig {
+	return types.TraceEmitterConfig{
+		Type:            s.Type,
+		FilePath:        s.FilePath,
+		Endpoint:        s.Endpoint,
+		MetricsEndpoint: s.MetricsEndpoint,
+		Protocol:        s.Protocol,
+	}
+}
+
+func guardRailSpecToType(s guardRailSpec) types.GuardRailConfig {
+	out := types.GuardRailConfig{
+		Type:          s.Type,
+		Phases:        s.Phases,
+		Endpoint:      s.Endpoint,
+		Model:         s.Model,
+		Threshold:     s.Threshold,
+		Criteria:      s.Criteria,
+		Think:         s.Think,
+		TimeoutMs:     s.TimeoutMs,
+		FailOpen:      s.FailOpen,
+		MinChunkChars: s.MinChunkChars,
+	}
+	if len(s.Stages) > 0 {
+		out.Stages = make([]types.GuardRailConfig, 0, len(s.Stages))
+		for _, st := range s.Stages {
+			out.Stages = append(out.Stages, guardRailSpecToType(st))
+		}
+	}
+	return out
+}

--- a/eval/spec/runconfig.go
+++ b/eval/spec/runconfig.go
@@ -15,7 +15,6 @@ import (
 //   - Providers map[string]ProviderConfig (named multi-provider lineup)
 //   - DynamicContext map[string]DynamicContextValue
 //   - GuardRailConfig.CustomCriteria map[string]string
-//   - TraceEmitterConfig.Headers map[string]string
 //   - TransportConfig (the eval runner is stdio-only)
 //   - ToolsConfig.MCPServers (slice of structs)
 //
@@ -55,8 +54,15 @@ type runConfigSpec struct {
 
 // runConfigOverridesSpec mirrors types.RunConfigOverrides. Every field
 // is a pointer / optional so a sparse overlay is the natural shape.
+//
+// Note: Mode is intentionally absent from the HCL surface. Per-task mode
+// is controlled by the task block's own `mode` attribute; the runner
+// always passes that on as the harness's --mode flag, which would
+// silently override anything written here. The Go type
+// RunConfigOverrides retains Mode for the experiment runner path,
+// which writes its own merged config and does not pass --mode on the
+// command line.
 type runConfigOverridesSpec struct {
-	Mode            string               `hcl:"mode,optional"`
 	MaxTurns        *int                 `hcl:"max_turns,optional"`
 	Provider        *providerSpec        `hcl:"provider,block"`
 	ModelRouter     *modelRouterSpec     `hcl:"model_router,block"`
@@ -196,11 +202,12 @@ type transportSpec struct {
 }
 
 type traceEmitterSpec struct {
-	Type            string `hcl:"type"`
-	FilePath        string `hcl:"file_path,optional"`
-	Endpoint        string `hcl:"endpoint,optional"`
-	MetricsEndpoint string `hcl:"metrics_endpoint,optional"`
-	Protocol        string `hcl:"protocol,optional"`
+	Type            string            `hcl:"type"`
+	FilePath        string            `hcl:"file_path,optional"`
+	Endpoint        string            `hcl:"endpoint,optional"`
+	MetricsEndpoint string            `hcl:"metrics_endpoint,optional"`
+	Protocol        string            `hcl:"protocol,optional"`
+	Headers         map[string]string `hcl:"headers,optional"`
 }
 
 type toolsSpec struct {
@@ -327,7 +334,6 @@ func runConfigOverridesSpecToType(s *runConfigOverridesSpec) *types.RunConfigOve
 		return nil
 	}
 	out := &types.RunConfigOverrides{
-		Mode:     s.Mode,
 		MaxTurns: s.MaxTurns,
 	}
 	if s.Provider != nil {
@@ -507,6 +513,7 @@ func traceEmitterSpecToType(s *traceEmitterSpec) types.TraceEmitterConfig {
 		Endpoint:        s.Endpoint,
 		MetricsEndpoint: s.MetricsEndpoint,
 		Protocol:        s.Protocol,
+		Headers:         s.Headers,
 	}
 }
 

--- a/eval/spec/runconfig.go
+++ b/eval/spec/runconfig.go
@@ -1,6 +1,9 @@
 package spec
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -242,6 +245,55 @@ type guardRailSpec struct {
 type observabilitySpec struct {
 	Environment      string `hcl:"environment,optional"`
 	ServiceNamespace string `hcl:"service_namespace,optional"`
+}
+
+// validateInlineAPIKeyRefs rejects any inline api_key_ref value that
+// is not a secret:// reference. The check duplicates the rule already
+// enforced by types.ValidateRunConfig so authors see the diagnostic
+// at HCL parse time — with the field path named — rather than as a
+// downstream validation error after the runner has already merged the
+// config. Without this layer the parse path silently accepts a
+// pasted-in literal API key; the merged run_config.json the harness
+// receives would carry the raw value (and the redacted artifact would
+// hide the misconfiguration from audit by rewriting it to
+// "secret://[REDACTED]"). Apply to every secret-bearing field
+// surfaced by the HCL grammar today: Provider.APIKeyRef on both the
+// inline run_config and per-task run_config_overrides, and
+// Executor.VcsBackend.APIKeyRef on the inline run_config.
+//
+// The set of fields here must stay in lockstep with the surface the
+// HCL grammar accepts. Adding a new secret-bearing field to
+// providerSpec / runConfigOverridesSpec / executorSpec without
+// extending this validator would create a parse-time hole.
+func validateInlineAPIKeyRefs(cfg *types.RunConfig, overrides *types.RunConfigOverrides) error {
+	checkRef := func(path, ref string) error {
+		if ref == "" {
+			return nil
+		}
+		if !strings.HasPrefix(ref, "secret://") {
+			return fmt.Errorf(
+				"%s %q: raw credentials are not permitted; use a secret:// reference",
+				path, ref,
+			)
+		}
+		return nil
+	}
+	if cfg != nil {
+		if err := checkRef("provider.api_key_ref", cfg.Provider.APIKeyRef); err != nil {
+			return err
+		}
+		if cfg.Executor.VcsBackend != nil {
+			if err := checkRef("executor.vcs_backend.api_key_ref", cfg.Executor.VcsBackend.APIKeyRef); err != nil {
+				return err
+			}
+		}
+	}
+	if overrides != nil && overrides.Provider != nil {
+		if err := checkRef("run_config_overrides.provider.api_key_ref", overrides.Provider.APIKeyRef); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // runConfigSpecToType materialises a parsed runConfigSpec into a

--- a/eval/spec/runconfig_test.go
+++ b/eval/spec/runconfig_test.go
@@ -224,6 +224,179 @@ suite "s" {
 	}
 }
 
+// TestLoadSuiteHCL_TaskRunConfigOverridesAllPointerBlocks pins the
+// pointer-typed overlay branches in runConfigOverridesSpecToType:
+// model_router, context_strategy, edit_strategy, and verifier. Each
+// must round-trip into a non-nil pointer on the resulting
+// *types.RunConfigOverrides with the named fields preserved.
+//
+// The sub-blocks exist on the runConfigOverridesSpec for parity with
+// the suite-level runConfigSpec; without this test, a typo in any of
+// the four converter branches (e.g. assigning to the wrong target
+// field) would silently drop the overlay.
+func TestLoadSuiteHCL_TaskRunConfigOverridesAllPointerBlocks(t *testing.T) {
+	src := `
+suite "s" {
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+
+    run_config_overrides {
+      model_router {
+        type     = "static"
+        provider = "anthropic"
+        model    = "claude-sonnet-4-6"
+      }
+
+      context_strategy {
+        type       = "truncate"
+        max_tokens = 8000
+      }
+
+      edit_strategy {
+        type            = "fuzzy"
+        fuzzy_threshold = 0.85
+      }
+
+      verifier {
+        type    = "test-command"
+        command = "true"
+      }
+    }
+
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "task-overrides-all-blocks.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if len(got.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(got.Tasks))
+	}
+	ov := got.Tasks[0].RunConfigOverrides
+	if ov == nil {
+		t.Fatalf("RunConfigOverrides should be non-nil")
+	}
+	if ov.ModelRouter == nil || ov.ModelRouter.Type != "static" || ov.ModelRouter.Model != "claude-sonnet-4-6" {
+		t.Errorf("ModelRouter overlay = %#v, want {Type:static Model:claude-sonnet-4-6}", ov.ModelRouter)
+	}
+	if ov.ContextStrategy == nil || ov.ContextStrategy.Type != "truncate" || ov.ContextStrategy.MaxTokens != 8000 {
+		t.Errorf("ContextStrategy overlay = %#v, want {Type:truncate MaxTokens:8000}", ov.ContextStrategy)
+	}
+	if ov.EditStrategy == nil || ov.EditStrategy.Type != "fuzzy" {
+		t.Errorf("EditStrategy overlay = %#v, want Type:fuzzy", ov.EditStrategy)
+	}
+	if ov.EditStrategy != nil && (ov.EditStrategy.FuzzyThreshold == nil || *ov.EditStrategy.FuzzyThreshold != 0.85) {
+		t.Errorf("EditStrategy.FuzzyThreshold = %v, want pointer to 0.85", ov.EditStrategy.FuzzyThreshold)
+	}
+	if ov.Verifier == nil || ov.Verifier.Type != "test-command" || ov.Verifier.Command != "true" {
+		t.Errorf("Verifier overlay = %#v, want {Type:test-command Command:true}", ov.Verifier)
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigOverridesRejectsMode pins the post-B2
+// invariant: run_config_overrides { mode = "..." } must be a parse
+// error. Accepting the field opens a silent-conflict footgun where
+// the overlay's mode is overwritten by the runner's --mode flag.
+// The check is structural — the HCL surface omits mode entirely, so
+// gohcl rejects it with an "unknown attribute" diagnostic.
+func TestLoadSuiteHCL_RunConfigOverridesRejectsMode(t *testing.T) {
+	src := `
+suite "s" {
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+
+    run_config_overrides {
+      mode = "planning"
+    }
+
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "task-overrides-mode.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatal("expected error for mode attribute inside run_config_overrides")
+	}
+	if !strings.Contains(err.Error(), "mode") {
+		t.Errorf("error = %q, want it to name the rejected attribute", err.Error())
+	}
+}
+
+// TestLoadSuiteHCL_ProviderWithCredential closes the
+// credentialSpecToType coverage gap. The credential block is a
+// security-critical path: a field-name typo silently drops an auth
+// parameter and the live run picks up a misconfigured credential at
+// runtime rather than at parse time.
+func TestLoadSuiteHCL_ProviderWithCredential(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    provider {
+      type = "bedrock"
+
+      credential {
+        type     = "web-identity"
+        role_arn = "arn:aws:iam::123456789012:role/eval"
+
+        token_source {
+          type    = "env_var"
+          env_var = "AWS_WEB_IDENTITY_TOKEN"
+        }
+      }
+    }
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-credential.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig == nil {
+		t.Fatal("RunConfig should be non-nil")
+	}
+	cred := got.RunConfig.Provider.Credential
+	if cred == nil {
+		t.Fatal("Provider.Credential should be non-nil")
+	}
+	if cred.Type != "web-identity" {
+		t.Errorf("Credential.Type = %q, want web-identity", cred.Type)
+	}
+	if cred.RoleARN != "arn:aws:iam::123456789012:role/eval" {
+		t.Errorf("Credential.RoleARN = %q, want canonical ARN", cred.RoleARN)
+	}
+	if cred.TokenSource == nil {
+		t.Fatal("Credential.TokenSource should be non-nil")
+	}
+	if cred.TokenSource.Type != "env_var" {
+		t.Errorf("Credential.TokenSource.Type = %q, want env_var", cred.TokenSource.Type)
+	}
+	if cred.TokenSource.EnvVar != "AWS_WEB_IDENTITY_TOKEN" {
+		t.Errorf("Credential.TokenSource.EnvVar = %q, want AWS_WEB_IDENTITY_TOKEN", cred.TokenSource.EnvVar)
+	}
+}
+
 // TestLoadSuiteHCL_RunConfigUnknownAttribute pins the "unknown
 // attributes are errors" contract on the inline `run_config` block.
 // Silently dropping a typo (e.g. `max_turn` instead of `max_turns`)
@@ -359,15 +532,41 @@ func TestLoadSuiteHCL_OpenAIResponsesSuiteUsesInlineRunConfig(t *testing.T) {
 
 // TestLoadSuiteHCL_RunConfigDeepBlocks exercises a richer inline
 // run_config — nested blocks (executor, network, resources,
-// permission_policy, code_scanner, guard_rail with stages) — to pin
-// that the recursive spec → types conversion preserves the full
-// shape. The intent is to catch field-mapping mistakes in
-// runConfigSpecToType without listing every leaf field in every test.
+// permission_policy, code_scanner, guard_rail with stages,
+// prompt_builder, context_strategy, edit_strategy, verifier with
+// recursive child, trace_emitter with headers) — to pin that the
+// recursive spec → types conversion preserves the full shape. The
+// intent is to catch field-mapping mistakes in runConfigSpecToType
+// without listing every leaf field in every test.
 func TestLoadSuiteHCL_RunConfigDeepBlocks(t *testing.T) {
 	src := `
 suite "s" {
   run_config {
     mode = "execution"
+
+    prompt_builder {
+      type     = "template"
+      template = "hello"
+    }
+
+    context_strategy {
+      type       = "truncate"
+      max_tokens = 8000
+    }
+
+    edit_strategy {
+      type            = "fuzzy"
+      fuzzy_threshold = 0.85
+    }
+
+    verifier {
+      type = "composite"
+
+      verifier {
+        type    = "test-command"
+        command = "true"
+      }
+    }
 
     executor {
       type      = "container"
@@ -408,6 +607,15 @@ suite "s" {
       }
     }
 
+    trace_emitter {
+      type     = "otel"
+      endpoint = "http://collector:4317"
+      protocol = "grpc"
+      headers = {
+        "Authorization" = "secret://GRAFANA_CLOUD_AUTH"
+      }
+    }
+
     observability {
       environment       = "staging"
       service_namespace = "stirrup-eval"
@@ -433,6 +641,24 @@ suite "s" {
 	if rc == nil {
 		t.Fatal("RunConfig should be non-nil")
 	}
+	if rc.PromptBuilder.Type != "template" || rc.PromptBuilder.Template != "hello" {
+		t.Errorf("PromptBuilder = %#v, want {Type:template Template:hello}", rc.PromptBuilder)
+	}
+	if rc.ContextStrategy.Type != "truncate" || rc.ContextStrategy.MaxTokens != 8000 {
+		t.Errorf("ContextStrategy = %#v, want {Type:truncate MaxTokens:8000}", rc.ContextStrategy)
+	}
+	if rc.EditStrategy.Type != "fuzzy" {
+		t.Errorf("EditStrategy.Type = %q, want fuzzy", rc.EditStrategy.Type)
+	}
+	if rc.EditStrategy.FuzzyThreshold == nil || *rc.EditStrategy.FuzzyThreshold != 0.85 {
+		t.Errorf("EditStrategy.FuzzyThreshold = %v, want pointer to 0.85", rc.EditStrategy.FuzzyThreshold)
+	}
+	if rc.Verifier.Type != "composite" {
+		t.Errorf("Verifier.Type = %q, want composite", rc.Verifier.Type)
+	}
+	if len(rc.Verifier.Verifiers) != 1 || rc.Verifier.Verifiers[0].Type != "test-command" || rc.Verifier.Verifiers[0].Command != "true" {
+		t.Errorf("Verifier.Verifiers = %#v, want one test-command child", rc.Verifier.Verifiers)
+	}
 	if rc.Executor.Type != "container" {
 		t.Errorf("Executor.Type = %q, want %q", rc.Executor.Type, "container")
 	}
@@ -453,6 +679,12 @@ suite "s" {
 	}
 	if rc.GuardRail == nil || len(rc.GuardRail.Stages) != 1 || rc.GuardRail.Stages[0].Type != "granite-guardian" {
 		t.Errorf("GuardRail.Stages = %#v, want one granite-guardian stage", rc.GuardRail.Stages)
+	}
+	if rc.TraceEmitter.Type != "otel" || rc.TraceEmitter.Endpoint != "http://collector:4317" || rc.TraceEmitter.Protocol != "grpc" {
+		t.Errorf("TraceEmitter = %#v, want otel/grpc/collector", rc.TraceEmitter)
+	}
+	if rc.TraceEmitter.Headers["Authorization"] != "secret://GRAFANA_CLOUD_AUTH" {
+		t.Errorf("TraceEmitter.Headers[Authorization] = %q, want secret://GRAFANA_CLOUD_AUTH", rc.TraceEmitter.Headers["Authorization"])
 	}
 	if rc.Observability.Environment != "staging" {
 		t.Errorf("Observability.Environment = %q, want staging", rc.Observability.Environment)

--- a/eval/spec/runconfig_test.go
+++ b/eval/spec/runconfig_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,7 +13,8 @@ import (
 // a suite-level `run_config_file = "..."` attribute populates the
 // corresponding EvalSuite field and leaves EvalSuite.RunConfig nil.
 // Tasks without per-task overrides must still have a nil
-// RunConfigOverrides.
+// RunConfigOverrides. The relative path is resolved against the suite
+// file's directory so authors can write intuitive relative paths.
 func TestLoadSuiteHCL_RunConfigFileOnly(t *testing.T) {
 	src := `
 suite "s" {
@@ -34,8 +36,9 @@ suite "s" {
 	if err != nil {
 		t.Fatalf("LoadSuiteHCL: %v", err)
 	}
-	if got.RunConfigFile != "configs/openai-base.json" {
-		t.Errorf("RunConfigFile = %q, want %q", got.RunConfigFile, "configs/openai-base.json")
+	want := filepath.Join(filepath.Dir(path), "configs/openai-base.json")
+	if got.RunConfigFile != want {
+		t.Errorf("RunConfigFile = %q, want %q", got.RunConfigFile, want)
 	}
 	if got.RunConfig != nil {
 		t.Errorf("RunConfig should be nil when only run_config_file set, got %#v", got.RunConfig)
@@ -45,6 +48,34 @@ suite "s" {
 	}
 	if got.Tasks[0].RunConfigOverrides != nil {
 		t.Errorf("task RunConfigOverrides should be nil, got %#v", got.Tasks[0].RunConfigOverrides)
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigFileAbsolutePath confirms that absolute paths
+// in `run_config_file` are preserved verbatim — the relative-resolution
+// pass must only join paths that are not already absolute.
+func TestLoadSuiteHCL_RunConfigFileAbsolutePath(t *testing.T) {
+	abs := "/etc/stirrup/baseline.json"
+	src := `
+suite "s" {
+  run_config_file = "` + abs + `"
+
+  task "t1" {
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-abs.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfigFile != abs {
+		t.Errorf("RunConfigFile = %q, want %q (absolute path should pass through)", got.RunConfigFile, abs)
 	}
 }
 

--- a/eval/spec/runconfig_test.go
+++ b/eval/spec/runconfig_test.go
@@ -721,3 +721,117 @@ suite "s" {
 		t.Errorf("Observability.Environment = %q, want staging", rc.Observability.Environment)
 	}
 }
+
+// TestLoadSuiteHCL_RejectsRawProviderAPIKey pins the parse-time
+// secret:// scheme guard on the inline run_config provider block.
+// Without this check a pasted-in literal API key would survive parse,
+// land in the merged run_config.json the harness receives, and the
+// retained redacted artifact would quietly rewrite it to "[REDACTED]"
+// — masking the misconfiguration from audit. ValidateRunConfig
+// catches the same shape at the types layer, but the parse-time
+// error names the offending field so authors see the diagnostic where
+// they wrote the value.
+func TestLoadSuiteHCL_RejectsRawProviderAPIKey(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    provider {
+      type        = "openai-responses"
+      api_key_ref = "sk-live-abc123"
+    }
+  }
+
+  task "t1" {
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "raw-provider-key.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatalf("LoadSuiteHCL: expected error for raw provider api_key_ref, got nil")
+	}
+	if !strings.Contains(err.Error(), "secret://") {
+		t.Errorf("error message %q does not mention secret:// scheme", err.Error())
+	}
+	if !strings.Contains(err.Error(), "provider.api_key_ref") {
+		t.Errorf("error message %q does not name the offending field", err.Error())
+	}
+}
+
+// TestLoadSuiteHCL_RejectsRawVcsBackendAPIKey extends the parse-time
+// guard to the executor.vcs_backend nested block — same invariant,
+// different field, same reasoning.
+func TestLoadSuiteHCL_RejectsRawVcsBackendAPIKey(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    executor {
+      type = "container"
+      vcs_backend {
+        type        = "github"
+        api_key_ref = "ghp_literaltokenvalue"
+      }
+    }
+  }
+
+  task "t1" {
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "raw-vcs-key.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatalf("LoadSuiteHCL: expected error for raw vcs_backend api_key_ref, got nil")
+	}
+	if !strings.Contains(err.Error(), "secret://") {
+		t.Errorf("error message %q does not mention secret:// scheme", err.Error())
+	}
+	if !strings.Contains(err.Error(), "executor.vcs_backend.api_key_ref") {
+		t.Errorf("error message %q does not name the offending field", err.Error())
+	}
+}
+
+// TestLoadSuiteHCL_RejectsRawAPIKeyInTaskOverrides pins the parse-time
+// guard on per-task run_config_overrides. The task-level overrides
+// produce a *types.RunConfigOverrides rather than a *types.RunConfig,
+// so the validator must walk both shapes.
+func TestLoadSuiteHCL_RejectsRawAPIKeyInTaskOverrides(t *testing.T) {
+	src := `
+suite "s" {
+  task "t1" {
+    prompt = "p"
+    run_config_overrides {
+      provider {
+        type        = "anthropic"
+        api_key_ref = "sk-ant-rawvalue"
+      }
+    }
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "raw-override-key.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatalf("LoadSuiteHCL: expected error for raw task-overrides api_key_ref, got nil")
+	}
+	if !strings.Contains(err.Error(), "secret://") {
+		t.Errorf("error message %q does not mention secret:// scheme", err.Error())
+	}
+	if !strings.Contains(err.Error(), "run_config_overrides.provider.api_key_ref") {
+		t.Errorf("error message %q does not name the offending field", err.Error())
+	}
+}

--- a/eval/spec/runconfig_test.go
+++ b/eval/spec/runconfig_test.go
@@ -287,15 +287,18 @@ suite "s" {
 	}
 }
 
-// TestLoadSuiteHCL_ExistingSuitesParse asserts that the live
-// guardrail.hcl and openai-responses-empty-tool-output.hcl files in
-// eval/suites/ continue to parse with the new code path and produce
-// zero-valued RunConfig fields (no new fields populated). This is the
-// backwards-compat contract from the issue.
+// TestLoadSuiteHCL_ExistingSuitesParse asserts that a suite which
+// never declared any of the chunk-2 RunConfig fields continues to
+// parse with the new code path and produce zero-valued RunConfig
+// fields. This is the backwards-compat contract from the issue.
+//
+// `openai-responses-empty-tool-output.hcl` was updated in chunk 4
+// to demonstrate the new authoring surface (it now sets a
+// suite-level `run_config` block); its parse is covered by
+// TestLoadSuiteHCL_OpenAIResponsesSuiteUsesInlineRunConfig below.
 func TestLoadSuiteHCL_ExistingSuitesParse(t *testing.T) {
 	cases := []string{
 		"../suites/guardrail.hcl",
-		"../suites/openai-responses-empty-tool-output.hcl",
 	}
 	for _, path := range cases {
 		t.Run(path, func(t *testing.T) {
@@ -318,6 +321,39 @@ func TestLoadSuiteHCL_ExistingSuitesParse(t *testing.T) {
 				t.Errorf("expected at least one task")
 			}
 		})
+	}
+}
+
+// TestLoadSuiteHCL_OpenAIResponsesSuiteUsesInlineRunConfig pins the
+// openai-responses regression suite's chunk-4 update: the suite now
+// authors a suite-level inline `run_config` block that nails the
+// provider type and model_router so the regression scenario cannot
+// be silently nullified by an operator's environment. The check is
+// deliberately shallow (presence + provider type + model) — the
+// full decoding surface is exhaustively tested elsewhere in this
+// file; here we only care that the live suite uses the new flow.
+func TestLoadSuiteHCL_OpenAIResponsesSuiteUsesInlineRunConfig(t *testing.T) {
+	got, err := LoadSuiteHCL("../suites/openai-responses-empty-tool-output.hcl")
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfigFile != "" {
+		t.Errorf("RunConfigFile should be empty (suite uses inline block), got %q", got.RunConfigFile)
+	}
+	if got.RunConfig == nil {
+		t.Fatal("RunConfig should be non-nil: the suite declares an inline run_config block")
+	}
+	if got.RunConfig.Provider.Type != "openai-responses" {
+		t.Errorf("Provider.Type = %q, want %q", got.RunConfig.Provider.Type, "openai-responses")
+	}
+	if got.RunConfig.Provider.APIKeyRef != "secret://OPENAI_KEY" {
+		t.Errorf("Provider.APIKeyRef = %q, want %q", got.RunConfig.Provider.APIKeyRef, "secret://OPENAI_KEY")
+	}
+	if got.RunConfig.ModelRouter.Model == "" {
+		t.Errorf("ModelRouter.Model should be non-empty")
+	}
+	if len(got.Tasks) == 0 {
+		t.Errorf("expected at least one task")
 	}
 }
 

--- a/eval/spec/runconfig_test.go
+++ b/eval/spec/runconfig_test.go
@@ -1,0 +1,424 @@
+package spec
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestLoadSuiteHCL_RunConfigFileOnly pins the simplest baseline shape:
+// a suite-level `run_config_file = "..."` attribute populates the
+// corresponding EvalSuite field and leaves EvalSuite.RunConfig nil.
+// Tasks without per-task overrides must still have a nil
+// RunConfigOverrides.
+func TestLoadSuiteHCL_RunConfigFileOnly(t *testing.T) {
+	src := `
+suite "s" {
+  description     = "file-baseline"
+  run_config_file = "configs/openai-base.json"
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-file.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfigFile != "configs/openai-base.json" {
+		t.Errorf("RunConfigFile = %q, want %q", got.RunConfigFile, "configs/openai-base.json")
+	}
+	if got.RunConfig != nil {
+		t.Errorf("RunConfig should be nil when only run_config_file set, got %#v", got.RunConfig)
+	}
+	if len(got.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(got.Tasks))
+	}
+	if got.Tasks[0].RunConfigOverrides != nil {
+		t.Errorf("task RunConfigOverrides should be nil, got %#v", got.Tasks[0].RunConfigOverrides)
+	}
+}
+
+// TestLoadSuiteHCL_InlineRunConfigBlock pins the inline `run_config` shape:
+// nested provider / model_router / scalar fields all decode into a
+// non-nil *types.RunConfig matching what callers would build by hand.
+func TestLoadSuiteHCL_InlineRunConfigBlock(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    mode      = "execution"
+    max_turns = 10
+
+    provider {
+      type        = "openai-responses"
+      api_key_ref = "secret://OPENAI_KEY"
+      base_url    = "https://api.openai.com/v1"
+    }
+
+    model_router {
+      type     = "static"
+      provider = "openai-responses"
+      model    = "gpt-5.4-nano"
+    }
+
+    permission_policy {
+      type = "deny-side-effects"
+    }
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-inline.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfigFile != "" {
+		t.Errorf("RunConfigFile should be empty, got %q", got.RunConfigFile)
+	}
+	if got.RunConfig == nil {
+		t.Fatalf("RunConfig should be non-nil")
+	}
+	want := &types.RunConfig{
+		Mode:     "execution",
+		MaxTurns: 10,
+		Provider: types.ProviderConfig{
+			Type:      "openai-responses",
+			APIKeyRef: "secret://OPENAI_KEY",
+			BaseURL:   "https://api.openai.com/v1",
+		},
+		ModelRouter: types.ModelRouterConfig{
+			Type:     "static",
+			Provider: "openai-responses",
+			Model:    "gpt-5.4-nano",
+		},
+		PermissionPolicy: types.PermissionPolicyConfig{
+			Type: "deny-side-effects",
+		},
+	}
+	if !reflect.DeepEqual(got.RunConfig, want) {
+		t.Fatalf("RunConfig mismatch\n got:  %#v\n want: %#v", got.RunConfig, want)
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigMutuallyExclusive asserts that setting both
+// `run_config_file` and `run_config` on the same suite is a parse error
+// that names the suite ID and both offending field names — operators
+// must be able to locate the conflict from the error alone.
+func TestLoadSuiteHCL_RunConfigMutuallyExclusive(t *testing.T) {
+	src := `
+suite "dual-baseline" {
+  run_config_file = "configs/base.json"
+
+  run_config {
+    max_turns = 5
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-both.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatal("expected error for suite setting both run_config_file and run_config")
+	}
+	frags := []string{"dual-baseline", "run_config_file", "run_config", "mutually exclusive"}
+	for _, f := range frags {
+		if !strings.Contains(err.Error(), f) {
+			t.Errorf("error = %q, want it to contain %q", err.Error(), f)
+		}
+	}
+}
+
+// TestLoadSuiteHCL_TaskRunConfigOverrides exercises the sparse
+// per-task overlay: a subset of fields are set, the rest must remain
+// unset (zero values / nil pointers) on the resulting
+// *types.RunConfigOverrides.
+func TestLoadSuiteHCL_TaskRunConfigOverrides(t *testing.T) {
+	src := `
+suite "s" {
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+
+    run_config_overrides {
+      max_turns = 4
+
+      provider {
+        type        = "anthropic"
+        api_key_ref = "secret://ANTHROPIC_KEY"
+      }
+    }
+
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "task-overrides.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if len(got.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(got.Tasks))
+	}
+	ov := got.Tasks[0].RunConfigOverrides
+	if ov == nil {
+		t.Fatalf("RunConfigOverrides should be non-nil")
+	}
+	if ov.MaxTurns == nil || *ov.MaxTurns != 4 {
+		t.Errorf("MaxTurns = %v, want pointer to 4", ov.MaxTurns)
+	}
+	if ov.Provider == nil {
+		t.Fatalf("Provider override should be non-nil")
+	}
+	if ov.Provider.Type != "anthropic" {
+		t.Errorf("Provider.Type = %q, want %q", ov.Provider.Type, "anthropic")
+	}
+	if ov.Provider.APIKeyRef != "secret://ANTHROPIC_KEY" {
+		t.Errorf("Provider.APIKeyRef = %q, want %q", ov.Provider.APIKeyRef, "secret://ANTHROPIC_KEY")
+	}
+	// Fields not set must stay nil/zero — the overrides surface is
+	// sparse by contract.
+	if ov.ModelRouter != nil {
+		t.Errorf("ModelRouter should be nil, got %#v", ov.ModelRouter)
+	}
+	if ov.ContextStrategy != nil {
+		t.Errorf("ContextStrategy should be nil, got %#v", ov.ContextStrategy)
+	}
+	if ov.EditStrategy != nil {
+		t.Errorf("EditStrategy should be nil, got %#v", ov.EditStrategy)
+	}
+	if ov.Verifier != nil {
+		t.Errorf("Verifier should be nil, got %#v", ov.Verifier)
+	}
+	if ov.Mode != "" {
+		t.Errorf("Mode should be empty, got %q", ov.Mode)
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigUnknownAttribute pins the "unknown
+// attributes are errors" contract on the inline `run_config` block.
+// Silently dropping a typo (e.g. `max_turn` instead of `max_turns`)
+// would let a regression suite be validated against the wrong config;
+// the parser must reject the construct.
+func TestLoadSuiteHCL_RunConfigUnknownAttribute(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    max_turn = 10
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-typo.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatal("expected error for unknown attribute in run_config block")
+	}
+	if !strings.Contains(err.Error(), "max_turn") {
+		t.Errorf("error = %q, want it to name the offending attribute", err.Error())
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigOverridesUnknownAttribute mirrors the
+// previous test for the per-task overlay: typos in
+// `run_config_overrides` must fail loudly.
+func TestLoadSuiteHCL_RunConfigOverridesUnknownAttribute(t *testing.T) {
+	src := `
+suite "s" {
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+
+    run_config_overrides {
+      maxturns = 4
+    }
+
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "task-overrides-typo.hcl", src)
+	_, err := LoadSuiteHCL(path)
+	if err == nil {
+		t.Fatal("expected error for unknown attribute in run_config_overrides block")
+	}
+	if !strings.Contains(err.Error(), "maxturns") {
+		t.Errorf("error = %q, want it to name the offending attribute", err.Error())
+	}
+}
+
+// TestLoadSuiteHCL_ExistingSuitesParse asserts that the live
+// guardrail.hcl and openai-responses-empty-tool-output.hcl files in
+// eval/suites/ continue to parse with the new code path and produce
+// zero-valued RunConfig fields (no new fields populated). This is the
+// backwards-compat contract from the issue.
+func TestLoadSuiteHCL_ExistingSuitesParse(t *testing.T) {
+	cases := []string{
+		"../suites/guardrail.hcl",
+		"../suites/openai-responses-empty-tool-output.hcl",
+	}
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			got, err := LoadSuiteHCL(path)
+			if err != nil {
+				t.Fatalf("LoadSuiteHCL(%s): %v", path, err)
+			}
+			if got.RunConfigFile != "" {
+				t.Errorf("RunConfigFile should be empty (backwards-compat), got %q", got.RunConfigFile)
+			}
+			if got.RunConfig != nil {
+				t.Errorf("RunConfig should be nil (backwards-compat), got %#v", got.RunConfig)
+			}
+			for _, task := range got.Tasks {
+				if task.RunConfigOverrides != nil {
+					t.Errorf("task %q RunConfigOverrides should be nil (backwards-compat), got %#v", task.ID, task.RunConfigOverrides)
+				}
+			}
+			if len(got.Tasks) == 0 {
+				t.Errorf("expected at least one task")
+			}
+		})
+	}
+}
+
+// TestLoadSuiteHCL_RunConfigDeepBlocks exercises a richer inline
+// run_config — nested blocks (executor, network, resources,
+// permission_policy, code_scanner, guard_rail with stages) — to pin
+// that the recursive spec → types conversion preserves the full
+// shape. The intent is to catch field-mapping mistakes in
+// runConfigSpecToType without listing every leaf field in every test.
+func TestLoadSuiteHCL_RunConfigDeepBlocks(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    mode = "execution"
+
+    executor {
+      type      = "container"
+      image     = "stirrup/sandbox:latest"
+      runtime   = "runsc"
+
+      network {
+        mode      = "allowlist"
+        allowlist = ["api.openai.com"]
+      }
+
+      resources {
+        cpus      = 2.0
+        memory_mb = 1024
+        disk_mb   = 2048
+        pids      = 256
+      }
+    }
+
+    permission_policy {
+      type        = "policy-engine"
+      policy_file = "policies/default.cedar"
+      fallback    = "deny-side-effects"
+    }
+
+    code_scanner {
+      type          = "composite"
+      scanners      = ["patterns", "semgrep"]
+      block_on_warn = true
+    }
+
+    guard_rail {
+      type = "composite"
+
+      stage {
+        type     = "granite-guardian"
+        endpoint = "http://localhost:8000/v1/chat/completions"
+      }
+    }
+
+    observability {
+      environment       = "staging"
+      service_namespace = "stirrup-eval"
+    }
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-deep.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	rc := got.RunConfig
+	if rc == nil {
+		t.Fatal("RunConfig should be non-nil")
+	}
+	if rc.Executor.Type != "container" {
+		t.Errorf("Executor.Type = %q, want %q", rc.Executor.Type, "container")
+	}
+	if rc.Executor.Network == nil || rc.Executor.Network.Mode != "allowlist" {
+		t.Errorf("Executor.Network = %#v, want allowlist", rc.Executor.Network)
+	}
+	if rc.Executor.Resources == nil || rc.Executor.Resources.CPUs != 2.0 {
+		t.Errorf("Executor.Resources = %#v, want cpus=2.0", rc.Executor.Resources)
+	}
+	if rc.PermissionPolicy.PolicyFile != "policies/default.cedar" {
+		t.Errorf("PermissionPolicy.PolicyFile = %q, want policies/default.cedar", rc.PermissionPolicy.PolicyFile)
+	}
+	if rc.CodeScanner == nil || !rc.CodeScanner.BlockOnWarn {
+		t.Errorf("CodeScanner = %#v, want BlockOnWarn=true", rc.CodeScanner)
+	}
+	if rc.GuardRail == nil || rc.GuardRail.Type != "composite" {
+		t.Errorf("GuardRail = %#v, want composite", rc.GuardRail)
+	}
+	if rc.GuardRail == nil || len(rc.GuardRail.Stages) != 1 || rc.GuardRail.Stages[0].Type != "granite-guardian" {
+		t.Errorf("GuardRail.Stages = %#v, want one granite-guardian stage", rc.GuardRail.Stages)
+	}
+	if rc.Observability.Environment != "staging" {
+		t.Errorf("Observability.Environment = %q, want staging", rc.Observability.Environment)
+	}
+}

--- a/eval/suites/openai-responses-empty-tool-output.hcl
+++ b/eval/suites/openai-responses-empty-tool-output.hcl
@@ -5,11 +5,19 @@
 # "Missing required parameter: 'input[N].output'".
 #
 # This suite is opt-in. It exercises a real round-trip against the
-# OpenAI Responses API and therefore requires:
+# OpenAI Responses API and therefore requires a real OpenAI API key
+# resolvable from the `secret://OPENAI_KEY` reference declared in
+# the suite-level `run_config` block below.
 #
-#   - A real OpenAI API key set in the environment.
-#   - The harness binary configured with
-#     `--provider openai-responses --model <model>`.
+# The suite pins its own provider posture inline (issue #177): the
+# suite-level `run_config` block sets `provider.type =
+# "openai-responses"` and the model_router, so the regression
+# scenario cannot be silently nullified by an operator invoking the
+# harness with a different provider. The runner merges this
+# baseline into a per-task RunConfig and invokes
+# `stirrup harness --config <merged>.json --prompt ... --mode ...`;
+# the redacted form is retained under `<output>/<suite>/<task>/
+# run_config.redacted.json` alongside the trace.
 #
 # The unit-level marshal tests in
 # harness/internal/provider/openai_responses_test.go (covering
@@ -34,7 +42,28 @@
 #       --output results/
 
 suite "openai-responses-empty-tool-output-regression" {
-  description = "Live-API regression for issue #172: the openai-responses adapter dropped the required `output` key from function_call_output items when a tool produced empty stdout, causing the next turn to be rejected with HTTP 400. Opt-in — requires a real OpenAI API key and the harness configured for --provider openai-responses; the unit tests in openai_responses_test.go are the per-PR gate, this suite is the end-to-end pin against the real Responses API."
+  description = "Live-API regression for issue #172: the openai-responses adapter dropped the required `output` key from function_call_output items when a tool produced empty stdout, causing the next turn to be rejected with HTTP 400. Opt-in — requires a real OpenAI API key resolvable from secret://OPENAI_KEY. The suite pins provider posture inline so the regression scenario cannot be nullified by an operator invoking the harness with a different provider. The unit tests in openai_responses_test.go are the per-PR gate; this suite is the end-to-end pin against the real Responses API."
+
+  # Suite-level baseline (issue #177). Every task inherits this
+  # RunConfig; per-task `run_config_overrides` blocks could
+  # overlay a sparse subset, but none are needed here. The runner
+  # merges this baseline into a fresh RunConfig per task, writes
+  # it to a per-task tempfile, and invokes
+  # `stirrup harness --config <path>`. The retained artifact under
+  # `--output` includes the redacted form (every `secret://` ref
+  # rewritten to `secret://[REDACTED]`).
+  run_config {
+    provider {
+      type        = "openai-responses"
+      api_key_ref = "secret://OPENAI_KEY"
+    }
+
+    model_router {
+      type     = "static"
+      provider = "openai-responses"
+      model    = "gpt-5.4-nano"
+    }
+  }
 
   task "empty-stdout-run-command-completes" {
     description = "Drives the agent through at least one run_command whose stdout is empty (`true`), then a write_file that drops a sentinel. Under the buggy adapter, turn 2's request is rejected with HTTP 400 and `completed.txt` is never written. Under the fix, the sentinel is present with the literal text `ok`."

--- a/types/eval.go
+++ b/types/eval.go
@@ -6,6 +6,19 @@ type EvalSuite struct {
 	ID          string     `json:"id"`
 	Description string     `json:"description"`
 	Tasks       []EvalTask `json:"tasks"`
+
+	// RunConfigFile is an optional path to a RunConfig JSON file that
+	// acts as the suite-level baseline applied to every task before any
+	// per-task overrides. The format matches what `stirrup harness
+	// --config` accepts. Empty means "not set". Mutually exclusive with
+	// RunConfig; the HCL parser rejects suites that set both.
+	RunConfigFile string `json:"runConfigFile,omitempty"`
+
+	// RunConfig is an optional inline RunConfig that acts as the
+	// suite-level baseline applied to every task before any per-task
+	// overrides. Nil means "not set". Mutually exclusive with
+	// RunConfigFile; the HCL parser rejects suites that set both.
+	RunConfig *RunConfig `json:"runConfig,omitempty"`
 }
 
 // EvalTask describes a single evaluation task.
@@ -17,6 +30,12 @@ type EvalTask struct {
 	Prompt      string    `json:"prompt"`
 	Mode        string    `json:"mode"`
 	Judge       EvalJudge `json:"judge"`
+
+	// RunConfigOverrides is a sparse per-task overlay applied on top of
+	// the suite-level RunConfig baseline (EvalSuite.RunConfigFile or
+	// EvalSuite.RunConfig). Nil means "no per-task overrides"; only set
+	// fields are layered onto the baseline.
+	RunConfigOverrides *RunConfigOverrides `json:"runConfigOverrides,omitempty"`
 }
 
 // EvalJudge describes how to judge a run's outcome.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1403,6 +1403,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateExecutorWorkspaceExportTo(config.Executor, &errs)
 	validateVerifierConfig(config.Verifier, "verifier", &errs)
 	validateProviderConfigs(config, retryDefaulted, &errs)
+	validateAPIKeyRefs(config, &errs)
 	validateBuiltInTools(config.Tools.BuiltIn, &errs)
 	validateCredentialConfig(config.Provider.Credential, "provider.credential", &errs)
 	for name, prov := range config.Providers {
@@ -1958,6 +1959,38 @@ func validateBuiltInTools(builtIns []string, errs *[]string) {
 		if !validBuiltInToolNames[name] {
 			*errs = append(*errs, fmt.Sprintf("tools.builtIn contains unsupported tool %q", name))
 		}
+	}
+}
+
+// validateAPIKeyRefs enforces that every secret-bearing apiKeyRef on
+// the config is either empty (the field is optional / driven by
+// credential federation) or begins with the "secret://" scheme.
+// Without this, an operator who pastes a literal API key into a
+// suite's run_config gets a confusing runtime failure (the harness
+// will try to resolve "sk-ant-..." through SecretStore and surface a
+// generic "no such secret" error) instead of a clear validation
+// message. Apply to every field redactProviderAPIKeyRefs and friends
+// know to scrub — the set of secret-bearing fields and the set of
+// fields the redactor handles must stay in lockstep, otherwise a new
+// field that the redactor missed would also miss this check.
+func validateAPIKeyRefs(config *RunConfig, errs *[]string) {
+	check := func(path, ref string) {
+		if ref == "" {
+			return
+		}
+		if !strings.HasPrefix(ref, "secret://") {
+			*errs = append(*errs, fmt.Sprintf("%s must be a secret reference (e.g. \"secret://NAME\"), got a literal value", path))
+		}
+	}
+	check("provider.apiKeyRef", config.Provider.APIKeyRef)
+	for name, prov := range config.Providers {
+		check(fmt.Sprintf("providers[%s].apiKeyRef", name), prov.APIKeyRef)
+	}
+	if config.Executor.VcsBackend != nil {
+		check("executor.vcsBackend.apiKeyRef", config.Executor.VcsBackend.APIKeyRef)
+	}
+	for i, server := range config.Tools.MCPServers {
+		check(fmt.Sprintf("tools.mcpServers[%d].apiKeyRef", i), server.APIKeyRef)
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -4462,3 +4462,68 @@ func TestValidateRunConfig_BedrockModelIDShape(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateRunConfig_APIKeyRefMustBeSecretReference asserts that
+// every secret-bearing apiKeyRef field is required to use the
+// "secret://" scheme. A literal API key landing in RunConfig is a
+// configuration mistake the validator should surface clearly rather
+// than letting SecretStore fail at first provider call with a
+// generic "no such secret" error.
+func TestValidateRunConfig_APIKeyRefMustBeSecretReference(t *testing.T) {
+	t.Run("provider.apiKeyRef literal rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Provider = ProviderConfig{Type: "anthropic", APIKeyRef: "sk-ant-literal-key"}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected error for literal provider.apiKeyRef")
+		}
+		if !strings.Contains(err.Error(), "secret://") {
+			t.Errorf("error = %q, want substring %q", err.Error(), "secret://")
+		}
+		if !strings.Contains(err.Error(), "provider.apiKeyRef") {
+			t.Errorf("error = %q, want it to name the offending field", err.Error())
+		}
+	})
+
+	t.Run("provider.apiKeyRef secret reference accepted", func(t *testing.T) {
+		c := validConfig()
+		c.Provider = ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_KEY"}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("provider.apiKeyRef empty accepted", func(t *testing.T) {
+		// Empty is the unset form — credential federation may leave
+		// apiKeyRef blank and resolve auth via Credential instead.
+		c := validConfig()
+		c.Provider = ProviderConfig{Type: "anthropic"}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("executor.vcsBackend.apiKeyRef literal rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Executor.VcsBackend = &VcsBackendConfig{Type: "github", APIKeyRef: "ghp_literal"}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected error for literal vcsBackend.apiKeyRef")
+		}
+		if !strings.Contains(err.Error(), "executor.vcsBackend.apiKeyRef") {
+			t.Errorf("error = %q, want it to name the offending field", err.Error())
+		}
+	})
+
+	t.Run("tools.mcpServers literal rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Tools.MCPServers = []MCPServerConfig{{Name: "x", URI: "http://localhost", APIKeyRef: "literal-token"}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected error for literal mcpServers apiKeyRef")
+		}
+		if !strings.Contains(err.Error(), "tools.mcpServers[0].apiKeyRef") {
+			t.Errorf("error = %q, want it to name the offending field index", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
Closes #177.

## Summary

- Adds three new HCL authoring affordances so eval suites can express the operator's full deployment posture:
  - suite-level `run_config_file = "..."` (path to a checked-in RunConfig JSON; resolved relative to the suite file's directory),
  - suite-level inline `run_config { ... }` (mutually exclusive with `run_config_file`),
  - per-task sparse `run_config_overrides { ... }` layered on top of the suite baseline.
- Runner now resolves the merged `RunConfig` per task, writes a per-task temp config (`0o600`), invokes `stirrup harness --config <temp>`, and retains a redacted `run_config.redacted.json` under `--output` for each task.
- `--dry-run` runs `ValidateRunConfig` per task; the live-run path also gates the subprocess on `ValidateRunConfig` so an invalid config fails fast without burning a harness launch.
- Backwards compatible: suites without any of the new blocks take the existing five-flag path unchanged. `guardrail.hcl` is untouched; `openai-responses-empty-tool-output.hcl` is updated to demonstrate the new flow end-to-end.

## Implementation notes

- `eval/spec/runconfig.go` introduces a parallel "spec" tree mirroring `types.RunConfig`. Unknown attributes are rejected to keep typos loud.
- Flag-precedence trap fixed: `--mode` / `--timeout` are no longer appended unconditionally — they would silently shadow the suite's `run_config { mode = ... }` and `timeout = ...`. The trace file path is threaded through the merged config's `TraceEmitter.FilePath` rather than `--trace` to avoid the harness's `--trace` → `TraceEmitter.Type = "jsonl"` coercion. The remaining authoritative flags (`--workspace`, `--prompt`, `--config`) are documented.
- `loadRunConfigFile` opens with `O_NONBLOCK` and rejects non-regular files (FIFOs, devices, sockets) before reading — closes a worker-pool DoS where a FIFO config path would deadlock the eval worker pool.
- Three-layer `secret://` defense for `apiKeyRef` values:
  1. **Parse time** — `eval/spec.validateInlineAPIKeyRefs` rejects raw values at HCL parse with the offending field path in the error message, so authors see the diagnostic where they wrote the value (commit `aec3d50`).
  2. **Validate time** — `types.ValidateRunConfig` rejects literal API keys in `Provider.APIKeyRef`, `Executor.VcsBackend.APIKeyRef`, named providers, and `Tools.MCPServers[*].APIKeyRef` regardless of how the config arrived (commit `9419e2b`).
  3. **Warn-at-marshal** — `eval/runner.warnIfRawAPIKeyRef` emits a stderr warning at artifact retention if any value ever reaches Redact() without the `secret://` prefix; without this, a regression in either earlier layer would be hidden by Redact()'s sentinel rewrite (commit `11eb8f0`).
- `EvalSuite` programmatic construction is guarded too: `resolveBaseline` errors if both `RunConfigFile` and `RunConfig` are set, not just at HCL parse time.
- `run_config_file` is resolved relative to the suite file's directory at parse time, so authors can write `configs/base.json` next to the suite without depending on the caller's working directory. Absolute paths pass through unchanged. The runner stays pure with respect to filesystem layout.
- Default timeout (`300s`) is injected into the merged config when no value is pinned, so the common authoring shape — an inline `run_config { ... }` that omits the runner-owned `timeout` field — does not false-fail `ValidateRunConfig` with "timeout is required". A value pinned by a JSON baseline or an overlay survives unchanged.

## Review history

Implemented as four sequential chunks (types → parser → runner → example/docs), reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers in parallel, synthesized into a single remediation brief, and remediated in seven follow-up commits before pushing. Reports retained in `.claude/worktrees/feat+issue-177-eval-runconfig-surface/reviews/` (not in the diff).

Four additional commits land the convergence with the parallel implementation in #181 (where #186 originated as an accidental duplicate). Reviewing #181's approach surfaced four improvements worth carrying over:
- `run_config_file` resolved relative to the suite file's directory at parse time (`f0b0941`).
- Parse-time `secret://` scheme validation in `eval/spec`, supplementing the existing types-layer check (`aec3d50`).
- Default timeout injection in the merged config so inline `run_config` blocks pass `ValidateRunConfig` (`af38555`).
- Defense-in-depth `warnIfRawAPIKeyRef` at artifact retention, closing the third layer of the secret:// guard (`11eb8f0`).

## Test plan

- [x] `just build` clean
- [x] `just test` green across `types`, `eval/spec`, `eval/runner`
- [x] `just lint` clean for touched files (16 pre-existing findings in unrelated files predate this PR; verified by diffing against `main`)
- [x] Coverage: `eval/spec` 92.8%, `eval/runner` 85.2%, `types` 91.9%
- [x] `guardrail.hcl` still parses with new code path (backwards compat assertion in `eval/spec/runconfig_test.go`)
- [x] `openai-responses-empty-tool-output.hcl` parses with the new `run_config` block and the suite's existing tasks remain valid
- [x] Argv assertions: no `--mode` / `--timeout` passed when a merged config is in use
- [x] Read-only-mode-with-allow-all-policy baseline → `runTask` returns `error` outcome with no subprocess launched
- [x] `loadRunConfigFile(FIFO)` → "not a regular file" error
- [x] `EvalSuite` with both `RunConfigFile` and `RunConfig` → mutual-exclusion error from `resolveBaseline`
- [x] `ValidateRunConfig` with literal `APIKeyRef` → rejected at parse-equivalent time
- [x] HCL `provider.api_key_ref = "raw-value"` → parse-time error naming the offending field
- [x] HCL `executor.vcs_backend.api_key_ref = "raw-value"` → parse-time error naming the offending field
- [x] HCL `run_config_overrides.provider.api_key_ref = "raw-value"` → parse-time error naming the offending field
- [x] Relative `run_config_file = "configs/base.json"` resolves to `<suite-dir>/configs/base.json`
- [x] Absolute `run_config_file = "/etc/.../base.json"` passes through unchanged
- [x] Inline `run_config { ... }` without `timeout` passes dry-run validation (default `300s` injected)
- [x] JSON baseline with explicit `timeout = 900` survives the merge unchanged
- [x] `warnIfRawAPIKeyRef` fires for raw values across `provider`, `providers[*]`, `executor.vcsBackend`, and `tools.mcpServers[*]`; stays silent for all-`secret://` configs
- [x] Retained `run_config.redacted.json` is `0o600`
- [x] `run_config_overrides { mode = "..." }` → "unknown attribute" HCL parse error (task mode is set via the task block's `mode` attribute, not via overrides)

## Out of scope (filed separately)

- TOCTOU in the harness binary's own copy of `loadRunConfigFile` — same pattern, different file; will track as a follow-up.
- Stale `--concurrency` doc lines in `docs/eval.md` (lines 93-94, 309, 457-458) predate this PR (issue #31 already landed concurrency).
- Multi-config matrix runs (`--config-matrix dir/*.json`) — issue #177 calls this out as future work.
- Experiment runner integration via the same `RunConfigOverrides` reuse — small follow-up.
- Spec/type lockstep growth guard (compile-time field-coverage test) — track when `RunConfig` growth accelerates.
- `run_config_overrides` without a suite baseline silently no-ops — non-blocking; consider a stderr warning later.
- HCL fields not yet surfaced from the parser: `RunConfig.Providers` map, `RunConfig.DynamicContext`, `GuardRailConfig.CustomCriteria`, `ToolsConfig.MCPServers`. The JSON `run_config_file` path supports these today.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
