### PR TITLE
cmd,types,docs: triage issues #193, #65, #74 — safe-by-default mode, fail-fast bedrock validator, gemini regression test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Requires `ANTHROPIC_API_KEY` environment variable for the default Anthropic prov
 | Flag | Default | Description |
 |---|---|---|
 | `--prompt` | (required) | User prompt, also accepted as a positional argument |
-| `--mode`, `-m` | `execution` | Run mode: execution, planning, review, research, toil |
+| `--mode`, `-m` | `planning` | Run mode: planning (default, read-only), execution, review, research, toil |
 | `--model` | `claude-sonnet-4-6` | Model to use |
 | `--provider` | `anthropic` | Provider type: anthropic, bedrock, openai-compatible (Chat Completions), openai-responses (Responses API), gemini (Vertex AI) |
 | `--api-key-ref` | `secret://ANTHROPIC_API_KEY` | Secret reference for API key |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,9 @@ to make a feature easier:
   enforce a hard invariant in `ValidateRunConfig`: the tool list
   excludes `write_file` / `run_command` / `edit_file`, and the
   permission policy is not `allow-all`. A new mode added to the
-  list inherits the invariant.
+  list inherits the invariant. The CLI defaults `--mode` to
+  `planning` so a bare invocation is safe-by-default; `execution`
+  is the explicit opt-in for editable runs.
 - **Hand-rolled HTTP over SDKs.** The container executor uses the
   Docker Engine REST API directly to avoid the `github.com/docker/docker`
   dependency tree. Provider adapters are stdlib HTTP+SSE for the

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Stirrup has two main modes of operation:
 ```sh
 just build # produces ./stirrup and ./stirrup-eval
 
-# simplest example
-ANTHROPIC_API_KEY=... ./stirrup harness --prompt "Fix the failing test in main_test.go"
+# simplest example — bare invocation lands in read-only `planning` mode by default
+ANTHROPIC_API_KEY=... ./stirrup harness --prompt "Outline a fix for the failing test in main_test.go"
+
+# editable run — opt in to writes and shell access with --mode execution
+ANTHROPIC_API_KEY=... ./stirrup harness --mode execution --prompt "Fix the failing test in main_test.go"
 
 # using example full RunConfig, see examples/runconfig/README.md for further details
 ./stirrup harness \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,17 +129,26 @@ the `TraceEmitter` records spans and metrics throughout.
 ## Modes
 
 Five run modes ship as partial `RunConfig` presets that select
-mode-appropriate tools, permissions, and prompt templates:
+mode-appropriate tools, permissions, and prompt templates. One is
+editable (`execution`); the other four are read-only, structurally
+enforced by `ValidateRunConfig` to exclude `write_file`,
+`edit_file`, and `run_command`.
 
 | Mode | Tools | Default permission | Output shape |
 |---|---|---|---|
 | `execution` | read, write, shell, search, web fetch, sub-agent | `allow-all` | Code changes |
-| `planning` | read-only | `deny-side-effects` | Structured plan |
+| `planning` (CLI default) | read-only | `deny-side-effects` | Structured plan |
 | `review` | read-only | `deny-side-effects` | Structured review |
 | `research` | read-only + web fetch | `deny-side-effects` | Research brief |
 | `toil` | read-only + web fetch | `deny-side-effects` | Structured briefing |
 
-Modes are not special — they are saved configurations. Any field can
+`planning` is the CLI default so a bare `stirrup harness --prompt
+"..."` invocation has no write or shell capability and passes Rule
+of Two (Ring 4) without operator-supplied overrides. Operators who
+need editing or shell access opt in explicitly via `--mode
+execution`; finer-grained tool and permission selection is
+available through `--config` or the individual CLI flags. Modes
+are not special — they are saved configurations, and any field can
 be overridden per-task via `RunConfig`.
 
 ## Provider adapters

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ the same flags grouped by concern.
 | Flag | Default | Notes |
 |---|---|---|
 | `--config <path>` | (none) | JSON `RunConfig`. |
-| `--mode`, `-m` | `execution` | One of `execution`, `planning`, `review`, `research`, `toil`. |
+| `--mode`, `-m` | `planning` | One of `execution`, `planning`, `review`, `research`, `toil`. `planning`, `review`, `research`, and `toil` are read-only (no writes, no shell); `execution` is the editable mode. The default is `planning` so a bare invocation has no write or shell capability — pass `--mode execution` to enable edits and shell. See [Read-only modes](#read-only-modes). |
 | `--name` | (none) | Human-readable session label, attached to logs/traces. Metadata only — not injected into the prompt. |
 | `--workspace`, `-w` | cwd | Workspace directory. |
 | `--max-turns` | `20` | Hard-capped at 100. |
@@ -201,6 +201,18 @@ invariant via `ValidateRunConfig`: the tool list must exclude
 `write_file`, `run_command`, and `edit_file`, and the permission
 policy must not be `allow-all`. The validator rejects any
 `RunConfig` that violates this before any component is constructed.
+
+`planning` is the CLI default. A bare `stirrup harness --prompt "..."`
+invocation therefore lands in a read-only posture with no write or
+shell capability and the `deny-side-effects` permission policy.
+Operators wanting the editable, shell-capable behaviour opt in
+explicitly with `--mode execution` (or by selecting one of the
+restrictive `permissionPolicy` types in [`safety-rings.md`](safety-rings.md)
+for finer-grained control). The read-only modes differ from each
+other only in prompt template: `planning` for "describe and reason
+before acting" first-touch use, `review` for change-review tasks,
+`research` for investigation across a codebase or the web, and
+`toil` for structured-briefing workflows.
 
 ## Limits and budgets
 

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -466,8 +466,8 @@ type RunConfig struct {
 	// constraints.
 	// Valid values:
 	//
-	//	"execution" — full read/write agent mode (default for CLI).
-	//	"planning"  — read-only; produces a plan without making changes.
+	//	"execution" — full read/write agent mode; opt in via --mode execution.
+	//	"planning"  — CLI default (read-only; safe first-touch posture).
 	//	"review"    — read-only; reviews code and provides feedback.
 	//	"research"  — read-only; investigates questions without side effects.
 	//	"toil"      — read-only; automates repetitive read tasks.

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -599,7 +599,13 @@ URI. The flag overrides executor.workspaceExportTo from --config when
 explicitly set. Default error semantics: upload failures are logged and
 the run's exit code is unchanged. Pass --export-workspace-required to
 flip that — a failed upload then exits the run non-zero, suitable for
-Cloud Run jobs whose downstream automation depends on the artifact.`,
+Cloud Run jobs whose downstream automation depends on the artifact.
+
+The default --mode is "planning" (read-only: no write_file / edit_file /
+run_command, deny-side-effects permission policy). Pass --mode execution
+to enable editing and shell access; the read-only modes (planning, review,
+research, toil) differ only in prompt template and ship as the safe-by-
+default first-touch posture.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runHarness,
 }
@@ -609,7 +615,7 @@ func init() {
 
 	f := harnessCmd.Flags()
 	f.String("config", "", "Path to a JSON RunConfig file (mirrors proto/harness/v1/harness.proto). Explicit flags still override individual fields; unset flags do not.")
-	f.StringP("mode", "m", "execution", "Run mode: execution, planning, review, research, toil")
+	f.StringP("mode", "m", "planning", "Run mode: execution, planning, review, research, toil. Default is the read-only `planning` mode (no edits, no shell, deny-side-effects policy); pass `--mode execution` for editable runs with shell access.")
 	f.String("model", "claude-sonnet-4-6", "Model to use (sets ModelRouter.Model; for dynamic/per-mode routers in --config files this only sets the default-model field, not the cheap/expensive override)")
 	f.String("provider", "anthropic", "Provider type: anthropic, bedrock, gemini (Vertex AI), openai-compatible (Chat Completions), openai-responses (Responses API). The two OpenAI variants speak different wire formats and must be selected explicitly.")
 	f.String("api-key-ref", "secret://ANTHROPIC_API_KEY", "Secret reference for API key")

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -111,6 +111,77 @@ func TestBuildHarnessRunConfig_OpenAIResponsesProvider(t *testing.T) {
 	}
 }
 
+// TestBuildHarnessRunConfig_BedrockDefaultModelFailsValidation pins
+// the fail-fast guard added for #65. Running `stirrup harness
+// --provider bedrock` without overriding --model would otherwise send
+// the Anthropic-API alias "claude-sonnet-4-6" to Bedrock, which
+// rejects it with an opaque ValidationException only after IAM/SigV4
+// setup and a network round-trip. The validator catches the shape
+// at config-load time and points the operator at the inference-
+// profile path.
+//
+// The test asserts that ValidateRunConfig (not the provider) is the
+// thing that complains, so the failure mode is "no network call, with
+// an actionable error" — the explicit acceptance criterion in #65.
+func TestBuildHarnessRunConfig_BedrockDefaultModelFailsValidation(t *testing.T) {
+	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "execution",
+		Prompt:        "test",
+		ProviderType:  "bedrock",
+		APIKeyRef:     "secret://ANTHROPIC_API_KEY", // CLI default; ignored by bedrock auth
+		Model:         "claude-sonnet-4-6",          // CLI default
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+	if err != nil {
+		t.Fatalf("buildHarnessRunConfig: %v", err)
+	}
+
+	verr := types.ValidateRunConfig(cfg)
+	if verr == nil {
+		t.Fatal("expected ValidateRunConfig to reject --provider bedrock with CLI-default --model")
+	}
+	errStr := verr.Error()
+	if !strings.Contains(errStr, "bedrock") {
+		t.Errorf("expected error to mention bedrock, got: %v", verr)
+	}
+	if !strings.Contains(errStr, "inference-profile") &&
+		!strings.Contains(errStr, "inference profile") &&
+		!strings.Contains(errStr, "list-inference-profiles") {
+		t.Errorf("expected error to point at the inference-profile remediation path, got: %v", verr)
+	}
+	if !strings.Contains(errStr, "claude-sonnet-4-6") {
+		t.Errorf("expected error to name the offending model id, got: %v", verr)
+	}
+}
+
+// TestBuildHarnessRunConfig_BedrockInferenceProfileValidates is the
+// positive complement: with a properly-shaped inference profile id,
+// the flag-only path produces a config that passes validation.
+func TestBuildHarnessRunConfig_BedrockInferenceProfileValidates(t *testing.T) {
+	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "execution",
+		Prompt:        "test",
+		ProviderType:  "bedrock",
+		APIKeyRef:     "secret://ANTHROPIC_API_KEY",
+		Model:         "eu.anthropic.claude-sonnet-4-6",
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+	if err != nil {
+		t.Fatalf("buildHarnessRunConfig: %v", err)
+	}
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		t.Fatalf("ValidateRunConfig rejected eu.anthropic.claude-sonnet-4-6 on bedrock: %v", err)
+	}
+}
+
 // TestBuildHarnessRunConfig_FillsDefaultReadOnlyToolList verifies that
 // when no explicit Tools.BuiltIn list is supplied, read-only modes get
 // the documented default list rather than passing validation by accident.

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -79,6 +79,71 @@ func TestBuildHarnessRunConfig_AllModesValidate(t *testing.T) {
 	}
 }
 
+// TestHarnessCmd_DefaultModeIsPlanning pins the CLI-surface default for
+// --mode after #74: a bare `stirrup harness` invocation lands in the
+// read-only `planning` mode, not the editable `execution` mode, so the
+// first-touch posture is safe by default and operators must explicitly
+// opt in to write/shell capabilities via --mode execution. The pin is
+// against the flag registration on harnessCmd itself rather than the
+// helper command, so a regression that flips the default in only one
+// of the two places fails this test.
+func TestHarnessCmd_DefaultModeIsPlanning(t *testing.T) {
+	flag := harnessCmd.Flags().Lookup("mode")
+	if flag == nil {
+		t.Fatal("--mode flag is not registered on harnessCmd")
+	}
+	if flag.DefValue != "planning" {
+		t.Errorf("default --mode = %q, want %q (safe-by-default per #74)", flag.DefValue, "planning")
+	}
+}
+
+// TestBuildHarnessRunConfig_BareInvocationValidatesAsPlanning proves the
+// safe-by-default property end-to-end: a flag-only invocation with only
+// the documented CLI defaults (no --mode override) produces a RunConfig
+// that has Mode == "planning" and passes ValidateRunConfig — including
+// the read-only-mode invariants (deny-side-effects policy, non-empty
+// Tools.BuiltIn that excludes write_file/edit_file/run_command).
+//
+// This pins acceptance criterion (a) from #74: "Validate cleanly
+// (already true after #73)" — but specifically through the new default
+// rather than relying on a caller passing --mode planning explicitly.
+func TestBuildHarnessRunConfig_BareInvocationValidatesAsPlanning(t *testing.T) {
+	defaultMode := harnessCmd.Flags().Lookup("mode").DefValue
+
+	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          defaultMode,
+		Prompt:        "test prompt",
+		ProviderType:  "anthropic",
+		APIKeyRef:     "secret://ANTHROPIC_API_KEY",
+		Model:         "claude-sonnet-4-6",
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+	if err != nil {
+		t.Fatalf("buildHarnessRunConfig: %v", err)
+	}
+	if cfg.Mode != "planning" {
+		t.Errorf("bare invocation should land in planning mode, got %q", cfg.Mode)
+	}
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		t.Fatalf("bare invocation must validate cleanly: %v", err)
+	}
+	if cfg.PermissionPolicy.Type != "deny-side-effects" {
+		t.Errorf("planning mode should default to deny-side-effects, got %q", cfg.PermissionPolicy.Type)
+	}
+	if len(cfg.Tools.BuiltIn) == 0 {
+		t.Fatal("planning mode should populate a non-empty Tools.BuiltIn list")
+	}
+	for _, tool := range cfg.Tools.BuiltIn {
+		if tool == "write_file" || tool == "edit_file" || tool == "run_command" {
+			t.Errorf("planning mode must not enable write tool %q in the default list", tool)
+		}
+	}
+}
+
 // TestBuildHarnessRunConfig_OpenAIResponsesProvider verifies that the
 // openai-responses provider type is accepted by both the CLI option-to-
 // RunConfig path and ValidateRunConfig. Before this case existed, picking
@@ -513,7 +578,7 @@ func newTestHarnessCommand() *cobra.Command {
 	cmd := &cobra.Command{Use: "harness"}
 	f := cmd.Flags()
 	f.String("config", "", "")
-	f.StringP("mode", "m", "execution", "")
+	f.StringP("mode", "m", "planning", "")
 	f.String("model", "claude-sonnet-4-6", "")
 	f.String("provider", "anthropic", "")
 	f.String("api-key-ref", "secret://ANTHROPIC_API_KEY", "")

--- a/harness/internal/provider/gemini_test.go
+++ b/harness/internal/provider/gemini_test.go
@@ -779,6 +779,49 @@ func TestGeminiAdapter_MalformedSSEChunk(t *testing.T) {
 	}
 }
 
+// TestGeminiAdapter_BlankFunctionCallName pins the empty-name guard in
+// the functionCall branch: a chunk whose functionCall part lacks a name
+// must surface as a single error event and abort the stream without
+// emitting a tool_call or message_complete. A blank Name was the bucket
+// key that motivated the explicit guard (#193); regressing it would
+// silently coalesce the chunk into a "" slot rather than failing fast.
+func TestGeminiAdapter_BlankFunctionCallName(t *testing.T) {
+	body := makeGeminiData(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"args":{"path":"x"}}}]}}]}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := newGeminiTestAdapter(srv.URL, &stubTokenSource{token: "tok"})
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{Model: "gemini-2.5-pro"})
+	if err != nil {
+		t.Fatalf("Stream(): %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	var errCount int
+	for _, ev := range events {
+		switch ev.Type {
+		case "error":
+			errCount++
+			if ev.Error == nil || !strings.Contains(ev.Error.Error(), "functionCall part missing name") {
+				t.Errorf("error event = %+v, want error containing %q", ev, "functionCall part missing name")
+			}
+		case "tool_call":
+			t.Errorf("unexpected tool_call event: %+v", ev)
+		case "message_complete":
+			t.Errorf("unexpected message_complete event: %+v", ev)
+		}
+	}
+	if errCount != 1 {
+		t.Errorf("expected exactly 1 error event, got %d (events=%+v)", errCount, events)
+	}
+}
+
 // TestGeminiAdapter_ToolCallBufferDrainOnFinishReason verifies the
 // drain path: a tool call with willContinue=true followed immediately
 // by a finishReason=STOP chunk (without a closing willContinue=false)

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -240,8 +240,8 @@ message RunConfig {
   // Required. The run mode, which determines prompt templates and security
   // constraints.
   // Valid values:
-  //   "execution" — full read/write agent mode (default for CLI).
-  //   "planning"  — read-only; produces a plan without making changes.
+  //   "execution" — full read/write agent mode; opt in via --mode execution.
+  //   "planning"  — CLI default (read-only; safe first-touch posture).
   //   "review"    — read-only; reviews code and provides feedback.
   //   "research"  — read-only; investigates questions without side effects.
   //   "toil"      — read-only; automates repetitive read tasks.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1332,8 +1332,11 @@ func DefaultReadOnlyBuiltInTools() []string {
 // list exists purely so RunConfig validation can reject impossible
 // combinations before the harness boots.
 var mutatingTools = map[string]bool{
-	"write_file":  true,
-	"run_command": true,
+	"write_file":     true,
+	"run_command":    true,
+	"edit_file":      true,
+	"search_replace": true,
+	"apply_diff":     true,
 }
 
 // ModePreset is a named set of RunConfig overrides.
@@ -1415,7 +1418,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	if readOnlyModes[config.Mode] {
 		if len(config.Tools.BuiltIn) == 0 {
 			errs = append(errs, fmt.Sprintf(
-				"read-only mode %q requires an explicit tools.builtIn list that excludes write tools (write_file, run_command)",
+				"read-only mode %q requires an explicit tools.builtIn list that excludes write tools (write_file, run_command, edit_file, search_replace, apply_diff)",
 				config.Mode))
 		} else {
 			for _, tool := range config.Tools.BuiltIn {

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1896,6 +1896,14 @@ func validateProviderConfigs(config *RunConfig, retryDefaulted map[string]provid
 	// Provider.Type is "gemini" and ModelRouter.Provider is unset.
 	validateGeminiModelName(config, errs)
 
+	// Per-provider model-id validation for Bedrock. The Anthropic-API
+	// alias shape ("claude-sonnet-4-6") is structurally invalid against
+	// Bedrock but the failure only surfaces after IAM/SigV4 setup and a
+	// network round-trip. Reject the shape here with an actionable
+	// pointer to the inference-profile path so the operator never sees
+	// the opaque ValidationException from AWS.
+	validateBedrockModelID(config, errs)
+
 	checkProviderRef := func(path, name string) {
 		if name == "" {
 			return
@@ -2528,6 +2536,86 @@ func validateGeminiModelName(config *RunConfig, errs *[]string) {
 			continue
 		}
 		if providerIsGemini(providerName) {
+			checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode), model)
+		}
+	}
+}
+
+// validateBedrockModelID rejects model identifiers that cannot be the
+// thing a Bedrock endpoint expects. Bedrock model ids fall into two
+// shapes: a dotted form like "anthropic.<model>" or
+// "<region>.anthropic.<model>" (inference profile), or a full ARN. The
+// CLI's flag-only default is "claude-sonnet-4-6" — the Anthropic API
+// alias — which Bedrock rejects with an opaque ValidationException only
+// after IAM/SigV4 setup and a network round-trip (see #65). We have
+// enough information at config-load time to fail closed with a message
+// that names the inference-profile shape and points the operator at
+// `aws bedrock list-inference-profiles`.
+//
+// The check trips whenever the resolved router provider is bedrock,
+// mirroring the resolution rules in validateGeminiModelName: explicit
+// Providers[name] entries, the "bedrock" type alias, ModeModels
+// "provider/model" overrides, and the implicit-default case where
+// ModelRouter.Provider is empty and Provider.Type == "bedrock".
+//
+// The shape test is deliberately permissive in the "looks valid"
+// direction: any identifier containing "." or starting with "arn:" is
+// accepted. We do not enumerate the set of valid Bedrock model ids
+// here — AWS adds new model and inference-profile ids continuously,
+// and a closed list would become a maintenance burden that produces
+// false negatives. The only thing we want to catch is the obvious
+// Anthropic-API alias shape (no separator, no ARN prefix) that has
+// already cost operators a wall-clock-second on-ramp failure.
+func validateBedrockModelID(config *RunConfig, errs *[]string) {
+	providerIsBedrock := func(name string) bool {
+		if name == "" {
+			return config.Provider.Type == "bedrock"
+		}
+		if name == "bedrock" {
+			return true
+		}
+		if p, ok := config.Providers[name]; ok {
+			return p.Type == "bedrock"
+		}
+		return false
+	}
+
+	checkModel := func(label, model string) {
+		// Empty string is handled by the router's own required-field
+		// validation (or simply not reaching a provider call for a
+		// static router that never sees a turn); skip it here so the
+		// operator gets the focused "required" error rather than a
+		// shape complaint about a value they did not set. Whitespace-
+		// only strings are not "empty" in that sense and trip the
+		// check below — they are never a valid Bedrock id and the
+		// operator almost certainly meant to type something else.
+		if model == "" {
+			return
+		}
+		if strings.TrimSpace(model) != "" && (strings.Contains(model, ".") || strings.HasPrefix(model, "arn:")) {
+			return
+		}
+		*errs = append(*errs, fmt.Sprintf(
+			"%s %q is invalid for provider type %q; Bedrock requires either a model id like "+
+				`"anthropic.<model>" or an inference profile id like "<region>.anthropic.<model>" `+
+				`(e.g. "eu.anthropic.claude-sonnet-4-6"). `+
+				`Use "aws bedrock list-inference-profiles" to enumerate profiles available in your region.`,
+			label, model, "bedrock"))
+	}
+
+	if providerIsBedrock(config.ModelRouter.Provider) {
+		checkModel("modelRouter.model", config.ModelRouter.Model)
+	}
+
+	for mode, spec := range config.ModelRouter.ModeModels {
+		providerName, model, ok := strings.Cut(spec, "/")
+		if !ok {
+			if providerIsBedrock(config.ModelRouter.Provider) {
+				checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode), spec)
+			}
+			continue
+		}
+		if providerIsBedrock(providerName) {
 			checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode), model)
 		}
 	}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -4330,3 +4330,133 @@ func TestRedact_ResultSinkAttributes(t *testing.T) {
 		t.Error("Redact mutated original ResultSink.Attributes")
 	}
 }
+
+// TestValidateRunConfig_BedrockModelIDShape pins the fail-fast guard
+// added for #65. The CLI's default --model is an Anthropic-API alias
+// ("claude-sonnet-4-6") that Bedrock rejects only after IAM/SigV4
+// setup and a network round-trip; the validator catches the shape
+// before any provider call and points the operator at the
+// inference-profile path.
+func TestValidateRunConfig_BedrockModelIDShape(t *testing.T) {
+	t.Run("valid_model_ids", func(t *testing.T) {
+		cases := []string{
+			"anthropic.claude-sonnet-4-6",
+			"eu.anthropic.claude-sonnet-4-6",
+			"global.anthropic.claude-sonnet-4-6",
+			"anthropic.claude-sonnet-4-5-20250929-v1:0",
+			"arn:aws:bedrock:eu-west-1:123456789012:inference-profile/eu.anthropic.claude-sonnet-4-6",
+		}
+		for _, model := range cases {
+			t.Run(model, func(t *testing.T) {
+				c := validConfig()
+				c.Provider = ProviderConfig{
+					Type:       "bedrock",
+					Region:     "us-east-1",
+					Credential: &CredentialConfig{Type: "aws-default"},
+				}
+				c.ModelRouter = ModelRouterConfig{Type: "static", Provider: "bedrock", Model: model}
+				if err := ValidateRunConfig(c); err != nil {
+					t.Fatalf("expected %q to be accepted on bedrock, got: %v", model, err)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid_anthropic_alias_shapes", func(t *testing.T) {
+		cases := []string{
+			"claude-sonnet-4-6",
+			"claude-opus-4-1",
+			"gpt-4",
+			" ", // whitespace-only — never a valid bedrock id
+		}
+		for _, model := range cases {
+			t.Run(model, func(t *testing.T) {
+				c := validConfig()
+				c.Provider = ProviderConfig{
+					Type:       "bedrock",
+					Region:     "us-east-1",
+					Credential: &CredentialConfig{Type: "aws-default"},
+				}
+				c.ModelRouter = ModelRouterConfig{Type: "static", Provider: "bedrock", Model: model}
+				err := ValidateRunConfig(c)
+				if err == nil {
+					t.Fatalf("expected %q to be rejected on bedrock, got nil", model)
+				}
+				errStr := err.Error()
+				// The error names the bedrock provider type and the
+				// inference-profile remediation path. Two anchors so
+				// the wording can evolve without losing coverage of
+				// the actionable parts.
+				if !strings.Contains(errStr, "bedrock") {
+					t.Errorf("expected error to mention bedrock, got: %v", err)
+				}
+				if !strings.Contains(errStr, "inference-profile") &&
+					!strings.Contains(errStr, "inference profile") &&
+					!strings.Contains(errStr, "list-inference-profiles") {
+					t.Errorf("expected error to point at the inference-profile remediation path, got: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("empty_model_defers_to_required_field_handling", func(t *testing.T) {
+		// An empty Model on a bedrock provider must not trip the new
+		// shape check — the operator should see whatever required-
+		// field complaint the rest of the validator emits for the
+		// router type they chose. ModelRouter.Type="static" with an
+		// empty Model produces no error today; that's accepted and
+		// we are only asserting that the bedrock shape check does
+		// not synthesise a spurious one.
+		c := validConfig()
+		c.Provider = ProviderConfig{
+			Type:       "bedrock",
+			Region:     "us-east-1",
+			Credential: &CredentialConfig{Type: "aws-default"},
+		}
+		c.ModelRouter = ModelRouterConfig{Type: "static", Provider: "bedrock", Model: ""}
+		err := ValidateRunConfig(c)
+		if err != nil && strings.Contains(err.Error(), "Bedrock requires either") {
+			t.Fatalf("empty model should not trip the bedrock shape check, got: %v", err)
+		}
+	})
+
+	t.Run("anthropic_provider_with_alias_still_valid", func(t *testing.T) {
+		// Regression guard: the bedrock-scoped check must not bleed
+		// into the anthropic path. "claude-sonnet-4-6" is the CLI
+		// default and the canonical Anthropic-API alias.
+		c := validConfig()
+		c.Provider = ProviderConfig{Type: "anthropic"}
+		c.ModelRouter = ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("anthropic provider with alias should be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("named_bedrock_provider_via_mode_models", func(t *testing.T) {
+		// The check resolves through Providers[name] entries too, so
+		// a per-mode override that points at a bedrock-typed named
+		// provider with an Anthropic-shaped alias is rejected.
+		c := validConfig()
+		c.Provider = ProviderConfig{Type: "anthropic"}
+		c.Providers = map[string]ProviderConfig{
+			"bdrk": {
+				Type:       "bedrock",
+				Region:     "us-east-1",
+				Credential: &CredentialConfig{Type: "aws-default"},
+			},
+		}
+		c.ModelRouter = ModelRouterConfig{
+			Type:       "per-mode",
+			Provider:   "anthropic",
+			Model:      "claude-sonnet-4-6",
+			ModeModels: map[string]string{"execution": "bdrk/claude-sonnet-4-6"},
+		}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected per-mode bedrock override with anthropic alias to be rejected")
+		}
+		if !strings.Contains(err.Error(), "bedrock") {
+			t.Errorf("expected error to mention bedrock, got: %v", err)
+		}
+	})
+}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -375,7 +375,7 @@ func TestValidateRunConfig_MultipleErrors(t *testing.T) {
 }
 
 func TestValidateRunConfig_ReadOnlyModeWithWriteToolInList(t *testing.T) {
-	writeTools := []string{"write_file", "run_command"}
+	writeTools := []string{"write_file", "run_command", "edit_file", "search_replace", "apply_diff"}
 	for _, mode := range []string{"planning", "review", "research", "toil"} {
 		for _, tool := range writeTools {
 			t.Run(fmt.Sprintf("%s/%s", mode, tool), func(t *testing.T) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -4345,8 +4345,8 @@ func TestValidateRunConfig_BedrockModelIDShape(t *testing.T) {
 			"global.anthropic.claude-sonnet-4-6",
 			"anthropic.claude-sonnet-4-5-20250929-v1:0",
 			"arn:aws:bedrock:eu-west-1:123456789012:inference-profile/eu.anthropic.claude-sonnet-4-6",
-			"arn:",                          // bare arn: prefix — deliberately permissive; Bedrock will reject at API layer
-			"meta.llama3-8b-instruct-v1:0",  // non-Anthropic vendor — dot rule is vendor-agnostic
+			"arn:",                         // bare arn: prefix — deliberately permissive; Bedrock will reject at API layer
+			"meta.llama3-8b-instruct-v1:0", // non-Anthropic vendor — dot rule is vendor-agnostic
 		}
 		for _, model := range cases {
 			t.Run(model, func(t *testing.T) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -4345,6 +4345,8 @@ func TestValidateRunConfig_BedrockModelIDShape(t *testing.T) {
 			"global.anthropic.claude-sonnet-4-6",
 			"anthropic.claude-sonnet-4-5-20250929-v1:0",
 			"arn:aws:bedrock:eu-west-1:123456789012:inference-profile/eu.anthropic.claude-sonnet-4-6",
+			"arn:",                          // bare arn: prefix — deliberately permissive; Bedrock will reject at API layer
+			"meta.llama3-8b-instruct-v1:0",  // non-Anthropic vendor — dot rule is vendor-agnostic
 		}
 		for _, model := range cases {
 			t.Run(model, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Workstream-1 backlog triage: closes three independent issues in a single PR.

- **Closes #193** — Adds `TestGeminiAdapter_BlankFunctionCallName` to pin the empty-`functionCall.name` guard at `harness/internal/provider/gemini.go:438`. Test-only; production code unchanged. This is the regression path that originally fired in the Gemini 3.x rollout that motivated #191.
- **Closes #65** — Implements **Option C** from the issue's four-proposal design space: a cross-field fail-fast check in `ValidateRunConfig` that rejects Anthropic-API-shaped model aliases (`claude-sonnet-4-6`, etc.) when `Provider.Type == "bedrock"`, with an actionable error pointing the operator at the inference-profile syntax and `aws bedrock list-inference-profiles`. The implementation mirrors `validateGeminiModelName`'s shape (same provider-resolution and `ModeModels` walk), so it slots into the existing per-provider-shape-check convention.
- **Closes #74** — Switches the CLI's default `--mode` from `execution` to `planning`. A bare `stirrup harness --prompt "..."` now lands in a read-only posture that passes the Rule of Two without operator action; `--mode execution` is the explicit opt-in for editable runs. `execution` mode semantics are deliberately untouched ("fitting of its namesake"). Modes are documented as a first-touchpoint across `docs/configuration.md`, `docs/architecture.md`, `README.md`, `CLAUDE.md`, and `AGENTS.md`.

## Scope decisions made up-front (not negotiated mid-PR)

- For **#65**, options A (provider-aware default model), B (auto-prefix in the Bedrock adapter), and D (CLI help-text nudge) were deliberately not implemented. Option C alone keeps the layering clean — adapters do not silently translate model ids, and provider-specific shape checks live alongside the existing pattern at `types/runconfig.go` for openai-only / gemini-only fields.
- For **#74**, proposals 1 (conservative default tool list for `execution`), 3 (default-to-container executor), and 4 (default `permissionPolicy.type` change) were deliberately deferred. `execution` mode is preserved as the "powerful/dangerous" capability envelope; safety lives at the mode-selector layer.

## Remediation pass

After the initial three implementer commits landed, a five-reviewer wave (`code-reviewer`, `security-reviewer`, `spec-compliance-reviewer`, `test-coverage-auditor`, `api-design-advisor`) ran on the full diff. `review-synthesizer` consolidated their reports into four blocking findings, all addressed by the trailing remediation commits:

| Finding | Fix | Commits |
|---|---|---|
| `mutatingTools` map missing `edit_file`, `search_replace`, `apply_diff` — `CLAUDE.md:103` asserts the invariant excludes `edit_file`, but the validator did not enforce it. Pre-existing gap, in-scope because the docs commit on this PR re-asserts the invariant. | Added the three tools to `mutatingTools` (`types/runconfig.go`) and extended the existing read-only-mode test's `writeTools` slice to cover all five mutating tools across all four read-only modes. | `bd26f5c` |
| `proto/harness/v1/harness.proto` comment block on the `mode` field still listed `execution` as the CLI default. | Comment updated; `gen/harness/v1/harness.pb.go` regenerated via `just proto` (comment-only delta). | `1e1feb0` |
| `AGENTS.md:72` flag table also listed `execution` as the `--mode` default. | Default column flipped to `planning`; description aligned with `docs/configuration.md`. | `1e1feb0` |
| Bedrock validator test table did not pin two semantically-significant acceptance boundaries: bare `arn:` prefix (deliberately permissive — Bedrock rejects at the API layer) and non-Anthropic dotted vendor ids (`meta.llama3-...`). | Two table entries added with inline comments documenting the permissive intent. A future tightening to `strings.Contains(model, ".anthropic.")` will now flag these as regressions. | `a2f2191` |

Twelve non-blocking findings are deferred — see `.coordinator-scratch/reviews/remediation.md` D1–D13 (the scratch directory is gitignored and not part of this PR; the brief lives only in the coordinator's records). Notable deferrals to file as follow-ups post-merge: the `toil` mode purpose sentence in `docs/configuration.md` (pre-existing gap), a `harnessapi` typed-constants-for-mode-names polish, mode-name consolidation before 1.0 freeze.

## Rebase context

The branch was rebased onto current `origin/main` (31 commits ahead of the original branch point, including the new `golangci-lint v2` CI gate from #205 and four lint-cleanup commits that resolved the project's existing baseline). The rebase introduced two textual conflicts:

- `types/runconfig_test.go` — pure additive conflict (HEAD added `traceEmitter`/`resultSink`/`workspaceExportTo` tests at end-of-file; this branch added the bedrock-shape test at the same location). Both kept verbatim.
- `harness/cmd/stirrup/cmd/harness.go` — `Long` description string overlapped between HEAD's workspace-export paragraph and this branch's mode-default paragraph. Both paragraphs preserved.

A trailing whitespace-only commit (`9152e70`) aligns the bedrock test table's gci column padding — required because the lint gate is now enforced in CI.

## Verification

```sh
just test    # all packages green; new tests: TestGeminiAdapter_BlankFunctionCallName,
             #   TestValidateRunConfig_BedrockModelIDShape (six sub-tests),
             #   TestBuildHarnessRunConfig_BedrockDefaultModelFailsValidation,
             #   TestBuildHarnessRunConfig_BareInvocationValidatesAsPlanning,
             #   plus extended read-only-mode coverage for the three new mutating tools.
just build   # ./stirrup and ./stirrup-eval build cleanly.
just lint    # 0 issues — matches the new CI gate.
```

## Test plan

- [ ] Confirm CI is green (test + lint gates).
- [ ] Run `./stirrup harness --prompt "x" --provider bedrock --model claude-sonnet-4-6 --provider-credential 'type=aws-default'` locally — should fail at validation time, before any AWS call, with an inference-profile remediation message.
- [ ] Run `./stirrup harness --prompt "x"` with default flags — should reach Rule of Two cleanly (mode = planning, no editable tools).
- [ ] Verify a config with `mode: "planning"` and `tools.builtIn: ["edit_file"]` is now rejected by `ValidateRunConfig` (was silently accepted before).
- [ ] Skim mode documentation in `docs/configuration.md` and `docs/architecture.md` from a new-operator perspective; the read-only-vs-editable distinction and the new default should be obvious within the first read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)