### PR TITLE
batch(phase-0): extract build*Request helpers from streaming adapters

### DIFF
--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -226,6 +226,22 @@ type sseMessageDelta struct {
 	} `json:"usage,omitempty"`
 }
 
+// buildAnthropicRequest projects a StreamParams into the Anthropic Messages
+// wire body. The stream argument toggles the "stream" field so a future
+// non-streaming caller (batch submission, phase 2 of issue #133) can reuse
+// the same projection without duplicating field-by-field copying.
+func buildAnthropicRequest(params types.StreamParams, stream bool) anthropicRequest {
+	return anthropicRequest{
+		Model:       params.Model,
+		System:      params.System,
+		Messages:    translateMessagesAnthropic(params.Messages),
+		Tools:       params.Tools,
+		MaxTokens:   params.MaxTokens,
+		Temperature: params.Temperature,
+		Stream:      stream,
+	}
+}
+
 // Stream sends a streaming request to the Anthropic Messages API and returns
 // a channel of StreamEvents. The channel is closed when the stream ends or
 // an error occurs. Cancelling the context terminates the stream.
@@ -236,15 +252,7 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, params types.StreamParams
 		attribute.String("provider.model", params.Model),
 	)
 
-	reqBody := anthropicRequest{
-		Model:       params.Model,
-		System:      params.System,
-		Messages:    translateMessagesAnthropic(params.Messages),
-		Tools:       params.Tools,
-		MaxTokens:   params.MaxTokens,
-		Temperature: params.Temperature,
-		Stream:      true,
-	}
+	reqBody := buildAnthropicRequest(params, true)
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -231,6 +231,10 @@ type sseMessageDelta struct {
 // wire body. The stream argument toggles the "stream" field so a future
 // non-streaming caller (batch submission, phase 2 of issue #133) can reuse
 // the same projection without duplicating field-by-field copying.
+//
+// TODO(batch): if the batch endpoint rejects fields the streaming endpoint
+// accepts (e.g. thinking_config), change the return type to
+// (json.RawMessage, error) and apply a batch-specific projection here.
 func buildAnthropicRequest(params types.StreamParams, stream bool) anthropicRequest {
 	return anthropicRequest{
 		Model:    params.Model,

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -232,10 +233,17 @@ type sseMessageDelta struct {
 // the same projection without duplicating field-by-field copying.
 func buildAnthropicRequest(params types.StreamParams, stream bool) anthropicRequest {
 	return anthropicRequest{
-		Model:       params.Model,
-		System:      params.System,
-		Messages:    translateMessagesAnthropic(params.Messages),
-		Tools:       params.Tools,
+		Model:    params.Model,
+		System:   params.System,
+		Messages: translateMessagesAnthropic(params.Messages),
+		// slices.Clone avoids aliasing params.Tools into the returned
+		// struct. translateMessagesAnthropic / translateTools(Responses)
+		// allocate fresh output slices for messages and tools on the
+		// sibling adapters; the Anthropic path was the only builder
+		// passing the input slice through by reference. Once the phase-2
+		// batch caller retains the returned struct across a retry or
+		// concurrent send, a caller mutating params.Tools would race.
+		Tools:       slices.Clone(params.Tools),
 		MaxTokens:   params.MaxTokens,
 		Temperature: params.Temperature,
 		Stream:      stream,

--- a/harness/internal/provider/anthropic_builder_test.go
+++ b/harness/internal/provider/anthropic_builder_test.go
@@ -88,13 +88,14 @@ func anthropicBuilderCases() []struct {
 func TestBuildAnthropicRequest_MatchesStream(t *testing.T) {
 	for _, tc := range anthropicBuilderCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			var captured []byte
+			capturedCh := make(chan []byte, 1)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				b, err := io.ReadAll(r.Body)
 				if err != nil {
-					t.Fatalf("read body: %v", err)
+					t.Errorf("read body: %v", err)
+					return
 				}
-				captured = b
+				capturedCh <- b
 				// Minimal valid stream so Stream returns without surfacing
 				// a parser error on the response side.
 				w.Header().Set("Content-Type", "text/event-stream")
@@ -112,6 +113,7 @@ func TestBuildAnthropicRequest_MatchesStream(t *testing.T) {
 			}
 			for range ch {
 			}
+			captured := <-capturedCh
 
 			built := buildAnthropicRequest(tc.params, true)
 			builtBytes, err := json.Marshal(built)

--- a/harness/internal/provider/anthropic_builder_test.go
+++ b/harness/internal/provider/anthropic_builder_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/types"
@@ -140,5 +141,49 @@ func TestBuildAnthropicRequest_StreamFlag(t *testing.T) {
 	}
 	if got := buildAnthropicRequest(params, false).Stream; got != false {
 		t.Errorf("stream=false argument: got Stream=%v, want false", got)
+	}
+}
+
+// TestBuildAnthropicRequest_ThoughtSignatureDropped pins the cross-provider
+// leakage invariant from issue #194 at the builder level. The Stream-path
+// equivalent (TestAnthropic_ThoughtSignatureNotLeakedToAnthropicAPI in
+// anthropic_test.go) covers translateMessagesAnthropic transitively through
+// Stream; the phase-2 batch caller will invoke buildAnthropicRequest
+// directly, bypassing Stream entirely. If translateMessagesAnthropic were
+// accidentally refactored to embed types.ContentBlock instead of the
+// local anthropicContentBlock wire type, the Stream-level test would still
+// pass while the batch path silently forwarded Vertex's encrypted
+// chain-of-thought blob to Anthropic. Asserting the builder output here
+// closes that structural gap.
+func TestBuildAnthropicRequest_ThoughtSignatureDropped(t *testing.T) {
+	const sig = "AY89SIGBLOB=="
+	params := types.StreamParams{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: 16,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "read it"}}},
+			{
+				Role: "assistant",
+				Content: []types.ContentBlock{
+					{
+						Type:             "tool_use",
+						ID:               "toolu_1",
+						Name:             "read_file",
+						Input:            json.RawMessage(`{"path":"main.go"}`),
+						ThoughtSignature: sig,
+					},
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(buildAnthropicRequest(params, false))
+	if err != nil {
+		t.Fatalf("marshal builder output: %v", err)
+	}
+	if strings.Contains(string(body), "thought_signature") {
+		t.Errorf("builder output contains \"thought_signature\" — Gemini-private state leaked to Anthropic batch path.\nbody = %s", body)
+	}
+	if strings.Contains(string(body), sig) {
+		t.Errorf("builder output contains the signature value %q.\nbody = %s", sig, body)
 	}
 }

--- a/harness/internal/provider/anthropic_builder_test.go
+++ b/harness/internal/provider/anthropic_builder_test.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// anthropicBuilderCases enumerates representative StreamParams shapes for
+// the builder vs Stream equivalence assertion. Each case exercises a
+// different combination of fields the helper has to project: minimal,
+// system prompt, multi-turn with tool_use round-trip, explicit
+// temperature, multiple tools.
+func anthropicBuilderCases() []struct {
+	name   string
+	params types.StreamParams
+} {
+	return []struct {
+		name   string
+		params types.StreamParams
+	}{
+		{
+			name: "minimal",
+			params: types.StreamParams{
+				Model:     "claude-sonnet-4-6",
+				MaxTokens: 1024,
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+				},
+			},
+		},
+		{
+			name: "system_and_temperature",
+			params: types.StreamParams{
+				Model:       "claude-sonnet-4-6",
+				System:      "You are helpful.",
+				MaxTokens:   2048,
+				Temperature: types.Float64Ptr(0.0),
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hello"}}},
+				},
+			},
+		},
+		{
+			name: "tools_and_multi_turn",
+			params: types.StreamParams{
+				Model:     "claude-sonnet-4-6",
+				System:    "Use tools when needed.",
+				MaxTokens: 4096,
+				Tools: []types.ToolDefinition{
+					{
+						Name:        "read_file",
+						Description: "Read a file from disk",
+						InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+					},
+					{
+						Name:        "write_file",
+						Description: "Write a file to disk",
+						InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}}}`),
+					},
+				},
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "read main.go"}}},
+					{Role: "assistant", Content: []types.ContentBlock{
+						{Type: "tool_use", ID: "toolu_1", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+					}},
+					{Role: "user", Content: []types.ContentBlock{
+						{Type: "tool_result", ToolUseID: "toolu_1", Content: "package main"},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// TestBuildAnthropicRequest_MatchesStream pins the invariant that
+// buildAnthropicRequest produces the same wire body the Stream method
+// would emit. The batch path (phase 2 of #133) reuses the builder and
+// must be byte-identical to streaming for the same StreamParams modulo
+// the stream toggle.
+func TestBuildAnthropicRequest_MatchesStream(t *testing.T) {
+	for _, tc := range anthropicBuilderCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				captured = b
+				// Minimal valid stream so Stream returns without surfacing
+				// a parser error on the response side.
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, makeSSE("message_delta", `{"delta":{"stop_reason":"end_turn"}}`)+makeSSE("message_stop", `{}`))
+			}))
+			defer srv.Close()
+
+			adapter := NewAnthropicAdapter(staticBearer("test-key"), AuthModeAPIKey)
+			adapter.baseURL = srv.URL
+
+			ch, err := adapter.Stream(context.Background(), tc.params)
+			if err != nil {
+				t.Fatalf("Stream() error: %v", err)
+			}
+			for range ch {
+			}
+
+			built := buildAnthropicRequest(tc.params, true)
+			builtBytes, err := json.Marshal(built)
+			if err != nil {
+				t.Fatalf("marshal builder output: %v", err)
+			}
+
+			if string(builtBytes) != string(captured) {
+				t.Errorf("builder vs Stream body mismatch\n builder: %s\n stream:  %s", builtBytes, captured)
+			}
+		})
+	}
+}
+
+// TestBuildAnthropicRequest_StreamFlag verifies the stream argument
+// drives the wire field, so a future batch caller passing false produces
+// a body with "stream":false. Pinning this here prevents the helper
+// from regressing to a hard-coded true once the batch path lands.
+func TestBuildAnthropicRequest_StreamFlag(t *testing.T) {
+	params := types.StreamParams{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: 1024,
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+	}
+	if got := buildAnthropicRequest(params, true).Stream; got != true {
+		t.Errorf("stream=true argument: got Stream=%v, want true", got)
+	}
+	if got := buildAnthropicRequest(params, false).Stream; got != false {
+		t.Errorf("stream=false argument: got Stream=%v, want false", got)
+	}
+}

--- a/harness/internal/provider/anthropic_builder_test.go
+++ b/harness/internal/provider/anthropic_builder_test.go
@@ -132,6 +132,12 @@ func TestBuildAnthropicRequest_MatchesStream(t *testing.T) {
 // drives the wire field, so a future batch caller passing false produces
 // a body with "stream":false. Pinning this here prevents the helper
 // from regressing to a hard-coded true once the batch path lands.
+//
+// The marshalled-body assertions catch the failure mode the struct-level
+// checks miss: if anthropicRequest.Stream were tagged omitempty, the
+// struct check would still pass while "stream":false silently disappeared
+// from the wire body. Anthropic's tag intentionally lacks omitempty, so
+// false must serialise as "stream":false — pin both.
 func TestBuildAnthropicRequest_StreamFlag(t *testing.T) {
 	params := types.StreamParams{
 		Model:     "claude-sonnet-4-6",
@@ -143,6 +149,20 @@ func TestBuildAnthropicRequest_StreamFlag(t *testing.T) {
 	}
 	if got := buildAnthropicRequest(params, false).Stream; got != false {
 		t.Errorf("stream=false argument: got Stream=%v, want false", got)
+	}
+	trueBody, err := json.Marshal(buildAnthropicRequest(params, true))
+	if err != nil {
+		t.Fatalf("marshal stream=true body: %v", err)
+	}
+	if !strings.Contains(string(trueBody), `"stream":true`) {
+		t.Errorf(`expected "stream":true in stream=true body: %s`, trueBody)
+	}
+	falseBody, err := json.Marshal(buildAnthropicRequest(params, false))
+	if err != nil {
+		t.Fatalf("marshal stream=false body: %v", err)
+	}
+	if !strings.Contains(string(falseBody), `"stream":false`) {
+		t.Errorf(`expected "stream":false in stream=false body: %s`, falseBody)
 	}
 }
 

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -336,6 +336,21 @@ func mapFinishReason(reason string) string {
 	}
 }
 
+// buildOpenAIRequest projects a StreamParams into the Chat Completions wire
+// body. The stream argument toggles the "stream" field so a future
+// non-streaming caller (batch submission, phase 2 of issue #133) can reuse
+// the same projection without duplicating field-by-field copying.
+func buildOpenAIRequest(params types.StreamParams, stream bool) openaiRequest {
+	return openaiRequest{
+		Model:               params.Model,
+		Messages:            translateMessages(params.System, params.Messages),
+		Tools:               translateTools(params.Tools),
+		MaxCompletionTokens: params.MaxTokens,
+		Temperature:         params.Temperature,
+		Stream:              stream,
+	}
+}
+
 // Stream sends a streaming request to the OpenAI Chat Completions API and
 // returns a channel of StreamEvents. The channel is closed when the stream
 // ends or an error occurs. Cancelling the context terminates the stream.
@@ -346,14 +361,7 @@ func (o *OpenAICompatibleAdapter) Stream(ctx context.Context, params types.Strea
 		attribute.String("provider.model", params.Model),
 	)
 
-	reqBody := openaiRequest{
-		Model:               params.Model,
-		Messages:            translateMessages(params.System, params.Messages),
-		Tools:               translateTools(params.Tools),
-		MaxCompletionTokens: params.MaxTokens,
-		Temperature:         params.Temperature,
-		Stream:              true,
-	}
+	reqBody := buildOpenAIRequest(params, true)
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -340,6 +340,11 @@ func mapFinishReason(reason string) string {
 // body. The stream argument toggles the "stream" field so a future
 // non-streaming caller (batch submission, phase 2 of issue #133) can reuse
 // the same projection without duplicating field-by-field copying.
+//
+// TODO(batch): if the batch endpoint rejects fields the streaming endpoint
+// accepts (e.g. top_p on Responses, equivalent constraints on Chat
+// Completions), change the return type to (json.RawMessage, error) and
+// apply a batch-specific projection here.
 func buildOpenAIRequest(params types.StreamParams, stream bool) openaiRequest {
 	return openaiRequest{
 		Model:               params.Model,

--- a/harness/internal/provider/openai_builder_test.go
+++ b/harness/internal/provider/openai_builder_test.go
@@ -86,13 +86,14 @@ func openaiBuilderCases() []struct {
 func TestBuildOpenAIRequest_MatchesStream(t *testing.T) {
 	for _, tc := range openaiBuilderCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			var captured []byte
+			capturedCh := make(chan []byte, 1)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				b, err := io.ReadAll(r.Body)
 				if err != nil {
-					t.Fatalf("read body: %v", err)
+					t.Errorf("read body: %v", err)
+					return
 				}
-				captured = b
+				capturedCh <- b
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.WriteHeader(http.StatusOK)
 				// Minimal valid chunk + DONE so Stream's SSE consumer
@@ -112,6 +113,7 @@ func TestBuildOpenAIRequest_MatchesStream(t *testing.T) {
 			}
 			for range ch {
 			}
+			captured := <-capturedCh
 
 			built := buildOpenAIRequest(tc.params, true)
 			builtBytes, err := json.Marshal(built)

--- a/harness/internal/provider/openai_builder_test.go
+++ b/harness/internal/provider/openai_builder_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/types"
@@ -75,6 +76,27 @@ func openaiBuilderCases() []struct {
 				},
 			},
 		},
+		{
+			// Pins the "Error: " prefix injection in translateMessages
+			// (openai.go) at the builder level. Covered by openai_test.go
+			// through Stream, but the batch path will call the builder
+			// directly; the MatchesStream harness extends that coverage
+			// here automatically.
+			name: "is_error_tool_result",
+			params: types.StreamParams{
+				Model:     "gpt-4o",
+				MaxTokens: 1024,
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "run it"}}},
+					{Role: "assistant", Content: []types.ContentBlock{
+						{Type: "tool_use", ID: "call_1", Name: "run", Input: json.RawMessage(`{}`)},
+					}},
+					{Role: "user", Content: []types.ContentBlock{
+						{Type: "tool_result", ToolUseID: "call_1", Content: "disk full", IsError: true},
+					}},
+				},
+			},
+		},
 	}
 }
 
@@ -132,6 +154,12 @@ func TestBuildOpenAIRequest_MatchesStream(t *testing.T) {
 // the wire field, so a future batch caller passing false produces a body
 // with "stream":false. Pinning this here prevents the helper from
 // regressing to a hard-coded true once the batch path lands.
+//
+// The marshalled-body assertions catch the failure mode the struct-level
+// checks miss: if openaiRequest.Stream were tagged omitempty, the struct
+// check would still pass while "stream":false silently disappeared from
+// the wire body. OpenAI's tag intentionally lacks omitempty, so false
+// must serialise as "stream":false — pin both.
 func TestBuildOpenAIRequest_StreamFlag(t *testing.T) {
 	params := types.StreamParams{
 		Model:     "gpt-4o",
@@ -143,5 +171,19 @@ func TestBuildOpenAIRequest_StreamFlag(t *testing.T) {
 	}
 	if got := buildOpenAIRequest(params, false).Stream; got != false {
 		t.Errorf("stream=false argument: got Stream=%v, want false", got)
+	}
+	trueBody, err := json.Marshal(buildOpenAIRequest(params, true))
+	if err != nil {
+		t.Fatalf("marshal stream=true body: %v", err)
+	}
+	if !strings.Contains(string(trueBody), `"stream":true`) {
+		t.Errorf(`expected "stream":true in stream=true body: %s`, trueBody)
+	}
+	falseBody, err := json.Marshal(buildOpenAIRequest(params, false))
+	if err != nil {
+		t.Fatalf("marshal stream=false body: %v", err)
+	}
+	if !strings.Contains(string(falseBody), `"stream":false`) {
+		t.Errorf(`expected "stream":false in stream=false body: %s`, falseBody)
 	}
 }

--- a/harness/internal/provider/openai_builder_test.go
+++ b/harness/internal/provider/openai_builder_test.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// openaiBuilderCases enumerates representative StreamParams shapes for
+// the builder vs Stream equivalence assertion. Each case exercises a
+// different combination of fields the helper has to project: minimal,
+// system+temperature, multi-turn with tool round-trip, multiple tools.
+func openaiBuilderCases() []struct {
+	name   string
+	params types.StreamParams
+} {
+	return []struct {
+		name   string
+		params types.StreamParams
+	}{
+		{
+			name: "minimal",
+			params: types.StreamParams{
+				Model:     "gpt-4o",
+				MaxTokens: 1024,
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+				},
+			},
+		},
+		{
+			name: "system_and_temperature",
+			params: types.StreamParams{
+				Model:       "gpt-4o",
+				System:      "You are helpful.",
+				MaxTokens:   2048,
+				Temperature: types.Float64Ptr(0.5),
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hello"}}},
+				},
+			},
+		},
+		{
+			name: "tools_and_multi_turn",
+			params: types.StreamParams{
+				Model:     "gpt-4o",
+				System:    "Use tools when needed.",
+				MaxTokens: 4096,
+				Tools: []types.ToolDefinition{
+					{
+						Name:        "read_file",
+						Description: "Read a file from disk",
+						InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+					},
+					{
+						Name:        "write_file",
+						Description: "Write a file to disk",
+						InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}}}`),
+					},
+				},
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "read main.go"}}},
+					{Role: "assistant", Content: []types.ContentBlock{
+						{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+					}},
+					{Role: "user", Content: []types.ContentBlock{
+						{Type: "tool_result", ToolUseID: "call_1", Content: "package main"},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// TestBuildOpenAIRequest_MatchesStream pins the invariant that
+// buildOpenAIRequest produces the same wire body the Stream method would
+// emit. The batch path (phase 6 of #133) reuses the builder and must be
+// byte-identical to streaming for the same StreamParams modulo the
+// stream toggle.
+func TestBuildOpenAIRequest_MatchesStream(t *testing.T) {
+	for _, tc := range openaiBuilderCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				captured = b
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				// Minimal valid chunk + DONE so Stream's SSE consumer
+				// terminates cleanly.
+				_, _ = fmt.Fprint(w,
+					makeOpenAIChunk(`{"id":"x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)+
+						"data: [DONE]\n\n",
+				)
+			}))
+			defer srv.Close()
+
+			adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+
+			ch, err := adapter.Stream(context.Background(), tc.params)
+			if err != nil {
+				t.Fatalf("Stream() error: %v", err)
+			}
+			for range ch {
+			}
+
+			built := buildOpenAIRequest(tc.params, true)
+			builtBytes, err := json.Marshal(built)
+			if err != nil {
+				t.Fatalf("marshal builder output: %v", err)
+			}
+
+			if string(builtBytes) != string(captured) {
+				t.Errorf("builder vs Stream body mismatch\n builder: %s\n stream:  %s", builtBytes, captured)
+			}
+		})
+	}
+}
+
+// TestBuildOpenAIRequest_StreamFlag verifies the stream argument drives
+// the wire field, so a future batch caller passing false produces a body
+// with "stream":false. Pinning this here prevents the helper from
+// regressing to a hard-coded true once the batch path lands.
+func TestBuildOpenAIRequest_StreamFlag(t *testing.T) {
+	params := types.StreamParams{
+		Model:     "gpt-4o",
+		MaxTokens: 1024,
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+	}
+	if got := buildOpenAIRequest(params, true).Stream; got != true {
+		t.Errorf("stream=true argument: got Stream=%v, want true", got)
+	}
+	if got := buildOpenAIRequest(params, false).Stream; got != false {
+		t.Errorf("stream=false argument: got Stream=%v, want false", got)
+	}
+}

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -112,8 +112,16 @@ type responsesRequest struct {
 	// pointer type so the unset-vs-explicit-zero distinction survives
 	// marshalling.
 	Temperature *float64 `json:"temperature,omitempty"`
-	Stream      bool     `json:"stream"`
-	Store       bool     `json:"store"`
+	// Stream carries omitempty so that buildResponsesRequest, which leaves
+	// the field at its zero value, produces a wire body with no "stream"
+	// key at all. The streaming caller sets reqBody.Stream = true after
+	// the builder returns, which serialises "stream":true. A future batch
+	// caller can marshal the helper output directly and be sure the field
+	// is absent — the Anthropic Messages Batches API explicitly rejects
+	// the field; the Responses batch endpoint's contract is unverified
+	// but omission is the safer default until that verification lands.
+	Stream bool `json:"stream,omitempty"`
+	Store  bool `json:"store"`
 }
 
 // responsesInput is one item in the Responses API input array. The Type
@@ -447,10 +455,13 @@ func translateToolsResponses(tools []types.ToolDefinition) []responsesTool {
 }
 
 // buildResponsesRequest projects a StreamParams into the Responses API wire
-// body, with Stream left at its zero value. Stream is set by the caller
-// (the streaming Stream method pins it true; a future batch caller leaves
-// it false). Phase-0 refactor for issue #133 — see commit message for why
-// the helper signature deviates from the sibling builders.
+// body. The Stream field is set by the streaming caller after this returns;
+// the builder leaves it false so batch callers get an omitted field (relies
+// on omitempty on the responsesRequest.Stream struct tag). Phase-0 refactor
+// for issue #133.
+//
+// TODO(batch): consider returning json.RawMessage if endpoint-contract drift
+// becomes a maintenance burden.
 func buildResponsesRequest(params types.StreamParams) responsesRequest {
 	return responsesRequest{
 		Model:           params.Model,

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -446,6 +446,23 @@ func translateToolsResponses(tools []types.ToolDefinition) []responsesTool {
 	return out
 }
 
+// buildResponsesRequest projects a StreamParams into the Responses API wire
+// body, with Stream left at its zero value. Stream is set by the caller
+// (the streaming Stream method pins it true; a future batch caller leaves
+// it false). Phase-0 refactor for issue #133 — see commit message for why
+// the helper signature deviates from the sibling builders.
+func buildResponsesRequest(params types.StreamParams) responsesRequest {
+	return responsesRequest{
+		Model:           params.Model,
+		Instructions:    params.System,
+		Input:           translateMessagesResponses(params.Messages),
+		Tools:           translateToolsResponses(params.Tools),
+		MaxOutputTokens: params.MaxTokens,
+		Temperature:     params.Temperature,
+		Store:           false,
+	}
+}
+
 // Stream sends a streaming request to the OpenAI Responses API and returns
 // a channel of StreamEvents. The channel is closed when the stream ends or
 // an error occurs. Cancelling the context terminates the stream.
@@ -456,16 +473,8 @@ func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.Stream
 		attribute.String("provider.model", params.Model),
 	)
 
-	reqBody := responsesRequest{
-		Model:           params.Model,
-		Instructions:    params.System,
-		Input:           translateMessagesResponses(params.Messages),
-		Tools:           translateToolsResponses(params.Tools),
-		MaxOutputTokens: params.MaxTokens,
-		Temperature:     params.Temperature,
-		Stream:          true,
-		Store:           false,
-	}
+	reqBody := buildResponsesRequest(params)
+	reqBody.Stream = true
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {

--- a/harness/internal/provider/openai_responses_builder_test.go
+++ b/harness/internal/provider/openai_responses_builder_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/types"
@@ -130,8 +131,12 @@ func TestBuildResponsesRequest_MatchesStream(t *testing.T) {
 }
 
 // TestBuildResponsesRequest_StreamDefaultFalse verifies the helper
-// leaves Stream at its zero value — the batch path relies on this so
-// a non-streaming submission does not need to clear a hard-coded true.
+// leaves Stream at its zero value AND that the marshalled wire body
+// omits the "stream" key entirely (via omitempty on the struct tag).
+// The batch path relies on this so a non-streaming submission does
+// not send "stream":false — the Anthropic Messages Batches API
+// rejects the field outright; the Responses batch endpoint contract
+// is unverified, and omission is the safer default.
 func TestBuildResponsesRequest_StreamDefaultFalse(t *testing.T) {
 	params := types.StreamParams{
 		Model:     "gpt-4o",
@@ -144,5 +149,12 @@ func TestBuildResponsesRequest_StreamDefaultFalse(t *testing.T) {
 	}
 	if got.Store != false {
 		t.Errorf("builder default: Store = %v, want false", got.Store)
+	}
+	body, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal builder output: %v", err)
+	}
+	if strings.Contains(string(body), `"stream"`) {
+		t.Errorf(`expected "stream" key to be omitted from builder output: %s`, body)
 	}
 }

--- a/harness/internal/provider/openai_responses_builder_test.go
+++ b/harness/internal/provider/openai_responses_builder_test.go
@@ -89,13 +89,14 @@ func responsesBuilderCases() []struct {
 func TestBuildResponsesRequest_MatchesStream(t *testing.T) {
 	for _, tc := range responsesBuilderCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			var captured []byte
+			capturedCh := make(chan []byte, 1)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				b, err := io.ReadAll(r.Body)
 				if err != nil {
-					t.Fatalf("read body: %v", err)
+					t.Errorf("read body: %v", err)
+					return
 				}
-				captured = b
+				capturedCh <- b
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.WriteHeader(http.StatusOK)
 				// Minimal completion event so Stream returns without a
@@ -115,6 +116,7 @@ func TestBuildResponsesRequest_MatchesStream(t *testing.T) {
 			}
 			for range ch {
 			}
+			captured := <-capturedCh
 
 			built := buildResponsesRequest(tc.params)
 			built.Stream = true

--- a/harness/internal/provider/openai_responses_builder_test.go
+++ b/harness/internal/provider/openai_responses_builder_test.go
@@ -1,0 +1,148 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// responsesBuilderCases enumerates representative StreamParams shapes
+// for the builder vs Stream equivalence assertion. The Responses API's
+// input[] discriminated union means we want at least one case that
+// exercises every variant: message (user/assistant), function_call,
+// function_call_output.
+func responsesBuilderCases() []struct {
+	name   string
+	params types.StreamParams
+} {
+	return []struct {
+		name   string
+		params types.StreamParams
+	}{
+		{
+			name: "minimal",
+			params: types.StreamParams{
+				Model:     "gpt-4o",
+				MaxTokens: 1024,
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+				},
+			},
+		},
+		{
+			name: "instructions_and_temperature",
+			params: types.StreamParams{
+				Model:       "gpt-4o",
+				System:      "You are helpful.",
+				MaxTokens:   2048,
+				Temperature: types.Float64Ptr(0.0),
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hello"}}},
+				},
+			},
+		},
+		{
+			name: "tools_and_multi_turn",
+			params: types.StreamParams{
+				Model:     "gpt-4o",
+				System:    "Use tools when needed.",
+				MaxTokens: 4096,
+				Tools: []types.ToolDefinition{
+					{
+						Name:        "read_file",
+						Description: "Read a file from disk",
+						InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+					},
+				},
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "read main.go"}}},
+					{Role: "assistant", Content: []types.ContentBlock{
+						{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+					}},
+					{Role: "user", Content: []types.ContentBlock{
+						{Type: "tool_result", ToolUseID: "call_1", Content: "package main"},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// TestBuildResponsesRequest_MatchesStream pins the invariant that
+// buildResponsesRequest produces the same wire body the Stream method
+// would emit, modulo the Stream field (the helper deliberately leaves
+// Stream at its zero value; Stream sets it to true after the call). The
+// batch path (phase 6 of #133) reuses the builder and must be
+// byte-identical otherwise.
+//
+// Equivalence is checked by setting Stream=true on the builder output
+// before marshalling, mirroring Stream's own pin. This both confirms
+// the projection is otherwise complete AND that the wire-toggle
+// responsibility lives at the call site (not the helper).
+func TestBuildResponsesRequest_MatchesStream(t *testing.T) {
+	for _, tc := range responsesBuilderCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				captured = b
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				// Minimal completion event so Stream returns without a
+				// parser error.
+				_, _ = fmt.Fprint(w,
+					"event: response.completed\n"+
+						`data: {"response":{"status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}}`+"\n\n",
+				)
+			}))
+			defer srv.Close()
+
+			adapter := NewOpenAIResponsesAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{})
+
+			ch, err := adapter.Stream(context.Background(), tc.params)
+			if err != nil {
+				t.Fatalf("Stream() error: %v", err)
+			}
+			for range ch {
+			}
+
+			built := buildResponsesRequest(tc.params)
+			built.Stream = true
+			builtBytes, err := json.Marshal(built)
+			if err != nil {
+				t.Fatalf("marshal builder output: %v", err)
+			}
+
+			if string(builtBytes) != string(captured) {
+				t.Errorf("builder vs Stream body mismatch\n builder: %s\n stream:  %s", builtBytes, captured)
+			}
+		})
+	}
+}
+
+// TestBuildResponsesRequest_StreamDefaultFalse verifies the helper
+// leaves Stream at its zero value — the batch path relies on this so
+// a non-streaming submission does not need to clear a hard-coded true.
+func TestBuildResponsesRequest_StreamDefaultFalse(t *testing.T) {
+	params := types.StreamParams{
+		Model:     "gpt-4o",
+		MaxTokens: 1024,
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+	}
+	got := buildResponsesRequest(params)
+	if got.Stream != false {
+		t.Errorf("builder default: Stream = %v, want false", got.Stream)
+	}
+	if got.Store != false {
+		t.Errorf("builder default: Store = %v, want false", got.Store)
+	}
+}

--- a/harness/internal/provider/openai_responses_builder_test.go
+++ b/harness/internal/provider/openai_responses_builder_test.go
@@ -72,6 +72,27 @@ func responsesBuilderCases() []struct {
 				},
 			},
 		},
+		{
+			// Pins the "Error: " prefix injection in
+			// translateMessagesResponses at the builder level. Covered by
+			// openai_responses_test.go through Stream, but the batch path
+			// will call the builder directly; the MatchesStream harness
+			// extends that coverage here automatically.
+			name: "is_error_tool_result",
+			params: types.StreamParams{
+				Model:     "gpt-4o",
+				MaxTokens: 1024,
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "run it"}}},
+					{Role: "assistant", Content: []types.ContentBlock{
+						{Type: "tool_use", ID: "call_1", Name: "run", Input: json.RawMessage(`{}`)},
+					}},
+					{Role: "user", Content: []types.ContentBlock{
+						{Type: "tool_result", ToolUseID: "call_1", Content: "disk full", IsError: true},
+					}},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Behaviour-neutral refactor extracting per-turn request-marshalling logic from each streaming provider adapter into standalone pure functions. This is the foundation PR for the batch-API stack (phases 0–6, issues #133–#139, parent #67) — every subsequent phase reuses these helpers as the canonical request builders.

- `buildAnthropicRequest(params types.StreamParams, stream bool) anthropicRequest` (anthropic.go)
- `buildOpenAIRequest(params types.StreamParams, stream bool) openaiRequest` (openai.go)
- `buildResponsesRequest(params types.StreamParams) responsesRequest` (openai_responses.go — no `stream bool` per the issue's explicit allowance; `responsesRequest.Stream` now carries `omitempty` so batch callers omit the field from the wire body)

Each `Stream` method now calls its helper rather than constructing the struct inline. The observable wire body, headers, and SSE consumer are unchanged.

`bedrock.go`, `replay.go`, and `gemini.go` are deliberately untouched (out of scope per the issue and per the design plan §13 Phase 6).

## Tests

Property-style equivalence tests added in three new files:
- `anthropic_builder_test.go`
- `openai_builder_test.go`
- `openai_responses_builder_test.go`

Each test captures the actual HTTP body sent by `Stream` via `httptest.NewServer` and byte-compares it against `json.Marshal(build*Request(...))`. Covers system-prompt present/absent, tools present/absent, multi-turn history, and `IsError: true` tool results. Stream-flag polarity and `thought_signature` drop are pinned at the builder level.

`go test -race ./harness/internal/provider/...` → PASS.

## Review wave

Five-reviewer cycle ran: code, security, spec-compliance, api-design, test-coverage. Synthesised brief: 2 blocking + 5 recommended findings, all resolved in commits 970d22d–bf2ecff before this PR opened.

- Blocking: `responsesRequest.Stream` wire-correctness (resolved via `omitempty`); missing `ThoughtSignatureDropped` builder-level test (added).
- Recommended: data race on shared `captured` test variable (fixed via buffered channel); missing `IsError` tool-result cases; marshalled-body assertions on `StreamFlag` tests; `params.Tools` slice aliasing in Anthropic builder (resolved with `slices.Clone`); TODO comments marking deferred struct-return-type debt.

Seven NITs deferred to follow-up issues (comment polish, naming, pre-existing `bytes.NewReader` cleanup, etc.) — to be filed after merge.

## Stack

This is PR 1 of 7 in the batch-API stack. Subsequent PRs target the previous phase's branch:
- phase-1 (#134) — `BatchProviderConfig` + `ValidateRunConfig` invariants
- phase-2 (#135) — `BatchAdapter` + `controlPlaneBatchClient` + factory wiring
- phase-3 (#136) — `--batch` CLI flag + docs
- phase-4 (#137) — `harnessPollingBatchClient` (Anthropic stdio)
- phase-5 (#138) — `TurnTrace.Mode` + lakehouse bucketing
- phase-6 (#139) — OpenAI batch path + Bedrock evaluation

## Test plan

- [x] `go build ./harness/...` passes
- [x] `go test -race ./harness/internal/provider/...` passes
- [ ] CI green on PR

Closes #133.