### PR TITLE
provider/gemini: disable streamFunctionCallArguments for 3.x compatibility

### DIFF
--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -288,7 +288,9 @@ type toolCallBuf struct {
 //   - FunctionCall parts arrive in two patterns:
 //     1) Streamed: one or more chunks with WillContinue=true and
 //     PartialArgs, then a final chunk with WillContinue=false and either
-//     Args or PartialArgs populated.
+//     Args or PartialArgs populated. Pattern 1 is handled defensively;
+//     with streamFunctionCallArguments=false the production path is
+//     always pattern 2.
 //     2) Single: one chunk with neither WillContinue nor partial markers,
 //     just Args.
 //   - finishReason on Candidates[0] terminates the turn — emit
@@ -463,6 +465,7 @@ func (g *GeminiAdapter) consumeSSE(
 							buf.args = snapshot
 						}
 
+						// Unreachable when streamFunctionCallArguments=false (current default); retained for correctness if the flag is re-enabled.
 						if !fc.WillContinue {
 							// Final chunk for this call: emit, then
 							// advance the sequence counter used for ID

--- a/harness/internal/provider/gemini_request.go
+++ b/harness/internal/provider/gemini_request.go
@@ -87,7 +87,7 @@ func BuildGenerateContentRequest(
 		req.ToolConfig = &geminiToolConfig{
 			FunctionCallingConfig: geminiFunctionCallingConfig{
 				Mode:                        "AUTO",
-				StreamFunctionCallArguments: true,
+				StreamFunctionCallArguments: false,
 			},
 		}
 	}

--- a/harness/internal/provider/gemini_request_test.go
+++ b/harness/internal/provider/gemini_request_test.go
@@ -326,7 +326,14 @@ func TestBuildGenerateContentRequest_CustomSafetySettings(t *testing.T) {
 	}
 }
 
-func TestBuildGenerateContentRequest_StreamFunctionCallArgumentsTrueWhenToolsPresent(t *testing.T) {
+// TestBuildGenerateContentRequest_StreamFunctionCallArgumentsFalseWhenToolsPresent
+// pins the request shape: when tools are declared the adapter sets
+// functionCallingConfig.mode="AUTO" and streamFunctionCallArguments=false.
+// The flag stays off because Gemini 3.x's streamed-args wire format
+// (JSON-path deltas with name only on the first chunk) would otherwise
+// break the parser — see geminiToolConfig in gemini_types.go for the full
+// rationale.
+func TestBuildGenerateContentRequest_StreamFunctionCallArgumentsFalseWhenToolsPresent(t *testing.T) {
 	body, _, err := BuildGenerateContentRequest(types.StreamParams{
 		Model: "gemini-2.5-pro",
 		Messages: []types.Message{
@@ -350,8 +357,8 @@ func TestBuildGenerateContentRequest_StreamFunctionCallArgumentsTrueWhenToolsPre
 	if dr.ToolConfig.FunctionCallingConfig.Mode != "AUTO" {
 		t.Errorf("mode = %q, want AUTO", dr.ToolConfig.FunctionCallingConfig.Mode)
 	}
-	if !dr.ToolConfig.FunctionCallingConfig.StreamFunctionCallArguments {
-		t.Errorf("streamFunctionCallArguments should be true")
+	if dr.ToolConfig.FunctionCallingConfig.StreamFunctionCallArguments {
+		t.Errorf("streamFunctionCallArguments should be false")
 	}
 	if len(dr.Tools) != 1 || len(dr.Tools[0].FunctionDeclarations) != 1 {
 		t.Fatalf("tool declarations not as expected: %+v", dr.Tools)

--- a/harness/internal/provider/gemini_test.go
+++ b/harness/internal/provider/gemini_test.go
@@ -922,3 +922,66 @@ func TestGeminiAdapter_HasTimeout(t *testing.T) {
 		t.Error("ResponseHeaderTimeout should be non-zero")
 	}
 }
+
+// TestGeminiAdapter_NonStreamedFunctionCall3xShape pins the parser against
+// the wire format Gemini 3.x emits when streamFunctionCallArguments is
+// false: one SSE chunk carrying a functionCall part with both `name` and
+// `args` populated, alongside finishReason="STOP" on the same candidate.
+// This is the shape both 2.5-pro and 3.x converge on with the flag off,
+// and is the shape the adapter must continue to handle after the
+// streamed-args feature was disabled (see gemini_request.go) to dodge
+// 3.x's new JSON-path delta format. The shape is derived from a real
+// captured Vertex AI response against gemini-3.1-pro-preview.
+func TestGeminiAdapter_NonStreamedFunctionCall3xShape(t *testing.T) {
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"docs/safety-rings.md"}}}]},"finishReason":"STOP"}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	var toolCalls []types.StreamEvent
+	var stop *types.StreamEvent
+	for i := range events {
+		switch events[i].Type {
+		case "tool_call":
+			toolCalls = append(toolCalls, events[i])
+		case "message_complete":
+			stop = &events[i]
+		case "error":
+			t.Fatalf("unexpected error event: %v", events[i].Error)
+		}
+	}
+
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool_call event, got %d: %+v", len(toolCalls), toolCalls)
+	}
+	tc := toolCalls[0]
+	if tc.Name != "read_file" {
+		t.Errorf("tool_call.Name = %q, want read_file", tc.Name)
+	}
+	if tc.Input["path"] != "docs/safety-rings.md" {
+		t.Errorf("tool_call.Input[path] = %v, want docs/safety-rings.md", tc.Input["path"])
+	}
+
+	if stop == nil {
+		t.Fatal("expected message_complete event")
+	}
+	// STOP must be promoted to tool_use because a functionCall was emitted
+	// during the stream — otherwise the agentic loop would terminate
+	// without dispatching the tool.
+	if stop.StopReason != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use", stop.StopReason)
+	}
+}

--- a/harness/internal/provider/gemini_types.go
+++ b/harness/internal/provider/gemini_types.go
@@ -115,7 +115,7 @@ type geminiToolConfig struct {
 // expose them.
 type geminiFunctionCallingConfig struct {
 	Mode                        string `json:"mode"`
-	StreamFunctionCallArguments bool   `json:"streamFunctionCallArguments"`
+	StreamFunctionCallArguments bool   `json:"streamFunctionCallArguments,omitempty"`
 }
 
 // geminiSafetySetting is the wire-format struct (HARM_CATEGORY_*,

--- a/harness/internal/provider/gemini_types.go
+++ b/harness/internal/provider/gemini_types.go
@@ -52,7 +52,10 @@ type geminiPart struct {
 // Args is the argument object the model produced. PartialArgs and
 // WillContinue are deserialise-only fields that appear on streamed chunks
 // when streamFunctionCallArguments is enabled — the request marshaller
-// never emits them.
+// never emits them. The adapter currently leaves streamFunctionCallArguments
+// off (see geminiToolConfig), so these fields are not exercised by the
+// happy path; they are retained so the parser remains tolerant of a future
+// wire-format reversion or an operator who flips the flag back on.
 type geminiFunctionCall struct {
 	Name         string          `json:"name"`
 	Args         json.RawMessage `json:"args,omitempty"`
@@ -90,10 +93,18 @@ type geminiFunctionDeclaration struct {
 }
 
 // geminiToolConfig pins tool-calling behaviour for the request.
-// streamFunctionCallArguments is always true for this adapter: it lets us
-// surface partial argument JSON to the trace, which is helpful for
-// debugging long tool inputs that would otherwise arrive as a single
-// blob at the end of the response.
+// streamFunctionCallArguments is deliberately left off for this adapter.
+// When the flag is true, Gemini 3.x streams a function call across
+// multiple SSE chunks where only the first carries `name` and subsequent
+// chunks deliver `partialArgs` as an array of JSON-path delta records
+// ({jsonPath, stringValue, willContinue}) rather than the cumulative
+// JSON-object snapshots emitted by the 2.x format. Supporting that shape
+// would require index-keyed slot correlation plus JSON-path synthesis on
+// the receive side, with no upside for this harness — the trace is
+// emitted post-turn, not mid-stream, so per-chunk argument visibility is
+// not load-bearing. With the flag off, both 2.5 and 3.x emit a single
+// functionCall part with `name` and `args` populated in one chunk, which
+// the parser already handles uniformly.
 type geminiToolConfig struct {
 	FunctionCallingConfig geminiFunctionCallingConfig `json:"functionCallingConfig"`
 }


### PR DESCRIPTION
## Summary

A live Vertex AI run against the new `gemini-3.1-pro-preview` model fails immediately with:

```
{"level":"ERROR","msg":"provider stream failed","provider":"gemini","model":"gemini-3.1-pro-preview","error":"functionCall part missing name"}
```

### Reproduction

```
GOOGLE_APPLICATION_CREDENTIALS="<service-account-key.json>" \
  ./stirrup harness \
    --prompt "Give me a summary of the safety rings doc" \
    --provider gemini \
    --gcp-project rubynerd-net \
    --model gemini-3.1-pro-preview \
    --workspace .
```

### Root cause

Under `toolConfig.functionCallingConfig.streamFunctionCallArguments=true`, the Gemini 3.x family streams a function call across multiple SSE chunks where only the first carries `name`. Continuation chunks deliver `partialArgs` as an **array of JSON-path delta records** (`{jsonPath, stringValue, willContinue}`) rather than the cumulative JSON-object snapshots the 2.x family emitted. A representative first continuation chunk from a captured Vertex response:

```
data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.path","stringValue":"docs/safety-rings.md","willContinue":true}],"willContinue":true}}]}}], ...}
```

The existing parser in `harness/internal/provider/gemini.go` keys per-call buffers by `fc.Name` and reads `partialArgs` as a cumulative JSON object. The first continuation chunk has an empty `Name` and trips the explicit `"functionCall part missing name"` guard.

### Why not implement the new delta format

Disabling the streamed-args flag is the right fix because:

- With the flag off, both `gemini-2.5-pro` and `gemini-3.1-pro-preview` emit a single `functionCall` part with `name` and `args` populated in one SSE chunk (verified empirically against `rubynerd-net`). The existing parser already handles that shape uniformly.
- Supporting the new delta format would require index-keyed slot correlation plus JSON-path synthesis on the receive side, for no operational upside — the harness emits its trace post-turn, not mid-stream, so per-chunk argument visibility is not load-bearing.
- The parser-side tolerance for `partialArgs` and the `"missing name"` guard are retained so the adapter remains correct if a future operator re-enables the flag.

### Changes

- `harness/internal/provider/gemini_request.go` — `StreamFunctionCallArguments: true` → `false`.
- `harness/internal/provider/gemini_types.go` — rewrote the `geminiToolConfig` rationale comment and updated the `geminiFunctionCall.PartialArgs/WillContinue` note to reflect that those fields are no longer exercised on the happy path.
- `harness/internal/provider/gemini_request_test.go` — renamed `TestBuildGenerateContentRequest_StreamFunctionCallArgumentsTrueWhenToolsPresent` → `...FalseWhenToolsPresent` and inverted the assertion.
- `harness/internal/provider/gemini_test.go` — added `TestGeminiAdapter_NonStreamedFunctionCall3xShape`, a regression test that replays the Gemini 3.x non-streamed shape (single SSE chunk with `name + args` populated alongside `finishReason: STOP`) and pins `STOP -> tool_use` promotion.

## Validation

- [x] `just test` — all packages pass.
- [x] `golangci-lint run ./harness/internal/provider/...` — 0 issues.
- [ ] Manual smoke against Vertex AI with the reproduction command above (maintainer, requires GCP creds).

## Follow-up

Not in this PR: Gemini 3.x parts carry `thoughtSignature` blobs that operators should round-trip on subsequent turns to preserve the model's hidden chain-of-thought across tool exchanges. The harness currently drops them on receive and never re-sends them. Worth tracking as a separate change.