### PR TITLE
ci: clear backlog of lint violations and gate PRs on golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,68 @@
+name: Lint
+
+# Gates pull requests on `just lint` (golangci-lint v2). Runs on every
+# PR open / synchronize / reopen so a reviewer never has to point out
+# a lint regression by hand. Also runs on push to main as a
+# defence-in-depth check — a direct push or a merge-queue path that
+# somehow lands without PR review still trips the gate before
+# downstream consumers (eval-gate, publish-container) start.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Cancel an in-progress lint when a PR is force-pushed. Pushes to main
+# never cancel — concurrency is keyed off the full ref so the main
+# branch always serialises.
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    name: just lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
+          cache-dependency-path: |
+            harness/go.mod
+            types/go.mod
+            eval/go.mod
+
+      - name: Install golangci-lint
+        env:
+          # Pinned to the version contributors run locally so the CI
+          # gate and `just lint` produce identical diagnostics. Bump
+          # this in lockstep with any local toolchain bump
+          # (CONTRIBUTING.md names golangci-lint v2 as the source of
+          # truth) so a local pass implies a CI pass.
+          GOLANGCI_LINT_VERSION: 2.12.2
+        run: |
+          set -euo pipefail
+          archive="golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.tar.gz"
+          curl --fail --silent --show-error --location \
+            --output "/tmp/${archive}" \
+            "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/${archive}"
+          mkdir -p "${HOME}/.local/bin"
+          tar -xzf "/tmp/${archive}" \
+            -C "${HOME}/.local/bin" \
+            --strip-components=1 \
+            "golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64/golangci-lint"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Run golangci-lint
+        # Mirrors `just lint` (golangci-lint run ./harness/... ./types/...
+        # ./eval/...). The recipe is invoked directly rather than via
+        # `just` to match the existing `_verify.yml` convention of
+        # running go tooling without an extra wrapper install step.
+        run: golangci-lint run ./harness/... ./types/... ./eval/...

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -65,7 +65,7 @@ func run(args []string, stdout io.Writer) int {
 
 	switch args[0] {
 	case "--version", "-v", "version":
-		fmt.Fprintf(stdout, "stirrup-eval version %s\n", version.Full())
+		_, _ = fmt.Fprintf(stdout, "stirrup-eval version %s\n", version.Full())
 		return 0
 	case "run":
 		cmdRun(args[1:])
@@ -782,20 +782,26 @@ func buildLabVsProductionReport(experimentID string, prodMetrics types.TraceMetr
 // injected so tests can supply io.Discard rather than mutating
 // os.Stderr globally; callers in cmdCompareToProduction pass os.Stderr.
 func printComparisonSummary(w io.Writer, report types.LabVsProductionReport) {
-	fmt.Fprintf(w, "Experiment: %s\n", report.ExperimentID)
-	fmt.Fprintf(w, "Production sample size: %d\n\n", report.Production.SampleSize)
+	// Writes target a terminal (os.Stderr in production, io.Discard in
+	// tests); a partial-write error here is unrecoverable and not worth
+	// propagating to the caller.
+	p := func(format string, args ...any) {
+		_, _ = fmt.Fprintf(w, format, args...)
+	}
+	p("Experiment: %s\n", report.ExperimentID)
+	p("Production sample size: %d\n\n", report.Production.SampleSize)
 
 	for _, v := range report.Variants {
-		fmt.Fprintf(w, "Variant: %s\n", v.Name)
-		fmt.Fprintf(w, "%-16s %12s %12s %12s\n", "Metric", "Production", "Lab", "Delta")
-		fmt.Fprintf(w, "%-16s %12s %12s %12s\n", "------", "----------", "---", "-----")
+		p("Variant: %s\n", v.Name)
+		p("%-16s %12s %12s %12s\n", "Metric", "Production", "Lab", "Delta")
+		p("%-16s %12s %12s %12s\n", "------", "----------", "---", "-----")
 
 		prodPassPct := report.Production.PassRate * 100
 		labPassPct := v.Results.PassRate * 100
-		fmt.Fprintf(w, "%-16s %11.1f%% %11.1f%% %+11.1fpp\n",
+		p("%-16s %11.1f%% %11.1f%% %+11.1fpp\n",
 			"Pass rate", prodPassPct, labPassPct, labPassPct-prodPassPct)
 
-		fmt.Fprintf(w, "%-16s %12.1f %12d %+12.1f\n",
+		p("%-16s %12.1f %12d %+12.1f\n",
 			"Mean turns",
 			report.Production.MeanTurns,
 			v.Results.MedianTurns,

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -712,7 +712,9 @@ func TestApplyOverrides_SessionNameExplicit(t *testing.T) {
 	if err := cmd.Flags().Set("name", "from-flag"); err != nil {
 		t.Fatalf("set name: %v", err)
 	}
-	applyOverrides(cmd, cfg, nil)
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
 
 	if cfg.SessionName != "from-flag" {
 		t.Errorf("explicit --name should win, got %q", cfg.SessionName)
@@ -728,7 +730,9 @@ func TestApplyOverrides_SessionNameFilePreserved(t *testing.T) {
 	cfg := baseFileConfig()
 	cfg.SessionName = "from-file"
 
-	applyOverrides(cmd, cfg, nil)
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
 
 	if cfg.SessionName != "from-file" {
 		t.Errorf("SessionName from file should survive, got %q", cfg.SessionName)
@@ -1172,7 +1176,9 @@ func TestApplyOverrides_SafetyRingFlagsOverride(t *testing.T) {
 	must("permission-policy-file", "/tmp/p.cedar")
 	must("code-scanner", "patterns")
 
-	applyOverrides(cmd, cfg, nil)
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
 
 	if cfg.Executor.Runtime != "runsc" {
 		t.Errorf("Executor.Runtime override failed: %q", cfg.Executor.Runtime)
@@ -1203,7 +1209,9 @@ func TestApplyOverrides_PermissionPolicyFileImpliesPolicyEngine(t *testing.T) {
 	if err := cmd.Flags().Set("permission-policy-file", "/tmp/p.cedar"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	applyOverrides(cmd, cfg, nil)
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
 
 	if cfg.PermissionPolicy.Type != "policy-engine" {
 		t.Errorf("expected type=policy-engine when file omitted type, got %q", cfg.PermissionPolicy.Type)
@@ -1226,7 +1234,9 @@ func TestApplyOverrides_DefaultSafetyRingFlagsDoNotOverride(t *testing.T) {
 	}
 	cfg.CodeScanner = &types.CodeScannerConfig{Type: "semgrep"}
 
-	applyOverrides(cmd, cfg, nil)
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
 
 	if cfg.Executor.Runtime != "kata" {
 		t.Errorf("Runtime: file value should survive, got %q", cfg.Executor.Runtime)

--- a/harness/internal/context/metrics_test.go
+++ b/harness/internal/context/metrics_test.go
@@ -68,7 +68,7 @@ func TestMetricRecorder_RecordsCompaction(t *testing.T) {
 	msgs := make([]types.Message, 5)
 	for i := range msgs {
 		msgs[i] = types.Message{
-			Role: "user",
+			Role:    "user",
 			Content: []types.ContentBlock{{Type: "text", Text: strings.Repeat("x", 400)}},
 		}
 	}
@@ -105,7 +105,7 @@ func TestMetricRecorder_LastCompactionPassthrough(t *testing.T) {
 	msgs := make([]types.Message, 5)
 	for i := range msgs {
 		msgs[i] = types.Message{
-			Role: "user",
+			Role:    "user",
 			Content: []types.ContentBlock{{Type: "text", Text: strings.Repeat("x", 400)}},
 		}
 	}

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -166,12 +166,13 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		}
 	}
 
-	// 7. Verifier. Constructed without metrics here; the metrics
-	// instance is built later (step 13). After metrics is available we
-	// rebuild the verifier so each Verify call records
-	// stirrup.verifier.runs / stirrup.verifier.duration_ms with the
-	// appropriate type label, including for composite sub-verifiers.
-	v := buildVerifier(config.Verifier, prov, nil)
+	// 7. Verifier. Declared here so step 8+ can reference it, but actual
+	// construction is deferred to step 13 (line ~296) once the run's
+	// metrics instance exists. buildVerifier wraps its result in a
+	// metric-recorder when metrics is non-nil, so calling it twice (once
+	// without metrics here, once with) would discard the first build —
+	// hence the deferred single construction.
+	var v verifier.Verifier
 
 	// 8. GuardRail. Constructed AFTER providers are built so cloud-judge
 	// can reuse the default ProviderAdapter. Returns guard.NewNoop() when
@@ -288,11 +289,11 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	// outer wrapper first, then unwrap to reach an inner *MultiStrategy.
 	wireEditMetrics(es, metrics)
 
-	// Rebuild the verifier now that metrics is available so each Verify
+	// Build the verifier now that metrics is available so each Verify
 	// call records stirrup.verifier.runs / stirrup.verifier.duration_ms
-	// with the appropriate type label. The first pass at step 7 was
-	// metrics-less; this re-construction is cheap (no I/O) and keeps the
-	// metric-recorder wrapping centralised in buildVerifier.
+	// with the appropriate type label. Construction is deferred to here
+	// (rather than step 7) so the metric-recorder wrapping centralised
+	// in buildVerifier sees a non-nil metrics on the only call site.
 	v = buildVerifier(config.Verifier, prov, metrics)
 
 	// Wrap the previously-built permission policy with metrics so

--- a/harness/internal/executor/egressproxy/proxy_sni_test.go
+++ b/harness/internal/executor/egressproxy/proxy_sni_test.go
@@ -185,9 +185,9 @@ func TestParseSNIFromHandshake_MalformedInputs(t *testing.T) {
 			name: "session_id length present, bytes overrun",
 			body: func() []byte {
 				b := []byte{0x01, 0x00, 0x00, 0x00}
-				b = append(b, []byte{0x03, 0x03}...)        // version
-				b = append(b, make([]byte, 32)...)          // random
-				b = append(b, 0xff /* sid len 255 */)       // truncated sid
+				b = append(b, []byte{0x03, 0x03}...)  // version
+				b = append(b, make([]byte, 32)...)    // random
+				b = append(b, 0xff /* sid len 255 */) // truncated sid
 				return b
 			}(),
 		},
@@ -368,4 +368,3 @@ func readAllUntilEOF(t *testing.T, conn net.Conn) []byte {
 	}
 	return out.Bytes()
 }
-

--- a/harness/internal/permission/metrics.go
+++ b/harness/internal/permission/metrics.go
@@ -62,7 +62,7 @@ func NewMetricRecorder(inner PermissionPolicy, metrics *observability.Metrics, p
 func (r *metricRecorder) Check(ctx context.Context, tool types.ToolDefinition, input json.RawMessage) (*PermissionResult, error) {
 	result, err := r.inner.Check(ctx, tool, input)
 
-	decision := "error"
+	var decision string
 	switch {
 	case err != nil:
 		decision = "error"

--- a/harness/internal/permission/metrics_test.go
+++ b/harness/internal/permission/metrics_test.go
@@ -178,7 +178,7 @@ func TestMetricRecorder_AddApprovalToolViaUnwrap(t *testing.T) {
 // AskUpstreamPolicy without exercising the wire path.
 type nopTransport struct{}
 
-func (nopTransport) Emit(_ types.HarnessEvent) error             { return nil }
+func (nopTransport) Emit(_ types.HarnessEvent) error            { return nil }
 func (nopTransport) OnControl(_ func(event types.ControlEvent)) {}
 
 // --- helpers ---

--- a/harness/internal/provider/retry.go
+++ b/harness/internal/provider/retry.go
@@ -181,14 +181,14 @@ func backoffDelay(n int, policy RetryPolicy, r *rand.Rand) time.Duration {
 //
 //   - succeeded:        terminal 2xx response (with or without retries).
 //   - exhausted:        retries exhausted by MaxAttempts on a retryable
-//                       status; the last response is returned to caller.
+//     status; the last response is returned to caller.
 //   - non_retryable:    terminal non-retryable status or transport error.
 //   - budget_exhausted: wall-clock budget would be exceeded by the next
-//                       sleep; the last response is returned to caller.
+//     sleep; the last response is returned to caller.
 //   - context_done:     ctx.Done() fired during the inter-attempt sleep.
 //   - rewind_failed:    req.GetBody() returned an error on attempt > 0;
-//                       no further attempt could be made even though
-//                       MaxAttempts had not been reached.
+//     no further attempt could be made even though
+//     MaxAttempts had not been reached.
 const (
 	retryOutcomeSucceeded       = "succeeded"
 	retryOutcomeExhausted       = "exhausted"
@@ -212,20 +212,20 @@ const (
 //
 // Fields:
 //   - Policy:       resolved retry configuration; a zero value
-//                   produces single-attempt behaviour.
+//     produces single-attempt behaviour.
 //   - Logger:       optional; nil falls back to slog.Default().
 //   - Metrics:      optional; nil disables outcome recording.
 //   - ProviderType: provider identity for log/metric/span attribution
-//                   (e.g. "openai", "anthropic"). Free-form string.
+//     (e.g. "openai", "anthropic"). Free-form string.
 //   - Model:        model identity for log/metric/span attribution.
 //   - ShouldRetry:  optional adapter-specific retry classifier. When
-//                   non-nil it is consulted before the default status
-//                   heuristic. It receives the response and returns
-//                   (retryable, consumed). If consumed=true, retryable
-//                   is the final answer for that response. If
-//                   consumed=false, the default retryableStatus
-//                   heuristic applies. Transport errors bypass this
-//                   classifier — they are routed through transientErr.
+//     non-nil it is consulted before the default status
+//     heuristic. It receives the response and returns
+//     (retryable, consumed). If consumed=true, retryable
+//     is the final answer for that response. If
+//     consumed=false, the default retryableStatus
+//     heuristic applies. Transport errors bypass this
+//     classifier — they are routed through transientErr.
 type RetryOptions struct {
 	Policy       RetryPolicy
 	Logger       *slog.Logger

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1418,7 +1418,7 @@ func validateRuleOfTwo(config *RunConfig, errs *[]string) {
 	holdsSensitive := ruleOfTwoSensitiveData(config)
 	canCommExternal := ruleOfTwoExternalComm(config)
 
-	if !(holdsUntrusted && holdsSensitive && canCommExternal) {
+	if !holdsUntrusted || !holdsSensitive || !canCommExternal {
 		return
 	}
 	if config.PermissionPolicy.Type == "ask-upstream" {


### PR DESCRIPTION
## Summary

- `just lint` was failing on `main` with 15 unique findings (8 errcheck, 4 gci, 2 ineffassign, 1 staticcheck). The first four commits clear that backlog without weakening any safety pattern.
- Adds `.github/workflows/lint.yml` so future PRs cannot reintroduce a regression — the workflow runs the same `golangci-lint run ./harness/... ./types/... ./eval/...` invocation that `just lint` runs, pinned to golangci-lint 2.12.2 so CI diagnostics match local ones.
- Workflow also runs on push-to-main as a backstop so a direct push or force-push that bypasses PR review still trips the gate before `eval-gate` and `publish-container` start.

## Commit-by-commit

1. **errcheck** — three `applyOverrides` callsites in `harness_test.go` now check the error (matching the ~40 sibling callsites). `printComparisonSummary` in `eval/cmd/eval/main.go` keeps its `io.Writer` parameter (tests need `io.Discard`) but routes Fprintf via a local `p` closure with explicit `_, _ =`; the version-banner Fprintf gets the same explicit discard.
2. **gci** — `golangci-lint fmt` produced the changes: struct-literal field alignment in two metrics tests, trailing-blank-line trim and inline-comment column alignment in `proxy_sni_test.go`, and Go 1.19+ doc-comment continuation indent in `provider/retry.go`. No semantic changes.
3. **ineffassign** — `factory.go` was double-constructing the verifier (once without metrics, then overwriting unconditionally with a metrics-aware build); replaced the first call with a `var v verifier.Verifier` declaration and updated the comment so a future reader doesn't reintroduce the dead pass. `permission/metrics.go` dropped a misleading `decision := "error"` initialiser in favour of `var decision string` ahead of the exhaustive switch.
4. **staticcheck QF1001** — applied De Morgan's law to the rule-of-two early-return guard in `types/runconfig.go`; the flipped form reads more naturally as "at least one leg is absent, bail".
5. **ci** — added the workflow.

## Test plan

- [x] `just lint` — 0 issues
- [x] `just test` — all modules pass
- [x] `actionlint .github/workflows/lint.yml` — clean
- [ ] CI lint job (this PR's first run) — confirm the install-and-run path works on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)