### PR TITLE
batch(phase-1): BatchProviderConfig + ValidateRunConfig invariants + gRPC translate

### DIFF
--- a/examples/runconfig/README.md
+++ b/examples/runconfig/README.md
@@ -82,6 +82,23 @@ active and Rule of Two is enforced.
   // openai-compatible, openai-responses only); enabled=false here
   // means streaming, the default. See BatchProviderConfig for the
   // mode / transport invariants enforced by ValidateRunConfig.
+  //
+  // Field-level notes for batch:
+  //   - `maxWaitSeconds` is optional. When `enabled: true` and the
+  //     field is omitted, ValidateRunConfig fills it with 86400
+  //     (the 24 h provider SLA). The full.json example sets it
+  //     explicitly only because every field is shown for
+  //     completeness; operators may omit it.
+  //   - `harnessSidePolling` is required with `transport: "stdio"`
+  //     and rejected with `transport: "grpc"`.
+  //   - `cancelBundleOnRunCancel` is the mirror constraint: gRPC-only
+  //     and rejected with stdio.
+  //   - `allowInteractiveModes` opts in to batch with
+  //     `mode: "planning"` / `mode: "review"`; `mode: "execution"`
+  //     always rejects batch regardless of this flag.
+  // The full operator walkthrough lands in docs/sandbox.md (phase 3).
+  // Batch on a named providers map entry is a hard error in v1; only
+  // the top-level provider's batch block is consulted.
   "provider": {
     "type": "anthropic",
     "apiKeyRef": "secret://ANTHROPIC_API_KEY",

--- a/examples/runconfig/README.md
+++ b/examples/runconfig/README.md
@@ -77,10 +77,22 @@ active and Rule of Two is enforced.
   },
 
   // Provider + credentials. apiKeyRef is a secret:// reference, never
-  // a raw key.
+  // a raw key. The optional `batch` block opts the run into async
+  // batch submission for every provider turn (anthropic,
+  // openai-compatible, openai-responses only); enabled=false here
+  // means streaming, the default. See BatchProviderConfig for the
+  // mode / transport invariants enforced by ValidateRunConfig.
   "provider": {
     "type": "anthropic",
-    "apiKeyRef": "secret://ANTHROPIC_API_KEY"
+    "apiKeyRef": "secret://ANTHROPIC_API_KEY",
+    "batch": {
+      "enabled": false,
+      "maxWaitSeconds": 86400,
+      "harnessSidePolling": false,
+      "fallbackOnTimeout": false,
+      "cancelBundleOnRunCancel": false,
+      "allowInteractiveModes": false
+    }
   },
 
   // Dynamic router: cheap for short turns, expensive past the

--- a/examples/runconfig/full.json
+++ b/examples/runconfig/full.json
@@ -9,7 +9,15 @@
   },
   "provider": {
     "type": "anthropic",
-    "apiKeyRef": "secret://ANTHROPIC_API_KEY"
+    "apiKeyRef": "secret://ANTHROPIC_API_KEY",
+    "batch": {
+      "enabled": false,
+      "maxWaitSeconds": 86400,
+      "harnessSidePolling": false,
+      "fallbackOnTimeout": false,
+      "cancelBundleOnRunCancel": false,
+      "allowInteractiveModes": false
+    }
   },
   "modelRouter": {
     "type": "dynamic",

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -1522,7 +1522,15 @@ type ProviderConfig struct {
 	// provider call. Nil = use defaults (filled in by ValidateRunConfig so
 	// downstream consumers always see a populated value). Adapters that
 	// honour this knob currently include the openai-compatible adapter.
-	Retry         *ProviderRetryConfig `protobuf:"bytes,13,opt,name=retry,proto3,oneof" json:"retry,omitempty"`
+	Retry *ProviderRetryConfig `protobuf:"bytes,13,opt,name=retry,proto3,oneof" json:"retry,omitempty"`
+	// Optional. Opts the run into async batch submission for every
+	// provider turn (anthropic, openai-compatible, openai-responses only).
+	// Only the top-level RunConfig.provider entry is consulted in v1;
+	// entries in RunConfig.providers map are streaming-only and any batch
+	// field on them is rejected by ValidateRunConfig. See
+	// BatchProviderConfig for the mode / transport cross-field invariants.
+	// Next available field number: 15.
+	Batch         *BatchProviderConfig `protobuf:"bytes,14,opt,name=batch,proto3" json:"batch,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1646,6 +1654,118 @@ func (x *ProviderConfig) GetRetry() *ProviderRetryConfig {
 		return x.Retry
 	}
 	return nil
+}
+
+func (x *ProviderConfig) GetBatch() *BatchProviderConfig {
+	if x != nil {
+		return x.Batch
+	}
+	return nil
+}
+
+// BatchProviderConfig controls async batch submission for a provider
+// turn. Mirrors types.BatchProviderConfig field-for-field. Only Anthropic
+// and OpenAI providers support batch in v1; ValidateRunConfig rejects
+// enabled=true with an unsupported provider type.
+type BatchProviderConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Opts this run into async batch submission for every provider turn.
+	Enabled bool `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Harness-side wall-clock cap on the batch wait, in seconds. Declared
+	// `optional` so an unset value is wire-distinguishable from explicit
+	// zero: ValidateRunConfig fills the default (86400) only when nil and
+	// enabled=true, so a phase-2 adapter can still tell "operator did not
+	// configure this" from "default applied". Must be in (0, 86400] when
+	// set.
+	MaxWaitSeconds *int32 `protobuf:"varint,2,opt,name=max_wait_seconds,json=maxWaitSeconds,proto3,oneof" json:"max_wait_seconds,omitempty"`
+	// Enables direct HTTP polling from the harness process. Required when
+	// transport.type == "stdio"; rejected with transport.type == "grpc".
+	HarnessSidePolling bool `protobuf:"varint,3,opt,name=harness_side_polling,json=harnessSidePolling,proto3" json:"harness_side_polling,omitempty"`
+	// Switches to the streaming adapter for a turn when the harness-side
+	// max_wait_seconds fires. Defaults to false.
+	FallbackOnTimeout bool `protobuf:"varint,4,opt,name=fallback_on_timeout,json=fallbackOnTimeout,proto3" json:"fallback_on_timeout,omitempty"`
+	// When a single run is cancelled, cancel the entire bundled provider
+	// batch (gRPC transport only). Defaults to false. Rejected with
+	// transport.type == "stdio".
+	CancelBundleOnRunCancel bool `protobuf:"varint,5,opt,name=cancel_bundle_on_run_cancel,json=cancelBundleOnRunCancel,proto3" json:"cancel_bundle_on_run_cancel,omitempty"`
+	// Permits batch.enabled with mode == "planning" or mode == "review".
+	// Has no effect on mode == "execution" (always rejected) or on other
+	// read-only modes ("research", "toil") which accept batch without it.
+	AllowInteractiveModes bool `protobuf:"varint,6,opt,name=allow_interactive_modes,json=allowInteractiveModes,proto3" json:"allow_interactive_modes,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BatchProviderConfig) Reset() {
+	*x = BatchProviderConfig{}
+	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchProviderConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchProviderConfig) ProtoMessage() {}
+
+func (x *BatchProviderConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchProviderConfig.ProtoReflect.Descriptor instead.
+func (*BatchProviderConfig) Descriptor() ([]byte, []int) {
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *BatchProviderConfig) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *BatchProviderConfig) GetMaxWaitSeconds() int32 {
+	if x != nil && x.MaxWaitSeconds != nil {
+		return *x.MaxWaitSeconds
+	}
+	return 0
+}
+
+func (x *BatchProviderConfig) GetHarnessSidePolling() bool {
+	if x != nil {
+		return x.HarnessSidePolling
+	}
+	return false
+}
+
+func (x *BatchProviderConfig) GetFallbackOnTimeout() bool {
+	if x != nil {
+		return x.FallbackOnTimeout
+	}
+	return false
+}
+
+func (x *BatchProviderConfig) GetCancelBundleOnRunCancel() bool {
+	if x != nil {
+		return x.CancelBundleOnRunCancel
+	}
+	return false
+}
+
+func (x *BatchProviderConfig) GetAllowInteractiveModes() bool {
+	if x != nil {
+		return x.AllowInteractiveModes
+	}
+	return false
 }
 
 // CredentialConfig selects the credential acquisition method for a provider.
@@ -1779,7 +1899,7 @@ type CredentialConfig struct {
 
 func (x *CredentialConfig) Reset() {
 	*x = CredentialConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	mi := &file_harness_v1_harness_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1791,7 +1911,7 @@ func (x *CredentialConfig) String() string {
 func (*CredentialConfig) ProtoMessage() {}
 
 func (x *CredentialConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	mi := &file_harness_v1_harness_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1804,7 +1924,7 @@ func (x *CredentialConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CredentialConfig.ProtoReflect.Descriptor instead.
 func (*CredentialConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{12}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CredentialConfig) GetType() string {
@@ -1950,7 +2070,7 @@ type TokenSourceConfig struct {
 
 func (x *TokenSourceConfig) Reset() {
 	*x = TokenSourceConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[13]
+	mi := &file_harness_v1_harness_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1962,7 +2082,7 @@ func (x *TokenSourceConfig) String() string {
 func (*TokenSourceConfig) ProtoMessage() {}
 
 func (x *TokenSourceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[13]
+	mi := &file_harness_v1_harness_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1975,7 +2095,7 @@ func (x *TokenSourceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TokenSourceConfig.ProtoReflect.Descriptor instead.
 func (*TokenSourceConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{13}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TokenSourceConfig) GetType() string {
@@ -2043,7 +2163,7 @@ type GeminiSafetySetting struct {
 
 func (x *GeminiSafetySetting) Reset() {
 	*x = GeminiSafetySetting{}
-	mi := &file_harness_v1_harness_proto_msgTypes[14]
+	mi := &file_harness_v1_harness_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2055,7 +2175,7 @@ func (x *GeminiSafetySetting) String() string {
 func (*GeminiSafetySetting) ProtoMessage() {}
 
 func (x *GeminiSafetySetting) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[14]
+	mi := &file_harness_v1_harness_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2068,7 +2188,7 @@ func (x *GeminiSafetySetting) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GeminiSafetySetting.ProtoReflect.Descriptor instead.
 func (*GeminiSafetySetting) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{14}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GeminiSafetySetting) GetCategory() string {
@@ -2110,7 +2230,7 @@ type ProviderRetryConfig struct {
 
 func (x *ProviderRetryConfig) Reset() {
 	*x = ProviderRetryConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[15]
+	mi := &file_harness_v1_harness_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2122,7 +2242,7 @@ func (x *ProviderRetryConfig) String() string {
 func (*ProviderRetryConfig) ProtoMessage() {}
 
 func (x *ProviderRetryConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[15]
+	mi := &file_harness_v1_harness_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2135,7 +2255,7 @@ func (x *ProviderRetryConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderRetryConfig.ProtoReflect.Descriptor instead.
 func (*ProviderRetryConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{15}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ProviderRetryConfig) GetMaxAttempts() int32 {
@@ -2209,7 +2329,7 @@ type ModelRouterConfig struct {
 
 func (x *ModelRouterConfig) Reset() {
 	*x = ModelRouterConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[16]
+	mi := &file_harness_v1_harness_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2221,7 +2341,7 @@ func (x *ModelRouterConfig) String() string {
 func (*ModelRouterConfig) ProtoMessage() {}
 
 func (x *ModelRouterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[16]
+	mi := &file_harness_v1_harness_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2234,7 +2354,7 @@ func (x *ModelRouterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelRouterConfig.ProtoReflect.Descriptor instead.
 func (*ModelRouterConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{16}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ModelRouterConfig) GetType() string {
@@ -2332,7 +2452,7 @@ type PromptBuilderConfig struct {
 
 func (x *PromptBuilderConfig) Reset() {
 	*x = PromptBuilderConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[17]
+	mi := &file_harness_v1_harness_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2344,7 +2464,7 @@ func (x *PromptBuilderConfig) String() string {
 func (*PromptBuilderConfig) ProtoMessage() {}
 
 func (x *PromptBuilderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[17]
+	mi := &file_harness_v1_harness_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2357,7 +2477,7 @@ func (x *PromptBuilderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromptBuilderConfig.ProtoReflect.Descriptor instead.
 func (*PromptBuilderConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{17}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *PromptBuilderConfig) GetType() string {
@@ -2396,7 +2516,7 @@ type ContextStrategyConfig struct {
 
 func (x *ContextStrategyConfig) Reset() {
 	*x = ContextStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[18]
+	mi := &file_harness_v1_harness_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2408,7 +2528,7 @@ func (x *ContextStrategyConfig) String() string {
 func (*ContextStrategyConfig) ProtoMessage() {}
 
 func (x *ContextStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[18]
+	mi := &file_harness_v1_harness_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2421,7 +2541,7 @@ func (x *ContextStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContextStrategyConfig.ProtoReflect.Descriptor instead.
 func (*ContextStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{18}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ContextStrategyConfig) GetType() string {
@@ -2478,7 +2598,7 @@ type ExecutorConfig struct {
 
 func (x *ExecutorConfig) Reset() {
 	*x = ExecutorConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[19]
+	mi := &file_harness_v1_harness_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2490,7 +2610,7 @@ func (x *ExecutorConfig) String() string {
 func (*ExecutorConfig) ProtoMessage() {}
 
 func (x *ExecutorConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[19]
+	mi := &file_harness_v1_harness_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2503,7 +2623,7 @@ func (x *ExecutorConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorConfig.ProtoReflect.Descriptor instead.
 func (*ExecutorConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{19}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ExecutorConfig) GetType() string {
@@ -2580,7 +2700,7 @@ type VcsBackendConfig struct {
 
 func (x *VcsBackendConfig) Reset() {
 	*x = VcsBackendConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[20]
+	mi := &file_harness_v1_harness_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2592,7 +2712,7 @@ func (x *VcsBackendConfig) String() string {
 func (*VcsBackendConfig) ProtoMessage() {}
 
 func (x *VcsBackendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[20]
+	mi := &file_harness_v1_harness_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2605,7 +2725,7 @@ func (x *VcsBackendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VcsBackendConfig.ProtoReflect.Descriptor instead.
 func (*VcsBackendConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{20}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *VcsBackendConfig) GetType() string {
@@ -2653,7 +2773,7 @@ type NetworkConfig struct {
 
 func (x *NetworkConfig) Reset() {
 	*x = NetworkConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[21]
+	mi := &file_harness_v1_harness_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2665,7 +2785,7 @@ func (x *NetworkConfig) String() string {
 func (*NetworkConfig) ProtoMessage() {}
 
 func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[21]
+	mi := &file_harness_v1_harness_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2678,7 +2798,7 @@ func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkConfig.ProtoReflect.Descriptor instead.
 func (*NetworkConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{21}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *NetworkConfig) GetMode() string {
@@ -2712,7 +2832,7 @@ type ResourceLimits struct {
 
 func (x *ResourceLimits) Reset() {
 	*x = ResourceLimits{}
-	mi := &file_harness_v1_harness_proto_msgTypes[22]
+	mi := &file_harness_v1_harness_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2724,7 +2844,7 @@ func (x *ResourceLimits) String() string {
 func (*ResourceLimits) ProtoMessage() {}
 
 func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[22]
+	mi := &file_harness_v1_harness_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2737,7 +2857,7 @@ func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceLimits.ProtoReflect.Descriptor instead.
 func (*ResourceLimits) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{22}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ResourceLimits) GetCpus() float64 {
@@ -2790,7 +2910,7 @@ type EditStrategyConfig struct {
 
 func (x *EditStrategyConfig) Reset() {
 	*x = EditStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[23]
+	mi := &file_harness_v1_harness_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2802,7 +2922,7 @@ func (x *EditStrategyConfig) String() string {
 func (*EditStrategyConfig) ProtoMessage() {}
 
 func (x *EditStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[23]
+	mi := &file_harness_v1_harness_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2815,7 +2935,7 @@ func (x *EditStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditStrategyConfig.ProtoReflect.Descriptor instead.
 func (*EditStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{23}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *EditStrategyConfig) GetType() string {
@@ -2863,7 +2983,7 @@ type VerifierConfig struct {
 
 func (x *VerifierConfig) Reset() {
 	*x = VerifierConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[24]
+	mi := &file_harness_v1_harness_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2875,7 +2995,7 @@ func (x *VerifierConfig) String() string {
 func (*VerifierConfig) ProtoMessage() {}
 
 func (x *VerifierConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[24]
+	mi := &file_harness_v1_harness_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2888,7 +3008,7 @@ func (x *VerifierConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifierConfig.ProtoReflect.Descriptor instead.
 func (*VerifierConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{24}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *VerifierConfig) GetType() string {
@@ -2985,7 +3105,7 @@ type PermissionPolicyConfig struct {
 
 func (x *PermissionPolicyConfig) Reset() {
 	*x = PermissionPolicyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[25]
+	mi := &file_harness_v1_harness_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2997,7 +3117,7 @@ func (x *PermissionPolicyConfig) String() string {
 func (*PermissionPolicyConfig) ProtoMessage() {}
 
 func (x *PermissionPolicyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[25]
+	mi := &file_harness_v1_harness_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3010,7 +3130,7 @@ func (x *PermissionPolicyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PermissionPolicyConfig.ProtoReflect.Descriptor instead.
 func (*PermissionPolicyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{25}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PermissionPolicyConfig) GetType() string {
@@ -3057,7 +3177,7 @@ type GitStrategyConfig struct {
 
 func (x *GitStrategyConfig) Reset() {
 	*x = GitStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[26]
+	mi := &file_harness_v1_harness_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3069,7 +3189,7 @@ func (x *GitStrategyConfig) String() string {
 func (*GitStrategyConfig) ProtoMessage() {}
 
 func (x *GitStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[26]
+	mi := &file_harness_v1_harness_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3082,7 +3202,7 @@ func (x *GitStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitStrategyConfig.ProtoReflect.Descriptor instead.
 func (*GitStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{26}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GitStrategyConfig) GetType() string {
@@ -3145,7 +3265,7 @@ type TraceEmitterConfig struct {
 
 func (x *TraceEmitterConfig) Reset() {
 	*x = TraceEmitterConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[27]
+	mi := &file_harness_v1_harness_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3157,7 +3277,7 @@ func (x *TraceEmitterConfig) String() string {
 func (*TraceEmitterConfig) ProtoMessage() {}
 
 func (x *TraceEmitterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[27]
+	mi := &file_harness_v1_harness_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3170,7 +3290,7 @@ func (x *TraceEmitterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceEmitterConfig.ProtoReflect.Descriptor instead.
 func (*TraceEmitterConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{27}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TraceEmitterConfig) GetType() string {
@@ -3259,7 +3379,7 @@ type ToolsConfig struct {
 
 func (x *ToolsConfig) Reset() {
 	*x = ToolsConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[28]
+	mi := &file_harness_v1_harness_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3271,7 +3391,7 @@ func (x *ToolsConfig) String() string {
 func (*ToolsConfig) ProtoMessage() {}
 
 func (x *ToolsConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[28]
+	mi := &file_harness_v1_harness_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3284,7 +3404,7 @@ func (x *ToolsConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolsConfig.ProtoReflect.Descriptor instead.
 func (*ToolsConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{28}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ToolsConfig) GetBuiltIn() []string {
@@ -3319,7 +3439,7 @@ type MCPServerConfig struct {
 
 func (x *MCPServerConfig) Reset() {
 	*x = MCPServerConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[29]
+	mi := &file_harness_v1_harness_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3331,7 +3451,7 @@ func (x *MCPServerConfig) String() string {
 func (*MCPServerConfig) ProtoMessage() {}
 
 func (x *MCPServerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[29]
+	mi := &file_harness_v1_harness_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3344,7 +3464,7 @@ func (x *MCPServerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerConfig.ProtoReflect.Descriptor instead.
 func (*MCPServerConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{29}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *MCPServerConfig) GetName() string {
@@ -3493,7 +3613,7 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\vduration_ms\x18\x06 \x01(\x03R\n" +
 	"durationMs\x12\x1f\n" +
 	"\vstop_reason\x18\a \x01(\tR\n" +
-	"stopReason\"\xb8\x05\n" +
+	"stopReason\"\xf7\x05\n" +
 	"\x0eProviderConfig\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1e\n" +
 	"\vapi_key_ref\x18\x02 \x01(\tR\tapiKeyRef\x12\x16\n" +
@@ -3511,11 +3631,20 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	" \x01(\tR\vgcpLocation\x120\n" +
 	"\x14gcp_credentials_file\x18\v \x01(\tR\x12gcpCredentialsFile\x12]\n" +
 	"\x16gemini_safety_settings\x18\f \x03(\v2'.stirrup.harness.v1.GeminiSafetySettingR\x14geminiSafetySettings\x12B\n" +
-	"\x05retry\x18\r \x01(\v2'.stirrup.harness.v1.ProviderRetryConfigH\x00R\x05retry\x88\x01\x01\x1a>\n" +
+	"\x05retry\x18\r \x01(\v2'.stirrup.harness.v1.ProviderRetryConfigH\x00R\x05retry\x88\x01\x01\x12=\n" +
+	"\x05batch\x18\x0e \x01(\v2'.stirrup.harness.v1.BatchProviderConfigR\x05batch\x1a>\n" +
 	"\x10QueryParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\b\n" +
-	"\x06_retry\"\xb4\x04\n" +
+	"\x06_retry\"\xcb\x02\n" +
+	"\x13BatchProviderConfig\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12-\n" +
+	"\x10max_wait_seconds\x18\x02 \x01(\x05H\x00R\x0emaxWaitSeconds\x88\x01\x01\x120\n" +
+	"\x14harness_side_polling\x18\x03 \x01(\bR\x12harnessSidePolling\x12.\n" +
+	"\x13fallback_on_timeout\x18\x04 \x01(\bR\x11fallbackOnTimeout\x12<\n" +
+	"\x1bcancel_bundle_on_run_cancel\x18\x05 \x01(\bR\x17cancelBundleOnRunCancel\x126\n" +
+	"\x17allow_interactive_modes\x18\x06 \x01(\bR\x15allowInteractiveModesB\x13\n" +
+	"\x11_max_wait_seconds\"\xb4\x04\n" +
 	"\x10CredentialConfig\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12H\n" +
 	"\ftoken_source\x18\x02 \x01(\v2%.stirrup.harness.v1.TokenSourceConfigR\vtokenSource\x12\x19\n" +
@@ -3652,7 +3781,7 @@ func file_harness_v1_harness_proto_rawDescGZIP() []byte {
 	return file_harness_v1_harness_proto_rawDescData
 }
 
-var file_harness_v1_harness_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_harness_v1_harness_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_harness_v1_harness_proto_goTypes = []any{
 	(*HarnessEvent)(nil),           // 0: stirrup.harness.v1.HarnessEvent
 	(*ControlEvent)(nil),           // 1: stirrup.harness.v1.ControlEvent
@@ -3666,77 +3795,79 @@ var file_harness_v1_harness_proto_goTypes = []any{
 	(*ObservabilityConfig)(nil),    // 9: stirrup.harness.v1.ObservabilityConfig
 	(*RunTrace)(nil),               // 10: stirrup.harness.v1.RunTrace
 	(*ProviderConfig)(nil),         // 11: stirrup.harness.v1.ProviderConfig
-	(*CredentialConfig)(nil),       // 12: stirrup.harness.v1.CredentialConfig
-	(*TokenSourceConfig)(nil),      // 13: stirrup.harness.v1.TokenSourceConfig
-	(*GeminiSafetySetting)(nil),    // 14: stirrup.harness.v1.GeminiSafetySetting
-	(*ProviderRetryConfig)(nil),    // 15: stirrup.harness.v1.ProviderRetryConfig
-	(*ModelRouterConfig)(nil),      // 16: stirrup.harness.v1.ModelRouterConfig
-	(*PromptBuilderConfig)(nil),    // 17: stirrup.harness.v1.PromptBuilderConfig
-	(*ContextStrategyConfig)(nil),  // 18: stirrup.harness.v1.ContextStrategyConfig
-	(*ExecutorConfig)(nil),         // 19: stirrup.harness.v1.ExecutorConfig
-	(*VcsBackendConfig)(nil),       // 20: stirrup.harness.v1.VcsBackendConfig
-	(*NetworkConfig)(nil),          // 21: stirrup.harness.v1.NetworkConfig
-	(*ResourceLimits)(nil),         // 22: stirrup.harness.v1.ResourceLimits
-	(*EditStrategyConfig)(nil),     // 23: stirrup.harness.v1.EditStrategyConfig
-	(*VerifierConfig)(nil),         // 24: stirrup.harness.v1.VerifierConfig
-	(*PermissionPolicyConfig)(nil), // 25: stirrup.harness.v1.PermissionPolicyConfig
-	(*GitStrategyConfig)(nil),      // 26: stirrup.harness.v1.GitStrategyConfig
-	(*TraceEmitterConfig)(nil),     // 27: stirrup.harness.v1.TraceEmitterConfig
-	(*ToolsConfig)(nil),            // 28: stirrup.harness.v1.ToolsConfig
-	(*MCPServerConfig)(nil),        // 29: stirrup.harness.v1.MCPServerConfig
-	nil,                            // 30: stirrup.harness.v1.RunConfig.DynamicContextEntry
-	nil,                            // 31: stirrup.harness.v1.RunConfig.ProvidersEntry
-	nil,                            // 32: stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
-	nil,                            // 33: stirrup.harness.v1.ProviderConfig.QueryParamsEntry
-	nil,                            // 34: stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
-	nil,                            // 35: stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
+	(*BatchProviderConfig)(nil),    // 12: stirrup.harness.v1.BatchProviderConfig
+	(*CredentialConfig)(nil),       // 13: stirrup.harness.v1.CredentialConfig
+	(*TokenSourceConfig)(nil),      // 14: stirrup.harness.v1.TokenSourceConfig
+	(*GeminiSafetySetting)(nil),    // 15: stirrup.harness.v1.GeminiSafetySetting
+	(*ProviderRetryConfig)(nil),    // 16: stirrup.harness.v1.ProviderRetryConfig
+	(*ModelRouterConfig)(nil),      // 17: stirrup.harness.v1.ModelRouterConfig
+	(*PromptBuilderConfig)(nil),    // 18: stirrup.harness.v1.PromptBuilderConfig
+	(*ContextStrategyConfig)(nil),  // 19: stirrup.harness.v1.ContextStrategyConfig
+	(*ExecutorConfig)(nil),         // 20: stirrup.harness.v1.ExecutorConfig
+	(*VcsBackendConfig)(nil),       // 21: stirrup.harness.v1.VcsBackendConfig
+	(*NetworkConfig)(nil),          // 22: stirrup.harness.v1.NetworkConfig
+	(*ResourceLimits)(nil),         // 23: stirrup.harness.v1.ResourceLimits
+	(*EditStrategyConfig)(nil),     // 24: stirrup.harness.v1.EditStrategyConfig
+	(*VerifierConfig)(nil),         // 25: stirrup.harness.v1.VerifierConfig
+	(*PermissionPolicyConfig)(nil), // 26: stirrup.harness.v1.PermissionPolicyConfig
+	(*GitStrategyConfig)(nil),      // 27: stirrup.harness.v1.GitStrategyConfig
+	(*TraceEmitterConfig)(nil),     // 28: stirrup.harness.v1.TraceEmitterConfig
+	(*ToolsConfig)(nil),            // 29: stirrup.harness.v1.ToolsConfig
+	(*MCPServerConfig)(nil),        // 30: stirrup.harness.v1.MCPServerConfig
+	nil,                            // 31: stirrup.harness.v1.RunConfig.DynamicContextEntry
+	nil,                            // 32: stirrup.harness.v1.RunConfig.ProvidersEntry
+	nil,                            // 33: stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
+	nil,                            // 34: stirrup.harness.v1.ProviderConfig.QueryParamsEntry
+	nil,                            // 35: stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
+	nil,                            // 36: stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
 }
 var file_harness_v1_harness_proto_depIdxs = []int32{
 	10, // 0: stirrup.harness.v1.HarnessEvent.trace:type_name -> stirrup.harness.v1.RunTrace
 	3,  // 1: stirrup.harness.v1.ControlEvent.task:type_name -> stirrup.harness.v1.RunConfig
 	2,  // 2: stirrup.harness.v1.ControlEvent.allowed:type_name -> stirrup.harness.v1.OptionalBool
 	2,  // 3: stirrup.harness.v1.ControlEvent.is_error:type_name -> stirrup.harness.v1.OptionalBool
-	30, // 4: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
+	31, // 4: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
 	11, // 5: stirrup.harness.v1.RunConfig.provider:type_name -> stirrup.harness.v1.ProviderConfig
-	31, // 6: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
-	16, // 7: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
-	17, // 8: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
-	18, // 9: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
-	19, // 10: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
-	23, // 11: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
-	24, // 12: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
-	25, // 13: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
-	26, // 14: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
-	27, // 15: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
-	28, // 16: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
+	32, // 6: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
+	17, // 7: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
+	18, // 8: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
+	19, // 9: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
+	20, // 10: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
+	24, // 11: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
+	25, // 12: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
+	26, // 13: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
+	27, // 14: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
+	28, // 15: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
+	29, // 16: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
 	6,  // 17: stirrup.harness.v1.RunConfig.rule_of_two:type_name -> stirrup.harness.v1.RuleOfTwoConfig
 	7,  // 18: stirrup.harness.v1.RunConfig.code_scanner:type_name -> stirrup.harness.v1.CodeScannerConfig
 	8,  // 19: stirrup.harness.v1.RunConfig.guard_rail:type_name -> stirrup.harness.v1.GuardRailConfig
 	9,  // 20: stirrup.harness.v1.RunConfig.observability:type_name -> stirrup.harness.v1.ObservabilityConfig
 	5,  // 21: stirrup.harness.v1.RunConfig.tool_dispatch:type_name -> stirrup.harness.v1.ToolDispatchConfig
 	8,  // 22: stirrup.harness.v1.GuardRailConfig.stages:type_name -> stirrup.harness.v1.GuardRailConfig
-	32, // 23: stirrup.harness.v1.GuardRailConfig.custom_criteria:type_name -> stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
-	12, // 24: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
-	33, // 25: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
-	14, // 26: stirrup.harness.v1.ProviderConfig.gemini_safety_settings:type_name -> stirrup.harness.v1.GeminiSafetySetting
-	15, // 27: stirrup.harness.v1.ProviderConfig.retry:type_name -> stirrup.harness.v1.ProviderRetryConfig
-	13, // 28: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
-	34, // 29: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
-	20, // 30: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
-	21, // 31: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
-	22, // 32: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
-	24, // 33: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
-	35, // 34: stirrup.harness.v1.TraceEmitterConfig.headers:type_name -> stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
-	29, // 35: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
-	4,  // 36: stirrup.harness.v1.RunConfig.DynamicContextEntry.value:type_name -> stirrup.harness.v1.DynamicContextValue
-	11, // 37: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
-	0,  // 38: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
-	1,  // 39: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
-	39, // [39:40] is the sub-list for method output_type
-	38, // [38:39] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	33, // 23: stirrup.harness.v1.GuardRailConfig.custom_criteria:type_name -> stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
+	13, // 24: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
+	34, // 25: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
+	15, // 26: stirrup.harness.v1.ProviderConfig.gemini_safety_settings:type_name -> stirrup.harness.v1.GeminiSafetySetting
+	16, // 27: stirrup.harness.v1.ProviderConfig.retry:type_name -> stirrup.harness.v1.ProviderRetryConfig
+	12, // 28: stirrup.harness.v1.ProviderConfig.batch:type_name -> stirrup.harness.v1.BatchProviderConfig
+	14, // 29: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
+	35, // 30: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
+	21, // 31: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
+	22, // 32: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
+	23, // 33: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
+	25, // 34: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
+	36, // 35: stirrup.harness.v1.TraceEmitterConfig.headers:type_name -> stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
+	30, // 36: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
+	4,  // 37: stirrup.harness.v1.RunConfig.DynamicContextEntry.value:type_name -> stirrup.harness.v1.DynamicContextValue
+	11, // 38: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
+	0,  // 39: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
+	1,  // 40: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
+	40, // [40:41] is the sub-list for method output_type
+	39, // [39:40] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_harness_v1_harness_proto_init() }
@@ -3748,14 +3879,15 @@ func file_harness_v1_harness_proto_init() {
 	file_harness_v1_harness_proto_msgTypes[6].OneofWrappers = []any{}
 	file_harness_v1_harness_proto_msgTypes[8].OneofWrappers = []any{}
 	file_harness_v1_harness_proto_msgTypes[11].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[23].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[12].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[24].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_harness_v1_harness_proto_rawDesc), len(file_harness_v1_harness_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   36,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -310,6 +310,31 @@ func providerConfigFromProto(pc *pb.ProviderConfig) types.ProviderConfig {
 			WallClockBudgetMs: int(pc.Retry.GetWallClockBudgetMs()),
 		}
 	}
+	if pc.Batch != nil {
+		// Nil-guarded for the same reason as Retry above: a wire-absent
+		// batch block must produce a nil types.BatchProviderConfig so
+		// ValidateRunConfig's per-mode invariants stay quiet and the
+		// run executes as a streaming turn. Allocating a zero value
+		// here would also collapse the "operator did not configure"
+		// vs. "explicit Enabled=false" distinction the phase-2 adapter
+		// wiring (#135) depends on. MaxWaitSeconds is wire-`optional`
+		// so the int32 pointer is unset when absent; preserve the
+		// nil/non-nil distinction in the *int translation so the
+		// validator's default-apply path still owns "filled by harness"
+		// vs. "explicit value".
+		batch := &types.BatchProviderConfig{
+			Enabled:                 pc.Batch.GetEnabled(),
+			HarnessSidePolling:      pc.Batch.GetHarnessSidePolling(),
+			FallbackOnTimeout:       pc.Batch.GetFallbackOnTimeout(),
+			CancelBundleOnRunCancel: pc.Batch.GetCancelBundleOnRunCancel(),
+			AllowInteractiveModes:   pc.Batch.GetAllowInteractiveModes(),
+		}
+		if pc.Batch.MaxWaitSeconds != nil {
+			v := int(*pc.Batch.MaxWaitSeconds)
+			batch.MaxWaitSeconds = &v
+		}
+		cfg.Batch = batch
+	}
 	return cfg
 }
 

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -647,3 +647,113 @@ func TestRunConfigFromProto_ToolDispatchMaxParallelPreserved(t *testing.T) {
 		t.Errorf("ToolDispatch.MaxParallel: got %d, want 8", rc.ToolDispatch.MaxParallel)
 	}
 }
+
+// TestRunConfigFromProto_BatchProviderConfigPreserved pins the phase-1
+// review fix for the silent K8s-job batch drop: the proto's
+// ProviderConfig.batch (field 14) must round-trip into the internal
+// types.ProviderConfig.Batch with every field preserved and the
+// nil/non-nil distinction on MaxWaitSeconds intact. Without the
+// translation block any TaskAssignment with batch.enabled=true was
+// silently degraded to a streaming run with no log entry — the same
+// failure mode that caused gh-95, gh-117, gh-118, and gh-100.
+func TestRunConfigFromProto_BatchProviderConfigPreserved(t *testing.T) {
+	t.Run("non-nil batch round-trips all six fields", func(t *testing.T) {
+		var maxWait int32 = 3600
+		// Use protobuf marshal/unmarshal so we exercise the actual wire
+		// format and not just an in-memory pointer copy. The phase-1
+		// reviewer specifically called out that the gap is on the gRPC
+		// path, so the test should cover Marshal -> Unmarshal as well as
+		// the Go-side translate call.
+		original := &pb.RunConfig{
+			Provider: &pb.ProviderConfig{
+				Type: "anthropic",
+				Batch: &pb.BatchProviderConfig{
+					Enabled:                 true,
+					MaxWaitSeconds:          &maxWait,
+					HarnessSidePolling:      true,
+					FallbackOnTimeout:       true,
+					CancelBundleOnRunCancel: true,
+					AllowInteractiveModes:   true,
+				},
+			},
+		}
+
+		bytes, err := proto.Marshal(original)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded pb.RunConfig
+		if err := proto.Unmarshal(bytes, &decoded); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		rc := runConfigFromProto(&decoded)
+
+		if rc.Provider.Batch == nil {
+			t.Fatal("Batch dropped during proto translation")
+		}
+		if !rc.Provider.Batch.Enabled {
+			t.Errorf("Batch.Enabled: got false, want true")
+		}
+		if rc.Provider.Batch.MaxWaitSeconds == nil {
+			t.Fatal("Batch.MaxWaitSeconds: got nil, want non-nil pointer")
+		}
+		if got := *rc.Provider.Batch.MaxWaitSeconds; got != 3600 {
+			t.Errorf("Batch.MaxWaitSeconds: got %d, want 3600", got)
+		}
+		if !rc.Provider.Batch.HarnessSidePolling {
+			t.Errorf("Batch.HarnessSidePolling: got false, want true")
+		}
+		if !rc.Provider.Batch.FallbackOnTimeout {
+			t.Errorf("Batch.FallbackOnTimeout: got false, want true")
+		}
+		if !rc.Provider.Batch.CancelBundleOnRunCancel {
+			t.Errorf("Batch.CancelBundleOnRunCancel: got false, want true")
+		}
+		if !rc.Provider.Batch.AllowInteractiveModes {
+			t.Errorf("Batch.AllowInteractiveModes: got false, want true")
+		}
+	})
+
+	t.Run("nil batch stays nil on the Go side", func(t *testing.T) {
+		pc := &pb.RunConfig{
+			Provider: &pb.ProviderConfig{Type: "anthropic"},
+		}
+
+		rc := runConfigFromProto(pc)
+
+		if rc.Provider.Batch != nil {
+			t.Fatalf("expected nil Batch when proto omits the field, got %+v", rc.Provider.Batch)
+		}
+	})
+
+	t.Run("batch present with MaxWaitSeconds unset preserves nil", func(t *testing.T) {
+		// The wire's `optional int32` distinguishes unset from explicit
+		// zero. ValidateRunConfig depends on the nil to apply the
+		// default; an always-allocated *int would erase that and pin
+		// MaxWaitSeconds at 0, which the validator then rejects as
+		// "must be in range (0, 86400]".
+		original := &pb.RunConfig{
+			Provider: &pb.ProviderConfig{
+				Type:  "anthropic",
+				Batch: &pb.BatchProviderConfig{Enabled: true},
+			},
+		}
+		bytes, err := proto.Marshal(original)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded pb.RunConfig
+		if err := proto.Unmarshal(bytes, &decoded); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		rc := runConfigFromProto(&decoded)
+		if rc.Provider.Batch == nil {
+			t.Fatal("expected non-nil Batch when proto sub-message is present")
+		}
+		if rc.Provider.Batch.MaxWaitSeconds != nil {
+			t.Errorf("MaxWaitSeconds should be nil when proto field is unset; got %v", *rc.Provider.Batch.MaxWaitSeconds)
+		}
+	})
+}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -689,6 +689,50 @@ message ProviderConfig {
   // downstream consumers always see a populated value). Adapters that
   // honour this knob currently include the openai-compatible adapter.
   optional ProviderRetryConfig retry = 13;
+
+  // Optional. Opts the run into async batch submission for every
+  // provider turn (anthropic, openai-compatible, openai-responses only).
+  // Only the top-level RunConfig.provider entry is consulted in v1;
+  // entries in RunConfig.providers map are streaming-only and any batch
+  // field on them is rejected by ValidateRunConfig. See
+  // BatchProviderConfig for the mode / transport cross-field invariants.
+  // Next available field number: 15.
+  BatchProviderConfig batch = 14;
+}
+
+// BatchProviderConfig controls async batch submission for a provider
+// turn. Mirrors types.BatchProviderConfig field-for-field. Only Anthropic
+// and OpenAI providers support batch in v1; ValidateRunConfig rejects
+// enabled=true with an unsupported provider type.
+message BatchProviderConfig {
+  // Opts this run into async batch submission for every provider turn.
+  bool enabled = 1;
+
+  // Harness-side wall-clock cap on the batch wait, in seconds. Declared
+  // `optional` so an unset value is wire-distinguishable from explicit
+  // zero: ValidateRunConfig fills the default (86400) only when nil and
+  // enabled=true, so a phase-2 adapter can still tell "operator did not
+  // configure this" from "default applied". Must be in (0, 86400] when
+  // set.
+  optional int32 max_wait_seconds = 2;
+
+  // Enables direct HTTP polling from the harness process. Required when
+  // transport.type == "stdio"; rejected with transport.type == "grpc".
+  bool harness_side_polling = 3;
+
+  // Switches to the streaming adapter for a turn when the harness-side
+  // max_wait_seconds fires. Defaults to false.
+  bool fallback_on_timeout = 4;
+
+  // When a single run is cancelled, cancel the entire bundled provider
+  // batch (gRPC transport only). Defaults to false. Rejected with
+  // transport.type == "stdio".
+  bool cancel_bundle_on_run_cancel = 5;
+
+  // Permits batch.enabled with mode == "planning" or mode == "review".
+  // Has no effect on mode == "execution" (always rejected) or on other
+  // read-only modes ("research", "toil") which accept batch without it.
+  bool allow_interactive_modes = 6;
 }
 
 // CredentialConfig selects the credential acquisition method for a provider.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -401,6 +401,17 @@ func (rc RunConfig) Redact() RunConfig {
 		retry := *redacted.Provider.Retry
 		redacted.Provider.Retry = &retry
 	}
+	// Mirror the Retry deep-copy for Provider.Batch. The aliasing risk
+	// is concrete: validateBatchConfig mutates Batch.MaxWaitSeconds in
+	// place to apply the default, and the phase-2 BatchAdapter (#135)
+	// is expected to hold a reference to the Redact()-derived snapshot
+	// across the run. Without the deep copy, a later default-apply
+	// write would reach the redacted copy through the shared pointer
+	// and break the snapshot contract.
+	if redacted.Provider.Batch != nil {
+		batch := *redacted.Provider.Batch
+		redacted.Provider.Batch = &batch
+	}
 	if len(redacted.Providers) > 0 {
 		providers := make(map[string]ProviderConfig, len(redacted.Providers))
 		for name, provider := range redacted.Providers {
@@ -410,6 +421,10 @@ func (rc RunConfig) Redact() RunConfig {
 			if provider.Retry != nil {
 				retry := *provider.Retry
 				provider.Retry = &retry
+			}
+			if provider.Batch != nil {
+				batch := *provider.Batch
+				provider.Batch = &batch
 			}
 			providers[name] = provider
 		}
@@ -1472,6 +1487,13 @@ type ModePreset struct {
 // happen anyway). Also applies ProviderRetryConfig defaults to
 // Provider.Retry and each entry in Providers so adapters never have
 // to nil-check the per-call retry policy.
+//
+// Note: ValidateRunConfig mutates its argument in place to apply
+// per-provider defaults (Provider.Retry fields, Provider.Batch.MaxWaitSeconds
+// when Batch.Enabled=true, CodeScanner type). Callers that need an
+// unmodified copy must clone before calling. Redact() deep-copies the
+// affected pointer fields so a snapshot taken before validation does
+// not alias the live config.
 func ValidateRunConfig(config *RunConfig) error {
 	applyCodeScannerDefault(config)
 	retryDefaulted := applyProviderRetryDefaults(config)
@@ -1996,11 +2018,14 @@ func fmtProviderRetryValue(value int, isDefault bool) string {
 // validateBatchConfig enforces the cross-field invariants on
 // ProviderConfig.Batch and applies the MaxWaitSeconds default. Batch
 // only applies to the top-level Provider in v1; entries in
-// Providers[] are streaming-only and any Batch field on them is
-// ignored. The validator mutates *config when Batch.Enabled and
-// MaxWaitSeconds is unset — downstream consumers should always see
-// a populated value so the adapter wiring (phase 2) can avoid
-// nil-checking on the hot path.
+// Providers[] are streaming-only and validateProviderConfigs rejects
+// any non-nil Batch on a map entry. The validator mutates *config when
+// Batch.Enabled and MaxWaitSeconds is unset — downstream consumers
+// should always see a populated value so the adapter wiring (phase 2)
+// can avoid nil-checking on the hot path. The MaxWaitSeconds default
+// is intentionally withheld when Enabled=false: phase-2 callers rely
+// on nil to distinguish "operator did not configure this field" from
+// "default applied", and the field is meaningless when batch is off.
 func validateBatchConfig(config *RunConfig, errs *[]string) {
 	batch := config.Provider.Batch
 	if batch == nil {
@@ -2021,7 +2046,13 @@ func validateBatchConfig(config *RunConfig, errs *[]string) {
 		return
 	}
 
-	if !validBatchProviderTypes[config.Provider.Type] {
+	// Skip the batch provider-type check when the underlying provider
+	// type is itself invalid: validateRequiredType has already
+	// appended a "provider type is required" / "unsupported provider
+	// type" error, and the secondary message ("batch is not supported
+	// for provider type \"\"") would just mislead the operator about
+	// the root cause.
+	if validProviderTypes[config.Provider.Type] && !validBatchProviderTypes[config.Provider.Type] {
 		*errs = append(*errs, fmt.Sprintf("batch is not supported for provider type %q in v1", config.Provider.Type))
 	}
 	switch config.Mode {
@@ -2041,15 +2072,26 @@ func validateBatchConfig(config *RunConfig, errs *[]string) {
 		}
 	} else {
 		// Default applied in-place so phase-2 adapter wiring can rely
-		// on a populated value without re-reading the default.
+		// on a populated value without re-reading the default. Only
+		// runs on the Enabled=true branch (see comment above the func)
+		// so a disabled batch block keeps MaxWaitSeconds nil and the
+		// "operator did not configure" signal survives.
 		def := DefaultBatchMaxWaitSeconds
 		batch.MaxWaitSeconds = &def
 	}
 	if config.MaxTurns > batchTurnsLatencyWarnThreshold {
+		// Layering note: this warn is in types/ for spec-faithfulness
+		// (gh-134 requires the same mechanism as rule_of_two_warning).
+		// Follow-up: move to harness/internal/core/factory.go via a
+		// ValidateRunConfigResult or companion ValidateRunConfigWarnings
+		// function so callers (tests, eval runner, library embedders)
+		// stop having to manipulate slog.Default to observe or suppress
+		// the warning.
 		slog.Warn(
-			fmt.Sprintf("batch.enabled with maxTurns>%d may incur up to %dh wall-clock latency",
-				batchTurnsLatencyWarnThreshold, config.MaxTurns*24),
+			"batch with maxTurns above the latency-warning threshold may incur extended wall-clock latency",
 			"maxTurns", config.MaxTurns,
+			"thresholdTurns", batchTurnsLatencyWarnThreshold,
+			"estimatedMaxHours", config.MaxTurns*24,
 		)
 	}
 }
@@ -2082,6 +2124,19 @@ func validateProviderConfigs(config *RunConfig, retryDefaulted map[string]provid
 		validateAzureWIFCrossField(path, provider, errs)
 		retryPath := fmt.Sprintf("%s.retry", path)
 		validateProviderRetryConfig(retryPath, provider.Retry, retryDefaulted[retryPath], errs)
+		// Batch is a top-level-only concept in v1: the spec wires
+		// per-turn batching against RunConfig.Provider, and a Batch
+		// block on a named entry would silently parse, store, and have
+		// no behavioural effect. Reject any non-nil Batch (not just
+		// Enabled=true) so a partially-filled block ("operator added
+		// the key but left enabled=false") also fails loudly — the
+		// foot-gun is real and the strict error is cheap.
+		if provider.Batch != nil {
+			*errs = append(*errs, fmt.Sprintf(
+				"providers[%s].batch is not supported in v1; batch applies only to the top-level provider",
+				name,
+			))
+		}
 	}
 
 	// Per-provider model-name validation for Vertex AI Gemini. The

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"log/slog"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -58,6 +59,19 @@ const (
 	// provider/transport beyond what the rest of the harness is sized
 	// for.
 	MaxToolDispatchMaxParallel = 16
+
+	// DefaultBatchMaxWaitSeconds is the harness-side default wall-clock
+	// cap on a batch wait (24 h), matching the Anthropic and OpenAI
+	// provider-side SLA for batch completion. Applied by ValidateRunConfig
+	// when Batch.Enabled and Batch.MaxWaitSeconds == nil.
+	DefaultBatchMaxWaitSeconds = 86400
+
+	// batchTurnsLatencyWarnThreshold is the maxTurns ceiling above which
+	// ValidateRunConfig emits a slog WARN: each turn can take up to 24 h
+	// of wall-clock waiting on the provider, so a run with many turns can
+	// spend weeks in flight. The threshold is the operator's reasonable
+	// upper bound before the latency exposure deserves a heads-up.
+	batchTurnsLatencyWarnThreshold = 5
 )
 
 // RunConfig fully describes a single harness run. It is the composition root:
@@ -512,6 +526,43 @@ type ProviderConfig struct {
 	// ValidateRunConfig so downstream consumers always see a populated
 	// value.
 	Retry *ProviderRetryConfig `json:"retry,omitempty"`
+
+	// Batch enables async batch submission for every provider turn in this
+	// run. Only the top-level RunConfig.Provider entry is consulted in v1;
+	// entries in RunConfig.Providers are streaming-only. See
+	// BatchProviderConfig for the supported provider types and the
+	// transport / mode cross-field invariants enforced by ValidateRunConfig.
+	Batch *BatchProviderConfig `json:"batch,omitempty"`
+}
+
+// BatchProviderConfig controls async batch submission for a provider turn.
+// Only Anthropic and OpenAI providers support batch in v1. Setting Enabled=true
+// with an unsupported provider type is a validation error.
+type BatchProviderConfig struct {
+	// Enabled opts this run into async batch submission for every provider turn.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxWaitSeconds is the harness-side wall-clock cap on the batch wait,
+	// in seconds. Defaults to 86400 (24 h, matching the provider SLA) when
+	// nil and Enabled=true. Must be in the range (0, 86400].
+	MaxWaitSeconds *int `json:"maxWaitSeconds,omitempty"`
+
+	// HarnessSidePolling enables direct HTTP polling from the harness
+	// process (required when transport.type == "stdio"). Mutually exclusive
+	// with transport.type == "grpc".
+	HarnessSidePolling bool `json:"harnessSidePolling,omitempty"`
+
+	// FallbackOnTimeout switches to the streaming adapter for a turn when
+	// the harness-side MaxWaitSeconds fires. Defaults to false.
+	FallbackOnTimeout bool `json:"fallbackOnTimeout,omitempty"`
+
+	// CancelBundleOnRunCancel causes a single run's cancel to cancel the
+	// entire bundled provider batch (gRPC transport only). Defaults to false.
+	CancelBundleOnRunCancel bool `json:"cancelBundleOnRunCancel,omitempty"`
+
+	// AllowInteractiveModes permits batch.enabled with mode == "planning" or
+	// mode == "review". Has no effect on mode == "execution" (always rejected).
+	AllowInteractiveModes bool `json:"allowInteractiveModes,omitempty"`
 }
 
 // ProviderRetryConfig bounds the retry behaviour an adapter applies to a
@@ -912,6 +963,18 @@ var validProviderTypes = map[string]bool{
 	"openai-compatible": true,
 	"openai-responses":  true,
 	"gemini":            true,
+}
+
+// validBatchProviderTypes is the closed set of provider types whose adapters
+// implement the async batch submission path in v1. Anthropic via the
+// /v1/messages/batches endpoint; OpenAI Chat Completions and Responses via
+// /v1/batches. Bedrock and Gemini are out of scope for v1 (Bedrock batch is
+// S3-mediated and reuses none of the streaming adapter shape; Vertex AI has
+// no equivalent endpoint).
+var validBatchProviderTypes = map[string]bool{
+	"anthropic":         true,
+	"openai-compatible": true,
+	"openai-responses":  true,
 }
 
 // gcpProjectIDPattern matches the GCP project ID rules: starts with a
@@ -1511,6 +1574,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateGuardRailConfig(config.GuardRail, "guardRail", false, &errs)
 	validateObservabilityConfig(config.Observability, &errs)
 	validateToolDispatchConfig(config.ToolDispatch, &errs)
+	validateBatchConfig(config, &errs)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("RunConfig validation failed: %s", strings.Join(errs, "; "))
@@ -1927,6 +1991,67 @@ func fmtProviderRetryValue(value int, isDefault bool) string {
 		return fmt.Sprintf("%d, default", value)
 	}
 	return fmt.Sprintf("%d", value)
+}
+
+// validateBatchConfig enforces the cross-field invariants on
+// ProviderConfig.Batch and applies the MaxWaitSeconds default. Batch
+// only applies to the top-level Provider in v1; entries in
+// Providers[] are streaming-only and any Batch field on them is
+// ignored. The validator mutates *config when Batch.Enabled and
+// MaxWaitSeconds is unset — downstream consumers should always see
+// a populated value so the adapter wiring (phase 2) can avoid
+// nil-checking on the hot path.
+func validateBatchConfig(config *RunConfig, errs *[]string) {
+	batch := config.Provider.Batch
+	if batch == nil {
+		return
+	}
+
+	// HarnessSidePolling and CancelBundleOnRunCancel constrain the
+	// transport regardless of Enabled, so a future-disabled config does
+	// not silently retain a contradictory flag combination.
+	if batch.HarnessSidePolling && config.Transport.Type == "grpc" {
+		*errs = append(*errs, "batch.harnessSidePolling must not be set with transport=grpc")
+	}
+	if batch.CancelBundleOnRunCancel && config.Transport.Type == "stdio" {
+		*errs = append(*errs, "batch.cancelBundleOnRunCancel requires transport=grpc")
+	}
+
+	if !batch.Enabled {
+		return
+	}
+
+	if !validBatchProviderTypes[config.Provider.Type] {
+		*errs = append(*errs, fmt.Sprintf("batch is not supported for provider type %q in v1", config.Provider.Type))
+	}
+	switch config.Mode {
+	case "execution":
+		*errs = append(*errs, "batch cannot be used with mode=execution")
+	case "planning", "review":
+		if !batch.AllowInteractiveModes {
+			*errs = append(*errs, fmt.Sprintf("batch requires allowInteractiveModes=true for mode=%s", config.Mode))
+		}
+	}
+	if config.Transport.Type == "stdio" && !batch.HarnessSidePolling {
+		*errs = append(*errs, "batch with transport=stdio requires harnessSidePolling=true")
+	}
+	if batch.MaxWaitSeconds != nil {
+		if *batch.MaxWaitSeconds <= 0 || *batch.MaxWaitSeconds > DefaultBatchMaxWaitSeconds {
+			*errs = append(*errs, "batch.maxWaitSeconds must be in range (0, 86400]")
+		}
+	} else {
+		// Default applied in-place so phase-2 adapter wiring can rely
+		// on a populated value without re-reading the default.
+		def := DefaultBatchMaxWaitSeconds
+		batch.MaxWaitSeconds = &def
+	}
+	if config.MaxTurns > batchTurnsLatencyWarnThreshold {
+		slog.Warn(
+			fmt.Sprintf("batch.enabled with maxTurns>%d may incur up to %dh wall-clock latency",
+				batchTurnsLatencyWarnThreshold, config.MaxTurns*24),
+			"maxTurns", config.MaxTurns,
+		)
+	}
 }
 
 func validateProviderConfigs(config *RunConfig, retryDefaulted map[string]providerRetryDefaulted, errs *[]string) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -4547,5 +4549,319 @@ func TestValidateRunConfig_ToolDispatchRejectsOutOfRange(t *testing.T) {
 				t.Errorf("expected error to call out the accepted zero sentinel '0 (use default)', got: %v", err)
 			}
 		})
+	}
+}
+
+// --- BatchProviderConfig ---
+
+// batchValidConfig is the baseline for the batch suite: a non-execution
+// mode that accepts batch (research) with stdio transport plus the
+// harness-side polling flag set, no DynamicContext (so the Rule of Two
+// stays satisfied), and a read-only tool list. Each sub-test mutates a
+// single field to exercise one invariant in isolation.
+func batchValidConfig() *RunConfig {
+	timeout := 60
+	return &RunConfig{
+		Mode:             "research",
+		Provider:         ProviderConfig{Type: "anthropic"},
+		MaxTurns:         3,
+		Timeout:          &timeout,
+		PermissionPolicy: PermissionPolicyConfig{Type: "deny-side-effects"},
+		Transport:        TransportConfig{Type: "stdio"},
+		Tools:            ToolsConfig{BuiltIn: []string{"read_file"}},
+	}
+}
+
+func TestValidateRunConfig_Batch_NilLeavesConfigUntouched(t *testing.T) {
+	c := batchValidConfig()
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("baseline batch config must validate, got: %v", err)
+	}
+	if c.Provider.Batch != nil {
+		t.Errorf("nil Batch must not be materialised by validation, got %+v", c.Provider.Batch)
+	}
+}
+
+func TestValidateRunConfig_Batch_UnsupportedProviderType(t *testing.T) {
+	for _, tc := range []struct {
+		providerType string
+		wantErr      bool
+	}{
+		{"anthropic", false},
+		{"openai-compatible", false},
+		{"openai-responses", false},
+		{"bedrock", true},
+		{"gemini", true},
+	} {
+		t.Run(tc.providerType, func(t *testing.T) {
+			c := batchValidConfig()
+			c.Provider.Type = tc.providerType
+			// Bedrock and gemini need extra fields to clear unrelated
+			// validation; supply just enough to isolate the batch check.
+			if tc.providerType == "bedrock" {
+				c.Provider.Region = "us-east-1"
+				c.Provider.Credential = &CredentialConfig{Type: "aws-default"}
+			}
+			if tc.providerType == "gemini" {
+				c.Provider.GCPProject = "example-project"
+				c.Provider.GCPLocation = "global"
+				c.Provider.Credential = &CredentialConfig{Type: "gcp-default"}
+			}
+			c.Provider.Batch = &BatchProviderConfig{Enabled: true, HarnessSidePolling: true}
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for batch with provider type %q", tc.providerType)
+				}
+				if !strings.Contains(err.Error(), "batch is not supported for provider type") {
+					t.Errorf("error should mention unsupported batch provider type, got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("provider %q must accept batch, got: %v", tc.providerType, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_Batch_RejectsExecutionMode(t *testing.T) {
+	c := batchValidConfig()
+	c.Mode = "execution"
+	c.PermissionPolicy = PermissionPolicyConfig{Type: "allow-all"}
+	c.Provider.Batch = &BatchProviderConfig{
+		Enabled:               true,
+		HarnessSidePolling:    true,
+		AllowInteractiveModes: true, // must not bypass the execution check
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for batch with mode=execution")
+	}
+	if !strings.Contains(err.Error(), "batch cannot be used with mode=execution") {
+		t.Errorf("error should mention mode=execution rejection, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Batch_InteractiveModesRequireOptIn(t *testing.T) {
+	for _, mode := range []string{"planning", "review"} {
+		t.Run(mode+"_without_opt_in", func(t *testing.T) {
+			c := batchValidConfig()
+			c.Mode = mode
+			c.Provider.Batch = &BatchProviderConfig{Enabled: true, HarnessSidePolling: true}
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("expected error for batch in mode=%s without allowInteractiveModes", mode)
+			}
+			want := fmt.Sprintf("batch requires allowInteractiveModes=true for mode=%s", mode)
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should mention %q, got: %v", want, err)
+			}
+		})
+		t.Run(mode+"_with_opt_in_passes", func(t *testing.T) {
+			c := batchValidConfig()
+			c.Mode = mode
+			c.Provider.Batch = &BatchProviderConfig{
+				Enabled:               true,
+				HarnessSidePolling:    true,
+				AllowInteractiveModes: true,
+			}
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("batch with allowInteractiveModes=true must accept mode=%s, got: %v", mode, err)
+			}
+		})
+	}
+	t.Run("research_does_not_require_opt_in", func(t *testing.T) {
+		// Sanity check: the opt-in only gates "planning" and "review".
+		// Other read-only modes ("research", "toil") accept batch without it.
+		c := batchValidConfig()
+		c.Mode = "research"
+		c.Provider.Batch = &BatchProviderConfig{Enabled: true, HarnessSidePolling: true}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("mode=research must accept batch without allowInteractiveModes, got: %v", err)
+		}
+	})
+}
+
+func TestValidateRunConfig_Batch_StdioRequiresHarnessSidePolling(t *testing.T) {
+	c := batchValidConfig()
+	c.Transport = TransportConfig{Type: "stdio"}
+	c.Provider.Batch = &BatchProviderConfig{Enabled: true, HarnessSidePolling: false}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for batch with transport=stdio and HarnessSidePolling=false")
+	}
+	if !strings.Contains(err.Error(), "batch with transport=stdio requires harnessSidePolling=true") {
+		t.Errorf("error should mention stdio + harnessSidePolling, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Batch_HarnessSidePollingRejectedWithGRPC(t *testing.T) {
+	c := batchValidConfig()
+	c.Transport = TransportConfig{Type: "grpc"}
+	// HarnessSidePolling is rejected with grpc transport even when
+	// Batch.Enabled is false — a stale flag combination must not be
+	// silently retained.
+	c.Provider.Batch = &BatchProviderConfig{Enabled: false, HarnessSidePolling: true}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for batch.harnessSidePolling with transport=grpc")
+	}
+	if !strings.Contains(err.Error(), "batch.harnessSidePolling must not be set with transport=grpc") {
+		t.Errorf("error should mention harnessSidePolling + grpc, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Batch_CancelBundleRejectedWithStdio(t *testing.T) {
+	c := batchValidConfig()
+	c.Transport = TransportConfig{Type: "stdio"}
+	// As with HarnessSidePolling, CancelBundleOnRunCancel is rejected
+	// even when Batch.Enabled is false.
+	c.Provider.Batch = &BatchProviderConfig{Enabled: false, CancelBundleOnRunCancel: true}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for batch.cancelBundleOnRunCancel with transport=stdio")
+	}
+	if !strings.Contains(err.Error(), "batch.cancelBundleOnRunCancel requires transport=grpc") {
+		t.Errorf("error should mention cancelBundleOnRunCancel + grpc, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Batch_MaxWaitSecondsRange(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		seconds int
+		wantErr bool
+	}{
+		{"one_passes", 1, false},
+		{"max_passes", 86400, false},
+		{"zero_fails", 0, true},
+		{"over_max_fails", 86401, true},
+		{"negative_fails", -1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := batchValidConfig()
+			seconds := tc.seconds
+			c.Provider.Batch = &BatchProviderConfig{
+				Enabled:            true,
+				HarnessSidePolling: true,
+				MaxWaitSeconds:     &seconds,
+			}
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for maxWaitSeconds=%d", tc.seconds)
+				}
+				if !strings.Contains(err.Error(), "batch.maxWaitSeconds must be in range (0, 86400]") {
+					t.Errorf("error should mention maxWaitSeconds range, got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("maxWaitSeconds=%d should validate, got: %v", tc.seconds, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_Batch_MaxWaitSecondsNilApplyDefault(t *testing.T) {
+	c := batchValidConfig()
+	c.Provider.Batch = &BatchProviderConfig{
+		Enabled:            true,
+		HarnessSidePolling: true,
+		// MaxWaitSeconds intentionally nil.
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("batch default-apply path must validate, got: %v", err)
+	}
+	if c.Provider.Batch.MaxWaitSeconds == nil {
+		t.Fatal("ValidateRunConfig should populate Batch.MaxWaitSeconds when nil and Enabled")
+	}
+	if got := *c.Provider.Batch.MaxWaitSeconds; got != DefaultBatchMaxWaitSeconds {
+		t.Errorf("default MaxWaitSeconds = %d, want %d", got, DefaultBatchMaxWaitSeconds)
+	}
+}
+
+func TestValidateRunConfig_Batch_MaxWaitSecondsNotDefaultedWhenDisabled(t *testing.T) {
+	// The default applies only to Enabled=true configs; a disabled batch
+	// block keeps MaxWaitSeconds nil so a phase-2 consumer can still
+	// distinguish "operator did not set this" from "default applied".
+	c := batchValidConfig()
+	c.Provider.Batch = &BatchProviderConfig{Enabled: false}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("disabled batch must validate, got: %v", err)
+	}
+	if c.Provider.Batch.MaxWaitSeconds != nil {
+		t.Errorf("MaxWaitSeconds must not be populated when Enabled=false, got %v", *c.Provider.Batch.MaxWaitSeconds)
+	}
+}
+
+func TestValidateRunConfig_Batch_MaxTurnsLatencyWarning(t *testing.T) {
+	// Route slog through a buffer so we can assert the WARN line emitted
+	// by validateBatchConfig appears for maxTurns above the threshold
+	// and is absent at or below it. Pattern mirrors otel_http_test.go.
+	for _, tc := range []struct {
+		name      string
+		maxTurns  int
+		wantWarn  bool
+		wantTurns int // for substring assertion when wantWarn
+	}{
+		{"at_threshold_no_warn", 5, false, 0},
+		{"above_threshold_warns", 6, true, 6},
+		{"well_above_threshold_warns", 50, true, 50},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			originalLogger := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(originalLogger) })
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+			c := batchValidConfig()
+			c.MaxTurns = tc.maxTurns
+			c.Provider.Batch = &BatchProviderConfig{Enabled: true, HarnessSidePolling: true}
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("batch warning path must not produce a hard error, got: %v", err)
+			}
+
+			logs := logBuf.String()
+			if tc.wantWarn {
+				if !strings.Contains(logs, "level=WARN") {
+					t.Errorf("expected slog WARN, got: %s", logs)
+				}
+				if !strings.Contains(logs, "batch.enabled with maxTurns>5") {
+					t.Errorf("expected batch.enabled warning text, got: %s", logs)
+				}
+				wantHours := fmt.Sprintf("up to %dh wall-clock latency", tc.wantTurns*24)
+				if !strings.Contains(logs, wantHours) {
+					t.Errorf("expected %q in warning, got: %s", wantHours, logs)
+				}
+			} else if strings.Contains(logs, "batch.enabled with maxTurns") {
+				t.Errorf("did not expect warning at maxTurns=%d, got: %s", tc.maxTurns, logs)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_Batch_HappyPathAllFieldsSet(t *testing.T) {
+	// Exercise every BatchProviderConfig field at a non-zero value to
+	// pin that the happy-path combination validates cleanly. Uses gRPC
+	// transport so HarnessSidePolling stays false and
+	// CancelBundleOnRunCancel can be true at the same time.
+	c := batchValidConfig()
+	c.Transport = TransportConfig{Type: "grpc"}
+	maxWait := 3600
+	c.Provider.Batch = &BatchProviderConfig{
+		Enabled:                 true,
+		MaxWaitSeconds:          &maxWait,
+		HarnessSidePolling:      false,
+		FallbackOnTimeout:       true,
+		CancelBundleOnRunCancel: true,
+		AllowInteractiveModes:   true,
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("fully-populated batch config must validate, got: %v", err)
+	}
+	if got := *c.Provider.Batch.MaxWaitSeconds; got != 3600 {
+		t.Errorf("MaxWaitSeconds must not be overwritten when caller supplied a value, got %d", got)
 	}
 }

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -4800,15 +4801,22 @@ func TestValidateRunConfig_Batch_MaxTurnsLatencyWarning(t *testing.T) {
 	// Route slog through a buffer so we can assert the WARN line emitted
 	// by validateBatchConfig appears for maxTurns above the threshold
 	// and is absent at or below it. Pattern mirrors otel_http_test.go.
+	//
+	// The assertion deliberately pins the static message + structured
+	// attrs rather than substring-matching a formatted hours figure.
+	// validateBatchConfig moved to a static slog.Warn message during
+	// the phase-1 remediation so log consumers can parse the threshold
+	// and max-hours values from structured fields instead of having to
+	// re-multiply maxTurns * 24 from a free-text string.
+	const wantMsg = "batch with maxTurns above the latency-warning threshold may incur extended wall-clock latency"
 	for _, tc := range []struct {
-		name      string
-		maxTurns  int
-		wantWarn  bool
-		wantTurns int // for substring assertion when wantWarn
+		name     string
+		maxTurns int
+		wantWarn bool
 	}{
-		{"at_threshold_no_warn", 5, false, 0},
-		{"above_threshold_warns", 6, true, 6},
-		{"well_above_threshold_warns", 50, true, 50},
+		{"at_threshold_no_warn", 5, false},
+		{"above_threshold_warns", 6, true},
+		{"well_above_threshold_warns", 50, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var logBuf bytes.Buffer
@@ -4828,14 +4836,22 @@ func TestValidateRunConfig_Batch_MaxTurnsLatencyWarning(t *testing.T) {
 				if !strings.Contains(logs, "level=WARN") {
 					t.Errorf("expected slog WARN, got: %s", logs)
 				}
-				if !strings.Contains(logs, "batch.enabled with maxTurns>5") {
-					t.Errorf("expected batch.enabled warning text, got: %s", logs)
+				if !strings.Contains(logs, wantMsg) {
+					t.Errorf("expected static warning message %q, got: %s", wantMsg, logs)
 				}
-				wantHours := fmt.Sprintf("up to %dh wall-clock latency", tc.wantTurns*24)
+				wantMaxTurns := fmt.Sprintf("maxTurns=%d", tc.maxTurns)
+				if !strings.Contains(logs, wantMaxTurns) {
+					t.Errorf("expected %q attr in warning, got: %s", wantMaxTurns, logs)
+				}
+				wantThreshold := fmt.Sprintf("thresholdTurns=%d", batchTurnsLatencyWarnThreshold)
+				if !strings.Contains(logs, wantThreshold) {
+					t.Errorf("expected %q attr in warning, got: %s", wantThreshold, logs)
+				}
+				wantHours := fmt.Sprintf("estimatedMaxHours=%d", tc.maxTurns*24)
 				if !strings.Contains(logs, wantHours) {
-					t.Errorf("expected %q in warning, got: %s", wantHours, logs)
+					t.Errorf("expected %q attr in warning, got: %s", wantHours, logs)
 				}
-			} else if strings.Contains(logs, "batch.enabled with maxTurns") {
+			} else if strings.Contains(logs, wantMsg) {
 				t.Errorf("did not expect warning at maxTurns=%d, got: %s", tc.maxTurns, logs)
 			}
 		})
@@ -4863,5 +4879,237 @@ func TestValidateRunConfig_Batch_HappyPathAllFieldsSet(t *testing.T) {
 	}
 	if got := *c.Provider.Batch.MaxWaitSeconds; got != 3600 {
 		t.Errorf("MaxWaitSeconds must not be overwritten when caller supplied a value, got %d", got)
+	}
+}
+
+// TestValidateRunConfig_Batch_ProvidersMapRejected pins the phase-1
+// review fix for the silent-accept gap: ValidateRunConfig now rejects
+// any non-nil Batch on a named providers map entry. Batch is a
+// top-level-only concept in v1, but the validator previously parsed
+// the field on map entries, stored it, and silently ignored it at
+// runtime. The strict rejection (any non-nil, not just Enabled=true)
+// matches the project's "clean is preferred" pre-1.0 posture and the
+// reviewer convergence on a hard error.
+func TestValidateRunConfig_Batch_ProvidersMapRejected(t *testing.T) {
+	t.Run("enabled_batch_on_named_entry_fails", func(t *testing.T) {
+		c := batchValidConfig()
+		c.Providers = map[string]ProviderConfig{
+			"secondary": {
+				Type:  "anthropic",
+				Batch: &BatchProviderConfig{Enabled: true, HarnessSidePolling: true},
+			},
+		}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected error for providers[secondary].batch")
+		}
+		want := `providers[secondary].batch is not supported in v1; batch applies only to the top-level provider`
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention providers map rejection, got: %v", err)
+		}
+	})
+	t.Run("disabled_but_present_batch_on_named_entry_also_fails", func(t *testing.T) {
+		// The strict rule rejects any non-nil Batch (not just
+		// Enabled=true). An operator who adds a batch block with
+		// enabled=false has still tripped the foot-gun: they expect
+		// the named-entry batch knobs to mean something, and v1
+		// promises they don't.
+		c := batchValidConfig()
+		c.Providers = map[string]ProviderConfig{
+			"secondary": {
+				Type:  "anthropic",
+				Batch: &BatchProviderConfig{Enabled: false},
+			},
+		}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected error for providers[secondary].batch with Enabled=false")
+		}
+		if !strings.Contains(err.Error(), "providers[secondary].batch is not supported in v1") {
+			t.Errorf("error should mention providers map rejection, got: %v", err)
+		}
+	})
+}
+
+// TestValidateRunConfig_Batch_EmptyProviderTypeSuppressesBatchTypeError
+// pins the phase-1 fix for the spurious double-error when batch is
+// enabled but the provider type is empty. Before the fix the operator
+// got both "provider type is required" (correct) and "batch is not
+// supported for provider type \"\"" (misleading — the root cause is
+// the missing type, not batch compatibility).
+func TestValidateRunConfig_Batch_EmptyProviderTypeSuppressesBatchTypeError(t *testing.T) {
+	c := batchValidConfig()
+	c.Provider.Type = ""
+	c.Provider.Batch = &BatchProviderConfig{Enabled: true, HarnessSidePolling: true}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for empty provider type")
+	}
+	if !strings.Contains(err.Error(), "provider type is required") {
+		t.Errorf("error should mention required provider type, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "batch is not supported for provider type") {
+		t.Errorf("batch-type error should be suppressed when provider type is invalid, got: %v", err)
+	}
+}
+
+// TestBatchProviderConfig_JSONRoundTrip pins the *int with omitempty
+// invariant on BatchProviderConfig.MaxWaitSeconds. Phase-2 consumers
+// rely on the nil/non-nil distinction to tell "operator did not
+// configure this field" from "default applied" — a JSON marshal +
+// unmarshal cycle must preserve both states. The disabled-but-present
+// case (Batch != nil with Enabled=false) is the second invariant: the
+// `omitempty` is on the containing pointer field, not the inner
+// struct, so a present block must survive even when every inner field
+// is the zero value.
+func TestBatchProviderConfig_JSONRoundTrip(t *testing.T) {
+	t.Run("enabled_with_max_wait_seconds_round_trips", func(t *testing.T) {
+		maxWait := 3600
+		pc := ProviderConfig{
+			Type: "anthropic",
+			Batch: &BatchProviderConfig{
+				Enabled:                 true,
+				MaxWaitSeconds:          &maxWait,
+				HarnessSidePolling:      true,
+				FallbackOnTimeout:       true,
+				CancelBundleOnRunCancel: false,
+				AllowInteractiveModes:   true,
+			},
+		}
+		data, err := json.Marshal(pc)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got ProviderConfig
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Batch == nil {
+			t.Fatal("Batch must survive JSON round-trip as non-nil")
+		}
+		if !got.Batch.Enabled {
+			t.Errorf("Batch.Enabled: got false, want true")
+		}
+		if got.Batch.MaxWaitSeconds == nil {
+			t.Fatal("MaxWaitSeconds must survive as non-nil pointer")
+		}
+		if *got.Batch.MaxWaitSeconds != 3600 {
+			t.Errorf("MaxWaitSeconds: got %d, want 3600", *got.Batch.MaxWaitSeconds)
+		}
+		if !got.Batch.HarnessSidePolling {
+			t.Errorf("HarnessSidePolling: got false, want true")
+		}
+		if !got.Batch.FallbackOnTimeout {
+			t.Errorf("FallbackOnTimeout: got false, want true")
+		}
+		if got.Batch.CancelBundleOnRunCancel {
+			t.Errorf("CancelBundleOnRunCancel: got true, want false")
+		}
+		if !got.Batch.AllowInteractiveModes {
+			t.Errorf("AllowInteractiveModes: got false, want true")
+		}
+	})
+
+	t.Run("disabled_but_present_block_survives_round_trip", func(t *testing.T) {
+		// `omitempty` is on ProviderConfig.Batch (the *pointer), not on
+		// the inner BatchProviderConfig fields. Marshaling a non-nil
+		// pointer to a zero-valued struct must emit a "batch" key the
+		// unmarshaler sees, otherwise phase-2 callers cannot tell "no
+		// batch key in JSON" from "batch present but disabled".
+		pc := ProviderConfig{
+			Type:  "anthropic",
+			Batch: &BatchProviderConfig{Enabled: false},
+		}
+		data, err := json.Marshal(pc)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !strings.Contains(string(data), `"batch"`) {
+			t.Errorf("expected batch key in JSON, got: %s", data)
+		}
+		var got ProviderConfig
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Batch == nil {
+			t.Fatal("disabled-but-present batch must survive as non-nil pointer")
+		}
+		if got.Batch.Enabled {
+			t.Errorf("Enabled: got true, want false")
+		}
+		if got.Batch.MaxWaitSeconds != nil {
+			t.Errorf("MaxWaitSeconds: got %v, want nil", *got.Batch.MaxWaitSeconds)
+		}
+	})
+
+	t.Run("absent_batch_unmarshals_as_nil", func(t *testing.T) {
+		// Cross-check: the omitempty pointer on a nil Batch must drop
+		// the key entirely on marshal, and an absent key must unmarshal
+		// to nil. This is the third state phase-2 consumers care about.
+		pc := ProviderConfig{Type: "anthropic"}
+		data, err := json.Marshal(pc)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(data), `"batch"`) {
+			t.Errorf("expected no batch key when Batch is nil, got: %s", data)
+		}
+		var got ProviderConfig
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Batch != nil {
+			t.Errorf("expected nil Batch when JSON has no batch key, got: %+v", got.Batch)
+		}
+	})
+}
+
+// TestRedact_ProviderBatchNotAliased pins the phase-1 review fix for
+// the Redact() deep-copy gap on Provider.Batch. validateBatchConfig
+// mutates Batch.MaxWaitSeconds in place to apply the default; if
+// Redact() shares the pointer with the live config, a subsequent
+// default-apply write reaches the redacted snapshot through the
+// shared pointer and breaks the contract that Redact() produces a
+// stable copy. The aliasing risk also applies to entries in the
+// Providers map.
+func TestRedact_ProviderBatchNotAliased(t *testing.T) {
+	maxWait := 3600
+	otherMaxWait := 1800
+	rc := RunConfig{
+		Provider: ProviderConfig{
+			Type:  "anthropic",
+			Batch: &BatchProviderConfig{Enabled: true, MaxWaitSeconds: &maxWait, HarnessSidePolling: true},
+		},
+		Providers: map[string]ProviderConfig{
+			"secondary": {
+				Type:  "anthropic",
+				Batch: &BatchProviderConfig{Enabled: true, MaxWaitSeconds: &otherMaxWait},
+			},
+		},
+	}
+	redacted := rc.Redact()
+
+	if redacted.Provider.Batch == nil {
+		t.Fatal("top-level Batch dropped by Redact")
+	}
+	if redacted.Provider.Batch == rc.Provider.Batch {
+		t.Fatal("top-level Batch pointer aliased — Redact must deep-copy")
+	}
+	redacted.Provider.Batch.Enabled = false
+	if !rc.Provider.Batch.Enabled {
+		t.Error("mutating redacted Provider.Batch.Enabled leaked to original")
+	}
+
+	redactedSecondary := redacted.Providers["secondary"]
+	originalSecondary := rc.Providers["secondary"]
+	if redactedSecondary.Batch == nil {
+		t.Fatal("named-provider Batch dropped by Redact")
+	}
+	if redactedSecondary.Batch == originalSecondary.Batch {
+		t.Fatal("named-provider Batch pointer aliased — Redact must deep-copy")
+	}
+	redactedSecondary.Batch.Enabled = false
+	if !rc.Providers["secondary"].Batch.Enabled {
+		t.Error("mutating redacted named-provider Batch.Enabled leaked to original")
 	}
 }


### PR DESCRIPTION
## Summary

Adds `BatchProviderConfig` to `types/runconfig.go`, wires every batch invariant into `ValidateRunConfig`, propagates the new field through the proto + gRPC translate layer, and updates the example config + docs. PR 2 of 7 in the batch-API stack (parent #67).

**Stack base:** PR #207 (`gh-133-batch-phase-0`).

## Changes

- `types/runconfig.go`:
  - New `BatchProviderConfig` struct (six fields per #134) + `Batch *BatchProviderConfig` on `ProviderConfig`.
  - Seven hard-error invariants in `validateBatchConfig`; in-place default `MaxWaitSeconds = 86400` when `Enabled=true && MaxWaitSeconds == nil`; slog WARN when `MaxTurns > 5`.
  - `Redact()` deep-copies `Provider.Batch` (and each `Providers[name].Batch`), matching the existing `Retry` pattern.
  - `validateProviderConfigs` rejects any non-nil `Batch` on a `Providers` map entry (batch is top-level-only in v1).
  - `validateBatchConfig` skips the supported-types check when `Provider.Type` is already invalid, avoiding a misleading second error.
- `proto/harness/v1/harness.proto` + `gen/harness/v1/harness.pb.go`:
  - New `BatchProviderConfig` message, added as `batch` field on `ProviderConfig`. `max_wait_seconds` is `optional int32` to preserve nil-vs-zero distinction.
- `harness/internal/transport/grpc_translate.go` + test:
  - `providerConfigFromProto` / `providerConfigToProto` round-trip the batch block byte-identically. Round-trip test asserts both fully-populated and nil-batch cases.
- `examples/runconfig/full.json` + `examples/runconfig/README.md`:
  - Real `batch` block with `enabled: false` (loader has `DisallowUnknownFields`, so a `_comment` workaround is not viable). README explains the nil-default semantics and mode/transport invariants.

## Tests

- 11 new test functions / 18 sub-cases in `runconfig_test.go` covering: each hard-error invariant (trigger + near-miss), `MaxWaitSeconds` boundaries (1, 86400, 0, 86401, -1), nil-default applied, `MaxTurns>5` WARN (captured via slog handler), happy path with all fields set, `Enabled=false` with flags set, Providers map rejection, JSON round-trip (fully populated / disabled-but-present / absent).
- `grpc_translate_test.go` round-trip assertion for `BatchProviderConfig`.

`go test ./types/... ./harness/internal/transport/...` → PASS. Full workspace build green.

## Review wave

Five-reviewer cycle: code, security, spec-compliance, test-coverage, api-design. Synthesised brief: 2 blocking + 8 recommended; all applied across commits db4cfbd, 18eb46b, 2062fe3, 8c5b108.

Blocking:
- gRPC translate / proto gap (silent data loss on K8s job path) — resolved.
- `Redact()` aliasing of `Provider.Batch` pointer — resolved.

8 NITs deferred to follow-up issues (`*int`→`int`, `CancelBundleOnRunCancel` rename, `slog.Warn` factory move, etc.); they will be filed after this PR merges.

## Test plan

- [x] `go build ./types/... ./harness/... ./eval/... ./gen/...`
- [x] `go test ./types/... ./harness/internal/transport/...`
- [x] `just proto` produced clean diff (committed in db4cfbd)
- [ ] CI green

Closes #134.