### PR TITLE
provider/openai-responses: split input items into per-type wire structs (#199)

### DIFF
--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -155,20 +155,20 @@ func (r responsesInput) MarshalJSON() ([]byte, error) {
 	switch r.Type {
 	case "message":
 		return json.Marshal(responsesMessageInputWire{
-			Type:    "message",
+			Type:    r.Type,
 			Role:    r.Role,
 			Content: r.Content,
 		})
 	case "function_call":
 		return json.Marshal(responsesFunctionCallInputWire{
-			Type:      "function_call",
+			Type:      r.Type,
 			CallID:    r.CallID,
 			Name:      r.Name,
 			Arguments: r.Arguments,
 		})
 	case "function_call_output":
 		return json.Marshal(responsesFunctionCallOutputInputWire{
-			Type:   "function_call_output",
+			Type:   r.Type,
 			CallID: r.CallID,
 			Output: r.Output,
 		})

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -119,25 +119,137 @@ type responsesRequest struct {
 // responsesInput is one item in the Responses API input array. The Type
 // field selects which other fields are populated; this matches the
 // discriminated-union shape OpenAI publishes for typed input items.
+//
+// The struct keeps an ergonomic flat shape so construction-site code
+// (translateMessagesResponses and friends) can build items without
+// branching on type. MarshalJSON below switches on Type and emits only
+// the keys valid for that variant, via per-type wire structs. This is
+// the structural fix for #199: stricter validators (Azure OpenAI's
+// Responses endpoint) reject "output":"" on message / function_call
+// items even though upstream OpenAI tolerates it.
+//
+// The per-variant wire shapes preserve the #172 invariant: the
+// function_call_output wire struct's Output field has no omitempty, so
+// the "output" key is always present on function_call_output items
+// even when the value is the empty string.
 type responsesInput struct {
-	Type    string                  `json:"type"`              // "message" | "function_call" | "function_call_output"
-	Role    string                  `json:"role,omitempty"`    // for "message"
-	Content []responsesContentBlock `json:"content,omitempty"` // for "message"
-	Name    string                  `json:"name,omitempty"`    // for "function_call"
-	// CallID retains omitempty because the harness's construction path
-	// guarantees a non-empty ToolUseID on every tool_result block (so the
-	// key is always populated in practice). The Responses API treats
-	// call_id as required on function_call_output items, structurally
-	// parallel to the output field below — a future contributor relaxing
-	// the construction-side invariant would resurface #172 through this
-	// field. Splitting responsesInput into per-type structs is the long-term
-	// remedy; for now, the construction-path invariant carries it.
-	CallID    string `json:"call_id,omitempty"`   // for "function_call" / "function_call_output"
-	Arguments string `json:"arguments,omitempty"` // for "function_call" — JSON string
-	// Output has no omitempty: the Responses API rejects function_call_output
-	// items missing the "output" key with HTTP 400 (Missing required parameter:
-	// 'input[N].output'), even when the value is the empty string. See #172.
-	Output string `json:"output"` // for "function_call_output" — required even when empty
+	Type      string                  `json:"-"` // "message" | "function_call" | "function_call_output"
+	Role      string                  `json:"-"` // for "message"
+	Content   []responsesContentBlock `json:"-"` // for "message"
+	Name      string                  `json:"-"` // for "function_call"
+	CallID    string                  `json:"-"` // for "function_call" / "function_call_output"
+	Arguments string                  `json:"-"` // for "function_call" — JSON string
+	Output    string                  `json:"-"` // for "function_call_output" — required even when empty
+}
+
+// MarshalJSON emits only the wire fields valid for the input item's Type
+// discriminant. Each Type maps to a dedicated wire struct so a future
+// edit cannot accidentally leak a field across variants — the original
+// shared-struct shape silently emitted "output":"" on every variant,
+// which #199 surfaced as an Azure OpenAI HTTP 400.
+//
+// function_call_output is the variant that requires the "output" key
+// even when its value is the empty string (see #172). Its wire struct's
+// Output field therefore has no omitempty.
+func (r responsesInput) MarshalJSON() ([]byte, error) {
+	switch r.Type {
+	case "message":
+		return json.Marshal(responsesMessageInputWire{
+			Type:    "message",
+			Role:    r.Role,
+			Content: r.Content,
+		})
+	case "function_call":
+		return json.Marshal(responsesFunctionCallInputWire{
+			Type:      "function_call",
+			CallID:    r.CallID,
+			Name:      r.Name,
+			Arguments: r.Arguments,
+		})
+	case "function_call_output":
+		return json.Marshal(responsesFunctionCallOutputInputWire{
+			Type:   "function_call_output",
+			CallID: r.CallID,
+			Output: r.Output,
+		})
+	default:
+		// Unknown variants would previously have been serialised as a
+		// pile of empty-string keys. Surfacing the type explicitly makes
+		// the failure mode debuggable rather than a silent wire-format
+		// mismatch.
+		return nil, fmt.Errorf("responsesInput: unknown type %q", r.Type)
+	}
+}
+
+// UnmarshalJSON is the inverse of MarshalJSON: it accepts any of the
+// per-type wire shapes and populates the ergonomic flat struct so test
+// roundtrips and any future caller-side parsing continues to work. The
+// adapter itself never decodes request bodies — this exists for symmetry
+// and to keep tests that send-then-receive a request able to inspect the
+// shape through the same struct that built it.
+func (r *responsesInput) UnmarshalJSON(data []byte) error {
+	var head struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &head); err != nil {
+		return err
+	}
+	r.Type = head.Type
+	switch head.Type {
+	case "message":
+		var w responsesMessageInputWire
+		if err := json.Unmarshal(data, &w); err != nil {
+			return err
+		}
+		r.Role = w.Role
+		r.Content = w.Content
+	case "function_call":
+		var w responsesFunctionCallInputWire
+		if err := json.Unmarshal(data, &w); err != nil {
+			return err
+		}
+		r.CallID = w.CallID
+		r.Name = w.Name
+		r.Arguments = w.Arguments
+	case "function_call_output":
+		var w responsesFunctionCallOutputInputWire
+		if err := json.Unmarshal(data, &w); err != nil {
+			return err
+		}
+		r.CallID = w.CallID
+		r.Output = w.Output
+	default:
+		return fmt.Errorf("responsesInput: unknown type %q", head.Type)
+	}
+	return nil
+}
+
+// responsesMessageInputWire is the wire shape for type=="message".
+// Only type/role/content are valid for this variant.
+type responsesMessageInputWire struct {
+	Type    string                  `json:"type"`
+	Role    string                  `json:"role,omitempty"`
+	Content []responsesContentBlock `json:"content,omitempty"`
+}
+
+// responsesFunctionCallInputWire is the wire shape for type=="function_call".
+// Only type/call_id/name/arguments are valid for this variant.
+type responsesFunctionCallInputWire struct {
+	Type      string `json:"type"`
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+// responsesFunctionCallOutputInputWire is the wire shape for
+// type=="function_call_output". Output deliberately lacks omitempty: the
+// Responses API rejects function_call_output items missing the "output"
+// key with HTTP 400 (Missing required parameter: 'input[N].output'),
+// even when the value is the empty string. See #172.
+type responsesFunctionCallOutputInputWire struct {
+	Type   string `json:"type"`
+	CallID string `json:"call_id,omitempty"`
+	Output string `json:"output"`
 }
 
 // responsesContentBlock is one part inside a message item.
@@ -145,9 +257,12 @@ type responsesInput struct {
 // assistant messages — the asymmetry is part of their wire format.
 //
 // Text deliberately lacks omitempty: the Responses API requires the "text"
-// key on input_text / output_text content parts, even when the value is the
-// empty string. Structurally parallel to responsesInput.Output — see #172
-// for the analogous HTTP 400 that the missing-key surface produces.
+// key on input_text / output_text content parts, even when the value is
+// the empty string. Both content-block variants today carry the same set
+// of fields (type, text), so a single struct expresses the wire shape
+// without the cross-variant leakage that motivated splitting
+// responsesInput. If a future variant introduces non-shared fields, this
+// struct should be split along the same lines.
 type responsesContentBlock struct {
 	Type string `json:"type"` // "input_text" | "output_text"
 	Text string `json:"text"`

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -1128,6 +1128,126 @@ func TestTranslateMessagesResponses_AssistantToolUseEmptyInput(t *testing.T) {
 	}
 }
 
+// TestResponsesInputMarshal_MessageOmitsOutput is the gh-199 wire-shape
+// regression: the original shared-struct shape emitted "output":"" on
+// every input item, including plain "message" items. Azure OpenAI's
+// stricter validator rejects the spurious key with HTTP 400 ("Unknown
+// parameter: 'input[0].output'"). The per-type marshaller must emit
+// only the keys valid for the message variant.
+func TestResponsesInputMarshal_MessageOmitsOutput(t *testing.T) {
+	item := responsesInput{
+		Type: "message",
+		Role: "user",
+		Content: []responsesContentBlock{
+			{Type: "input_text", Text: "hello"},
+		},
+	}
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(raw, []byte(`"output"`)) {
+		t.Errorf("message item must not emit 'output' key (gh-199): %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"call_id"`)) {
+		t.Errorf("message item must not emit 'call_id' key: %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"name"`)) {
+		t.Errorf("message item must not emit 'name' key: %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"arguments"`)) {
+		t.Errorf("message item must not emit 'arguments' key: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"type":"message"`)) {
+		t.Errorf("message item must emit type=message: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"role":"user"`)) {
+		t.Errorf("message item must emit role: %s", raw)
+	}
+}
+
+// TestResponsesInputMarshal_FunctionCallOmitsOutput pins the gh-199 fix
+// on the function_call variant: only type/call_id/name/arguments are
+// valid, so the spurious "output" key (and "role"/"content") must not
+// leak across the discriminant.
+func TestResponsesInputMarshal_FunctionCallOmitsOutput(t *testing.T) {
+	item := responsesInput{
+		Type:      "function_call",
+		CallID:    "call_abc",
+		Name:      "read_file",
+		Arguments: `{"path":"main.go"}`,
+	}
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(raw, []byte(`"output"`)) {
+		t.Errorf("function_call item must not emit 'output' key (gh-199): %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"role"`)) {
+		t.Errorf("function_call item must not emit 'role' key: %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"content"`)) {
+		t.Errorf("function_call item must not emit 'content' key: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"type":"function_call"`)) {
+		t.Errorf("function_call item must emit type=function_call: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"call_id":"call_abc"`)) {
+		t.Errorf("function_call item must emit call_id: %s", raw)
+	}
+}
+
+// TestResponsesInputMarshal_FunctionCallOutputKeepsEmptyOutput preserves
+// the #172 invariant under the per-type marshaller: function_call_output
+// items must emit "output":"" even when the value is the empty string,
+// otherwise the Responses API rejects the request with HTTP 400
+// ("Missing required parameter: 'input[N].output'").
+func TestResponsesInputMarshal_FunctionCallOutputKeepsEmptyOutput(t *testing.T) {
+	item := responsesInput{
+		Type:   "function_call_output",
+		CallID: "call_1",
+		Output: "",
+	}
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"output":""`)) {
+		t.Errorf("function_call_output must emit 'output':'' even when empty (#172): %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"role"`)) {
+		t.Errorf("function_call_output must not emit 'role' key: %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"content"`)) {
+		t.Errorf("function_call_output must not emit 'content' key: %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"name"`)) {
+		t.Errorf("function_call_output must not emit 'name' key: %s", raw)
+	}
+	if bytes.Contains(raw, []byte(`"arguments"`)) {
+		t.Errorf("function_call_output must not emit 'arguments' key: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"type":"function_call_output"`)) {
+		t.Errorf("function_call_output must emit type=function_call_output: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"call_id":"call_1"`)) {
+		t.Errorf("function_call_output must emit call_id: %s", raw)
+	}
+}
+
+// TestResponsesInputMarshal_UnknownTypeErrors guards against a future
+// edit accidentally introducing a new Type value without adding a wire
+// variant. The previous shared-struct shape silently serialised unknown
+// types as a pile of empty-string keys; the per-type marshaller surfaces
+// the gap explicitly so it cannot land as a quiet wire-format mismatch.
+func TestResponsesInputMarshal_UnknownTypeErrors(t *testing.T) {
+	item := responsesInput{Type: "reasoning"}
+	if _, err := json.Marshal(item); err == nil {
+		t.Errorf("expected error marshalling unknown type, got nil")
+	}
+}
+
 func TestTranslateToolsResponses(t *testing.T) {
 	tools := []types.ToolDefinition{
 		{

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -1236,6 +1236,32 @@ func TestResponsesInputMarshal_FunctionCallOutputKeepsEmptyOutput(t *testing.T) 
 	}
 }
 
+// TestResponsesInputMarshal_FunctionCallOutputNonEmpty pairs with the
+// empty-output pin: a function_call_output item carrying a real result
+// string must put it under the "output" key on the wire. Together the
+// two tests fence the field on both sides — required when empty
+// (#172), and faithfully transmitted when populated.
+func TestResponsesInputMarshal_FunctionCallOutputNonEmpty(t *testing.T) {
+	item := responsesInput{
+		Type:   "function_call_output",
+		CallID: "call_1",
+		Output: "some result",
+	}
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"output":"some result"`)) {
+		t.Errorf("function_call_output must carry non-empty output verbatim: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"type":"function_call_output"`)) {
+		t.Errorf("function_call_output must emit type=function_call_output: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"call_id":"call_1"`)) {
+		t.Errorf("function_call_output must emit call_id: %s", raw)
+	}
+}
+
 // TestResponsesInputMarshal_UnknownTypeErrors guards against a future
 // edit accidentally introducing a new Type value without adding a wire
 // variant. The previous shared-struct shape silently serialised unknown
@@ -1245,6 +1271,105 @@ func TestResponsesInputMarshal_UnknownTypeErrors(t *testing.T) {
 	item := responsesInput{Type: "reasoning"}
 	if _, err := json.Marshal(item); err == nil {
 		t.Errorf("expected error marshalling unknown type, got nil")
+	}
+}
+
+// TestResponsesInputRoundTrip exercises the MarshalJSON/UnmarshalJSON
+// pair across all three valid variants. The Unmarshal path exists to
+// keep test roundtrips (and any future caller-side parsing) able to
+// inspect a wire body through the same struct that built it, so the
+// invariant being pinned is: marshalling then unmarshalling returns
+// a struct equal to the original on every field valid for that
+// variant.
+func TestResponsesInputRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   responsesInput
+	}{
+		{
+			name: "message",
+			in: responsesInput{
+				Type: "message",
+				Role: "user",
+				Content: []responsesContentBlock{
+					{Type: "input_text", Text: "hello"},
+				},
+			},
+		},
+		{
+			name: "function_call",
+			in: responsesInput{
+				Type:      "function_call",
+				CallID:    "call_abc",
+				Name:      "read_file",
+				Arguments: `{"path":"main.go"}`,
+			},
+		},
+		{
+			name: "function_call_output",
+			in: responsesInput{
+				Type:   "function_call_output",
+				CallID: "call_abc",
+				Output: "file contents",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var got responsesInput
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.Type != tc.in.Type {
+				t.Errorf("Type = %q, want %q", got.Type, tc.in.Type)
+			}
+			switch tc.in.Type {
+			case "message":
+				if got.Role != tc.in.Role {
+					t.Errorf("Role = %q, want %q", got.Role, tc.in.Role)
+				}
+				if len(got.Content) != len(tc.in.Content) {
+					t.Fatalf("Content len = %d, want %d", len(got.Content), len(tc.in.Content))
+				}
+				for i := range tc.in.Content {
+					if got.Content[i] != tc.in.Content[i] {
+						t.Errorf("Content[%d] = %+v, want %+v", i, got.Content[i], tc.in.Content[i])
+					}
+				}
+			case "function_call":
+				if got.CallID != tc.in.CallID {
+					t.Errorf("CallID = %q, want %q", got.CallID, tc.in.CallID)
+				}
+				if got.Name != tc.in.Name {
+					t.Errorf("Name = %q, want %q", got.Name, tc.in.Name)
+				}
+				if got.Arguments != tc.in.Arguments {
+					t.Errorf("Arguments = %q, want %q", got.Arguments, tc.in.Arguments)
+				}
+			case "function_call_output":
+				if got.CallID != tc.in.CallID {
+					t.Errorf("CallID = %q, want %q", got.CallID, tc.in.CallID)
+				}
+				if got.Output != tc.in.Output {
+					t.Errorf("Output = %q, want %q", got.Output, tc.in.Output)
+				}
+			}
+		})
+	}
+}
+
+// TestResponsesInputUnmarshal_UnknownTypeErrors is the inverse of the
+// marshal-side guard: receiving a wire item with an unrecognised type
+// discriminant must surface as an error rather than silently zeroing
+// the struct. Mirrors TestResponsesInputMarshal_UnknownTypeErrors.
+func TestResponsesInputUnmarshal_UnknownTypeErrors(t *testing.T) {
+	var got responsesInput
+	if err := json.Unmarshal([]byte(`{"type":"reasoning"}`), &got); err == nil {
+		t.Errorf("expected error unmarshalling unknown type, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #199.

Azure OpenAI's Responses endpoint rejects the first turn with HTTP 400 — `Unknown parameter: 'input[0].output'.` — because the harness was unconditionally serialising `"output": ""` on every input item, including plain `message` items. Upstream OpenAI tolerates the spurious key; Azure does not.

Root cause: `responsesInput` was a single discriminated-union struct whose `Output` field had to drop `omitempty` so that `function_call_output` items would carry the `"output"` key even when empty (the #172 invariant). The pre-existing code comments at the relevant lines already anticipated the long-term remedy — *"Splitting `responsesInput` into per-type structs is the long-term remedy"* — and that is what this PR implements.

## What changed

- `responsesInput` keeps its ergonomic flat construction shape (callers still build items without branching on type). All json tags on the fields are now `-`.
- `MarshalJSON` switches on `Type` and writes the request through one of three dedicated wire structs:
  - `responsesMessageInputWire` — `type`, `role`, `content`
  - `responsesFunctionCallInputWire` — `type`, `call_id`, `name`, `arguments`
  - `responsesFunctionCallOutputInputWire` — `type`, `call_id`, `output` (no `omitempty` on `output`, preserves #172)
- Unknown `Type` values now return an explicit error from `MarshalJSON` instead of silently producing an empty-string-stuffed object.
- A mirror `UnmarshalJSON` exists for test-roundtrip ergonomics — the adapter itself never decodes request bodies in production.
- `responsesContentBlock` is intentionally left as a single struct: both `input_text` and `output_text` variants share the same `(type, text)` field set today. The comment documents the rule and flags when to split if a new content-block variant diverges.
- No per-vendor branching — the wire shape is correct for every Responses endpoint, OpenAI or Azure. The PR explicitly avoids the kind of drift #192 (per-model request-shape overrides) is intended to consolidate.

## Tests

New unit tests in `harness/internal/provider/openai_responses_test.go`:

- `TestResponsesInputMarshal_MessageOmitsOutput` — gh-199 regression: a `message` item does not emit `output` / `call_id` / `name` / `arguments`.
- `TestResponsesInputMarshal_FunctionCallOmitsOutput` — `function_call` items do not emit `output` / `role` / `content`.
- `TestResponsesInputMarshal_FunctionCallOutputKeepsEmptyOutput` — #172 invariant pin: `function_call_output` with `Output: ""` still emits `"output":""`.
- `TestResponsesInputMarshal_FunctionCallOutputNonEmpty` — non-empty `Output` passes through verbatim.
- `TestResponsesInputMarshal_UnknownTypeErrors` — `MarshalJSON` errors on unknown types instead of silently emitting empty-key payloads.
- `TestResponsesInputRoundTrip` — table-driven marshal-then-unmarshal across all three valid variants asserts field equality.
- `TestResponsesInputUnmarshal_UnknownTypeErrors` — mirror of the marshal-side guard on the decode path.

Existing tests including `TestOpenAIResponsesAdapter_RequestBody_EmptyToolResult` (the end-to-end #172 pin) continue to pass unchanged.

## Reviewer notes

Five reviewer agents ran against `876b193` (the initial fix commit) before the follow-up commits below: code, security, spec-compliance, test-coverage, and api-design. The synthesis returned **zero blocking findings** and four cheap same-pass non-blocking items, three of which are addressed in the follow-up commits:

- `3c9e11f` — source the wire `Type` field from `r.Type` instead of repeating string literals in each switch arm.
- `3c0552e` — add `UnmarshalJSON` round-trip coverage and the non-empty `Output` test case (NB-1 and NB-2 from the review brief).

The fourth NB item (a comment citing a missing test) turned out to be a false alarm — the cited test `TestTranslateMessagesResponses_UserTextAndToolResultOrder` does exist at `openai_responses_test.go:2107`, so no change was needed there.

Deferred items tracked for follow-up (not in this PR):
- Moving `UnmarshalJSON` out of production code into a test helper to enforce the "adapter never decodes request bodies" boundary at compile time rather than by comment.
- `DisallowUnknownFields` on the `UnmarshalJSON` decoder to catch cross-variant tamper.
- Pre-emptively splitting `responsesContentBlock` and adding a field-isolation test before a diverging variant lands.
- Raw-body level absence assertion in the existing end-to-end `TestOpenAIResponsesAdapter_RequestBody` to complement the unit-level wire-shape pins.

## Test plan

- [ ] `just build` succeeds.
- [ ] `just test` passes (full suite).
- [ ] Reproduce the issue from #199 against a real Azure OpenAI `…/openai/v1` endpoint and confirm the first turn no longer 400s on `Unknown parameter: 'input[0].output'`.
- [ ] Smoke-test against upstream OpenAI to confirm the existing tool-result round-trip (the #172 invariant) still works end-to-end.

## Related

- Closes #199 — Azure OpenAI rejecting `output: ""` on non-`function_call_output` items.
- Preserves #172 — `function_call_output` items still carry `"output"` even when the value is empty.
- Adjacent to #192 — per-model request-shape overrides. This fix is deliberately vendor-agnostic and is the kind of consolidation #192 is meant to drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)