### PR TITLE
provider/gemini: round-trip thoughtSignature on 3.x to preserve chain-of-thought (#194)

### DIFF
--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -943,6 +943,66 @@ func TestBuildLoop_InvalidConfig(t *testing.T) {
 	}
 }
 
+// TestStreamEventsToResult_ThoughtSignaturePropagatedToBlock pins the
+// in-loop hop that carries the Gemini 3.x thoughtSignature from the
+// StreamEvent channel onto the persisted assistant ContentBlock
+// (#194). The assignment lives at a single point in streamEventsToResult
+// — without this regression test, deleting that one line is invisible
+// to the entire suite and silently drops cross-turn reasoning state.
+func TestStreamEventsToResult_ThoughtSignaturePropagatedToBlock(t *testing.T) {
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+
+	t.Run("non_empty_signature_survives", func(t *testing.T) {
+		ch := make(chan types.StreamEvent, 2)
+		ch <- types.StreamEvent{
+			Type:             "tool_call",
+			ID:               "c1",
+			Name:             "fn",
+			Input:            map[string]any{},
+			ThoughtSignature: "AY89==",
+		}
+		ch <- types.StreamEvent{Type: "message_complete"}
+		close(ch)
+
+		result, err := streamEventsToResult(context.Background(), ch, tp, slog.Default())
+		if err != nil {
+			t.Fatalf("streamEventsToResult() error: %v", err)
+		}
+		if len(result.Blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d: %+v", len(result.Blocks), result.Blocks)
+		}
+		if result.Blocks[0].Type != "tool_use" {
+			t.Errorf("Blocks[0].Type = %q, want tool_use", result.Blocks[0].Type)
+		}
+		if result.Blocks[0].ThoughtSignature != "AY89==" {
+			t.Errorf("Blocks[0].ThoughtSignature = %q, want %q", result.Blocks[0].ThoughtSignature, "AY89==")
+		}
+	})
+
+	t.Run("empty_signature_stays_empty", func(t *testing.T) {
+		ch := make(chan types.StreamEvent, 2)
+		ch <- types.StreamEvent{
+			Type:  "tool_call",
+			ID:    "c2",
+			Name:  "fn",
+			Input: map[string]any{},
+		}
+		ch <- types.StreamEvent{Type: "message_complete"}
+		close(ch)
+
+		result, err := streamEventsToResult(context.Background(), ch, tp, slog.Default())
+		if err != nil {
+			t.Fatalf("streamEventsToResult() error: %v", err)
+		}
+		if len(result.Blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d: %+v", len(result.Blocks), result.Blocks)
+		}
+		if result.Blocks[0].ThoughtSignature != "" {
+			t.Errorf("Blocks[0].ThoughtSignature = %q, want empty (zero value must not be mutated)", result.Blocks[0].ThoughtSignature)
+		}
+	})
+}
+
 func TestStreamEventsToResult_MergesMessageCompleteFields(t *testing.T) {
 	ch := make(chan types.StreamEvent, 3)
 	ch <- types.StreamEvent{Type: "text_delta", Text: "Hello"}

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -500,11 +500,18 @@ func streamEventsToResult(ctx context.Context, ch <-chan types.StreamEvent, tp t
 				currentText = ""
 			}
 			inputBytes, _ := json.Marshal(event.Input)
+			// ThoughtSignature is provider-opaque state that the harness
+			// must echo back unchanged on the next request so the model
+			// can resume its prior reasoning. Currently populated only by
+			// the Gemini 3.x adapter (#194). Adapters that do not emit
+			// the field leave it empty, and `omitempty` keeps it off the
+			// wire for downstream consumers (request marshallers, traces).
 			result.Blocks = append(result.Blocks, types.ContentBlock{
-				Type:  "tool_use",
-				ID:    event.ID,
-				Name:  event.Name,
-				Input: json.RawMessage(inputBytes),
+				Type:             "tool_use",
+				ID:               event.ID,
+				Name:             event.Name,
+				Input:            json.RawMessage(inputBytes),
+				ThoughtSignature: event.ThoughtSignature,
 			})
 
 		case "message_complete":

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -109,13 +109,16 @@ func (a *AnthropicAdapter) AuthMode() AuthMode {
 // the upstream StreamParams.Temperature pointer type so the
 // unset-vs-explicit-zero distinction survives marshalling.
 //
-// Messages is intentionally typed as []anthropicMessage rather than
-// []types.Message: ContentBlock carries a Gemini-private
-// `thought_signature` field (#194) that must never appear in a body
-// destined for Anthropic's API. Multi-provider runs (e.g. the model
-// router falling back from Gemini to Anthropic) would otherwise leak
-// Vertex's encrypted chain-of-thought blob into Anthropic infrastructure.
-// The local wire type below mirrors only the fields Anthropic accepts.
+// Messages is typed as []anthropicMessage, not []types.Message, to
+// enforce a cross-provider confidentiality invariant: each adapter owns
+// its egress wire type, so no field that another provider populates on
+// types.ContentBlock can be transmitted to Anthropic by accident.
+// types.ContentBlock is a shared carrier — fields accumulate on it as
+// providers need round-trip state — which means the egress shape must
+// be enforced at the adapter, not the carrier. #194 (Vertex's
+// thought_signature leaking via the model router) was the motivating
+// incident; the pattern generalises to any provider-private state added
+// later, and matches what every other adapter already does.
 type anthropicRequest struct {
 	Model       string                 `json:"model"`
 	System      string                 `json:"system,omitempty"`
@@ -127,18 +130,24 @@ type anthropicRequest struct {
 }
 
 // anthropicMessage is the Anthropic-side wire shape for a single message.
-// Locally defined so that provider-private fields on types.ContentBlock
-// (notably ThoughtSignature) cannot leak into the request body.
+// Locally defined so that the set of fields reaching api.anthropic.com is
+// an explicit allowlist, not whatever types.ContentBlock happens to carry
+// for some other provider's benefit. Adding a field here is an active
+// decision that Anthropic's Messages API accepts it on the wire.
 type anthropicMessage struct {
 	Role    string                  `json:"role"`
 	Content []anthropicContentBlock `json:"content"`
 }
 
-// anthropicContentBlock mirrors the fields Anthropic's Messages API
-// accepts on a content block. ThoughtSignature is intentionally absent —
-// it is a Vertex-private artefact (#194) and must not be transmitted to
-// Anthropic. Any future provider-private field added to
-// types.ContentBlock should likewise be omitted here.
+// anthropicContentBlock is the allowlist of content-block fields the
+// Anthropic Messages API accepts. types.ContentBlock is the shared carrier
+// across providers and may grow new fields over time to hold opaque
+// per-provider state (e.g. ThoughtSignature, added for Vertex in #194);
+// any such field stays absent here by construction. The rule for
+// extending this struct is: add a field only if Anthropic's API
+// documents support for it. Provider-private state added to
+// types.ContentBlock by some other adapter is, by default, dropped on
+// egress to Anthropic.
 type anthropicContentBlock struct {
 	Type      string          `json:"type"`
 	Text      string          `json:"text,omitempty"`
@@ -151,10 +160,14 @@ type anthropicContentBlock struct {
 }
 
 // translateMessagesAnthropic copies a slice of types.Message into the
-// adapter-local anthropicMessage shape, dropping any provider-private
-// fields (currently just ThoughtSignature) so they cannot reach
-// Anthropic's API. This is the structural guard against the
-// cross-provider leakage class identified in issue #194.
+// adapter-local anthropicMessage shape. It is the structural guard that
+// enforces the cross-provider confidentiality invariant: any field on
+// types.ContentBlock that is not mirrored onto anthropicContentBlock is
+// dropped here, rather than relying on call sites to scrub egress.
+// #194 was the motivating incident (Vertex's thought_signature would
+// otherwise have been forwarded to api.anthropic.com via the model
+// router); the same mechanism covers any provider-private field added
+// to the shared carrier in the future.
 func translateMessagesAnthropic(messages []types.Message) []anthropicMessage {
 	out := make([]anthropicMessage, len(messages))
 	for i, msg := range messages {

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -108,14 +108,75 @@ func (a *AnthropicAdapter) AuthMode() AuthMode {
 // verbatim, including an explicit 0.0 for greedy decoding. This mirrors
 // the upstream StreamParams.Temperature pointer type so the
 // unset-vs-explicit-zero distinction survives marshalling.
+//
+// Messages is intentionally typed as []anthropicMessage rather than
+// []types.Message: ContentBlock carries a Gemini-private
+// `thought_signature` field (#194) that must never appear in a body
+// destined for Anthropic's API. Multi-provider runs (e.g. the model
+// router falling back from Gemini to Anthropic) would otherwise leak
+// Vertex's encrypted chain-of-thought blob into Anthropic infrastructure.
+// The local wire type below mirrors only the fields Anthropic accepts.
 type anthropicRequest struct {
 	Model       string                 `json:"model"`
 	System      string                 `json:"system,omitempty"`
-	Messages    []types.Message        `json:"messages"`
+	Messages    []anthropicMessage     `json:"messages"`
 	Tools       []types.ToolDefinition `json:"tools,omitempty"`
 	MaxTokens   int                    `json:"max_tokens"`
 	Temperature *float64               `json:"temperature,omitempty"`
 	Stream      bool                   `json:"stream"`
+}
+
+// anthropicMessage is the Anthropic-side wire shape for a single message.
+// Locally defined so that provider-private fields on types.ContentBlock
+// (notably ThoughtSignature) cannot leak into the request body.
+type anthropicMessage struct {
+	Role    string                  `json:"role"`
+	Content []anthropicContentBlock `json:"content"`
+}
+
+// anthropicContentBlock mirrors the fields Anthropic's Messages API
+// accepts on a content block. ThoughtSignature is intentionally absent —
+// it is a Vertex-private artefact (#194) and must not be transmitted to
+// Anthropic. Any future provider-private field added to
+// types.ContentBlock should likewise be omitted here.
+type anthropicContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
+// translateMessagesAnthropic copies a slice of types.Message into the
+// adapter-local anthropicMessage shape, dropping any provider-private
+// fields (currently just ThoughtSignature) so they cannot reach
+// Anthropic's API. This is the structural guard against the
+// cross-provider leakage class identified in issue #194.
+func translateMessagesAnthropic(messages []types.Message) []anthropicMessage {
+	out := make([]anthropicMessage, len(messages))
+	for i, msg := range messages {
+		blocks := make([]anthropicContentBlock, len(msg.Content))
+		for j, b := range msg.Content {
+			blocks[j] = anthropicContentBlock{
+				Type:      b.Type,
+				Text:      b.Text,
+				ID:        b.ID,
+				Name:      b.Name,
+				Input:     b.Input,
+				ToolUseID: b.ToolUseID,
+				Content:   b.Content,
+				IsError:   b.IsError,
+			}
+		}
+		out[i] = anthropicMessage{
+			Role:    msg.Role,
+			Content: blocks,
+		}
+	}
+	return out
 }
 
 // SSE event types from the Anthropic API.
@@ -165,7 +226,7 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, params types.StreamParams
 	reqBody := anthropicRequest{
 		Model:       params.Model,
 		System:      params.System,
-		Messages:    params.Messages,
+		Messages:    translateMessagesAnthropic(params.Messages),
 		Tools:       params.Tools,
 		MaxTokens:   params.MaxTokens,
 		Temperature: params.Temperature,

--- a/harness/internal/provider/anthropic_test.go
+++ b/harness/internal/provider/anthropic_test.go
@@ -803,3 +803,76 @@ func TestAnthropicAdapter_WIFModeUsesAuthorizationBearer(t *testing.T) {
 	for range ch {
 	}
 }
+
+// TestAnthropic_ThoughtSignatureNotLeakedToAnthropicAPI is a regression
+// guard for issue #194 cross-provider data leakage: ContentBlock now
+// carries a Gemini-private `thought_signature` field, and a multi-provider
+// run (model router) can route history blocks produced by the Gemini
+// adapter into an Anthropic request. The adapter must serialise messages
+// through a local wire type that omits ThoughtSignature so Vertex's
+// encrypted chain-of-thought blob never reaches Anthropic infrastructure.
+//
+// The assertion is structural: the marshalled request body must not
+// contain the substring "thought_signature" anywhere, even when an input
+// ContentBlock carries a populated value.
+func TestAnthropic_ThoughtSignatureNotLeakedToAnthropicAPI(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, makeSSE("message_stop", `{}`))
+	}))
+	defer srv.Close()
+
+	adapter := NewAnthropicAdapter(staticBearer("test-key"), AuthModeAPIKey)
+	adapter.baseURL = srv.URL
+
+	// Construct a message history that mirrors what the harness builds
+	// after a Gemini 3.x turn that emitted a thoughtSignature: an
+	// assistant message with a tool_use ContentBlock carrying the blob.
+	const sig = "AY89SIGBLOB=="
+	messages := []types.Message{
+		{
+			Role: "user",
+			Content: []types.ContentBlock{
+				{Type: "text", Text: "read it"},
+			},
+		},
+		{
+			Role: "assistant",
+			Content: []types.ContentBlock{
+				{
+					Type:             "tool_use",
+					ID:               "toolu_1",
+					Name:             "read_file",
+					Input:            json.RawMessage(`{"path":"main.go"}`),
+					ThoughtSignature: sig,
+				},
+			},
+		},
+	}
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "claude-sonnet-4-6",
+		Messages:  messages,
+		MaxTokens: 16,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+
+	if len(capturedBody) == 0 {
+		t.Fatal("expected the Anthropic server to receive a request body")
+	}
+	bodyStr := string(capturedBody)
+	if strings.Contains(bodyStr, "thought_signature") {
+		t.Errorf("Anthropic request body contains \"thought_signature\" — Gemini-private state leaked to Anthropic API.\nbody = %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, sig) {
+		t.Errorf("Anthropic request body contains the signature value %q.\nbody = %s", sig, bodyStr)
+	}
+}

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -502,7 +502,14 @@ func (g *GeminiAdapter) consumeSSE(
 							buf.thoughtSignature = part.ThoughtSignature
 						}
 
-						// Unreachable when streamFunctionCallArguments=false (current default); retained for correctness if the flag is re-enabled.
+						// With streamFunctionCallArguments=false (the
+						// current default) WillContinue is never set,
+						// so every functionCall part falls directly
+						// into this branch — this is the only path
+						// through which production tool calls are
+						// emitted. The willContinue=true accumulation
+						// path above is retained defensively for
+						// compatibility if the flag is re-enabled.
 						if !fc.WillContinue {
 							// Final chunk for this call: emit, then
 							// advance the sequence counter used for ID

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -272,9 +272,17 @@ func mapGeminiFinishReason(in string) string {
 //
 // The retained blob is bounded at maxToolInputSize (10 MB) to mirror the
 // Anthropic adapter's safety cap.
+//
+// thoughtSignature holds the latest non-empty `thoughtSignature` observed
+// on the part across the buffer's chunks. Vertex emits the signature on
+// the same part as the functionCall (it is a property of the part, not
+// the call), so the most recently received non-empty value is the one
+// associated with the call's final shape. Only the assistant's terminal
+// signature for the part is meaningful for round-trip.
 type toolCallBuf struct {
-	name string
-	args []byte
+	name             string
+	args             []byte
+	thoughtSignature string
 }
 
 // consumeSSE reads SSE events from the response body and emits StreamEvents
@@ -352,7 +360,13 @@ func (g *GeminiAdapter) consumeSSE(
 	// follow-up chunk with the same name does not double-emit. The ID
 	// is synthesised from streamN and the monotonic nextPartIdx counter
 	// (incremented by the caller after a successful emit).
-	emitToolCall := func(name string, fullArgs []byte, idForSeq int) bool {
+	//
+	// thoughtSignature is the part-level Gemini 3.x reasoning blob. It is
+	// propagated onto the StreamEvent so the agentic loop can copy it
+	// onto the persisted assistant ContentBlock and the next request
+	// can round-trip it back to Vertex (issue #194). Empty for 2.x
+	// responses, where Vertex does not emit the field.
+	emitToolCall := func(name string, fullArgs []byte, idForSeq int, thoughtSignature string) bool {
 		var input map[string]any
 		argsBytes := fullArgs
 		if len(argsBytes) == 0 {
@@ -363,10 +377,11 @@ func (g *GeminiAdapter) consumeSSE(
 			return false
 		}
 		emitEvent(types.StreamEvent{
-			Type:  "tool_call",
-			ID:    fmt.Sprintf("gemini-%d-%d", streamN, idForSeq),
-			Name:  name,
-			Input: input,
+			Type:             "tool_call",
+			ID:               fmt.Sprintf("gemini-%d-%d", streamN, idForSeq),
+			Name:             name,
+			Input:            input,
+			ThoughtSignature: thoughtSignature,
 		})
 		delete(toolBufs, name)
 		return true
@@ -419,6 +434,18 @@ func (g *GeminiAdapter) consumeSSE(
 				for _, part := range cand.Content.Parts {
 					switch {
 					case part.Text != "":
+						// TODO(#194): Gemini 3.x can also attach a
+						// thoughtSignature to text parts. Threading the
+						// signature onto the assembled text ContentBlock
+						// would require additional plumbing through
+						// streamEventsToResult (which currently
+						// concatenates text deltas into a single block
+						// at message_complete time). The tool_use case
+						// is the load-bearing one for multi-turn agentic
+						// loops, so the text-side signature is deferred.
+						// When a text-part signature does arrive, it
+						// will be silently dropped here — same behaviour
+						// as before this change for that specific case.
 						emitEvent(types.StreamEvent{
 							Type: "text_delta",
 							Text: part.Text,
@@ -465,6 +492,16 @@ func (g *GeminiAdapter) consumeSSE(
 							buf.args = snapshot
 						}
 
+						// Gemini 3.x emits `thoughtSignature` alongside
+						// the functionCall part. The signature is a
+						// property of the part, not the call itself —
+						// retain the most recent non-empty value so we
+						// associate the buffer with the assistant's
+						// terminal reasoning blob for the part (#194).
+						if part.ThoughtSignature != "" {
+							buf.thoughtSignature = part.ThoughtSignature
+						}
+
 						// Unreachable when streamFunctionCallArguments=false (current default); retained for correctness if the flag is re-enabled.
 						if !fc.WillContinue {
 							// Final chunk for this call: emit, then
@@ -472,7 +509,7 @@ func (g *GeminiAdapter) consumeSSE(
 							// synthesis. nextPartIdx is no longer the
 							// slot key — emitting deletes the named
 							// slot directly.
-							if !emitToolCall(buf.name, buf.args, nextPartIdx) {
+							if !emitToolCall(buf.name, buf.args, nextPartIdx, buf.thoughtSignature) {
 								return
 							}
 							nextPartIdx++
@@ -490,7 +527,7 @@ func (g *GeminiAdapter) consumeSSE(
 				// represents a distinct tool name — order between
 				// drained calls is not load-bearing.
 				for _, buf := range toolBufs {
-					if !emitToolCall(buf.name, buf.args, nextPartIdx) {
+					if !emitToolCall(buf.name, buf.args, nextPartIdx, buf.thoughtSignature) {
 						return
 					}
 					nextPartIdx++

--- a/harness/internal/provider/gemini_request.go
+++ b/harness/internal/provider/gemini_request.go
@@ -171,14 +171,28 @@ func translateMessagesGemini(system string, messages []types.Message) ([]geminiC
 					if block.Text == "" {
 						continue
 					}
-					parts = append(parts, geminiPart{Text: block.Text})
+					// ThoughtSignature is round-tripped on assistant text
+					// parts when the previous turn captured one (#194).
+					// Vertex 2.x never emits the field, so it stays empty
+					// in that case and `omitempty` drops it from the
+					// serialised request.
+					parts = append(parts, geminiPart{
+						Text:             block.Text,
+						ThoughtSignature: block.ThoughtSignature,
+					})
 				case "tool_use":
 					args := normaliseToolArgs(block.Input)
+					// ThoughtSignature is round-tripped on the part
+					// carrying the functionCall — the load-bearing case
+					// for multi-turn tool exchanges on Gemini 3.x where
+					// dropping the blob breaks the model's chain-of-
+					// thought continuity (#194).
 					parts = append(parts, geminiPart{
 						FunctionCall: &geminiFunctionCall{
 							Name: block.Name,
 							Args: args,
 						},
+						ThoughtSignature: block.ThoughtSignature,
 					})
 					if block.ID != "" {
 						toolNameByID[block.ID] = block.Name

--- a/harness/internal/provider/gemini_request_test.go
+++ b/harness/internal/provider/gemini_request_test.go
@@ -755,13 +755,18 @@ func TestBuildGenerateContentRequest_NoThoughtSignatureWhenAbsent(t *testing.T) 
 	}
 }
 
-// TestGeminiThoughtSignatureFullRoundTrip combines the receive- and
-// send-side paths: parse a Gemini 3.x SSE response containing a
-// functionCall with a thoughtSignature, persist the signature onto the
-// ContentBlock the harness would build (mirroring what
-// streamEventsToResult does), and assert the next request body emits
-// the same signature back to Vertex. This is the end-to-end contract
-// for issue #194.
+// TestGeminiThoughtSignatureFullRoundTrip confirms JSON decode of the
+// Vertex wire type and serialisation by BuildGenerateContentRequest:
+// parse a Gemini 3.x response chunk containing a functionCall with a
+// thoughtSignature, hand-build the ContentBlock the harness would
+// persist, and assert the next request body emits the same signature
+// back to Vertex. This is the end-to-end JSON-shape contract for
+// issue #194.
+//
+// The SSE receive path and loop plumbing are covered separately by
+// TestGeminiAdapter_ThoughtSignatureCapturedOnToolCall and
+// TestStreamEventsToResult_ThoughtSignaturePropagatedToBlock; this
+// test does NOT drive consumeSSE or streamEventsToResult directly.
 func TestGeminiThoughtSignatureFullRoundTrip(t *testing.T) {
 	const sig = "AY89a18t+D98lADcFYKgjMgoHS7rOPAQUE=="
 

--- a/harness/internal/provider/gemini_request_test.go
+++ b/harness/internal/provider/gemini_request_test.go
@@ -29,6 +29,7 @@ type decodedPart struct {
 	Text             string               `json:"text,omitempty"`
 	FunctionCall     *decodedFunctionCall `json:"functionCall,omitempty"`
 	FunctionResponse *decodedFuncResponse `json:"functionResponse,omitempty"`
+	ThoughtSignature string               `json:"thoughtSignature,omitempty"`
 }
 
 type decodedFunctionCall struct {
@@ -632,5 +633,179 @@ func TestBuildGenerateContentRequest_UserTextAndToolResultOrdering(t *testing.T)
 	}
 	if dr.Contents[2].Role != "user" || dr.Contents[2].Parts[0].Text != "follow-up note" {
 		t.Errorf("contents[2] mismatch: %+v", dr.Contents[2])
+	}
+}
+
+// TestBuildGenerateContentRequest_ThoughtSignatureRoundTrip pins the
+// send side of the issue #194 fix: when an assistant `tool_use` block
+// carries a ThoughtSignature, the marshalled request must emit the
+// `thoughtSignature` field on the corresponding part. Without this the
+// Gemini 3.x model cannot resume its prior reasoning across turns.
+func TestBuildGenerateContentRequest_ThoughtSignatureRoundTrip(t *testing.T) {
+	const sig = "AY89a18t+D98lADcFYKgjMgoHS7rOPAQUE=="
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model: "gemini-3.1-pro-preview",
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "Read main.go"}}},
+			{Role: "assistant", Content: []types.ContentBlock{
+				{
+					Type:             "tool_use",
+					ID:               "call_1",
+					Name:             "read_file",
+					Input:            json.RawMessage(`{"path":"main.go"}`),
+					ThoughtSignature: sig,
+				},
+			}},
+			{Role: "user", Content: []types.ContentBlock{
+				{Type: "tool_result", ToolUseID: "call_1", Content: "package main"},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dr := decodeGeminiRequest(t, body)
+	// Find the model-role content; assert the functionCall part carries
+	// the signature back to Vertex unchanged.
+	var modelContent *decodedContent
+	for i := range dr.Contents {
+		if dr.Contents[i].Role == "model" {
+			modelContent = &dr.Contents[i]
+			break
+		}
+	}
+	if modelContent == nil {
+		t.Fatal("expected a model-role content in the request body")
+	}
+	if len(modelContent.Parts) != 1 {
+		t.Fatalf("expected 1 part on the model content, got %d", len(modelContent.Parts))
+	}
+	if modelContent.Parts[0].FunctionCall == nil {
+		t.Fatal("expected functionCall on the model part")
+	}
+	if modelContent.Parts[0].ThoughtSignature != sig {
+		t.Errorf("model.parts[0].thoughtSignature = %q, want %q", modelContent.Parts[0].ThoughtSignature, sig)
+	}
+}
+
+// TestBuildGenerateContentRequest_ThoughtSignatureRoundTripOnText pins
+// the text-part round-trip path: assistant `text` blocks that carry a
+// ThoughtSignature must also re-emit it on the part. The Gemini 3.x
+// receive-side capture of signatures on text parts is deferred (see
+// TODO(#194) in the SSE consumer), but the send-side path supports the
+// field today, so a future caller constructing a Message history with
+// text-block signatures (e.g. trace replay) continues to round-trip
+// correctly.
+func TestBuildGenerateContentRequest_ThoughtSignatureRoundTripOnText(t *testing.T) {
+	const sig = "TEXTPARTSIGNATURE=="
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model: "gemini-3.1-pro-preview",
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+			{Role: "assistant", Content: []types.ContentBlock{
+				{Type: "text", Text: "hello!", ThoughtSignature: sig},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dr := decodeGeminiRequest(t, body)
+	var modelContent *decodedContent
+	for i := range dr.Contents {
+		if dr.Contents[i].Role == "model" {
+			modelContent = &dr.Contents[i]
+			break
+		}
+	}
+	if modelContent == nil || len(modelContent.Parts) != 1 {
+		t.Fatalf("expected one model part, got %+v", modelContent)
+	}
+	if modelContent.Parts[0].Text != "hello!" {
+		t.Errorf("model.parts[0].text = %q, want hello!", modelContent.Parts[0].Text)
+	}
+	if modelContent.Parts[0].ThoughtSignature != sig {
+		t.Errorf("model.parts[0].thoughtSignature = %q, want %q", modelContent.Parts[0].ThoughtSignature, sig)
+	}
+}
+
+// TestBuildGenerateContentRequest_NoThoughtSignatureWhenAbsent
+// confirms that assistant blocks without a ThoughtSignature do NOT
+// emit the field on the wire. This protects 2.x compatibility:
+// Vertex 2.x ignores unknown fields, but emitting an empty string on
+// every part still flunks visual diffing against captured fixtures.
+// `omitempty` on both the wire type and ContentBlock is the only safe
+// way to keep parity with the pre-#194 request shape when no signature
+// is present.
+func TestBuildGenerateContentRequest_NoThoughtSignatureWhenAbsent(t *testing.T) {
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model: "gemini-2.5-pro",
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+			{Role: "assistant", Content: []types.ContentBlock{
+				{Type: "tool_use", ID: "c1", Name: "read_file", Input: json.RawMessage(`{"path":"x"}`)},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(body), "thoughtSignature") {
+		t.Errorf("request body must not contain thoughtSignature when no signature was set; body=%s", body)
+	}
+}
+
+// TestGeminiThoughtSignatureFullRoundTrip combines the receive- and
+// send-side paths: parse a Gemini 3.x SSE response containing a
+// functionCall with a thoughtSignature, persist the signature onto the
+// ContentBlock the harness would build (mirroring what
+// streamEventsToResult does), and assert the next request body emits
+// the same signature back to Vertex. This is the end-to-end contract
+// for issue #194.
+func TestGeminiThoughtSignatureFullRoundTrip(t *testing.T) {
+	const sig = "AY89a18t+D98lADcFYKgjMgoHS7rOPAQUE=="
+
+	// Parse the response chunk via the same decoder the adapter uses.
+	chunkJSON := `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"docs/safety-rings.md"}},"thoughtSignature":"` + sig + `"}]},"finishReason":"STOP"}]}`
+	var chunk generateContentChunk
+	if err := json.Unmarshal([]byte(chunkJSON), &chunk); err != nil {
+		t.Fatalf("decode chunk: %v", err)
+	}
+	if len(chunk.Candidates) == 0 || chunk.Candidates[0].Content == nil || len(chunk.Candidates[0].Content.Parts) == 0 {
+		t.Fatal("decoded chunk has no parts")
+	}
+	gotSig := chunk.Candidates[0].Content.Parts[0].ThoughtSignature
+	if gotSig != sig {
+		t.Fatalf("decoded thoughtSignature = %q, want %q", gotSig, sig)
+	}
+
+	// Simulate what the agentic loop persists: a tool_use ContentBlock
+	// carrying the signature captured from the StreamEvent.
+	messages := []types.Message{
+		{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "Read it"}}},
+		{Role: "assistant", Content: []types.ContentBlock{
+			{
+				Type:             "tool_use",
+				ID:               "call_1",
+				Name:             "read_file",
+				Input:            json.RawMessage(`{"path":"docs/safety-rings.md"}`),
+				ThoughtSignature: gotSig,
+			},
+		}},
+		{Role: "user", Content: []types.ContentBlock{
+			{Type: "tool_result", ToolUseID: "call_1", Content: "..."},
+		}},
+	}
+
+	// Render the next request and assert the blob made it back.
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model:    "gemini-3.1-pro-preview",
+		Messages: messages,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildGenerateContentRequest: %v", err)
+	}
+	if !strings.Contains(string(body), `"thoughtSignature":"`+sig+`"`) {
+		t.Errorf("round-tripped request body missing thoughtSignature=%q\nbody=%s", sig, body)
 	}
 }

--- a/harness/internal/provider/gemini_test.go
+++ b/harness/internal/provider/gemini_test.go
@@ -985,3 +985,85 @@ func TestGeminiAdapter_NonStreamedFunctionCall3xShape(t *testing.T) {
 		t.Errorf("stop_reason = %q, want tool_use", stop.StopReason)
 	}
 }
+
+// TestGeminiAdapter_ThoughtSignatureCapturedOnToolCall pins the receive
+// side of the issue #194 fix: when Vertex emits a functionCall part with a
+// `thoughtSignature` blob attached, the adapter must surface that blob on
+// the emitted tool_call StreamEvent so the agentic loop can persist it
+// onto the ContentBlock for next-turn round-trip. The fixture is the
+// 3.x non-streamed shape captured from Vertex against
+// `gemini-3.1-pro-preview`.
+func TestGeminiAdapter_ThoughtSignatureCapturedOnToolCall(t *testing.T) {
+	const sig = "AY89a18t+D98lADcFYKgjMgoHS7rOPAQUE=="
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"docs/safety-rings.md"}},"thoughtSignature":"` + sig + `"}]},"finishReason":"STOP"}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	var toolCall *types.StreamEvent
+	for i := range events {
+		if events[i].Type == "tool_call" {
+			toolCall = &events[i]
+		}
+		if events[i].Type == "error" {
+			t.Fatalf("unexpected error event: %v", events[i].Error)
+		}
+	}
+	if toolCall == nil {
+		t.Fatal("expected a tool_call event")
+	}
+	if toolCall.ThoughtSignature != sig {
+		t.Errorf("tool_call.ThoughtSignature = %q, want %q", toolCall.ThoughtSignature, sig)
+	}
+}
+
+// TestGeminiAdapter_ThoughtSignatureMissingIsEmpty confirms that a
+// pre-3.x response (no `thoughtSignature` on the part) leaves the
+// StreamEvent's ThoughtSignature empty. This is the negative case that
+// protects the `omitempty` invariant on the send side: an empty
+// signature must round-trip to a request body that does NOT include
+// the field.
+func TestGeminiAdapter_ThoughtSignatureMissingIsEmpty(t *testing.T) {
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"x"}}}]},"finishReason":"STOP"}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-2.5-pro"})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+	var toolCall *types.StreamEvent
+	for i := range events {
+		if events[i].Type == "tool_call" {
+			toolCall = &events[i]
+		}
+	}
+	if toolCall == nil {
+		t.Fatal("expected a tool_call event")
+	}
+	if toolCall.ThoughtSignature != "" {
+		t.Errorf("tool_call.ThoughtSignature = %q, want empty", toolCall.ThoughtSignature)
+	}
+}

--- a/harness/internal/provider/gemini_test.go
+++ b/harness/internal/provider/gemini_test.go
@@ -1067,3 +1067,129 @@ func TestGeminiAdapter_ThoughtSignatureMissingIsEmpty(t *testing.T) {
 		t.Errorf("tool_call.ThoughtSignature = %q, want empty", toolCall.ThoughtSignature)
 	}
 }
+
+// TestGeminiAdapter_ThoughtSignatureCapturedViaDrainPath pins the drain
+// branch of the SSE consumer (gemini.go around the finishReason-triggered
+// drain): a tool call left open with willContinue=true is flushed when
+// finishReason arrives, and the buffered thoughtSignature must travel
+// with it onto the emitted StreamEvent. The existing drain test
+// (TestGeminiAdapter_ToolCallBufferDrainOnFinishReason) does not set a
+// signature on the willContinue chunk, so a regression that dropped
+// buf.thoughtSignature from the drain emit call would not be caught
+// there. (#194; synthesis B3 / test-coverage Gap 2.)
+func TestGeminiAdapter_ThoughtSignatureCapturedViaDrainPath(t *testing.T) {
+	const sig = "DRAINABLE=="
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","partialArgs":{"path":"x.go"},"willContinue":true},"thoughtSignature":"`+sig+`"}]}}]}`) +
+		makeGeminiData(`{"candidates":[{"finishReason":"STOP"}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+	if err != nil {
+		t.Fatalf("Stream(): %v", err)
+	}
+
+	events := collectEvents(t, ch)
+	var calls []types.StreamEvent
+	for _, ev := range events {
+		if ev.Type == "tool_call" {
+			calls = append(calls, ev)
+		}
+		if ev.Type == "error" {
+			t.Fatalf("unexpected error event: %v", ev.Error)
+		}
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 tool_call from the drain path, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].ThoughtSignature != sig {
+		t.Errorf("drained tool_call.ThoughtSignature = %q, want %q", calls[0].ThoughtSignature, sig)
+	}
+}
+
+// TestGeminiAdapter_ThoughtSignatureLastNonEmptyWins documents and pins
+// the deliberate multi-chunk accumulation policy: across willContinue=true
+// chunks the buffer retains the most recent NON-EMPTY thoughtSignature
+// value. The `if part.ThoughtSignature != ""` guard in gemini.go encodes
+// the "absent field on a continuation chunk does not clobber a prior
+// signature" semantic; removing that guard would break sub-case B.
+// (#194; synthesis B4 / test-coverage Gap 3.)
+func TestGeminiAdapter_ThoughtSignatureLastNonEmptyWins(t *testing.T) {
+	t.Run("later_non_empty_supersedes_earlier", func(t *testing.T) {
+		body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","partialArgs":{"path":"a"},"willContinue":true},"thoughtSignature":"FIRST=="}]}}]}`) +
+			makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","partialArgs":{"path":"ab"},"willContinue":true}}]}}]}`) +
+			makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"abc"}},"thoughtSignature":"LAST=="}]},"finishReason":"STOP"}]}`)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, body)
+		}))
+		defer srv.Close()
+
+		adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+		ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+		if err != nil {
+			t.Fatalf("Stream(): %v", err)
+		}
+
+		events := collectEvents(t, ch)
+		var toolCall *types.StreamEvent
+		for i := range events {
+			if events[i].Type == "tool_call" {
+				toolCall = &events[i]
+			}
+			if events[i].Type == "error" {
+				t.Fatalf("unexpected error event: %v", events[i].Error)
+			}
+		}
+		if toolCall == nil {
+			t.Fatal("expected a tool_call event")
+		}
+		if toolCall.ThoughtSignature != "LAST==" {
+			t.Errorf("tool_call.ThoughtSignature = %q, want %q", toolCall.ThoughtSignature, "LAST==")
+		}
+	})
+
+	t.Run("absent_field_on_later_chunks_does_not_clobber", func(t *testing.T) {
+		body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","partialArgs":{"path":"a"},"willContinue":true},"thoughtSignature":"ONLY=="}]}}]}`) +
+			makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","partialArgs":{"path":"ab"},"willContinue":true}}]}}]}`) +
+			makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"abc"}}}]},"finishReason":"STOP"}]}`)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, body)
+		}))
+		defer srv.Close()
+
+		adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+		ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+		if err != nil {
+			t.Fatalf("Stream(): %v", err)
+		}
+
+		events := collectEvents(t, ch)
+		var toolCall *types.StreamEvent
+		for i := range events {
+			if events[i].Type == "tool_call" {
+				toolCall = &events[i]
+			}
+			if events[i].Type == "error" {
+				t.Fatalf("unexpected error event: %v", events[i].Error)
+			}
+		}
+		if toolCall == nil {
+			t.Fatal("expected a tool_call event")
+		}
+		if toolCall.ThoughtSignature != "ONLY==" {
+			t.Errorf("tool_call.ThoughtSignature = %q, want %q (later chunks without the field must not clobber the earlier value)", toolCall.ThoughtSignature, "ONLY==")
+		}
+	})
+}

--- a/harness/internal/provider/gemini_types.go
+++ b/harness/internal/provider/gemini_types.go
@@ -42,10 +42,20 @@ type geminiContent struct {
 // FunctionResponse should be populated per part. (InlineData /
 // fileData / videoMetadata exist in the spec but are intentionally not
 // supported by this adapter — the harness is text-and-tools only.)
+//
+// ThoughtSignature is the one non-discriminator field on this struct: it is
+// an opaque blob Vertex emits alongside `text` or `functionCall` parts on
+// Gemini 3.x responses (the model's encrypted chain-of-thought for
+// cross-turn reasoning continuity). The harness echoes it back unchanged on
+// the corresponding part of the assistant's content the next time the same
+// history is rendered so the model can resume its prior reasoning. We do
+// not introspect, log, or mutate the value — it is provider-private state
+// that just happens to be threaded through the message history.
 type geminiPart struct {
 	Text             string                  `json:"text,omitempty"`
 	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
 	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+	ThoughtSignature string                  `json:"thoughtSignature,omitempty"`
 }
 
 // geminiFunctionCall is a model-emitted call to one of the declared tools.

--- a/harness/internal/provider/gemini_types.go
+++ b/harness/internal/provider/gemini_types.go
@@ -51,6 +51,12 @@ type geminiContent struct {
 // history is rendered so the model can resume its prior reasoning. We do
 // not introspect, log, or mutate the value — it is provider-private state
 // that just happens to be threaded through the message history.
+//
+// The `thoughtSignature` JSON tag matches the Vertex AI wire format
+// directly (camelCase); this differs from the snake_case convention on
+// types.ContentBlock and types.StreamEvent (`thought_signature`). Do not
+// "fix" this tag to snake_case — Vertex will not recognise it and the
+// round-trip will silently break for Gemini 3.x model turns.
 type geminiPart struct {
 	Text             string                  `json:"text,omitempty"`
 	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`

--- a/harness/internal/provider/replay.go
+++ b/harness/internal/provider/replay.go
@@ -69,11 +69,19 @@ func (rp *ReplayProvider) Stream(ctx context.Context, _ types.StreamParams) (<-c
 				}
 				// Estimate tokens from the JSON input size.
 				estimatedTokens += len(block.Input) / 4
+				// ThoughtSignature is intentionally forwarded here so
+				// live-continuation paths seeded from this recording
+				// (e.g. mineFailureTasks) carry the model's prior
+				// reasoning state into the next Vertex request (#194).
+				// Pure eval replay (no live API calls) is unaffected:
+				// the blob is never re-submitted to any provider in
+				// that scenario, so forwarding adds no leakage surface.
 				ch <- types.StreamEvent{
-					Type:  "tool_call",
-					ID:    block.ID,
-					Name:  block.Name,
-					Input: inputMap,
+					Type:             "tool_call",
+					ID:               block.ID,
+					Name:             block.Name,
+					Input:            inputMap,
+					ThoughtSignature: block.ThoughtSignature,
 				}
 			}
 		}

--- a/harness/internal/provider/replay_test.go
+++ b/harness/internal/provider/replay_test.go
@@ -210,3 +210,50 @@ func TestReplayProvider_EmptyModelOutput(t *testing.T) {
 		t.Errorf("StopReason = %q, want end_turn", events[0].StopReason)
 	}
 }
+
+// TestReplayProvider_ForwardsThoughtSignature pins the issue #194
+// follow-on behaviour: a tool_use ContentBlock in a TurnRecord that
+// carries a ThoughtSignature must surface that value on the emitted
+// tool_call StreamEvent. The load-bearing path is live-continuation
+// (mineFailureTasks) where ReplayProvider seeds the history of a run
+// that subsequently calls a real Vertex provider — dropping the
+// signature there would silently degrade cross-turn reasoning
+// continuity for exactly the multi-turn agentic sequences likely to
+// appear in a failure recording.
+func TestReplayProvider_ForwardsThoughtSignature(t *testing.T) {
+	const sig = "REPLAYED-SIG=="
+	turns := []types.TurnRecord{
+		{
+			Turn: 1,
+			ModelOutput: []types.ContentBlock{
+				{
+					Type:             "tool_use",
+					ID:               "toolu_abc",
+					Name:             "read_file",
+					Input:            json.RawMessage(`{"path":"main.go"}`),
+					ThoughtSignature: sig,
+				},
+			},
+		},
+	}
+
+	rp := NewReplayProvider(turns)
+	ch, err := rp.Stream(context.Background(), types.StreamParams{})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+	var toolCall *types.StreamEvent
+	for i := range events {
+		if events[i].Type == "tool_call" {
+			toolCall = &events[i]
+		}
+	}
+	if toolCall == nil {
+		t.Fatal("expected a tool_call event")
+	}
+	if toolCall.ThoughtSignature != sig {
+		t.Errorf("tool_call.ThoughtSignature = %q, want %q", toolCall.ThoughtSignature, sig)
+	}
+}

--- a/types/events.go
+++ b/types/events.go
@@ -38,6 +38,15 @@ type StreamEvent struct {
 	OutputTokens int            `json:"outputTokens,omitempty"`
 	Content      []ContentBlock `json:"content,omitempty"`
 	Error        error          `json:"-"`
+
+	// ThoughtSignature is the opaque provider-private blob captured for
+	// round-trip on the next turn. Currently only populated by the Gemini
+	// adapter on "tool_call" events (and, in the future, "text_delta"
+	// events when the text-part case is wired). The agentic loop copies
+	// this onto the persisted assistant ContentBlock so that the next
+	// request reproduces it verbatim. `omitempty` keeps it off the wire
+	// for adapters that do not emit it.
+	ThoughtSignature string `json:"thought_signature,omitempty"`
 }
 
 // StreamParams holds the parameters for a model streaming request.

--- a/types/events.go
+++ b/types/events.go
@@ -46,6 +46,13 @@ type StreamEvent struct {
 	// this onto the persisted assistant ContentBlock so that the next
 	// request reproduces it verbatim. `omitempty` keeps it off the wire
 	// for adapters that do not emit it.
+	//
+	// ProviderAdapter implementations that do not support per-turn
+	// reasoning state MUST leave this field at its zero value. Adapter-
+	// side wire types are expected to drop the field (see
+	// anthropicContentBlock for the established pattern) so a populated
+	// value on a ContentBlock cannot accidentally cross provider
+	// boundaries.
 	ThoughtSignature string `json:"thought_signature,omitempty"`
 }
 

--- a/types/messages.go
+++ b/types/messages.go
@@ -24,6 +24,16 @@ type Message struct {
 // log it verbatim, or mutate it. A future generalisation (e.g. renaming
 // to ProviderState or moving to a metadata map) is intentionally a non-goal
 // for the current change.
+//
+// Rename-decision (recorded for the next maintainer who needs this):
+// the name `ThoughtSignature` is Gemini-specific. When a second provider
+// requires analogous opaque round-trip state, rename this field to
+// `ProviderState` (JSON: `provider_state`) and update the RunRecording
+// schema at the same time — do NOT add a second provider-specific field
+// alongside this one. Adapter-private wire types (see
+// anthropicContentBlock for the established pattern) must continue to
+// omit any provider-state field they do not own, so the rename does
+// not relax the cross-provider leakage guard introduced for #194.
 type ContentBlock struct {
 	Type             string          `json:"type"` // "text" | "tool_use" | "tool_result"
 	Text             string          `json:"text,omitempty"`

--- a/types/messages.go
+++ b/types/messages.go
@@ -12,15 +12,28 @@ type Message struct {
 
 // ContentBlock is a single block of content within a message.
 // Use the Type field to determine which variant fields are populated.
+//
+// ThoughtSignature is a provider-opaque blob attached to an assistant block
+// so the harness can round-trip it back to the provider on the next turn.
+// Currently it is only populated by the Gemini adapter, which threads the
+// `thoughtSignature` field that Vertex AI emits on parts of 3.x model
+// responses (Gemini's encrypted chain-of-thought for cross-turn reasoning
+// continuity, see https://cloud.google.com/vertex-ai/generative-ai/docs/thinking).
+// The field is `omitempty` so other adapters never see it on the wire.
+// Treat the value as fully opaque — the harness must not introspect it,
+// log it verbatim, or mutate it. A future generalisation (e.g. renaming
+// to ProviderState or moving to a metadata map) is intentionally a non-goal
+// for the current change.
 type ContentBlock struct {
-	Type      string          `json:"type"` // "text" | "tool_use" | "tool_result"
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Content   string          `json:"content,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	Type             string          `json:"type"` // "text" | "tool_use" | "tool_result"
+	Text             string          `json:"text,omitempty"`
+	ID               string          `json:"id,omitempty"`
+	Name             string          `json:"name,omitempty"`
+	Input            json.RawMessage `json:"input,omitempty"`
+	ToolUseID        string          `json:"tool_use_id,omitempty"`
+	Content          string          `json:"content,omitempty"`
+	IsError          bool            `json:"is_error,omitempty"`
+	ThoughtSignature string          `json:"thought_signature,omitempty"`
 }
 
 // ToolDefinition describes a tool available to the model.


### PR DESCRIPTION
Closes #194.

## Context

Surfaced during diagnosis of #191. Gemini 3.x SSE responses attach a `thoughtSignature` blob to each `parts[*]` entry. The blob carries the model's encrypted chain-of-thought across turns; per Vertex documentation, operators are expected to round-trip it unchanged on the next turn so the model can resume its prior reasoning. The harness previously dropped the field on parse and lacked any storage path for it, so 3.x multi-turn tool exchanges silently lost CoT continuity.

## Approach

Threaded the signature through `types.ContentBlock` (the cross-provider message-block contract). The adapter is reconstructed-from-history each `Stream()` call — there is no durable adapter-local state — so the only viable persistence surface for round-tripping is the message itself. The issue called this option the "cleanest" of the two it proposed.

End-to-end chain:

```
Vertex SSE `parts[*].thoughtSignature`
  → geminiPart.ThoughtSignature
    → toolCallBuf.thoughtSignature (accumulated across willContinue=true chunks)
      → StreamEvent.ThoughtSignature
        → ContentBlock.ThoughtSignature (in the persisted assistant message)
          → geminiPart.ThoughtSignature (on the next request body)
```

All non-Gemini paths are insulated by `omitempty` and a private wire type on the Anthropic adapter (see review-cycle Section B1 below).

## What landed

**Implementation (4 commits):**
- `c970c7f` types: add ThoughtSignature field to ContentBlock for provider CoT round-trip
- `c9871e3` provider/gemini: capture thoughtSignature on receive and re-emit on send
- `e18eeac` core: thread StreamEvent.ThoughtSignature into persisted assistant block
- `d8c402e` provider/gemini: pin thoughtSignature round-trip with unit tests

**Remediation after 5-reviewer cycle (5 commits):**
- `e9e4da2` provider/anthropic: isolate wire type so Gemini ThoughtSignature does not leak
- `351cd7a` provider/replay: forward ThoughtSignature on tool_use replay
- `e18b286` core: pin ThoughtSignature propagation in streamEventsToResult
- `df8a7c3` provider/gemini: cover drain and accumulation paths for thoughtSignature
- `aee2020` types,provider: document ThoughtSignature contract and rename rationale

## Review cycle outcome

Five reviewers ran in parallel against the initial 4 commits; the [review-synthesizer](../tree/gh-194/reviews) consolidated their findings into a remediation brief. Verdicts:

| Reviewer | Initial verdict | After remediation |
|---|---|---|
| code-reviewer | approve-with-nits (3 minor) | all nits applied |
| security-reviewer | 1 HIGH, 2 MEDIUM, 2 INFO | HIGH closed in this PR; 2 MEDIUMs deferred (see Follow-ups) |
| spec-compliance-reviewer | COMPLIANT (4/4 scope items PASS) | unchanged |
| test-coverage-auditor | NEEDS WORK (1 BLOCKING, 2 MAJOR gaps) | all 3 required tests added |
| api-design-advisor | approve-with-recommendations (1 MAJOR) | MAJOR closed; rename decision recorded as comment |

Key resolutions documented in `reviews/issue-194-synthesis.md` (kept on the branch for the reviewer):

- **B1 (security HIGH, blocker).** The Anthropic adapter previously embedded `[]types.Message` directly in its wire struct, which meant any `ContentBlock` carrying a Gemini `ThoughtSignature` would be serialised verbatim into Anthropic API requests in multi-provider configurations — leaking Google's encrypted CoT to Anthropic's infrastructure. Fixed by introducing private `anthropicContentBlock`/`anthropicMessage` wire types that omit the field, plus a regression test asserting `thought_signature` never appears in an Anthropic request body.
- **Cross-finding conflict on `ReplayProvider`.** Security review said dropping the signature on replay was correct; API design review said it would break `mineFailureTasks`-style live-continuation paths seeded from a recording. Sided with API design: forward the signature; pure-replay execution has no Vertex call so there is no leakage surface, and live-continuation paths need the CoT.
- **Rename-now-or-never on `ThoughtSignature` vs `ProviderBlob`.** Kept `ThoughtSignature` for this PR. Renaming without a concrete second use-case risks naming it wrong again; the `messages.go` comment now records the future rename path (`ProviderState` / `provider_state`) so the decision is durable.

## Validation

- `just test` — green across all four modules (`harness`, `types`, `eval`, plus eval cmds).
- `just lint` — no new findings on touched files. Pre-existing lint findings in unrelated files (`eval/cmd/eval/main.go`, `harness/cmd/stirrup/cmd/harness_test.go`, `harness/internal/context/metrics_test.go`, `harness/internal/core/factory.go`, `harness/internal/permission/*.go`, `types/runconfig.go`) are untouched.
- **Live smoke test** against `gemini-3.1-pro-preview`:
  ```
  GOOGLE_APPLICATION_CREDENTIALS=... ./stirrup harness --prompt "Give me a summary of the safety rings doc" \
    --provider gemini --gcp-project rubynerd-net --model gemini-3.1-pro-preview --workspace .
  ```
  Result: 3 turns, 2 tool_use→tool_result exchanges, terminated `stopReason=success` with zero error/fatal log lines. Vertex would have returned 4xx on a malformed `thoughtSignature` echo; the clean multi-turn completion is strong end-to-end evidence the round-trip is wire-correct.

## Out of scope / follow-ups

The following items came out of the review cycle but are explicitly deferred per the remediation synthesis:

- **Size cap on `buf.thoughtSignature`** (security MEDIUM, CWE-400). Practical risk is low given current Vertex blob sizes; tracked as a follow-up.
- **Recording persistence scrubbing** (security MEDIUM, CWE-532). `TurnRecord.ModelOutput` and `TurnRecord.ModelInput.Messages` currently serialise `ThoughtSignature` into `RunRecording` JSON files. A `ContentBlock.StripProviderState()` helper would close this; tracked as a follow-up. Recordings are operator-local, so the immediate exposure is bounded.
- **Text-part receive-side `ThoughtSignature` capture** (deferred by design — `TODO(#194)` at `gemini.go`). Tool-call CoT is the load-bearing case for multi-turn agentic loops. The send-side already handles text-block signatures correctly, so the round-trip becomes complete once the receive-side is wired.
- **Rename to `ProviderState`** — rationale recorded as a comment in `types/messages.go` for the next adapter that needs analogous opaque round-trip state.
- **Three minor test additions** (Gap 4–6 from the test-coverage audit): mixed-content per-block, text-part deferral pin, and `StreamEvent` `omitempty` pin. Recommended-not-blocking; the implementation paths they would cover are exercised indirectly by existing tests.

## Test plan

- [x] `just test` — full suite green
- [x] `just lint` — no new findings on touched files
- [x] Live smoke test against `gemini-3.1-pro-preview` — clean multi-turn completion
- [x] B1 regression test (`TestBuildAnthropicRequest_OmitsThoughtSignature` or equivalent) — `thought_signature` absent from Anthropic request body
- [x] B2 regression pin (`TestStreamEventsToResult_ThoughtSignaturePropagatedToBlock`) — fails if `core/types.go` copy is removed
- [x] B3 regression pin (`TestGeminiAdapter_ThoughtSignatureCapturedViaDrainPath`) — fails if drain-side `emitToolCall` is changed to pass `""`
- [x] B4 regression pin (`TestGeminiAdapter_ThoughtSignatureLastNonEmptyWins`) — fails if the `!= ""` guard is removed

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>