### PR TITLE
WS1 triage: gemini round-trip + blank-name test, bedrock validation, safe-by-default execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Requires `ANTHROPIC_API_KEY` environment variable for the default Anthropic prov
 | Flag | Default | Description |
 |---|---|---|
 | `--prompt` | (required) | User prompt, also accepted as a positional argument |
-| `--mode`, `-m` | `execution` | Run mode: execution, planning, review, research, toil |
+| `--mode`, `-m` | `execution` | Run mode: execution, planning, review, research, toil. Execution mode defaults to a conservative `Tools.BuiltIn` allowlist (no `web_fetch`, no `run_command`) and `permissionPolicy.type=deny-side-effects` — opt-in to the legacy unconstrained posture via `--config`. See [`docs/configuration.md`](docs/configuration.md#default-safe-by-default-posture-execution-mode). |
 | `--model` | `claude-sonnet-4-6` | Model to use |
 | `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible (Chat Completions), openai-responses (Responses API), gemini (Vertex AI) |
 | `--api-key-ref` | `secret://ANTHROPIC_API_KEY` | Secret reference for API key |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,13 @@ to make a feature easier:
   excludes `write_file` / `run_command` / `edit_file`, and the
   permission policy is not `allow-all`. A new mode added to the
   list inherits the invariant.
+- **Safe-by-default execution mode.** A bare `stirrup harness` run
+  inherits `permissionPolicy.type=deny-side-effects` and the
+  `DefaultExecutionBuiltInTools()` allowlist (no `web_fetch`, no
+  `run_command`). Loosening either default — re-enabling all
+  built-ins for empty `Tools.BuiltIn`, or flipping the policy back
+  to `allow-all` — is a regression of issue #74. Opt-in remains
+  per-knob via `--config`.
 - **Hand-rolled HTTP over SDKs.** The container executor uses the
   Docker Engine REST API directly to avoid the `github.com/docker/docker`
   dependency tree. Provider adapters are stdlib HTTP+SSE for the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,6 +194,25 @@ configuration space — the common cases. Anything below requires
 
 The CLI flags for each of these set the *type* selection only.
 
+## Default safe-by-default posture (execution mode)
+
+A bare `stirrup harness --prompt "x"` with no `--config`, no explicit
+`Tools.BuiltIn`, and no explicit `PermissionPolicy` lands on the
+following conservative defaults (issue #74):
+
+| Knob | Default | Notes |
+|---|---|---|
+| `permissionPolicy.type` | `deny-side-effects` | Workspace-mutating tools (`write_file`, `edit_file`, `run_command`) are denied. Opt out with `permissionPolicy.type: allow-all` in `--config` or pair with `--permission-policy-file` for Cedar. |
+| `tools.builtIn` | `["read_file", "list_directory", "search_files", "edit_file", "spawn_agent"]` | Conservative starter set. `web_fetch` (external egress + untrusted ingress) and `run_command` (host shell) are opt-in: list them explicitly under `tools.builtIn` in `--config`. |
+
+Operators who explicitly set either knob in `--config` survive the
+fixup — `applyModeDefaults` only fills *unset* fields. Setting
+`permissionPolicy.type: allow-all` does not re-enable the excluded
+tools automatically; both axes are independent.
+
+Read-only modes (below) continue to use their pre-existing
+conservative defaults from `DefaultReadOnlyBuiltInTools()`.
+
 ## Read-only modes
 
 `planning`, `review`, `research`, and `toil` enforce a structural

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -479,16 +479,32 @@ func retryDurationToMs(flagName string, d time.Duration) (int, error) {
 	return int(d / time.Millisecond), nil
 }
 
-// applyModeDefaults fills in PermissionPolicy and the read-only Tools.BuiltIn
-// list based on cfg.Mode, but only for fields the caller has not set
-// explicitly. This is shared between the flag-only path (buildHarnessRunConfig)
-// and the --config path (runHarness, after applyOverrides) so the two paths
-// produce architecturally consistent configs.
+// applyModeDefaults fills in PermissionPolicy and the Tools.BuiltIn list
+// based on cfg.Mode, but only for fields the caller has not set
+// explicitly. This is shared between the flag-only path
+// (buildHarnessRunConfig) and the --config path (runHarness, after
+// applyOverrides) so the two paths produce architecturally consistent
+// configs.
 //
-// The function never strips an explicit configuration — if the caller set
-// allow-all on a read-only mode, ValidateRunConfig will reject it with a
-// clear error rather than this function silently rewriting the choice.
-// That keeps user intent visible: a wrong combination fails loudly.
+// Execution mode landed on safe-by-default defaults in issue #74:
+//
+//   - PermissionPolicy.Type defaults to "deny-side-effects" (was
+//     "allow-all"). Workspace-mutating tools and approval-gated
+//     operations are denied until the operator explicitly opts in with
+//     a --config override.
+//   - Tools.BuiltIn defaults to DefaultExecutionBuiltInTools(), a
+//     conservative allowlist that excludes web_fetch (external egress
+//     + untrusted ingress) and run_command (host shell). Opting in
+//     requires listing them under Tools.BuiltIn in --config.
+//
+// Read-only modes already used deny-side-effects + a conservative
+// allowlist; the change brings execution mode into line.
+//
+// The function never strips an explicit configuration — if the caller
+// set allow-all on a read-only mode, ValidateRunConfig will reject it
+// with a clear error rather than this function silently rewriting the
+// choice. That keeps user intent visible: a wrong combination fails
+// loudly.
 func applyModeDefaults(cfg *types.RunConfig) {
 	if types.IsReadOnlyMode(cfg.Mode) {
 		if cfg.PermissionPolicy.Type == "" {
@@ -501,8 +517,15 @@ func applyModeDefaults(cfg *types.RunConfig) {
 		if len(cfg.Tools.BuiltIn) == 0 {
 			cfg.Tools.BuiltIn = types.DefaultReadOnlyBuiltInTools()
 		}
-	} else if cfg.PermissionPolicy.Type == "" {
-		cfg.PermissionPolicy = types.PermissionPolicyConfig{Type: "allow-all"}
+		return
+	}
+	// Execution mode (or any future editable mode that lands outside the
+	// read-only set).
+	if cfg.PermissionPolicy.Type == "" {
+		cfg.PermissionPolicy = types.PermissionPolicyConfig{Type: "deny-side-effects"}
+	}
+	if len(cfg.Tools.BuiltIn) == 0 {
+		cfg.Tools.BuiltIn = types.DefaultExecutionBuiltInTools()
 	}
 }
 

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -111,6 +111,63 @@ func TestBuildHarnessRunConfig_OpenAIResponsesProvider(t *testing.T) {
 	}
 }
 
+// TestBuildHarnessRunConfig_BedrockWithAnthropicAliasRejected pins
+// the fail-fast posture from issue #65: a bare `--provider bedrock`
+// invocation that inherits the CLI default `--model claude-sonnet-4-6`
+// must be rejected at config validation with a message that names the
+// inference-profile path, not silently sent to AWS to fail server-side
+// with a generic ValidationException after a full SigV4 round-trip.
+func TestBuildHarnessRunConfig_BedrockWithAnthropicAliasRejected(t *testing.T) {
+	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "execution",
+		Prompt:        "test",
+		ProviderType:  "bedrock",
+		Model:         "claude-sonnet-4-6", // CLI default; an Anthropic-API alias
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+	if err != nil {
+		t.Fatalf("buildHarnessRunConfig: %v", err)
+	}
+	verr := types.ValidateRunConfig(cfg)
+	if verr == nil {
+		t.Fatal("expected ValidateRunConfig to reject bedrock + anthropic-alias model")
+	}
+	msg := verr.Error()
+	for _, want := range []string{"bedrock", "inference profile", "claude-sonnet-4-6"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("validation error %q missing substring %q", msg, want)
+		}
+	}
+}
+
+// TestBuildHarnessRunConfig_BedrockWithInferenceProfileAccepted is the
+// positive companion to the alias-rejection test: a properly-shaped
+// inference profile id must validate cleanly so operators with a
+// configured Bedrock setup are unimpeded.
+func TestBuildHarnessRunConfig_BedrockWithInferenceProfileAccepted(t *testing.T) {
+	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "execution",
+		Prompt:        "test",
+		ProviderType:  "bedrock",
+		Model:         "eu.anthropic.claude-sonnet-4-6",
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+	if err != nil {
+		t.Fatalf("buildHarnessRunConfig: %v", err)
+	}
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		t.Fatalf("ValidateRunConfig rejected a valid bedrock inference profile: %v", err)
+	}
+}
+
 // TestBuildHarnessRunConfig_FillsDefaultReadOnlyToolList verifies that
 // when no explicit Tools.BuiltIn list is supplied, read-only modes get
 // the documented default list rather than passing validation by accident.

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -212,6 +212,60 @@ func TestApplyModeDefaults_RespectsExplicitTools(t *testing.T) {
 	}
 }
 
+// TestApplyModeDefaults_ExecutionSafeDefaults pins the safe-by-default
+// posture for execution mode from issue #74: a bare invocation with no
+// explicit Tools.BuiltIn list and no explicit PermissionPolicy lands
+// on the conservative DefaultExecutionBuiltInTools() allowlist and the
+// deny-side-effects permission policy. Regressing either knob would
+// silently re-enable web_fetch / run_command and allow-all on the
+// first turn of a fresh `stirrup harness --prompt "x"` run.
+func TestApplyModeDefaults_ExecutionSafeDefaults(t *testing.T) {
+	cfg := &types.RunConfig{Mode: "execution"}
+	applyModeDefaults(cfg)
+
+	if cfg.PermissionPolicy.Type != "deny-side-effects" {
+		t.Errorf("PermissionPolicy.Type = %q, want deny-side-effects", cfg.PermissionPolicy.Type)
+	}
+
+	wantTools := types.DefaultExecutionBuiltInTools()
+	if len(cfg.Tools.BuiltIn) != len(wantTools) {
+		t.Fatalf("Tools.BuiltIn = %v, want %v", cfg.Tools.BuiltIn, wantTools)
+	}
+	for i, name := range wantTools {
+		if cfg.Tools.BuiltIn[i] != name {
+			t.Errorf("Tools.BuiltIn[%d] = %q, want %q", i, cfg.Tools.BuiltIn[i], name)
+		}
+	}
+
+	// Defence-in-depth: the two opt-in-only tools must NOT appear.
+	for _, banned := range []string{"web_fetch", "run_command"} {
+		for _, got := range cfg.Tools.BuiltIn {
+			if got == banned {
+				t.Errorf("execution default unexpectedly includes %q: %v", banned, cfg.Tools.BuiltIn)
+			}
+		}
+	}
+}
+
+// TestApplyModeDefaults_ExecutionAllowAllOptIn confirms that an operator
+// who explicitly opts in to the legacy unconstrained posture (allow-all
+// + a tool list including run_command / web_fetch) survives the
+// safe-default fixup. The defaults must only fill *unset* fields.
+func TestApplyModeDefaults_ExecutionAllowAllOptIn(t *testing.T) {
+	cfg := &types.RunConfig{
+		Mode:             "execution",
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"run_command", "web_fetch"}},
+	}
+	applyModeDefaults(cfg)
+	if cfg.PermissionPolicy.Type != "allow-all" {
+		t.Errorf("explicit allow-all should survive, got %q", cfg.PermissionPolicy.Type)
+	}
+	if len(cfg.Tools.BuiltIn) != 2 || cfg.Tools.BuiltIn[0] != "run_command" || cfg.Tools.BuiltIn[1] != "web_fetch" {
+		t.Errorf("explicit tool list should survive, got %v", cfg.Tools.BuiltIn)
+	}
+}
+
 // TestApplyModeDefaults_RespectsExplicitPolicy verifies that an
 // explicit PermissionPolicy survives applyModeDefaults — even one that
 // will later fail validation (allow-all on a read-only mode). Auto-

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -469,6 +469,12 @@ type streamResult struct {
 func streamEventsToResult(ctx context.Context, ch <-chan types.StreamEvent, tp transport.Transport, logger *slog.Logger) (*streamResult, error) {
 	result := &streamResult{}
 	var currentText string
+	// textSig retains the last non-empty thought signature observed on
+	// streamed text deltas in the current text run. Vertex 3.x attaches
+	// the signature once per part regardless of how many delta chunks
+	// build the part; carrying the latest seen value lets the assembled
+	// text block round-trip the signature on the next turn.
+	var textSig string
 	inText := false
 
 	for event := range ch {
@@ -483,8 +489,12 @@ func streamEventsToResult(ctx context.Context, ch <-chan types.StreamEvent, tp t
 			if !inText {
 				inText = true
 				currentText = ""
+				textSig = ""
 			}
 			currentText += event.Text
+			if event.ThoughtSignature != "" {
+				textSig = event.ThoughtSignature
+			}
 			if err := tp.Emit(types.HarnessEvent{
 				Type: "text_delta",
 				Text: event.Text,
@@ -495,22 +505,25 @@ func streamEventsToResult(ctx context.Context, ch <-chan types.StreamEvent, tp t
 		case "tool_call":
 			// Flush any accumulated text block.
 			if inText {
-				result.Blocks = append(result.Blocks, types.ContentBlock{Type: "text", Text: currentText})
+				result.Blocks = append(result.Blocks, types.ContentBlock{Type: "text", Text: currentText, ThoughtSignature: textSig})
 				inText = false
 				currentText = ""
+				textSig = ""
 			}
 			inputBytes, _ := json.Marshal(event.Input)
 			result.Blocks = append(result.Blocks, types.ContentBlock{
-				Type:  "tool_use",
-				ID:    event.ID,
-				Name:  event.Name,
-				Input: json.RawMessage(inputBytes),
+				Type:             "tool_use",
+				ID:               event.ID,
+				Name:             event.Name,
+				Input:            json.RawMessage(inputBytes),
+				ThoughtSignature: event.ThoughtSignature,
 			})
 
 		case "message_complete":
 			if inText {
-				result.Blocks = append(result.Blocks, types.ContentBlock{Type: "text", Text: currentText})
+				result.Blocks = append(result.Blocks, types.ContentBlock{Type: "text", Text: currentText, ThoughtSignature: textSig})
 				inText = false
+				textSig = ""
 			}
 			if event.StopReason != "" {
 				result.StopReason = event.StopReason
@@ -527,7 +540,7 @@ func streamEventsToResult(ctx context.Context, ch <-chan types.StreamEvent, tp t
 	}
 
 	if inText {
-		result.Blocks = append(result.Blocks, types.ContentBlock{Type: "text", Text: currentText})
+		result.Blocks = append(result.Blocks, types.ContentBlock{Type: "text", Text: currentText, ThoughtSignature: textSig})
 	}
 
 	return result, nil

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -270,11 +270,17 @@ func mapGeminiFinishReason(in string) string {
 // (or when the stream terminates on a finishReason without a closing
 // chunk, in which case we treat the latest snapshot as final).
 //
+// thoughtSignature is captured separately: Gemini 3.x attaches it to the
+// part wrapping the functionCall, not to the functionCall sub-object. We
+// retain the last non-empty signature seen on the slot so the value
+// survives multi-chunk streamed calls and is available at emit time.
+//
 // The retained blob is bounded at maxToolInputSize (10 MB) to mirror the
 // Anthropic adapter's safety cap.
 type toolCallBuf struct {
-	name string
-	args []byte
+	name             string
+	args             []byte
+	thoughtSignature string
 }
 
 // consumeSSE reads SSE events from the response body and emits StreamEvents
@@ -352,9 +358,9 @@ func (g *GeminiAdapter) consumeSSE(
 	// follow-up chunk with the same name does not double-emit. The ID
 	// is synthesised from streamN and the monotonic nextPartIdx counter
 	// (incremented by the caller after a successful emit).
-	emitToolCall := func(name string, fullArgs []byte, idForSeq int) bool {
+	emitToolCall := func(buf *toolCallBuf, idForSeq int) bool {
 		var input map[string]any
-		argsBytes := fullArgs
+		argsBytes := buf.args
 		if len(argsBytes) == 0 {
 			argsBytes = []byte("{}")
 		}
@@ -363,12 +369,13 @@ func (g *GeminiAdapter) consumeSSE(
 			return false
 		}
 		emitEvent(types.StreamEvent{
-			Type:  "tool_call",
-			ID:    fmt.Sprintf("gemini-%d-%d", streamN, idForSeq),
-			Name:  name,
-			Input: input,
+			Type:             "tool_call",
+			ID:               fmt.Sprintf("gemini-%d-%d", streamN, idForSeq),
+			Name:             buf.name,
+			Input:            input,
+			ThoughtSignature: buf.thoughtSignature,
 		})
-		delete(toolBufs, name)
+		delete(toolBufs, buf.name)
 		return true
 	}
 
@@ -420,8 +427,9 @@ func (g *GeminiAdapter) consumeSSE(
 					switch {
 					case part.Text != "":
 						emitEvent(types.StreamEvent{
-							Type: "text_delta",
-							Text: part.Text,
+							Type:             "text_delta",
+							Text:             part.Text,
+							ThoughtSignature: part.ThoughtSignature,
 						})
 					case part.FunctionCall != nil:
 						sawFunctionCall = true
@@ -465,6 +473,15 @@ func (g *GeminiAdapter) consumeSSE(
 							buf.args = snapshot
 						}
 
+						// thoughtSignature lives on the wrapping part, not
+						// inside functionCall. Retain the latest non-empty
+						// value so a multi-chunk streamed call that carries
+						// the signature on (say) the first chunk still
+						// surfaces it on the eventual emit.
+						if part.ThoughtSignature != "" {
+							buf.thoughtSignature = part.ThoughtSignature
+						}
+
 						// Unreachable when streamFunctionCallArguments=false (current default); retained for correctness if the flag is re-enabled.
 						if !fc.WillContinue {
 							// Final chunk for this call: emit, then
@@ -472,7 +489,7 @@ func (g *GeminiAdapter) consumeSSE(
 							// synthesis. nextPartIdx is no longer the
 							// slot key — emitting deletes the named
 							// slot directly.
-							if !emitToolCall(buf.name, buf.args, nextPartIdx) {
+							if !emitToolCall(buf, nextPartIdx) {
 								return
 							}
 							nextPartIdx++
@@ -490,7 +507,7 @@ func (g *GeminiAdapter) consumeSSE(
 				// represents a distinct tool name — order between
 				// drained calls is not load-bearing.
 				for _, buf := range toolBufs {
-					if !emitToolCall(buf.name, buf.args, nextPartIdx) {
+					if !emitToolCall(buf, nextPartIdx) {
 						return
 					}
 					nextPartIdx++

--- a/harness/internal/provider/gemini_request.go
+++ b/harness/internal/provider/gemini_request.go
@@ -171,7 +171,10 @@ func translateMessagesGemini(system string, messages []types.Message) ([]geminiC
 					if block.Text == "" {
 						continue
 					}
-					parts = append(parts, geminiPart{Text: block.Text})
+					parts = append(parts, geminiPart{
+						Text:             block.Text,
+						ThoughtSignature: block.ThoughtSignature,
+					})
 				case "tool_use":
 					args := normaliseToolArgs(block.Input)
 					parts = append(parts, geminiPart{
@@ -179,6 +182,7 @@ func translateMessagesGemini(system string, messages []types.Message) ([]geminiC
 							Name: block.Name,
 							Args: args,
 						},
+						ThoughtSignature: block.ThoughtSignature,
 					})
 					if block.ID != "" {
 						toolNameByID[block.ID] = block.Name

--- a/harness/internal/provider/gemini_request_test.go
+++ b/harness/internal/provider/gemini_request_test.go
@@ -29,6 +29,7 @@ type decodedPart struct {
 	Text             string               `json:"text,omitempty"`
 	FunctionCall     *decodedFunctionCall `json:"functionCall,omitempty"`
 	FunctionResponse *decodedFuncResponse `json:"functionResponse,omitempty"`
+	ThoughtSignature string               `json:"thoughtSignature,omitempty"`
 }
 
 type decodedFunctionCall struct {
@@ -632,5 +633,76 @@ func TestBuildGenerateContentRequest_UserTextAndToolResultOrdering(t *testing.T)
 	}
 	if dr.Contents[2].Role != "user" || dr.Contents[2].Parts[0].Text != "follow-up note" {
 		t.Errorf("contents[2] mismatch: %+v", dr.Contents[2])
+	}
+}
+
+// TestBuildGenerateContentRequest_RoundTripsThoughtSignature pins the
+// outbound wire shape for #194: when the prior assistant turn carried a
+// ThoughtSignature on a text or tool_use block, the marshaller must echo
+// the blob verbatim on the corresponding part of the next request so
+// Gemini 3.x can resume its hidden chain-of-thought.
+func TestBuildGenerateContentRequest_RoundTripsThoughtSignature(t *testing.T) {
+	const textSig = "AY-text-sig-001=="
+	const toolSig = "AY-tool-sig-002=="
+
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model: "gemini-3.1-pro-preview",
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "Read safety-rings"}}},
+			{Role: "assistant", Content: []types.ContentBlock{
+				{Type: "text", Text: "Reading now.", ThoughtSignature: textSig},
+				{Type: "tool_use", ID: "c1", Name: "read_file", Input: json.RawMessage(`{"path":"docs/safety-rings.md"}`), ThoughtSignature: toolSig},
+			}},
+			{Role: "user", Content: []types.ContentBlock{
+				{Type: "tool_result", ToolUseID: "c1", Content: "..."},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dr := decodeGeminiRequest(t, body)
+	if len(dr.Contents) < 2 {
+		t.Fatalf("expected at least 2 contents, got %d", len(dr.Contents))
+	}
+	model := dr.Contents[1]
+	if model.Role != "model" || len(model.Parts) != 2 {
+		t.Fatalf("contents[1] mismatch: %+v", model)
+	}
+	if model.Parts[0].ThoughtSignature != textSig {
+		t.Errorf("text part thoughtSignature = %q, want %q", model.Parts[0].ThoughtSignature, textSig)
+	}
+	if model.Parts[1].ThoughtSignature != toolSig {
+		t.Errorf("tool_use part thoughtSignature = %q, want %q", model.Parts[1].ThoughtSignature, toolSig)
+	}
+
+	// Defence-in-depth: the wire JSON must not emit the field for the
+	// user / function_response parts that never carried a signature.
+	if strings.Count(string(body), "thoughtSignature") != 2 {
+		t.Errorf("expected exactly 2 thoughtSignature occurrences on the wire, got: %s", body)
+	}
+}
+
+// TestBuildGenerateContentRequest_OmitsEmptyThoughtSignature confirms that
+// the field is omitted from the wire when the block carries no signature,
+// so the legacy Gemini 2.x shape is preserved on operators that never
+// touch 3.x.
+func TestBuildGenerateContentRequest_OmitsEmptyThoughtSignature(t *testing.T) {
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model: "gemini-2.5-pro",
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+			{Role: "assistant", Content: []types.ContentBlock{
+				{Type: "text", Text: "hello"},
+				{Type: "tool_use", ID: "c1", Name: "noop", Input: json.RawMessage(`{}`)},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(body), "thoughtSignature") {
+		t.Errorf("body should not mention thoughtSignature when blocks carry none: %s", body)
 	}
 }

--- a/harness/internal/provider/gemini_test.go
+++ b/harness/internal/provider/gemini_test.go
@@ -985,3 +985,79 @@ func TestGeminiAdapter_NonStreamedFunctionCall3xShape(t *testing.T) {
 		t.Errorf("stop_reason = %q, want tool_use", stop.StopReason)
 	}
 }
+
+// TestGeminiAdapter_ThoughtSignatureFromFunctionCallPart pins the parse
+// side of #194: a Gemini 3.x chunk that carries a thoughtSignature on the
+// part wrapping a functionCall surfaces the blob on the corresponding
+// tool_call StreamEvent so the agentic loop can persist it onto the
+// resulting ContentBlock for round-tripping on the next turn.
+func TestGeminiAdapter_ThoughtSignatureFromFunctionCallPart(t *testing.T) {
+	const sig = "AY89a18t+D98lADcFYKgjMgoHS7rROUND_TRIP=="
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"docs/safety-rings.md"}},"thoughtSignature":"` + sig + `"}]},"finishReason":"STOP"}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	var toolCall *types.StreamEvent
+	for _, ev := range collectEvents(t, ch) {
+		if ev.Type == "tool_call" {
+			toolCall = &ev
+		}
+		if ev.Type == "error" {
+			t.Fatalf("unexpected error event: %v", ev.Error)
+		}
+	}
+	if toolCall == nil {
+		t.Fatal("expected tool_call event")
+	}
+	if toolCall.ThoughtSignature != sig {
+		t.Errorf("tool_call.ThoughtSignature = %q, want %q", toolCall.ThoughtSignature, sig)
+	}
+}
+
+// TestGeminiAdapter_ThoughtSignatureFromTextPart confirms that signatures
+// attached to text parts also surface on the corresponding text_delta
+// event. The signature applies to the whole part regardless of how many
+// delta chunks build it, so the adapter forwards it on the chunk it was
+// observed on.
+func TestGeminiAdapter_ThoughtSignatureFromTextPart(t *testing.T) {
+	const sig = "AY-text-sig-roundtrip=="
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello","thoughtSignature":"`+sig+`"}]}}]}`) +
+		makeGeminiData(`{"candidates":[{"finishReason":"STOP"}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	var sawSig bool
+	for _, ev := range collectEvents(t, ch) {
+		if ev.Type == "text_delta" && ev.ThoughtSignature == sig {
+			sawSig = true
+		}
+		if ev.Type == "error" {
+			t.Fatalf("unexpected error event: %v", ev.Error)
+		}
+	}
+	if !sawSig {
+		t.Errorf("expected a text_delta event carrying thoughtSignature=%q", sig)
+	}
+}

--- a/harness/internal/provider/gemini_test.go
+++ b/harness/internal/provider/gemini_test.go
@@ -986,6 +986,47 @@ func TestGeminiAdapter_NonStreamedFunctionCall3xShape(t *testing.T) {
 	}
 }
 
+// TestGeminiAdapter_BlankFunctionCallName pins the blank-name guard in
+// the SSE consumer (gemini.go's "functionCall part missing name" branch).
+// A chunk with a functionCall part that omits the name is a protocol
+// violation; the adapter must surface it as a stream error rather than
+// silently bucket the chunk into an empty-name slot. Closes #193.
+func TestGeminiAdapter_BlankFunctionCallName(t *testing.T) {
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"args":{"path":"x"}}}]}}]}`) +
+		makeGeminiData(`{"candidates":[{"finishReason":"STOP"}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-3.1-pro-preview"})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	var errorEvents []types.StreamEvent
+	for _, ev := range collectEvents(t, ch) {
+		switch ev.Type {
+		case "error":
+			errorEvents = append(errorEvents, ev)
+		case "tool_call":
+			t.Errorf("unexpected tool_call event for a name-less functionCall part: %+v", ev)
+		case "message_complete":
+			t.Errorf("unexpected message_complete event after a protocol-violating chunk: %+v", ev)
+		}
+	}
+	if len(errorEvents) != 1 {
+		t.Fatalf("expected exactly 1 error event, got %d: %+v", len(errorEvents), errorEvents)
+	}
+	if errorEvents[0].Error == nil || !strings.Contains(errorEvents[0].Error.Error(), "functionCall part missing name") {
+		t.Errorf("error message = %v, want substring %q", errorEvents[0].Error, "functionCall part missing name")
+	}
+}
+
 // TestGeminiAdapter_ThoughtSignatureFromFunctionCallPart pins the parse
 // side of #194: a Gemini 3.x chunk that carries a thoughtSignature on the
 // part wrapping a functionCall surfaces the blob on the corresponding

--- a/harness/internal/provider/gemini_types.go
+++ b/harness/internal/provider/gemini_types.go
@@ -42,10 +42,17 @@ type geminiContent struct {
 // FunctionResponse should be populated per part. (InlineData /
 // fileData / videoMetadata exist in the spec but are intentionally not
 // supported by this adapter — the harness is text-and-tools only.)
+//
+// ThoughtSignature is emitted by Gemini 3.x on parts produced by the model
+// (text and functionCall). It encodes the model's hidden chain-of-thought
+// and must be echoed back unchanged on the corresponding part of the next
+// request so the model can resume reasoning across multi-turn tool
+// exchanges. Empty on 2.x responses and on operator-side parts.
 type geminiPart struct {
 	Text             string                  `json:"text,omitempty"`
 	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
 	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+	ThoughtSignature string                  `json:"thoughtSignature,omitempty"`
 }
 
 // geminiFunctionCall is a model-emitted call to one of the declared tools.

--- a/types/events.go
+++ b/types/events.go
@@ -37,7 +37,13 @@ type StreamEvent struct {
 	StopReason   string         `json:"stopReason,omitempty"`
 	OutputTokens int            `json:"outputTokens,omitempty"`
 	Content      []ContentBlock `json:"content,omitempty"`
-	Error        error          `json:"-"`
+	// ThoughtSignature is an opaque provider-specific blob attached to the
+	// part the event represents (Gemini 3.x hidden chain-of-thought). The
+	// agentic loop persists it onto the resulting ContentBlock so the next
+	// turn can round-trip it back to the provider. Empty for providers
+	// that do not emit a signature.
+	ThoughtSignature string `json:"thoughtSignature,omitempty"`
+	Error            error  `json:"-"`
 }
 
 // StreamParams holds the parameters for a model streaming request.

--- a/types/messages.go
+++ b/types/messages.go
@@ -12,15 +12,23 @@ type Message struct {
 
 // ContentBlock is a single block of content within a message.
 // Use the Type field to determine which variant fields are populated.
+//
+// ThoughtSignature is an opaque, provider-specific blob the model emits
+// alongside a part to encode its hidden chain-of-thought. Today only the
+// Gemini 3.x adapter populates it (on text and tool_use blocks); the
+// harness preserves the blob unchanged across turns so the model can
+// resume its prior reasoning. Other providers ignore the field on
+// translation.
 type ContentBlock struct {
-	Type      string          `json:"type"` // "text" | "tool_use" | "tool_result"
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Content   string          `json:"content,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	Type             string          `json:"type"` // "text" | "tool_use" | "tool_result"
+	Text             string          `json:"text,omitempty"`
+	ID               string          `json:"id,omitempty"`
+	Name             string          `json:"name,omitempty"`
+	Input            json.RawMessage `json:"input,omitempty"`
+	ToolUseID        string          `json:"tool_use_id,omitempty"`
+	Content          string          `json:"content,omitempty"`
+	IsError          bool            `json:"is_error,omitempty"`
+	ThoughtSignature string          `json:"thought_signature,omitempty"`
 }
 
 // ToolDefinition describes a tool available to the model.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1182,6 +1182,39 @@ func DefaultReadOnlyBuiltInTools() []string {
 	}
 }
 
+// DefaultExecutionBuiltInTools returns the default set of built-in tools
+// enabled for execution mode when the caller has not supplied an explicit
+// Tools.BuiltIn list. Mirrors DefaultReadOnlyBuiltInTools for the
+// editable mode.
+//
+// The list is the conservative safe-by-default surface from issue #74:
+// introspection plus a multi-strategy editor and the sub-agent helper.
+// Two tools are deliberately excluded and must be opted in explicitly by
+// listing them in Tools.BuiltIn:
+//
+//   - web_fetch: external HTTP egress + untrusted-input ingress, two of
+//     the three Rule-of-Two legs all by itself.
+//   - run_command: arbitrary host-shell access. Lethal-by-default
+//     when paired with the local executor and no sandbox.
+//
+// MCP servers remain opt-in via MCPServers declarations; they were
+// always declaration-gated, this defaulting change does not alter
+// their posture.
+//
+// Operators wanting the previous "everything enabled" behaviour can
+// either list every built-in explicitly under Tools.BuiltIn in
+// --config, or pair the conservative default with an explicit
+// permissionPolicy=allow-all opt-out.
+func DefaultExecutionBuiltInTools() []string {
+	return []string{
+		"read_file",
+		"list_directory",
+		"search_files",
+		"edit_file",
+		"spawn_agent",
+	}
+}
+
 // mutatingTools enumerates built-in tools that mutate workspace state and
 // must therefore be excluded from read-only modes (research, review,
 // planning, toil). Other policy-relevant attributes (such as whether a

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1743,6 +1743,13 @@ func validateProviderConfigs(config *RunConfig, retryDefaulted map[string]provid
 	// Provider.Type is "gemini" and ModelRouter.Provider is unset.
 	validateGeminiModelName(config, errs)
 
+	// Per-provider model-shape validation for AWS Bedrock. Anthropic-API
+	// aliases (e.g. "claude-sonnet-4-6", the CLI default) cannot resolve
+	// at Bedrock and fail server-side with a generic
+	// ValidationException. Fail fast here with an actionable message
+	// pointing at the inference-profile path (issue #65).
+	validateBedrockModelShape(config, errs)
+
 	checkProviderRef := func(path, name string) {
 		if name == "" {
 			return
@@ -2375,6 +2382,83 @@ func validateGeminiModelName(config *RunConfig, errs *[]string) {
 			continue
 		}
 		if providerIsGemini(providerName) {
+			checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode), model)
+		}
+	}
+}
+
+// validateBedrockModelShape rejects model identifiers configured against
+// a bedrock-typed provider that structurally cannot resolve at AWS
+// Bedrock — specifically, the Anthropic-API aliases (e.g.
+// "claude-sonnet-4-6") that the harness's default `--model` flag emits.
+// Bedrock requires either a model id prefixed with a vendor segment
+// (e.g. "anthropic.claude-sonnet-4-5-20250929-v1:0"), an inference
+// profile id of the form "<region>.<vendor>.<model>" (e.g.
+// "eu.anthropic.claude-sonnet-4-6"), or a full ARN
+// ("arn:aws:bedrock:...:inference-profile/...").
+//
+// Without this check Bedrock fails the request server-side with a
+// generic `ValidationException: The provided model identifier is
+// invalid.`, after a full network round-trip plus SigV4 + IAM setup.
+// Failing at config-load time saves the user that round-trip and names
+// the inference-profile path in the error so the next attempt is
+// actionable.
+//
+// The check applies whenever a bedrock-typed provider would actually
+// service the configured ModelRouter — the same surface area as
+// validateGeminiModelName above. Mirrors the gemini-specific check.
+func validateBedrockModelShape(config *RunConfig, errs *[]string) {
+	providerIsBedrock := func(name string) bool {
+		if name == "" {
+			return config.Provider.Type == "bedrock"
+		}
+		if name == "bedrock" {
+			return true
+		}
+		if p, ok := config.Providers[name]; ok {
+			return p.Type == "bedrock"
+		}
+		return false
+	}
+
+	checkModel := func(label, model string) {
+		if model == "" {
+			return
+		}
+		// A full ARN is always accepted — the literal "arn:" prefix is
+		// the documented Bedrock identifier shape for inference profiles
+		// and provisioned-throughput models. Anything else must contain
+		// a "." separator: Bedrock model ids partition on
+		// "<region-or-vendor>.<...>".
+		if strings.HasPrefix(model, "arn:") {
+			return
+		}
+		if strings.Contains(model, ".") {
+			return
+		}
+		*errs = append(*errs, fmt.Sprintf(
+			"%s %q is invalid for provider type %q: Bedrock requires a vendor-prefixed model id "+
+				"(e.g. %q), an inference profile id (e.g. %q), or a full ARN. "+
+				"Use \"aws bedrock list-inference-profiles\" to enumerate profiles available in your region.",
+			label, model, "bedrock",
+			"anthropic.claude-sonnet-4-5-20250929-v1:0",
+			"eu.anthropic.claude-sonnet-4-6",
+		))
+	}
+
+	if providerIsBedrock(config.ModelRouter.Provider) {
+		checkModel("modelRouter.model", config.ModelRouter.Model)
+	}
+
+	for mode, spec := range config.ModelRouter.ModeModels {
+		providerName, model, ok := strings.Cut(spec, "/")
+		if !ok {
+			if providerIsBedrock(config.ModelRouter.Provider) {
+				checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode), spec)
+			}
+			continue
+		}
+		if providerIsBedrock(providerName) {
 			checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode), model)
 		}
 	}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -468,6 +468,46 @@ func TestDefaultReadOnlyBuiltInTools_PassesValidation(t *testing.T) {
 	}
 }
 
+// TestDefaultExecutionBuiltInTools_PassesValidation pins the safe-by-
+// default execution allowlist (issue #74) against ValidateRunConfig
+// under the new default permission policy (deny-side-effects). A
+// regression that introduced a tool the validator rejects, or that
+// regressed the policy default back to allow-all, would surface here.
+func TestDefaultExecutionBuiltInTools_PassesValidation(t *testing.T) {
+	defaults := DefaultExecutionBuiltInTools()
+	if len(defaults) == 0 {
+		t.Fatal("DefaultExecutionBuiltInTools returned an empty list")
+	}
+
+	// All entries must be recognised built-ins.
+	for _, name := range defaults {
+		if !validBuiltInToolNames[name] {
+			t.Errorf("DefaultExecutionBuiltInTools contains unknown tool %q", name)
+		}
+	}
+
+	// Safety-ring invariant: the two tools that singlehandedly trip
+	// Rule of Two (web_fetch: untrusted ingress + external comm;
+	// run_command: host shell access) must NOT be in the default set.
+	bannedFromDefault := map[string]bool{"web_fetch": true, "run_command": true}
+	for _, name := range defaults {
+		if bannedFromDefault[name] {
+			t.Errorf("DefaultExecutionBuiltInTools includes opt-in-only tool %q", name)
+		}
+	}
+
+	// Validation must accept the defaults paired with deny-side-effects
+	// on execution mode — the exact combination applyModeDefaults
+	// lands on for a bare `stirrup harness --prompt "x"` invocation.
+	c := validConfig()
+	c.Mode = "execution"
+	c.PermissionPolicy = PermissionPolicyConfig{Type: "deny-side-effects"}
+	c.Tools = ToolsConfig{BuiltIn: defaults}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("DefaultExecutionBuiltInTools + deny-side-effects must validate, got: %v", err)
+	}
+}
+
 func TestIsReadOnlyMode(t *testing.T) {
 	readOnly := []string{"planning", "review", "research", "toil"}
 	for _, m := range readOnly {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -3934,3 +3934,114 @@ func TestValidateRunConfig_ProviderRetryNamedProviderDefaultsIndependently(t *te
 		t.Errorf("top-level provider Retry not defaulted independently; got %+v", c.Provider.Retry)
 	}
 }
+
+// TestValidateRunConfig_BedrockModelShape exercises the fail-fast check
+// added for issue #65. Anthropic-API aliases (no "." and no "arn:"
+// prefix) cannot resolve at AWS Bedrock and previously surfaced only
+// after a full network round-trip as a generic ValidationException.
+func TestValidateRunConfig_BedrockModelShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		model        string
+		wantErr      bool
+		wantContains []string
+	}{
+		// Invalid: Anthropic-API aliases that the CLI default and the
+		// Anthropic provider docs encourage. Must surface the
+		// inference-profile redirect in the error message.
+		{name: "anthropic_alias_sonnet_4_6", model: "claude-sonnet-4-6", wantErr: true, wantContains: []string{"bedrock", "inference profile", "claude-sonnet-4-6"}},
+		{name: "anthropic_alias_opus_4", model: "claude-opus-4", wantErr: true, wantContains: []string{"bedrock", "inference profile"}},
+		{name: "openai_id", model: "gpt-4", wantErr: true, wantContains: []string{"bedrock"}},
+
+		// Valid: vendor-prefixed model id (on-demand throughput models).
+		{name: "anthropic_prefixed", model: "anthropic.claude-sonnet-4-5-20250929-v1:0", wantErr: false},
+		// Valid: inference profile id.
+		{name: "eu_inference_profile", model: "eu.anthropic.claude-sonnet-4-6", wantErr: false},
+		{name: "us_inference_profile", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0", wantErr: false},
+		{name: "global_inference_profile", model: "global.anthropic.claude-sonnet-4-6", wantErr: false},
+		// Valid: full ARN to an inference profile.
+		{name: "arn_inference_profile", model: "arn:aws:bedrock:eu-west-1:123456789012:inference-profile/eu.anthropic.claude-sonnet-4-6", wantErr: false},
+		// Empty: validated elsewhere (or means "use a per-mode model"); the
+		// shape check must not introduce a phantom error here.
+		{name: "empty_model", model: "", wantErr: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := validConfig()
+			c.Provider = ProviderConfig{Type: "bedrock", Region: "eu-west-1"}
+			c.ModelRouter = ModelRouterConfig{Type: "static", Model: tc.model}
+
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for bedrock model %q, got nil", tc.model)
+				}
+				for _, want := range tc.wantContains {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q missing substring %q", err, want)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error for bedrock model %q: %v", tc.model, err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_BedrockModelShape_NonBedrockProviderUnaffected
+// confirms the shape check is provider-scoped: an Anthropic provider
+// using "claude-sonnet-4-6" must continue to validate, otherwise we
+// regress the default `stirrup harness` invocation.
+func TestValidateRunConfig_BedrockModelShape_NonBedrockProviderUnaffected(t *testing.T) {
+	c := validConfig() // anthropic
+	c.ModelRouter = ModelRouterConfig{Type: "static", Model: "claude-sonnet-4-6"}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("anthropic + claude-sonnet-4-6 must remain valid, got: %v", err)
+	}
+}
+
+// TestValidateRunConfig_BedrockModelShape_PerModeOverride exercises the
+// per-mode router branch. A bedrock-typed default with a per-mode entry
+// "bedrock/claude-sonnet-4-6" must fail with the same redirect.
+func TestValidateRunConfig_BedrockModelShape_PerModeOverride(t *testing.T) {
+	c := validConfig()
+	c.Provider = ProviderConfig{Type: "bedrock", Region: "eu-west-1"}
+	c.ModelRouter = ModelRouterConfig{
+		Type:       "per-mode",
+		Model:      "eu.anthropic.claude-sonnet-4-6", // valid default
+		ModeModels: map[string]string{"execution": "bedrock/claude-opus-4"},
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected per-mode bedrock override to be rejected for anthropic-shaped alias")
+	}
+	if !strings.Contains(err.Error(), "modelRouter.modeModels[execution]") {
+		t.Errorf("error should name the per-mode key, got: %v", err)
+	}
+}
+
+// TestValidateRunConfig_BedrockModelShape_NamedProvider exercises the
+// Providers map branch. A named provider declared as bedrock-typed and
+// referenced from ModelRouter.Provider must trigger the same check.
+func TestValidateRunConfig_BedrockModelShape_NamedProvider(t *testing.T) {
+	c := validConfig()
+	c.Providers = map[string]ProviderConfig{
+		"aws": {Type: "bedrock", Region: "eu-west-1"},
+	}
+	c.ModelRouter = ModelRouterConfig{
+		Type:     "static",
+		Provider: "aws",
+		Model:    "claude-sonnet-4-6",
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for named bedrock provider with anthropic-alias model")
+	}
+	if !strings.Contains(err.Error(), "modelRouter.model") {
+		t.Errorf("error should name modelRouter.model, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements WS1 of the GitHub Issues backlog triage. Four logically
independent changes on the same branch, one commit per issue, each
self-contained for review:

| Commit | Issue | Scope |
|---|---|---|
| `provider/gemini: round-trip thoughtSignature across 3.x turns` | #194 | Add `ThoughtSignature` to `types.ContentBlock` + `types.StreamEvent`, capture from gemini SSE chunks, echo on wire. |
| `provider/gemini: cover blank-name functionCall guard with a regression test` | #193 | Pure test addition pinning the empty-name guard at `gemini.go:438-441`. |
| `types: fail-fast on bedrock + anthropic-alias model combinations` | #65 | New `validateBedrockModelShape` rejects Anthropic-API aliases against `--provider bedrock` with a message naming the inference-profile path. Option C from the issue. |
| `cmd,types,docs: safe-by-default execution mode` | #74 | New `DefaultExecutionBuiltInTools()`, execution mode now defaults to that allowlist + `deny-side-effects` rather than empty + `allow-all`. `web_fetch` and `run_command` are opt-in. |

#192 is intentionally out of scope here: the design plan lives in
PR #196 and the registry implementation is a follow-up wave.
#199 is already closed (PR #203).

## Per-issue notes

### #194 — Gemini thoughtSignature round-trip

The cross-provider `ContentBlock` path was chosen over a provider-
local map: a thought signature is structurally a per-block attribute,
not an out-of-band side-channel keyed by tool-call ID. The
cross-provider footprint is one optional field with `omitempty`; no
other adapter populates or reads it. The text-streaming case retains
the latest non-empty signature observed across a text run, so the
collapsed text block round-trips a single signature.

Test coverage:
- `TestBuildGenerateContentRequest_RoundTripsThoughtSignature`
- `TestBuildGenerateContentRequest_OmitsEmptyThoughtSignature`
- `TestGeminiAdapter_ThoughtSignatureFromFunctionCallPart`
- `TestGeminiAdapter_ThoughtSignatureFromTextPart`

### #193 — Blank-name functionCall test

Pure test addition: `TestGeminiAdapter_BlankFunctionCallName`. No
production code touched.

### #65 — Bedrock fail-fast

Option C from the issue: the validator rejects model ids that look
like Anthropic-API aliases when `Provider.Type == "bedrock"`. Accepts
vendor-prefixed ids (`anthropic.…`), inference profile ids
(`<region>.anthropic.…`), and full ARNs. Error message names
`aws bedrock list-inference-profiles` as the discovery path.

Mirrors `validateGeminiModelName` for the routing surface: default
provider, named provider via `Providers[k]`, per-mode router
overrides.

Test coverage: `TestValidateRunConfig_BedrockModelShape` (table-
driven), plus dedicated regression tests for the non-bedrock
unaffected case, per-mode overrides, and named-provider routing, plus
two CLI-level regression tests against `buildHarnessRunConfig`.

### #74 — Safe-by-default execution mode

Adds `DefaultExecutionBuiltInTools()` mirroring the existing
read-only helper, and updates `applyModeDefaults` so a bare execution
run lands on `deny-side-effects` + the conservative allowlist.
Explicit operator configuration on either axis still wins —
`applyModeDefaults` only fills *unset* fields.

The `--mode` default stays at `execution`. Whether to land a safer
default mode is intentionally deferred.

CLAUDE.md picks up a new invariant under "Project-specific
invariants" so a future regression registers as such. AGENTS.md's
flags table and `docs/configuration.md` document the new defaults
and the opt-out paths.

## Test plan

- [x] `go build ./harness/... ./types/... ./eval/...`
- [x] `go test ./harness/cmd/stirrup/... ./types/... ./harness/internal/core/... ./harness/internal/provider/... ./harness/internal/permission/...` — all pass
- [x] All new tests pass; no pre-existing test regressed
- [ ] Reviewer: confirm the cross-provider `ContentBlock` choice for #194 is the right call vs the provider-local map suggestion in the issue body
- [ ] Reviewer: confirm the error message wording in `validateBedrockModelShape` is operator-actionable
- [ ] Reviewer: confirm the deferred `--permission-policy` CLI flag for #74 is acceptable (operators currently escape via `--config` only)

Pre-existing sandbox failures in `harness/internal/git` and
`harness/internal/prompt` (git commit signing) are unrelated to
this work — verified to fail on `main` at HEAD `f283300` too.

Refs #194, #193, #65, #74.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLdgKYi7vXX3wsR8Hzm9Lq)_