### PR TITLE
provider: fix post-merge break and flake in openai_test.go

### DIFF
--- a/harness/internal/provider/openai_test.go
+++ b/harness/internal/provider/openai_test.go
@@ -404,7 +404,7 @@ func TestOpenAIAdapter_RawBodyShape(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{})
+			adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
 
 			ch, err := adapter.Stream(context.Background(), types.StreamParams{
 				Model:       "gpt-5.4",

--- a/harness/internal/provider/openai_test.go
+++ b/harness/internal/provider/openai_test.go
@@ -1279,15 +1279,17 @@ func TestOpenAIAdapter_429ExhaustedSurfacesTerminalError(t *testing.T) {
 
 // TestOpenAIAdapter_429BudgetExhaustedSurfacesTerminalError covers the
 // `retryOutcomeBudgetExhausted` branch in DoWithRetry. The previous
-// test exhausts via MaxAttempts; this one exhausts via WallClockBudget
-// — the WallClockBudget=5ms is smaller than the first retry's InitialDelay,
-// so the budget check fires before the second attempt is even made. The
-// rate_limited span event still fires on the resulting terminal 429.
+// test exhausts via MaxAttempts; this one exhausts via WallClockBudget.
+// The server returns a deterministic Retry-After-Ms hint that exceeds
+// the budget — using the hint path (rather than backoff) avoids the
+// full-jitter randomness in backoffDelay, which can produce a delay
+// smaller than the budget and skip the budget check. The rate_limited
+// span event still fires on the resulting terminal 429.
 func TestOpenAIAdapter_429BudgetExhaustedSurfacesTerminalError(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		calls.Add(1)
-		w.Header().Set("Retry-After", "0")
+		w.Header().Set("Retry-After-Ms", "100")
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = fmt.Fprint(w, `{"error":{"message":"budget should run out"}}`)
 	}))
@@ -1298,8 +1300,9 @@ func TestOpenAIAdapter_429BudgetExhaustedSurfacesTerminalError(t *testing.T) {
 	tracer := tp.Tracer("test")
 
 	// Allow up to 10 attempts but cap the wall-clock at 5ms so the budget
-	// is the binding constraint. InitialDelay=50ms guarantees the first
-	// retry's sleep would already exceed the budget.
+	// is the binding constraint. The server's 100ms Retry-After-Ms hint
+	// (capped at MaxDelay=100ms) guarantees the first retry's sleep would
+	// exceed the budget.
 	budgetPolicy := RetryPolicy{
 		MaxAttempts:     10,
 		InitialDelay:    50 * time.Millisecond,


### PR DESCRIPTION
## Summary

Two fixes to `harness/internal/provider/openai_test.go`, both surfaced when the suite was run after the recent #197/#200 merges landed on main.

**1. Build break: missing `RetryPolicy` argument** (3767c43)

PR #200's `TestOpenAIAdapter_RawBodyShape` was authored against the three-argument `NewOpenAICompatibleAdapter` signature, while PR #197 concurrently added a fourth `RetryPolicy` parameter. Both merged without a rebase, so one call site at `openai_test.go:407` is now stale and breaks `go test ./harness/internal/provider/...`. Pass `RetryPolicy{}` to match every other call site in the file.

**2. Deflake `TestOpenAIAdapter_429BudgetExhaustedSurfacesTerminalError`** (9c53af0)

This test (added in #197) is racy under the existing implementation. Its docstring asserts that "WallClockBudget=5ms is smaller than the first retry's InitialDelay=50ms, so the budget check fires before the second attempt is even made" — but `backoffDelay` applies full jitter, sampling uniformly in `[0, InitialDelay)`. On ~1 in 10 runs the sampled delay was small enough not to trip the budget guard at `retry.go:395`, and a second request reached the server, failing the call-count assertion.

The fix returns `Retry-After-Ms: 100` from the test server. The retry-hint path bypasses `backoffDelay` entirely (`retry.go:357`–`362`) and caps the delay at `MaxDelay=100ms` — deterministically larger than the 5ms budget. This mirrors the deterministic-hint pattern already used by `TestDoWithRetry_BudgetExhausted` in `retry_test.go`.

Verified stable across 200 sequential runs.

## Test plan

- [x] `just test` — full suite green
- [x] `go test ./harness/internal/provider/ -run TestOpenAIAdapter_429BudgetExhaustedSurfacesTerminalError -count=200` — no flakes
- [x] Each commit reviewed independently for build pass before stacking the next

🤖 Generated with [Claude Code](https://claude.com/claude-code)