### PR TITLE
batch(phase-2): BatchAdapter + controlPlaneBatchClient + factory wiring (gRPC)

### DIFF
--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -370,7 +370,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 			maxWaitSec = *config.Provider.Batch.MaxWaitSeconds
 		}
 		maxWait := time.Duration(maxWaitSec) * time.Second
-		batchClient := provider.NewControlPlaneBatchClient(tp, maxWait)
+		batchClient := provider.NewControlPlaneBatchClient(tp, maxWait, config.Provider.Batch.CancelBundleOnRunCancel)
 		prov = provider.NewBatchAdapter(prov, batchClient, config.Provider.Batch, config.Provider.Type, config.RunID)
 		// Replace the entry in the providers map so model-router lookups
 		// route to the batched wrapper rather than the raw streaming

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -350,6 +350,36 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		}
 	}
 
+	// 14b. Optional BatchAdapter wrapping. Only the top-level provider is
+	// wrapped — entries in config.Providers are streaming-only in v1, per
+	// the BatchProviderConfig docstring. The streaming inner is retained
+	// so cfg.FallbackOnTimeout can delegate to it without a second build.
+	//
+	// The stdio polling client (#137) is not wired here: the validator
+	// already requires HarnessSidePolling=true for stdio, but the polling
+	// adapter itself does not exist yet. When transport.type=="stdio"
+	// and batch.enabled is set, the loop runs as a streaming turn until
+	// phase 4 lands the polling branch.
+	if config.Provider.Batch != nil && config.Provider.Batch.Enabled && config.Transport.Type == "grpc" {
+		// MaxWaitSeconds is filled with the documented default
+		// (86_400) by ValidateRunConfig when batch.enabled is true, so
+		// the nil check below is defence-in-depth for callers bypassing
+		// the validator.
+		maxWaitSec := 86_400
+		if config.Provider.Batch.MaxWaitSeconds != nil {
+			maxWaitSec = *config.Provider.Batch.MaxWaitSeconds
+		}
+		maxWait := time.Duration(maxWaitSec) * time.Second
+		batchClient := provider.NewControlPlaneBatchClient(tp, maxWait)
+		prov = provider.NewBatchAdapter(prov, batchClient, config.Provider.Batch, config.Provider.Type, config.RunID)
+		// Replace the entry in the providers map so model-router lookups
+		// route to the batched wrapper rather than the raw streaming
+		// adapter (#194-style cross-routing risk: a router that picks
+		// the default provider by type would otherwise bypass batching
+		// entirely).
+		providers[config.Provider.Type] = prov
+	}
+
 	loop := &AgenticLoop{
 		Provider:     prov,
 		Providers:    providers,

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -2308,6 +2308,116 @@ func TestBuildProvider_OpenAIResponsesNilBearerErrors(t *testing.T) {
 	}
 }
 
+// --- BatchAdapter wiring (phase 2 / #135) ---
+
+// intPtr returns a pointer to v. Local helper to avoid pulling in a
+// dependency just for a one-off literal pointer.
+func intPtr(v int) *int { return &v }
+
+// TestBuildLoopWithTransport_BatchAdapterWiredWhenEnabled asserts the
+// gRPC + batch.enabled wiring path in the factory: the top-level provider
+// and the entry in the providers map are both replaced with a
+// *provider.BatchAdapter. Without the map replacement, model-router
+// lookups by provider type would silently bypass batching.
+func TestBuildLoopWithTransport_BatchAdapterWiredWhenEnabled(t *testing.T) {
+	t.Setenv("TEST_ANTHROPIC_KEY", "test-key")
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-batch",
+		Mode:             "planning",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://TEST_ANTHROPIC_KEY"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		Transport:        types.TransportConfig{Type: "grpc"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+	config.Provider.Batch = &types.BatchProviderConfig{
+		Enabled:               true,
+		MaxWaitSeconds:        intPtr(86400),
+		AllowInteractiveModes: true,
+	}
+
+	// Inject a transport so buildTransport (gRPC) does not try to dial.
+	injected := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, injected)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	ba, ok := loop.Provider.(*provider.BatchAdapter)
+	if !ok {
+		t.Fatalf("loop.Provider: got %T, want *provider.BatchAdapter", loop.Provider)
+	}
+	mapped, ok := loop.Providers[config.Provider.Type]
+	if !ok {
+		t.Fatalf("loop.Providers[%q] missing", config.Provider.Type)
+	}
+	if mapped != ba {
+		t.Errorf("loop.Providers[%q]: %T %p, want same *BatchAdapter %p", config.Provider.Type, mapped, mapped, ba)
+	}
+}
+
+// TestBuildLoopWithTransport_BatchAdapterNotWiredOnStdio is the
+// near-miss case. transport=stdio with HarnessSidePolling=true passes
+// validation (the harness polling client lands in phase 4) but the
+// factory has no wire for it yet, so loop.Provider must remain the raw
+// streaming adapter. This assertion will be inverted when phase 4 lands.
+func TestBuildLoopWithTransport_BatchAdapterNotWiredOnStdio(t *testing.T) {
+	t.Setenv("TEST_ANTHROPIC_KEY", "test-key")
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-batch-stdio",
+		Mode:             "planning",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://TEST_ANTHROPIC_KEY"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		Transport:        types.TransportConfig{Type: "stdio"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+	config.Provider.Batch = &types.BatchProviderConfig{
+		Enabled:               true,
+		MaxWaitSeconds:        intPtr(86400),
+		HarnessSidePolling:    true,
+		AllowInteractiveModes: true,
+	}
+
+	injected := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, injected)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	if _, ok := loop.Provider.(*provider.BatchAdapter); ok {
+		t.Fatalf("loop.Provider is *BatchAdapter on stdio; phase 4 wiring landed earlier than expected — invert this assertion")
+	}
+}
+
 // --- stubSecretStore ---
 
 type stubSecretStore struct {

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -159,7 +159,7 @@ func NewBatchAdapter(
 // streaming adapter would have produced for the same response.
 func (a *BatchAdapter) Stream(ctx context.Context, params types.StreamParams) (<-chan types.StreamEvent, error) {
 	turn := a.turnCount.Add(1)
-	customID := fmt.Sprintf("%s-turn-%d", a.runID, turn)
+	customID := fmt.Sprintf("stirrup-%s-turn-%d", a.runID, turn)
 
 	body, err := a.marshalRequestBody(params)
 	if err != nil {

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -108,11 +108,18 @@ type BatchResultError struct {
 // HarnessEvent's Input field. The control plane uses it to construct the
 // provider-side batch entry.
 type BatchSubmission struct {
+	// SchemaVersion identifies the payload shape so the control plane
+	// can route legacy submissions without ambiguity. Submit always
+	// emits 1 in phase 2; increment when adding fields that consumers
+	// must know about (phase 6 may bump to 2 for OpenAI base_url /
+	// endpoint routing).
+	SchemaVersion int `json:"schema_version"`
+
 	// ProviderType is the provider shape the Body conforms to.
 	// "anthropic" | "openai-compatible" | "openai-responses".
 	ProviderType string `json:"provider_type"`
 
-	// CustomID is the entry's correlation handle ("<runID>-turn-<n>").
+	// CustomID is the entry's correlation handle ("stirrup-<runID>-turn-<n>").
 	// The control plane includes it on the provider-side batch entry so
 	// the returned batch_result.content can carry it back unchanged.
 	CustomID string `json:"custom_id"`
@@ -122,6 +129,10 @@ type BatchSubmission struct {
 	// or /v1/responses.
 	Body json.RawMessage `json:"body"`
 }
+
+// batchSubmissionSchemaVersion is the current BatchSubmission payload
+// shape version. See the field doc on BatchSubmission.SchemaVersion.
+const batchSubmissionSchemaVersion = 1
 
 // BatchAdapter wraps a streaming ProviderAdapter and fakes the streaming
 // channel from a completed batch response. The streaming inner is retained
@@ -248,9 +259,7 @@ func (a *BatchAdapter) awaitAndFabricate(
 		return
 	}
 
-	if err := fabricateStream(ch, entry.Response, a.provType); err != nil {
-		ch <- types.StreamEvent{Type: "error", Error: err}
-	}
+	fabricateStream(ch, entry.Response, a.provType)
 }
 
 // pumpInner relays events from the streaming fallback into the
@@ -290,20 +299,27 @@ func isBatchTimeout(err error) bool {
 
 // fabricateStream decodes a batch response and emits the StreamEvent
 // sequence the streaming adapter would have produced for the same body.
-// Only Anthropic is implemented in phase 2; OpenAI variants emit a single
-// error event so the OpenAI batch path lands cleanly in phase 6 (#139).
-func fabricateStream(ch chan<- types.StreamEvent, response json.RawMessage, provType string) error {
+// Only Anthropic is implemented in phase 2; OpenAI variants and any
+// unsupported provider type emit a single error event so the caller
+// (awaitAndFabricate) does not have to track a separate error return —
+// mirrors the ProviderAdapter.Stream convention where all failures
+// surface as in-channel error events.
+func fabricateStream(ch chan<- types.StreamEvent, response json.RawMessage, provType string) {
 	switch provType {
 	case "anthropic":
-		return fabricateAnthropicStream(ch, response)
+		if err := fabricateAnthropicStream(ch, response); err != nil {
+			ch <- types.StreamEvent{Type: "error", Error: err}
+		}
 	case "openai-compatible", "openai-responses":
 		ch <- types.StreamEvent{
 			Type:  "error",
 			Error: errors.New("OpenAI batch fabrication not yet implemented"),
 		}
-		return nil
 	default:
-		return fmt.Errorf("fabricateStream: unsupported provider type %q", provType)
+		ch <- types.StreamEvent{
+			Type:  "error",
+			Error: fmt.Errorf("fabricateStream: unsupported provider type %q", provType),
+		}
 	}
 }
 
@@ -330,6 +346,11 @@ type anthropicBatchContentBlock struct {
 // produces in anthropic.go: one text_delta per text content block, one
 // tool_call per tool_use block, then a single message_complete carrying
 // the assembled content blocks plus stop_reason / output_tokens.
+//
+// Emits one text_delta per text content block (not per token) — the
+// assembled ContentBlock in message_complete matches streamEventsToResult's
+// reconstruction so a fabricated stream is observationally
+// indistinguishable from the live SSE path for the agentic loop.
 func fabricateAnthropicStream(ch chan<- types.StreamEvent, response json.RawMessage) error {
 	var resp anthropicBatchResponse
 	if err := json.Unmarshal(response, &resp); err != nil {
@@ -393,8 +414,12 @@ type controlPlaneBatchClient struct {
 	maxWait            time.Duration
 	cancelBundleOnExit bool
 
-	mu       sync.Mutex
-	nextID   int
+	mu     sync.Mutex
+	nextID int
+	// pending and customID are keyed by requestID. The client always
+	// submits size-1 batches (see Submit); the map[customID]→*BatchResult
+	// shape returned by Result is for forward compatibility with phase-4
+	// multi-entry batches (harnessPollingBatchClient, #137).
 	pending  map[string]chan *BatchResult
 	customID map[string]string // requestID -> originating entry CustomID
 }
@@ -497,9 +522,10 @@ func (c *controlPlaneBatchClient) Submit(ctx context.Context, entries []BatchEnt
 	entry := entries[0]
 
 	payload := BatchSubmission{
-		ProviderType: entry.Provider,
-		CustomID:     entry.CustomID,
-		Body:         entry.Body,
+		SchemaVersion: batchSubmissionSchemaVersion,
+		ProviderType:  entry.Provider,
+		CustomID:      entry.CustomID,
+		Body:          entry.Body,
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -544,7 +570,12 @@ func (c *controlPlaneBatchClient) Result(ctx context.Context, batchID string) (m
 
 	timeout := c.maxWait
 	if timeout <= 0 {
-		timeout = transport.DefaultCorrelatorTimeout
+		// The harness-side default for batch waits is the same as the
+		// validator's documented MaxWaitSeconds default (24 h); reusing
+		// transport.DefaultCorrelatorTimeout here was a copy-paste from
+		// the askupstream pattern and would silently expire long batches
+		// after the much shorter correlator default.
+		timeout = time.Duration(types.DefaultBatchMaxWaitSeconds) * time.Second
 	}
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -272,14 +271,21 @@ func (a *BatchAdapter) pumpInner(ctx context.Context, ch chan<- types.StreamEven
 	}
 }
 
-// isBatchTimeout reports whether err is a wall-clock batch_expired
-// timeout from the BatchClient. The client surfaces this by returning an
-// error whose message contains "batch_expired".
+// errBatchExpired is the sentinel returned by BatchClient.Result when the
+// harness-side wall-clock cap fires before a batch_result arrives.
+// BatchAdapter checks for it via isBatchTimeout to decide between an
+// error event and the FallbackOnTimeout streaming path. The wire-level
+// vocabulary (BatchResultError.Type == "batch_expired") is independent
+// of this Go-side sentinel.
+var errBatchExpired = errors.New("batch expired")
+
+// isBatchTimeout reports whether err wraps errBatchExpired — i.e. the
+// BatchClient reported its wall-clock cap fired before the batch
+// resolved. Both control-plane and (phase-4) polling clients wrap the
+// same sentinel so the BatchAdapter timeout-fallback branch is provider-
+// independent.
 func isBatchTimeout(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), "batch_expired")
+	return errors.Is(err, errBatchExpired)
 }
 
 // fabricateStream decodes a batch response and emits the StreamEvent
@@ -383,8 +389,9 @@ func fabricateAnthropicStream(ch chan<- types.StreamEvent, response json.RawMess
 // the correlator's pending-map pattern locally rather than reusing
 // transport.Correlator (which exposes only the emit-and-await shape).
 type controlPlaneBatchClient struct {
-	transport transport.Transport
-	maxWait   time.Duration
+	transport          transport.Transport
+	maxWait            time.Duration
+	cancelBundleOnExit bool
 
 	mu       sync.Mutex
 	nextID   int
@@ -396,12 +403,17 @@ type controlPlaneBatchClient struct {
 // provider-side batch lifecycle to the control plane via the gRPC
 // transport. maxWait is the wall-clock cap on Result; the BatchAdapter
 // also applies this via cfg.MaxWaitSeconds (defence in depth).
-func NewControlPlaneBatchClient(t transport.Transport, maxWait time.Duration) *controlPlaneBatchClient {
+// cancelBundleOnExit, when true, causes the client to emit a
+// batch_cancel_request HarnessEvent on ctx-cancel or wall-clock-cap exit
+// from Result so the control plane can cancel the matching provider-side
+// batch entry (Provider.Batch.CancelBundleOnRunCancel).
+func NewControlPlaneBatchClient(t transport.Transport, maxWait time.Duration, cancelBundleOnExit bool) *controlPlaneBatchClient {
 	c := &controlPlaneBatchClient{
-		transport: t,
-		maxWait:   maxWait,
-		pending:   make(map[string]chan *BatchResult),
-		customID:  make(map[string]string),
+		transport:          t,
+		maxWait:            maxWait,
+		cancelBundleOnExit: cancelBundleOnExit,
+		pending:            make(map[string]chan *BatchResult),
+		customID:           make(map[string]string),
 	}
 	t.OnControl(c.handleControl)
 	return c
@@ -410,6 +422,12 @@ func NewControlPlaneBatchClient(t transport.Transport, maxWait time.Duration) *c
 // handleControl routes batch_result ControlEvents to the pending Result
 // caller. Mirrors transport.Correlator.deliver, but specialised for the
 // BatchResult payload so we can keep the channel typed.
+//
+// Result owns deletion from both c.pending and c.customID on every exit
+// path; handleControl never deletes. The non-blocking send below covers
+// the case where Result has already abandoned the entry (timeout, ctx
+// cancel) — releasePending will have removed the map entry so the next
+// lookup is safely absent.
 func (c *controlPlaneBatchClient) handleControl(event types.ControlEvent) {
 	if event.Type != eventBatchResult || event.RequestID == "" {
 		return
@@ -418,27 +436,43 @@ func (c *controlPlaneBatchClient) handleControl(event types.ControlEvent) {
 
 	c.mu.Lock()
 	ch, ok := c.pending[event.RequestID]
-	if ok {
-		delete(c.pending, event.RequestID)
-	}
 	c.mu.Unlock()
 
 	if !ok {
 		return
 	}
-	// Channel has capacity 1 and we just removed it from the pending map
-	// under the lock, so the send cannot block.
-	ch <- result
+	select {
+	case ch <- result:
+	default:
+		// Result already drained or abandoned this entry; map cleanup
+		// runs on the Result side via releasePending.
+	}
 }
 
+// maxBatchResponseBytes caps the size of a batch_result Content payload
+// the harness will decode. The cap exists as a defence-in-depth measure:
+// the control plane is partially trusted, and an unbounded payload here
+// would let a misbehaving plane allocate arbitrary harness-side memory
+// (CWE-400). 4 MiB is comfortably above the largest plausible Anthropic
+// Messages-API response while still bounded.
+const maxBatchResponseBytes = 4 * 1024 * 1024
+
 // decodeBatchResult turns a batch_result ControlEvent's content into a
-// *BatchResult. An empty content or malformed JSON surfaces as a
-// BatchResult.Err so the BatchAdapter sees a non-nil entry even when the
-// control plane mis-frames the event.
+// *BatchResult. An empty content, oversize payload, or malformed JSON
+// surfaces as a BatchResult.Err so the BatchAdapter sees a non-nil entry
+// even when the control plane mis-frames the event.
 func decodeBatchResult(event types.ControlEvent) *BatchResult {
 	if event.Content == "" {
 		return &BatchResult{
 			Err: &BatchResultError{Type: "invalid_request_error", Message: "batch_result missing content"},
+		}
+	}
+	if len(event.Content) > maxBatchResponseBytes {
+		return &BatchResult{
+			Err: &BatchResultError{
+				Type:    "invalid_request_error",
+				Message: fmt.Sprintf("batch_result content exceeds %d-byte limit", maxBatchResponseBytes),
+			},
 		}
 	}
 	var result BatchResult
@@ -517,19 +551,35 @@ func (c *controlPlaneBatchClient) Result(ctx context.Context, batchID string) (m
 
 	select {
 	case result := <-ch:
-		// handleControl already removed the entry from pending; just
-		// drop the customID side-table now that the wait is done.
-		c.mu.Lock()
-		delete(c.customID, batchID)
-		c.mu.Unlock()
+		// Result owns map cleanup on every exit path; releasePending
+		// drops both c.pending and c.customID atomically.
+		c.releasePending(batchID)
 		return map[string]*BatchResult{customID: result}, nil
 	case <-timer.C:
 		c.releasePending(batchID)
-		return nil, fmt.Errorf("controlPlaneBatchClient: batch_expired: timed out after %s waiting for batch_result (batchID=%s)", timeout, batchID)
+		c.maybeEmitCancelRequest(batchID)
+		return nil, fmt.Errorf("%w: timed out after %s (batchID=%s)", errBatchExpired, timeout, batchID)
 	case <-ctx.Done():
 		c.releasePending(batchID)
+		c.maybeEmitCancelRequest(batchID)
 		return nil, fmt.Errorf("controlPlaneBatchClient: cancelled: %w", ctx.Err())
 	}
+}
+
+// maybeEmitCancelRequest emits a batch_cancel_request HarnessEvent for the
+// given submission when the client was constructed with
+// cancelBundleOnExit=true. Errors from Emit are intentionally ignored:
+// the transport is already breaking, and surfacing a secondary error
+// here would obscure the primary timeout/cancel surface returned by
+// Result. Fire-and-forget mirrors the heartbeat goroutine.
+func (c *controlPlaneBatchClient) maybeEmitCancelRequest(requestID string) {
+	if !c.cancelBundleOnExit {
+		return
+	}
+	_ = c.transport.Emit(types.HarnessEvent{
+		Type:      eventBatchCancelRequest,
+		RequestID: requestID,
+	})
 }
 
 // releasePending removes a pending entry. Safe to call when the entry has

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -14,11 +14,26 @@ import (
 	"github.com/rxbynerd/stirrup/types"
 )
 
-// batchWaitingHeartbeatInterval is the cadence at which the
-// controlPlaneBatchClient emits batch_waiting HarnessEvents while a batch
-// submission is in flight. Exposed as a package-level var (not const) so
-// tests can override it without sleeping for minutes.
-var batchWaitingHeartbeatInterval = 5 * time.Minute
+// batchWaitingHeartbeatIntervalNs holds the cadence (in nanoseconds) at
+// which the controlPlaneBatchClient emits batch_waiting HarnessEvents
+// while a batch submission is in flight. Stored as an atomic so tests
+// can lower it without racing the heartbeat goroutines that earlier
+// tests may still be running. Use getBatchWaitingHeartbeatInterval /
+// setBatchWaitingHeartbeatInterval rather than touching this directly.
+var batchWaitingHeartbeatIntervalNs atomic.Int64
+
+func init() {
+	batchWaitingHeartbeatIntervalNs.Store(int64(5 * time.Minute))
+}
+
+func getBatchWaitingHeartbeatInterval() time.Duration {
+	return time.Duration(batchWaitingHeartbeatIntervalNs.Load())
+}
+
+func setBatchWaitingHeartbeatInterval(d time.Duration) time.Duration {
+	prev := batchWaitingHeartbeatIntervalNs.Swap(int64(d))
+	return time.Duration(prev)
+}
 
 // BatchClient submits batch entries to a provider and retrieves results.
 // The multi-entry shape is required to support OpenAI's file-upload flow;
@@ -532,7 +547,7 @@ func (c *controlPlaneBatchClient) nextRequestID() string {
 // to Result via the underlying RPC, which is a more reliable signal than
 // a heartbeat error.
 func (c *controlPlaneBatchClient) heartbeat(ctx context.Context, requestID string) {
-	ticker := time.NewTicker(batchWaitingHeartbeatInterval)
+	ticker := time.NewTicker(getBatchWaitingHeartbeatInterval())
 	defer ticker.Stop()
 	for {
 		select {

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -1,0 +1,554 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// batchWaitingHeartbeatInterval is the cadence at which the
+// controlPlaneBatchClient emits batch_waiting HarnessEvents while a batch
+// submission is in flight. Exposed as a package-level var (not const) so
+// tests can override it without sleeping for minutes.
+var batchWaitingHeartbeatInterval = 5 * time.Minute
+
+// BatchClient submits batch entries to a provider and retrieves results.
+// The multi-entry shape is required to support OpenAI's file-upload flow;
+// the gRPC control-plane client always submits size-1 slices.
+type BatchClient interface {
+	// Submit dispatches the given entries to the provider's batch
+	// endpoint (directly, or via the control plane) and returns an opaque
+	// batchID that can be passed to Result. The batchID is the harness's
+	// correlation handle; the provider-side batch identifier may differ
+	// and is carried inside the eventual BatchResult.
+	Submit(ctx context.Context, entries []BatchEntry) (batchID string, err error)
+
+	// Result blocks until the batch identified by batchID resolves (or
+	// the context / the client's own wall-clock cap fires). The returned
+	// map is keyed by BatchEntry.CustomID.
+	Result(ctx context.Context, batchID string) (map[string]*BatchResult, error)
+}
+
+// BatchEntry is a single submission within a batch.
+type BatchEntry struct {
+	// CustomID is the per-entry correlation handle echoed back in the
+	// batch_result. The BatchAdapter uses the shape "<runID>-turn-<n>".
+	CustomID string `json:"custom_id"`
+
+	// Provider names the upstream API shape the Body conforms to.
+	// "anthropic" | "openai-compatible" | "openai-responses".
+	Provider string `json:"provider"`
+
+	// Body is the marshalled request the streaming adapter would have
+	// sent — see build*Request helpers in the sibling adapter files.
+	Body json.RawMessage `json:"body"`
+}
+
+// BatchResult is the per-entry outcome of a batch submission.
+type BatchResult struct {
+	// Response is the provider's Messages-API-compatible response JSON on
+	// success. Nil when Err is non-nil.
+	Response json.RawMessage `json:"response,omitempty"`
+
+	// Err is populated when the provider reported a non-success result
+	// for this entry. The streaming wrapper maps this to a single error
+	// StreamEvent; a future phase will surface the type as a TurnTrace
+	// outcome.
+	Err *BatchResultError `json:"err,omitempty"`
+}
+
+// BatchResultError categorises a non-success batch outcome.
+type BatchResultError struct {
+	// Type discriminates the failure category. Recognised values mirror
+	// the provider's own taxonomy:
+	//   - "invalid_request_error"
+	//   - "server_error"
+	//   - "batch_expired"
+	//   - "batch_cancelled"
+	Type string `json:"type"`
+
+	// Message is a human-readable description of the failure.
+	Message string `json:"message,omitempty"`
+}
+
+// BatchSubmission is the JSON payload carried in the batch_submission
+// HarnessEvent's Input field. The control plane uses it to construct the
+// provider-side batch entry.
+type BatchSubmission struct {
+	// ProviderType is the provider shape the Body conforms to.
+	// "anthropic" | "openai-compatible" | "openai-responses".
+	ProviderType string `json:"provider_type"`
+
+	// CustomID is the entry's correlation handle ("<runID>-turn-<n>").
+	// The control plane includes it on the provider-side batch entry so
+	// the returned batch_result.content can carry it back unchanged.
+	CustomID string `json:"custom_id"`
+
+	// Body is the marshalled provider request — what the streaming
+	// adapter would have POSTed to /v1/messages or /v1/chat/completions
+	// or /v1/responses.
+	Body json.RawMessage `json:"body"`
+}
+
+// BatchAdapter wraps a streaming ProviderAdapter and fakes the streaming
+// channel from a completed batch response. The streaming inner is retained
+// only as a fallback for cfg.FallbackOnTimeout.
+type BatchAdapter struct {
+	inner     ProviderAdapter
+	client    BatchClient
+	cfg       *types.BatchProviderConfig
+	provType  string
+	runID     string
+	turnCount atomic.Int64
+}
+
+// NewBatchAdapter constructs a BatchAdapter. cfg.MaxWaitSeconds is read
+// on each Stream call; the client is expected to enforce the same cap
+// internally (defence in depth).
+func NewBatchAdapter(
+	inner ProviderAdapter,
+	client BatchClient,
+	cfg *types.BatchProviderConfig,
+	provType string,
+	runID string,
+) *BatchAdapter {
+	return &BatchAdapter{
+		inner:    inner,
+		client:   client,
+		cfg:      cfg,
+		provType: provType,
+		runID:    runID,
+	}
+}
+
+// Stream submits the turn as a single-entry batch, awaits the result, and
+// emits a fabricated StreamEvent sequence equivalent to what the inner
+// streaming adapter would have produced for the same response.
+func (a *BatchAdapter) Stream(ctx context.Context, params types.StreamParams) (<-chan types.StreamEvent, error) {
+	turn := a.turnCount.Add(1)
+	customID := fmt.Sprintf("%s-turn-%d", a.runID, turn)
+
+	body, err := a.marshalRequestBody(params)
+	if err != nil {
+		ch := make(chan types.StreamEvent, 1)
+		ch <- types.StreamEvent{Type: "error", Error: err}
+		close(ch)
+		return ch, nil
+	}
+
+	batchID, err := a.client.Submit(ctx, []BatchEntry{{
+		CustomID: customID,
+		Provider: a.provType,
+		Body:     body,
+	}})
+	if err != nil {
+		ch := make(chan types.StreamEvent, 1)
+		ch <- types.StreamEvent{Type: "error", Error: fmt.Errorf("batch submit: %w", err)}
+		close(ch)
+		return ch, nil
+	}
+
+	ch := make(chan types.StreamEvent, 64)
+	go a.awaitAndFabricate(ctx, ch, params, customID, batchID)
+	return ch, nil
+}
+
+// marshalRequestBody projects params into the wire body for the
+// configured provider type. Unsupported provider types surface as a
+// marshal-time error so the caller can emit a single error StreamEvent.
+func (a *BatchAdapter) marshalRequestBody(params types.StreamParams) (json.RawMessage, error) {
+	switch a.provType {
+	case "anthropic":
+		return json.Marshal(buildAnthropicRequest(params, false))
+	case "openai-compatible":
+		return json.Marshal(buildOpenAIRequest(params, false))
+	case "openai-responses":
+		return json.Marshal(buildResponsesRequest(params))
+	default:
+		return nil, fmt.Errorf("batch: unsupported provider type %q", a.provType)
+	}
+}
+
+// awaitAndFabricate runs in a goroutine, blocks on the batch result, and
+// drains either the fabricated stream, a fallback inner stream, or a
+// single error event onto ch before closing it.
+func (a *BatchAdapter) awaitAndFabricate(
+	ctx context.Context,
+	ch chan<- types.StreamEvent,
+	params types.StreamParams,
+	customID string,
+	batchID string,
+) {
+	defer close(ch)
+
+	results, err := a.client.Result(ctx, batchID)
+	if err != nil {
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			ch <- types.StreamEvent{Type: "error", Error: fmt.Errorf("batch wait cancelled: %w", err)}
+		case isBatchTimeout(err):
+			if a.cfg != nil && a.cfg.FallbackOnTimeout && a.inner != nil {
+				a.pumpInner(ctx, ch, params)
+				return
+			}
+			ch <- types.StreamEvent{Type: "error", Error: fmt.Errorf("batch wait timed out: %w", err)}
+		default:
+			ch <- types.StreamEvent{Type: "error", Error: fmt.Errorf("batch result: %w", err)}
+		}
+		return
+	}
+
+	entry, ok := results[customID]
+	if !ok || entry == nil {
+		ch <- types.StreamEvent{Type: "error", Error: fmt.Errorf("batch result missing entry for custom_id %q", customID)}
+		return
+	}
+
+	if entry.Err != nil {
+		// Prefix the error type so reviewers (and the eventual outcome
+		// mapper in #138) can distinguish batch-side failure categories
+		// from inner provider errors without parsing the wrapped chain.
+		ch <- types.StreamEvent{
+			Type:  "error",
+			Error: fmt.Errorf("[%s] %s", entry.Err.Type, entry.Err.Message),
+		}
+		return
+	}
+
+	if err := fabricateStream(ch, entry.Response, a.provType); err != nil {
+		ch <- types.StreamEvent{Type: "error", Error: err}
+	}
+}
+
+// pumpInner relays events from the streaming fallback into the
+// BatchAdapter's outbound channel. Used only when FallbackOnTimeout is
+// true and the batch wait fired its wall-clock cap.
+func (a *BatchAdapter) pumpInner(ctx context.Context, ch chan<- types.StreamEvent, params types.StreamParams) {
+	innerCh, err := a.inner.Stream(ctx, params)
+	if err != nil {
+		ch <- types.StreamEvent{Type: "error", Error: fmt.Errorf("batch fallback to streaming failed: %w", err)}
+		return
+	}
+	for ev := range innerCh {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- ev:
+		}
+	}
+}
+
+// isBatchTimeout reports whether err is a wall-clock batch_expired
+// timeout from the BatchClient. The client surfaces this by returning an
+// error whose message contains "batch_expired".
+func isBatchTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "batch_expired")
+}
+
+// fabricateStream decodes a batch response and emits the StreamEvent
+// sequence the streaming adapter would have produced for the same body.
+// Only Anthropic is implemented in phase 2; OpenAI variants emit a single
+// error event so the OpenAI batch path lands cleanly in phase 6 (#139).
+func fabricateStream(ch chan<- types.StreamEvent, response json.RawMessage, provType string) error {
+	switch provType {
+	case "anthropic":
+		return fabricateAnthropicStream(ch, response)
+	case "openai-compatible", "openai-responses":
+		ch <- types.StreamEvent{
+			Type:  "error",
+			Error: errors.New("OpenAI batch fabrication not yet implemented"),
+		}
+		return nil
+	default:
+		return fmt.Errorf("fabricateStream: unsupported provider type %q", provType)
+	}
+}
+
+// anthropicBatchResponse mirrors the Anthropic Messages API response
+// shape the batch endpoint returns for a successful entry. Only the
+// fields the fabrication path consumes are decoded.
+type anthropicBatchResponse struct {
+	Content    []anthropicBatchContentBlock `json:"content"`
+	StopReason string                       `json:"stop_reason"`
+	Usage      struct {
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+type anthropicBatchContentBlock struct {
+	Type  string          `json:"type"` // "text" | "tool_use"
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// fabricateAnthropicStream mirrors the SSE event sequence consumeSSE
+// produces in anthropic.go: one text_delta per text content block, one
+// tool_call per tool_use block, then a single message_complete carrying
+// the assembled content blocks plus stop_reason / output_tokens.
+func fabricateAnthropicStream(ch chan<- types.StreamEvent, response json.RawMessage) error {
+	var resp anthropicBatchResponse
+	if err := json.Unmarshal(response, &resp); err != nil {
+		return fmt.Errorf("fabricate anthropic stream: decode response: %w", err)
+	}
+
+	blocks := make([]types.ContentBlock, 0, len(resp.Content))
+	for _, block := range resp.Content {
+		switch block.Type {
+		case "text":
+			ch <- types.StreamEvent{Type: "text_delta", Text: block.Text}
+			blocks = append(blocks, types.ContentBlock{
+				Type: "text",
+				Text: block.Text,
+			})
+		case "tool_use":
+			var input map[string]any
+			if len(block.Input) > 0 {
+				if err := json.Unmarshal(block.Input, &input); err != nil {
+					return fmt.Errorf("fabricate anthropic stream: decode tool input: %w", err)
+				}
+			}
+			ch <- types.StreamEvent{
+				Type:  "tool_call",
+				ID:    block.ID,
+				Name:  block.Name,
+				Input: input,
+			}
+			blocks = append(blocks, types.ContentBlock{
+				Type:  "tool_use",
+				ID:    block.ID,
+				Name:  block.Name,
+				Input: block.Input,
+			})
+		}
+	}
+
+	ch <- types.StreamEvent{
+		Type:         "message_complete",
+		StopReason:   resp.StopReason,
+		OutputTokens: resp.Usage.OutputTokens,
+		Content:      blocks,
+	}
+	return nil
+}
+
+// controlPlaneBatchClient implements BatchClient by emitting a
+// batch_submission HarnessEvent and awaiting a matching batch_result
+// ControlEvent on the transport. The control plane owns the provider
+// batch lifecycle (polling, webhooks); the harness only sees the
+// request/result boundary.
+//
+// The Submit/Result split (vs. emit-then-await in one call, as the
+// AskUpstreamPolicy does) is dictated by the BatchClient contract: the
+// BatchAdapter must hand the streaming goroutine a non-blocking Submit
+// so it can run the heartbeat alongside Result. We therefore reproduce
+// the correlator's pending-map pattern locally rather than reusing
+// transport.Correlator (which exposes only the emit-and-await shape).
+type controlPlaneBatchClient struct {
+	transport transport.Transport
+	maxWait   time.Duration
+
+	mu       sync.Mutex
+	nextID   int
+	pending  map[string]chan *BatchResult
+	customID map[string]string // requestID -> originating entry CustomID
+}
+
+// NewControlPlaneBatchClient constructs a batch client that delegates the
+// provider-side batch lifecycle to the control plane via the gRPC
+// transport. maxWait is the wall-clock cap on Result; the BatchAdapter
+// also applies this via cfg.MaxWaitSeconds (defence in depth).
+func NewControlPlaneBatchClient(t transport.Transport, maxWait time.Duration) *controlPlaneBatchClient {
+	c := &controlPlaneBatchClient{
+		transport: t,
+		maxWait:   maxWait,
+		pending:   make(map[string]chan *BatchResult),
+		customID:  make(map[string]string),
+	}
+	t.OnControl(c.handleControl)
+	return c
+}
+
+// handleControl routes batch_result ControlEvents to the pending Result
+// caller. Mirrors transport.Correlator.deliver, but specialised for the
+// BatchResult payload so we can keep the channel typed.
+func (c *controlPlaneBatchClient) handleControl(event types.ControlEvent) {
+	if event.Type != "batch_result" || event.RequestID == "" {
+		return
+	}
+	result := decodeBatchResult(event)
+
+	c.mu.Lock()
+	ch, ok := c.pending[event.RequestID]
+	if ok {
+		delete(c.pending, event.RequestID)
+	}
+	c.mu.Unlock()
+
+	if !ok {
+		return
+	}
+	// Channel has capacity 1 and we just removed it from the pending map
+	// under the lock, so the send cannot block.
+	ch <- result
+}
+
+// decodeBatchResult turns a batch_result ControlEvent's content into a
+// *BatchResult. An empty content or malformed JSON surfaces as a
+// BatchResult.Err so the BatchAdapter sees a non-nil entry even when the
+// control plane mis-frames the event.
+func decodeBatchResult(event types.ControlEvent) *BatchResult {
+	if event.Content == "" {
+		return &BatchResult{
+			Err: &BatchResultError{Type: "invalid_request_error", Message: "batch_result missing content"},
+		}
+	}
+	var result BatchResult
+	if err := json.Unmarshal([]byte(event.Content), &result); err != nil {
+		return &BatchResult{
+			Err: &BatchResultError{Type: "invalid_request_error", Message: fmt.Sprintf("decode batch_result: %v", err)},
+		}
+	}
+	return &result
+}
+
+// Submit emits a single-entry batch_submission HarnessEvent and returns
+// the correlator-assigned request ID. Result blocks on the matching
+// batch_result ControlEvent later, on the same client.
+func (c *controlPlaneBatchClient) Submit(ctx context.Context, entries []BatchEntry) (string, error) {
+	if len(entries) != 1 {
+		// The control-plane wire contract is one batch_submission per
+		// harness turn. Multi-entry submission is reserved for the
+		// future stdio polling client (phase 4).
+		return "", fmt.Errorf("controlPlaneBatchClient: expected exactly 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+
+	payload := BatchSubmission{
+		ProviderType: entry.Provider,
+		CustomID:     entry.CustomID,
+		Body:         entry.Body,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal batch submission: %w", err)
+	}
+
+	requestID := c.nextRequestID()
+	ch := make(chan *BatchResult, 1)
+
+	c.mu.Lock()
+	c.pending[requestID] = ch
+	c.customID[requestID] = entry.CustomID
+	c.mu.Unlock()
+
+	if err := c.transport.Emit(types.HarnessEvent{
+		Type:      "batch_submission",
+		RequestID: requestID,
+		Input:     payloadBytes,
+	}); err != nil {
+		c.releasePending(requestID)
+		return "", fmt.Errorf("emit batch_submission: %w", err)
+	}
+
+	// The heartbeat goroutine watches the pending map for self-cleanup;
+	// it exits when the entry is no longer present (resolved or timed
+	// out) or when ctx fires.
+	go c.heartbeat(ctx, requestID)
+
+	return requestID, nil
+}
+
+// Result blocks until the batch_result for batchID arrives, the maxWait
+// fires (returning a batch_expired error), or the context is cancelled.
+func (c *controlPlaneBatchClient) Result(ctx context.Context, batchID string) (map[string]*BatchResult, error) {
+	c.mu.Lock()
+	ch, ok := c.pending[batchID]
+	customID := c.customID[batchID]
+	c.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("controlPlaneBatchClient: no pending submission for batchID %q", batchID)
+	}
+
+	timeout := c.maxWait
+	if timeout <= 0 {
+		timeout = transport.DefaultCorrelatorTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case result := <-ch:
+		// handleControl already removed the entry from pending; just
+		// drop the customID side-table now that the wait is done.
+		c.mu.Lock()
+		delete(c.customID, batchID)
+		c.mu.Unlock()
+		return map[string]*BatchResult{customID: result}, nil
+	case <-timer.C:
+		c.releasePending(batchID)
+		return nil, fmt.Errorf("controlPlaneBatchClient: batch_expired: timed out after %s waiting for batch_result (batchID=%s)", timeout, batchID)
+	case <-ctx.Done():
+		c.releasePending(batchID)
+		return nil, fmt.Errorf("controlPlaneBatchClient: cancelled: %w", ctx.Err())
+	}
+}
+
+// releasePending removes a pending entry. Safe to call when the entry has
+// already been removed (e.g. because handleControl resolved it
+// concurrently with a timeout firing).
+func (c *controlPlaneBatchClient) releasePending(requestID string) {
+	c.mu.Lock()
+	delete(c.pending, requestID)
+	delete(c.customID, requestID)
+	c.mu.Unlock()
+}
+
+// nextRequestID issues a monotonically increasing request ID. The
+// "batch-<n>" shape mirrors the askupstream "perm-<n>" convention from
+// transport.Correlator.
+func (c *controlPlaneBatchClient) nextRequestID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nextID++
+	return fmt.Sprintf("batch-%d", c.nextID)
+}
+
+// heartbeat emits a batch_waiting HarnessEvent at the configured cadence
+// until ctx fires or the pending entry is removed. Errors from Emit are
+// ignored — a transport that breaks mid-wait will surface the same break
+// to Result via the underlying RPC, which is a more reliable signal than
+// a heartbeat error.
+func (c *controlPlaneBatchClient) heartbeat(ctx context.Context, requestID string) {
+	ticker := time.NewTicker(batchWaitingHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.mu.Lock()
+			_, stillPending := c.pending[requestID]
+			c.mu.Unlock()
+			if !stillPending {
+				return
+			}
+			_ = c.transport.Emit(types.HarnessEvent{
+				Type:      "batch_waiting",
+				RequestID: requestID,
+			})
+		}
+	}
+}

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -14,6 +14,17 @@ import (
 	"github.com/rxbynerd/stirrup/types"
 )
 
+// Event-type discriminators for the batch wire protocol. HarnessEvents
+// flow harness → control plane; the single ControlEvent type flows
+// control plane → harness. The strings are part of the wire contract
+// (see types/events.go HarnessEvent.Type / ControlEvent.Type docs).
+const (
+	eventBatchSubmission    = "batch_submission"
+	eventBatchWaiting       = "batch_waiting"
+	eventBatchCancelRequest = "batch_cancel_request"
+	eventBatchResult        = "batch_result"
+)
+
 // batchWaitingHeartbeatIntervalNs holds the cadence (in nanoseconds) at
 // which the controlPlaneBatchClient emits batch_waiting HarnessEvents
 // while a batch submission is in flight. Stored as an atomic so tests
@@ -400,7 +411,7 @@ func NewControlPlaneBatchClient(t transport.Transport, maxWait time.Duration) *c
 // caller. Mirrors transport.Correlator.deliver, but specialised for the
 // BatchResult payload so we can keep the channel typed.
 func (c *controlPlaneBatchClient) handleControl(event types.ControlEvent) {
-	if event.Type != "batch_result" || event.RequestID == "" {
+	if event.Type != eventBatchResult || event.RequestID == "" {
 		return
 	}
 	result := decodeBatchResult(event)
@@ -470,7 +481,7 @@ func (c *controlPlaneBatchClient) Submit(ctx context.Context, entries []BatchEnt
 	c.mu.Unlock()
 
 	if err := c.transport.Emit(types.HarnessEvent{
-		Type:      "batch_submission",
+		Type:      eventBatchSubmission,
 		RequestID: requestID,
 		Input:     payloadBytes,
 	}); err != nil {
@@ -561,7 +572,7 @@ func (c *controlPlaneBatchClient) heartbeat(ctx context.Context, requestID strin
 				return
 			}
 			_ = c.transport.Emit(types.HarnessEvent{
-				Type:      "batch_waiting",
+				Type:      eventBatchWaiting,
 				RequestID: requestID,
 			})
 		}

--- a/harness/internal/provider/batch_test.go
+++ b/harness/internal/provider/batch_test.go
@@ -1,0 +1,679 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeBatchClient is a controllable BatchClient for table-driven tests.
+type fakeBatchClient struct {
+	submitErr error
+	submitFn  func(entries []BatchEntry) (string, error)
+
+	resultErr error
+	resultFn  func(batchID string) (map[string]*BatchResult, error)
+
+	mu             sync.Mutex
+	submitted      [][]BatchEntry
+	resultRequests []string
+}
+
+func (f *fakeBatchClient) Submit(_ context.Context, entries []BatchEntry) (string, error) {
+	f.mu.Lock()
+	f.submitted = append(f.submitted, entries)
+	f.mu.Unlock()
+
+	if f.submitFn != nil {
+		return f.submitFn(entries)
+	}
+	if f.submitErr != nil {
+		return "", f.submitErr
+	}
+	return "fake-batch-1", nil
+}
+
+func (f *fakeBatchClient) Result(_ context.Context, batchID string) (map[string]*BatchResult, error) {
+	f.mu.Lock()
+	f.resultRequests = append(f.resultRequests, batchID)
+	f.mu.Unlock()
+
+	if f.resultFn != nil {
+		return f.resultFn(batchID)
+	}
+	if f.resultErr != nil {
+		return nil, f.resultErr
+	}
+	return nil, errors.New("fakeBatchClient: no result configured")
+}
+
+// stubProvider is a streaming ProviderAdapter that replays a fixed sequence
+// of StreamEvents. Used to assert FallbackOnTimeout pumps the inner.
+type stubProvider struct {
+	events []types.StreamEvent
+	called atomic.Int64
+}
+
+func (s *stubProvider) Stream(_ context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	s.called.Add(1)
+	ch := make(chan types.StreamEvent, len(s.events))
+	go func() {
+		defer close(ch)
+		for _, ev := range s.events {
+			ch <- ev
+		}
+	}()
+	return ch, nil
+}
+
+// drain reads everything from ch with a generous wall-clock cap so a hung
+// goroutine fails the test rather than wedging the whole suite.
+func drain(t *testing.T, ch <-chan types.StreamEvent) []types.StreamEvent {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	var out []types.StreamEvent
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-deadline:
+			t.Fatalf("drain: timed out waiting for channel close (collected %d events)", len(out))
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// fabricateStream
+// -----------------------------------------------------------------------------
+
+func TestFabricateStream_AnthropicTextAndToolUse(t *testing.T) {
+	response := []byte(`{
+		"content": [
+			{"type": "text", "text": "hello "},
+			{"type": "text", "text": "world"},
+			{"type": "tool_use", "id": "tu_1", "name": "read_file", "input": {"path": "/etc/hosts"}}
+		],
+		"stop_reason": "tool_use",
+		"usage": {"output_tokens": 42}
+	}`)
+
+	ch := make(chan types.StreamEvent, 8)
+	if err := fabricateStream(ch, response, "anthropic"); err != nil {
+		t.Fatalf("fabricateStream: %v", err)
+	}
+	close(ch)
+
+	var got []types.StreamEvent
+	for ev := range ch {
+		got = append(got, ev)
+	}
+
+	if len(got) != 4 {
+		t.Fatalf("expected 4 events (2 text_delta + 1 tool_call + 1 message_complete), got %d: %+v", len(got), got)
+	}
+	if got[0].Type != "text_delta" || got[0].Text != "hello " {
+		t.Errorf("event 0: got %+v, want text_delta(hello )", got[0])
+	}
+	if got[1].Type != "text_delta" || got[1].Text != "world" {
+		t.Errorf("event 1: got %+v, want text_delta(world)", got[1])
+	}
+	if got[2].Type != "tool_call" || got[2].ID != "tu_1" || got[2].Name != "read_file" {
+		t.Errorf("event 2: got %+v, want tool_call(tu_1, read_file)", got[2])
+	}
+	if got[2].Input["path"] != "/etc/hosts" {
+		t.Errorf("event 2 input: got %+v, want path=/etc/hosts", got[2].Input)
+	}
+	if got[3].Type != "message_complete" {
+		t.Fatalf("event 3: got %+v, want message_complete", got[3])
+	}
+	if got[3].StopReason != "tool_use" {
+		t.Errorf("event 3 stop_reason: got %q, want tool_use", got[3].StopReason)
+	}
+	if got[3].OutputTokens != 42 {
+		t.Errorf("event 3 output_tokens: got %d, want 42", got[3].OutputTokens)
+	}
+	// message_complete carries the assembled content blocks the
+	// streaming consumer would have produced for the same response.
+	if len(got[3].Content) != 3 {
+		t.Fatalf("event 3 content: got %d blocks, want 3", len(got[3].Content))
+	}
+}
+
+func TestFabricateStream_OpenAINotImplemented(t *testing.T) {
+	for _, provType := range []string{"openai-compatible", "openai-responses"} {
+		t.Run(provType, func(t *testing.T) {
+			ch := make(chan types.StreamEvent, 1)
+			if err := fabricateStream(ch, []byte(`{}`), provType); err != nil {
+				t.Fatalf("fabricateStream: %v", err)
+			}
+			close(ch)
+
+			got := <-ch
+			if got.Type != "error" {
+				t.Errorf("got type %q, want error", got.Type)
+			}
+			if got.Error == nil || !strings.Contains(got.Error.Error(), "OpenAI batch fabrication not yet implemented") {
+				t.Errorf("expected 'not yet implemented' error, got: %v", got.Error)
+			}
+		})
+	}
+}
+
+func TestFabricateStream_UnsupportedProviderReturnsError(t *testing.T) {
+	ch := make(chan types.StreamEvent, 1)
+	err := fabricateStream(ch, []byte(`{}`), "bedrock")
+	if err == nil {
+		t.Fatal("expected error for unsupported provider type")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider type") {
+		t.Errorf("got %v, want error mentioning unsupported provider type", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// BatchAdapter
+// -----------------------------------------------------------------------------
+
+func batchAdapter(t *testing.T, client BatchClient, cfg *types.BatchProviderConfig, inner ProviderAdapter) *BatchAdapter {
+	t.Helper()
+	return NewBatchAdapter(inner, client, cfg, "anthropic", "run-test")
+}
+
+func anthropicParams() types.StreamParams {
+	return types.StreamParams{
+		Model:     "claude-3-5-sonnet-20241022",
+		System:    "be brief",
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}}},
+		MaxTokens: 256,
+	}
+}
+
+func TestBatchAdapter_Stream_HappyPath(t *testing.T) {
+	response := json.RawMessage(`{
+		"content": [{"type": "text", "text": "hello"}],
+		"stop_reason": "end_turn",
+		"usage": {"output_tokens": 7}
+	}`)
+	client := &fakeBatchClient{
+		resultFn: func(batchID string) (map[string]*BatchResult, error) {
+			return map[string]*BatchResult{
+				"run-test-turn-1": {Response: response},
+			}, nil
+		},
+	}
+
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true}, nil)
+	ch, err := a.Stream(context.Background(), anthropicParams())
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := drain(t, ch)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "text_delta" || events[0].Text != "hello" {
+		t.Errorf("event 0: %+v", events[0])
+	}
+	if events[1].Type != "message_complete" || events[1].StopReason != "end_turn" {
+		t.Errorf("event 1: %+v", events[1])
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.submitted) != 1 || len(client.submitted[0]) != 1 {
+		t.Fatalf("expected one single-entry submit, got %+v", client.submitted)
+	}
+	if client.submitted[0][0].CustomID != "run-test-turn-1" {
+		t.Errorf("custom_id: got %q, want run-test-turn-1", client.submitted[0][0].CustomID)
+	}
+	if client.submitted[0][0].Provider != "anthropic" {
+		t.Errorf("provider: got %q, want anthropic", client.submitted[0][0].Provider)
+	}
+}
+
+func TestBatchAdapter_Stream_TurnCounterIncrements(t *testing.T) {
+	emptyResponse := json.RawMessage(`{"content":[],"stop_reason":"end_turn","usage":{"output_tokens":0}}`)
+	client := &fakeBatchClient{
+		resultFn: func(batchID string) (map[string]*BatchResult, error) {
+			return map[string]*BatchResult{}, nil // missing -> error, but we only inspect submitted
+		},
+		submitFn: func(entries []BatchEntry) (string, error) { return "id", nil },
+	}
+	_ = emptyResponse
+
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true}, nil)
+	for i := 0; i < 3; i++ {
+		ch, err := a.Stream(context.Background(), anthropicParams())
+		if err != nil {
+			t.Fatalf("Stream %d: %v", i, err)
+		}
+		_ = drain(t, ch)
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.submitted) != 3 {
+		t.Fatalf("expected 3 submits, got %d", len(client.submitted))
+	}
+	for i, batch := range client.submitted {
+		want := fmt.Sprintf("run-test-turn-%d", i+1)
+		if batch[0].CustomID != want {
+			t.Errorf("submit %d: custom_id %q, want %q", i, batch[0].CustomID, want)
+		}
+	}
+}
+
+func TestBatchAdapter_Stream_SubmitError(t *testing.T) {
+	client := &fakeBatchClient{submitErr: errors.New("network unreachable")}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true}, nil)
+
+	ch, err := a.Stream(context.Background(), anthropicParams())
+	if err != nil {
+		t.Fatalf("Stream returned err: %v (should surface via channel)", err)
+	}
+	events := drain(t, ch)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 error event, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "error" {
+		t.Errorf("got type %q, want error", events[0].Type)
+	}
+	if events[0].Error == nil || !strings.Contains(events[0].Error.Error(), "network unreachable") {
+		t.Errorf("expected submit error chain, got: %v", events[0].Error)
+	}
+}
+
+func TestBatchAdapter_Stream_ResultError(t *testing.T) {
+	client := &fakeBatchClient{
+		resultFn: func(_ string) (map[string]*BatchResult, error) {
+			return map[string]*BatchResult{
+				"run-test-turn-1": {Err: &BatchResultError{Type: "batch_cancelled", Message: "user aborted"}},
+			}, nil
+		},
+	}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true}, nil)
+	ch, err := a.Stream(context.Background(), anthropicParams())
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := drain(t, ch)
+	if len(events) != 1 || events[0].Type != "error" {
+		t.Fatalf("expected single error event, got %+v", events)
+	}
+	if msg := events[0].Error.Error(); !strings.Contains(msg, "batch_cancelled") || !strings.Contains(msg, "user aborted") {
+		t.Errorf("error chain: %q (want both 'batch_cancelled' and 'user aborted')", msg)
+	}
+}
+
+func TestBatchAdapter_Stream_MissingEntry(t *testing.T) {
+	client := &fakeBatchClient{
+		resultFn: func(_ string) (map[string]*BatchResult, error) {
+			return map[string]*BatchResult{"other-id": {Response: json.RawMessage(`{}`)}}, nil
+		},
+	}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true}, nil)
+	ch, _ := a.Stream(context.Background(), anthropicParams())
+	events := drain(t, ch)
+	if len(events) != 1 || events[0].Type != "error" {
+		t.Fatalf("expected single error event, got %+v", events)
+	}
+	if !strings.Contains(events[0].Error.Error(), "missing entry") {
+		t.Errorf("expected 'missing entry' in error, got %q", events[0].Error)
+	}
+}
+
+func TestBatchAdapter_Stream_CtxCancel(t *testing.T) {
+	client := &fakeBatchClient{
+		resultFn: func(_ string) (map[string]*BatchResult, error) {
+			return nil, context.Canceled
+		},
+	}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch, err := a.Stream(ctx, anthropicParams())
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := drain(t, ch)
+	if len(events) != 1 || events[0].Type != "error" {
+		t.Fatalf("expected single error event, got %+v", events)
+	}
+	if !strings.Contains(events[0].Error.Error(), "cancelled") {
+		t.Errorf("expected 'cancelled' in error, got %q", events[0].Error)
+	}
+}
+
+func TestBatchAdapter_Stream_TimeoutWithoutFallback(t *testing.T) {
+	client := &fakeBatchClient{
+		resultFn: func(_ string) (map[string]*BatchResult, error) {
+			return nil, errors.New("controlPlaneBatchClient: batch_expired: timed out after 1s")
+		},
+	}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true, FallbackOnTimeout: false}, nil)
+	ch, _ := a.Stream(context.Background(), anthropicParams())
+	events := drain(t, ch)
+	if len(events) != 1 || events[0].Type != "error" {
+		t.Fatalf("expected single error event, got %+v", events)
+	}
+	if !strings.Contains(events[0].Error.Error(), "timed out") {
+		t.Errorf("expected 'timed out' in error, got %q", events[0].Error)
+	}
+}
+
+func TestBatchAdapter_Stream_TimeoutFallback(t *testing.T) {
+	client := &fakeBatchClient{
+		resultFn: func(_ string) (map[string]*BatchResult, error) {
+			return nil, errors.New("controlPlaneBatchClient: batch_expired: timed out after 1s")
+		},
+	}
+	inner := &stubProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "fallback"},
+			{Type: "message_complete", StopReason: "end_turn", OutputTokens: 3},
+		},
+	}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true, FallbackOnTimeout: true}, inner)
+
+	ch, _ := a.Stream(context.Background(), anthropicParams())
+	events := drain(t, ch)
+
+	if inner.called.Load() != 1 {
+		t.Errorf("expected inner adapter to be called once, got %d", inner.called.Load())
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events from inner, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "text_delta" || events[0].Text != "fallback" {
+		t.Errorf("event 0: %+v", events[0])
+	}
+	if events[1].Type != "message_complete" {
+		t.Errorf("event 1: %+v", events[1])
+	}
+}
+
+func TestBatchAdapter_Stream_UnsupportedProviderEmitsError(t *testing.T) {
+	client := &fakeBatchClient{}
+	a := NewBatchAdapter(nil, client, &types.BatchProviderConfig{Enabled: true}, "bedrock", "run-test")
+	ch, err := a.Stream(context.Background(), anthropicParams())
+	if err != nil {
+		t.Fatalf("Stream returned err: %v (should surface via channel)", err)
+	}
+	events := drain(t, ch)
+	if len(events) != 1 || events[0].Type != "error" {
+		t.Fatalf("expected single error event, got %+v", events)
+	}
+	if !strings.Contains(events[0].Error.Error(), `unsupported provider type "bedrock"`) {
+		t.Errorf("expected unsupported provider error, got: %v", events[0].Error)
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.submitted) != 0 {
+		t.Errorf("expected no submits for unsupported provider, got %+v", client.submitted)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// controlPlaneBatchClient
+// -----------------------------------------------------------------------------
+
+type mockBatchTransport struct {
+	mu       sync.Mutex
+	emitted  []types.HarnessEvent
+	handlers []func(types.ControlEvent)
+}
+
+func (m *mockBatchTransport) Emit(event types.HarnessEvent) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.emitted = append(m.emitted, event)
+	return nil
+}
+
+func (m *mockBatchTransport) OnControl(handler func(types.ControlEvent)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers = append(m.handlers, handler)
+}
+
+func (m *mockBatchTransport) Close() error { return nil }
+
+func (m *mockBatchTransport) deliver(event types.ControlEvent) {
+	m.mu.Lock()
+	hs := make([]func(types.ControlEvent), len(m.handlers))
+	copy(hs, m.handlers)
+	m.mu.Unlock()
+	for _, h := range hs {
+		h(event)
+	}
+}
+
+func (m *mockBatchTransport) lastEmitted() *types.HarnessEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.emitted) == 0 {
+		return nil
+	}
+	e := m.emitted[len(m.emitted)-1]
+	return &e
+}
+
+func (m *mockBatchTransport) emittedSnapshot() []types.HarnessEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]types.HarnessEvent, len(m.emitted))
+	copy(out, m.emitted)
+	return out
+}
+
+func TestControlPlaneBatchClient_SubmitAndResult(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, 5*time.Second)
+
+	entry := BatchEntry{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{"model":"claude-3-5-sonnet-20241022"}`),
+	}
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{entry})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	em := tr.lastEmitted()
+	if em == nil || em.Type != "batch_submission" {
+		t.Fatalf("expected batch_submission emitted, got %+v", em)
+	}
+	if em.RequestID != batchID {
+		t.Errorf("requestID echoed: got %q, want %q", em.RequestID, batchID)
+	}
+	var payload BatchSubmission
+	if err := json.Unmarshal(em.Input, &payload); err != nil {
+		t.Fatalf("unmarshal submission payload: %v", err)
+	}
+	if payload.ProviderType != "anthropic" || payload.CustomID != "run-test-turn-1" {
+		t.Errorf("payload: %+v", payload)
+	}
+	if string(payload.Body) != string(entry.Body) {
+		t.Errorf("payload body mismatch")
+	}
+
+	// Inject the matching batch_result; Result should return a map keyed
+	// by the original custom_id.
+	go func() {
+		// Small delay so Result blocks first.
+		time.Sleep(20 * time.Millisecond)
+		tr.deliver(types.ControlEvent{
+			Type:      "batch_result",
+			RequestID: batchID,
+			Content:   `{"response":{"content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"output_tokens":1}}}`,
+		})
+	}()
+
+	results, err := c.Result(context.Background(), batchID)
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	got, ok := results["run-test-turn-1"]
+	if !ok {
+		t.Fatalf("expected result keyed by custom_id, got %+v", results)
+	}
+	if got.Err != nil {
+		t.Errorf("expected success, got err %+v", got.Err)
+	}
+	if !strings.Contains(string(got.Response), `"text":"hi"`) {
+		t.Errorf("unexpected response: %s", got.Response)
+	}
+}
+
+func TestControlPlaneBatchClient_SubmitMultiEntryRejected(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Second)
+	_, err := c.Submit(context.Background(), []BatchEntry{{}, {}})
+	if err == nil || !strings.Contains(err.Error(), "expected exactly 1 entry") {
+		t.Errorf("expected single-entry contract error, got: %v", err)
+	}
+}
+
+func TestControlPlaneBatchClient_Result_Timeout(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, 50*time.Millisecond)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	_, err = c.Result(context.Background(), batchID)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "batch_expired") {
+		t.Errorf("expected batch_expired in error, got %q", err.Error())
+	}
+}
+
+func TestControlPlaneBatchClient_Result_ContextCancel(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Hour)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err = c.Result(ctx, batchID)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled in chain, got: %v", err)
+	}
+}
+
+func TestControlPlaneBatchClient_BatchWaitingHeartbeat(t *testing.T) {
+	prev := setBatchWaitingHeartbeatInterval(25 * time.Millisecond)
+	t.Cleanup(func() { setBatchWaitingHeartbeatInterval(prev) })
+
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Second)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	// Resolve the batch after enough ticks have fired so we can assert
+	// at least two heartbeats land alongside the result.
+	go func() {
+		time.Sleep(90 * time.Millisecond)
+		tr.deliver(types.ControlEvent{
+			Type:      "batch_result",
+			RequestID: batchID,
+			Content:   `{"response":{"content":[],"stop_reason":"end_turn","usage":{"output_tokens":0}}}`,
+		})
+	}()
+
+	if _, err := c.Result(context.Background(), batchID); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	// Settle: give the heartbeat goroutine one extra tick to notice the
+	// pending entry was removed and exit cleanly.
+	time.Sleep(40 * time.Millisecond)
+
+	var waiting int
+	for _, ev := range tr.emittedSnapshot() {
+		if ev.Type == "batch_waiting" && ev.RequestID == batchID {
+			waiting++
+		}
+	}
+	if waiting < 2 {
+		t.Errorf("expected at least 2 batch_waiting heartbeats, got %d (emitted=%+v)", waiting, tr.emittedSnapshot())
+	}
+}
+
+func TestControlPlaneBatchClient_IgnoresUnrelatedControlEvents(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Second)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		// Unrelated event types and wrong request IDs must not unblock
+		// the Result wait.
+		tr.deliver(types.ControlEvent{Type: "permission_response", RequestID: batchID})
+		tr.deliver(types.ControlEvent{Type: "batch_result", RequestID: "wrong-id"})
+		// Empty content surfaces a synthetic invalid_request_error so
+		// the BatchAdapter still sees a non-nil entry.
+		tr.deliver(types.ControlEvent{Type: "batch_result", RequestID: batchID})
+	}()
+
+	results, err := c.Result(context.Background(), batchID)
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	got, ok := results["run-test-turn-1"]
+	if !ok || got == nil {
+		t.Fatalf("expected entry, got %+v", results)
+	}
+	if got.Err == nil || got.Err.Type != "invalid_request_error" {
+		t.Errorf("expected synthetic invalid_request_error, got %+v", got.Err)
+	}
+}

--- a/harness/internal/provider/batch_test.go
+++ b/harness/internal/provider/batch_test.go
@@ -109,9 +109,7 @@ func TestFabricateStream_AnthropicTextAndToolUse(t *testing.T) {
 	}`)
 
 	ch := make(chan types.StreamEvent, 8)
-	if err := fabricateStream(ch, response, "anthropic"); err != nil {
-		t.Fatalf("fabricateStream: %v", err)
-	}
+	fabricateStream(ch, response, "anthropic")
 	close(ch)
 
 	var got []types.StreamEvent
@@ -154,9 +152,7 @@ func TestFabricateStream_OpenAINotImplemented(t *testing.T) {
 	for _, provType := range []string{"openai-compatible", "openai-responses"} {
 		t.Run(provType, func(t *testing.T) {
 			ch := make(chan types.StreamEvent, 1)
-			if err := fabricateStream(ch, []byte(`{}`), provType); err != nil {
-				t.Fatalf("fabricateStream: %v", err)
-			}
+			fabricateStream(ch, []byte(`{}`), provType)
 			close(ch)
 
 			got := <-ch
@@ -170,14 +166,16 @@ func TestFabricateStream_OpenAINotImplemented(t *testing.T) {
 	}
 }
 
-func TestFabricateStream_UnsupportedProviderReturnsError(t *testing.T) {
+func TestFabricateStream_UnsupportedProviderEmitsError(t *testing.T) {
 	ch := make(chan types.StreamEvent, 1)
-	err := fabricateStream(ch, []byte(`{}`), "bedrock")
-	if err == nil {
-		t.Fatal("expected error for unsupported provider type")
+	fabricateStream(ch, []byte(`{}`), "bedrock")
+	close(ch)
+	got := <-ch
+	if got.Type != "error" {
+		t.Errorf("got type %q, want error", got.Type)
 	}
-	if !strings.Contains(err.Error(), "unsupported provider type") {
-		t.Errorf("got %v, want error mentioning unsupported provider type", err)
+	if got.Error == nil || !strings.Contains(got.Error.Error(), "unsupported provider type") {
+		t.Errorf("expected unsupported-provider error, got %v", got.Error)
 	}
 }
 
@@ -550,6 +548,14 @@ func TestControlPlaneBatchClient_SubmitAndResult(t *testing.T) {
 	if !strings.Contains(string(got.Response), `"text":"hi"`) {
 		t.Errorf("unexpected response: %s", got.Response)
 	}
+
+	// Cleanup proof (R10): a second Result on the same batchID surfaces
+	// "no pending submission", confirming the success path called
+	// releasePending and dropped both maps.
+	if _, err := c.Result(context.Background(), batchID); err == nil ||
+		!strings.Contains(err.Error(), "no pending submission") {
+		t.Errorf("expected 'no pending submission' on second Result, got %v", err)
+	}
 }
 
 func TestControlPlaneBatchClient_SubmitMultiEntryRejected(t *testing.T) {
@@ -901,5 +907,233 @@ func TestControlPlaneBatchClient_SubmitEmitFailureCleansUp(t *testing.T) {
 	if _, err := c.Result(context.Background(), requestID); err == nil ||
 		!strings.Contains(err.Error(), "no pending submission") {
 		t.Errorf("expected 'no pending submission' after Submit failure, got %v", err)
+	}
+}
+
+// TestControlPlaneBatchClient_HeartbeatExitsOnCtxCancel (R3) asserts the
+// heartbeat goroutine terminates promptly when its context is cancelled
+// before any tick has fired.
+func TestControlPlaneBatchClient_HeartbeatExitsOnCtxCancel(t *testing.T) {
+	// Use a long interval so the ticker cannot fire during the test
+	// window; the goroutine should exit via the ctx.Done() arm.
+	prev := setBatchWaitingHeartbeatInterval(time.Hour)
+	t.Cleanup(func() { setBatchWaitingHeartbeatInterval(prev) })
+
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Hour, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	batchID, err := c.Submit(ctx, []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	cancel()
+	c.releasePending(batchID)
+
+	// Settle. With the long interval, no batch_waiting events should
+	// have been emitted; only the original batch_submission is on the
+	// wire.
+	time.Sleep(20 * time.Millisecond)
+	for _, ev := range tr.emittedSnapshot() {
+		if ev.Type == "batch_waiting" {
+			t.Errorf("unexpected batch_waiting emitted before ticker fired: %+v", ev)
+		}
+	}
+}
+
+// TestBatchAdapter_Stream_TimeoutFallback_InnerStreamError (R5) asserts
+// that when FallbackOnTimeout fires and the inner adapter itself
+// returns an error, the BatchAdapter surfaces a single error event.
+func TestBatchAdapter_Stream_TimeoutFallback_InnerStreamError(t *testing.T) {
+	client := &fakeBatchClient{
+		resultFn: func(_ string) (map[string]*BatchResult, error) {
+			return nil, fmt.Errorf("%w: simulated", errBatchExpired)
+		},
+	}
+	inner := &erroringProvider{err: errors.New("upstream provider down")}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true, FallbackOnTimeout: true}, inner)
+
+	ch, _ := a.Stream(context.Background(), anthropicParams())
+	events := drain(t, ch)
+
+	if len(events) != 1 || events[0].Type != "error" {
+		t.Fatalf("expected single error event, got %+v", events)
+	}
+	if !strings.Contains(events[0].Error.Error(), "batch fallback to streaming failed") {
+		t.Errorf("expected fallback-failure error, got %v", events[0].Error)
+	}
+}
+
+// erroringProvider is a ProviderAdapter that always fails on Stream.
+type erroringProvider struct{ err error }
+
+func (e *erroringProvider) Stream(_ context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	return nil, e.err
+}
+
+// TestBatchAdapter_Stream_TimeoutFallback_CtxCancelDuringRelay (R5)
+// asserts the channel closes cleanly when ctx is cancelled mid-relay.
+func TestBatchAdapter_Stream_TimeoutFallback_CtxCancelDuringRelay(t *testing.T) {
+	client := &fakeBatchClient{
+		resultFn: func(_ string) (map[string]*BatchResult, error) {
+			return nil, fmt.Errorf("%w: simulated", errBatchExpired)
+		},
+	}
+	inner := &blockingProvider{first: types.StreamEvent{Type: "text_delta", Text: "first"}, release: make(chan struct{})}
+	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true, FallbackOnTimeout: true}, inner)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, _ := a.Stream(ctx, anthropicParams())
+
+	// Read the first event from the relay, then cancel.
+	deadline := time.After(2 * time.Second)
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before first event")
+		}
+		if ev.Type != "text_delta" || ev.Text != "first" {
+			t.Fatalf("unexpected first event: %+v", ev)
+		}
+	case <-deadline:
+		t.Fatal("timed out waiting for first event from inner")
+	}
+
+	cancel()
+	close(inner.release)
+
+	// Channel must close cleanly (no goroutine leak). The relay races
+	// the second send against ctx.Done() per event — Go's select is
+	// non-deterministic so the second event may or may not land before
+	// pumpInner notices the cancellation. Either way, the channel must
+	// close without wedging.
+	deadline = time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return // success: closed cleanly
+			}
+		case <-deadline:
+			t.Fatal("channel did not close after ctx cancel")
+		}
+	}
+}
+
+// blockingProvider emits `first`, then waits for release to close
+// before emitting a second event and closing the channel. Used to drive
+// the ctx-cancel-during-relay path.
+type blockingProvider struct {
+	first   types.StreamEvent
+	release chan struct{}
+}
+
+func (b *blockingProvider) Stream(_ context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	ch := make(chan types.StreamEvent, 1)
+	go func() {
+		defer close(ch)
+		ch <- b.first
+		<-b.release
+		ch <- types.StreamEvent{Type: "text_delta", Text: "second"}
+	}()
+	return ch, nil
+}
+
+// TestBatchAdapter_Stream_OpenAIVariantsEmitNotImplemented (R6) pins
+// the phase-6 OpenAI integration point: both openai-compatible and
+// openai-responses provType values surface a single
+// "not yet implemented" error event from the marshal/fabricate path.
+func TestBatchAdapter_Stream_OpenAIVariantsEmitNotImplemented(t *testing.T) {
+	for _, provType := range []string{"openai-compatible", "openai-responses"} {
+		t.Run(provType, func(t *testing.T) {
+			response := json.RawMessage(`{}`)
+			client := &fakeBatchClient{
+				resultFn: func(_ string) (map[string]*BatchResult, error) {
+					return map[string]*BatchResult{
+						"stirrup-run-test-turn-1": {Response: response},
+					}, nil
+				},
+			}
+			a := NewBatchAdapter(nil, client, &types.BatchProviderConfig{Enabled: true}, provType, "run-test")
+			ch, err := a.Stream(context.Background(), anthropicParams())
+			if err != nil {
+				t.Fatalf("Stream: %v", err)
+			}
+			events := drain(t, ch)
+			if len(events) != 1 || events[0].Type != "error" {
+				t.Fatalf("expected single error event, got %+v", events)
+			}
+			if !strings.Contains(events[0].Error.Error(), "OpenAI batch fabrication not yet implemented") {
+				t.Errorf("expected 'not yet implemented' error, got %v", events[0].Error)
+			}
+		})
+	}
+}
+
+// TestFabricateStream_AnthropicParityWithReference (R8) compares the
+// fabricator's output against a hand-rolled reference sequence for a
+// single text + tool_use fixture. Guards against drift between the SSE
+// consumer (consumeSSE in anthropic.go) and the batch fabricator.
+func TestFabricateStream_AnthropicParityWithReference(t *testing.T) {
+	response := []byte(`{
+		"content": [
+			{"type": "text", "text": "hi"},
+			{"type": "tool_use", "id": "tu_a", "name": "read_file", "input": {"path": "/etc/hosts"}}
+		],
+		"stop_reason": "tool_use",
+		"usage": {"output_tokens": 5}
+	}`)
+
+	ch := make(chan types.StreamEvent, 8)
+	if err := fabricateAnthropicStream(ch, response); err != nil {
+		t.Fatalf("fabricateAnthropicStream: %v", err)
+	}
+	close(ch)
+
+	var got []types.StreamEvent
+	for ev := range ch {
+		got = append(got, ev)
+	}
+
+	// Reference sequence: one text_delta per text block, one tool_call
+	// per tool_use block, then a single message_complete carrying the
+	// assembled content blocks.
+	want := []types.StreamEvent{
+		{Type: "text_delta", Text: "hi"},
+		{Type: "tool_call", ID: "tu_a", Name: "read_file", Input: map[string]any{"path": "/etc/hosts"}},
+		{Type: "message_complete", StopReason: "tool_use", OutputTokens: 5, Content: []types.ContentBlock{
+			{Type: "text", Text: "hi"},
+			{Type: "tool_use", ID: "tu_a", Name: "read_file", Input: json.RawMessage(`{"path": "/etc/hosts"}`)},
+		}},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("event count: got %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Type != want[i].Type {
+			t.Errorf("event %d: type %q, want %q", i, got[i].Type, want[i].Type)
+		}
+		if got[i].Text != want[i].Text {
+			t.Errorf("event %d: text %q, want %q", i, got[i].Text, want[i].Text)
+		}
+		if got[i].ID != want[i].ID || got[i].Name != want[i].Name {
+			t.Errorf("event %d: id/name %q/%q, want %q/%q", i, got[i].ID, got[i].Name, want[i].ID, want[i].Name)
+		}
+		if want[i].StopReason != "" && got[i].StopReason != want[i].StopReason {
+			t.Errorf("event %d: stop_reason %q, want %q", i, got[i].StopReason, want[i].StopReason)
+		}
+		if want[i].OutputTokens != 0 && got[i].OutputTokens != want[i].OutputTokens {
+			t.Errorf("event %d: output_tokens %d, want %d", i, got[i].OutputTokens, want[i].OutputTokens)
+		}
+		// Tool input check (event index 1).
+		if want[i].Type == "tool_call" {
+			if got[i].Input["path"] != want[i].Input["path"] {
+				t.Errorf("event %d: tool input path %v, want %v", i, got[i].Input, want[i].Input)
+			}
+		}
 	}
 }

--- a/harness/internal/provider/batch_test.go
+++ b/harness/internal/provider/batch_test.go
@@ -360,7 +360,7 @@ func TestBatchAdapter_Stream_CtxCancel(t *testing.T) {
 func TestBatchAdapter_Stream_TimeoutWithoutFallback(t *testing.T) {
 	client := &fakeBatchClient{
 		resultFn: func(_ string) (map[string]*BatchResult, error) {
-			return nil, errors.New("controlPlaneBatchClient: batch_expired: timed out after 1s")
+			return nil, fmt.Errorf("%w: simulated", errBatchExpired)
 		},
 	}
 	a := batchAdapter(t, client, &types.BatchProviderConfig{Enabled: true, FallbackOnTimeout: false}, nil)
@@ -369,15 +369,15 @@ func TestBatchAdapter_Stream_TimeoutWithoutFallback(t *testing.T) {
 	if len(events) != 1 || events[0].Type != "error" {
 		t.Fatalf("expected single error event, got %+v", events)
 	}
-	if !strings.Contains(events[0].Error.Error(), "timed out") {
-		t.Errorf("expected 'timed out' in error, got %q", events[0].Error)
+	if !errors.Is(events[0].Error, errBatchExpired) {
+		t.Errorf("expected errBatchExpired in chain, got %v", events[0].Error)
 	}
 }
 
 func TestBatchAdapter_Stream_TimeoutFallback(t *testing.T) {
 	client := &fakeBatchClient{
 		resultFn: func(_ string) (map[string]*BatchResult, error) {
-			return nil, errors.New("controlPlaneBatchClient: batch_expired: timed out after 1s")
+			return nil, fmt.Errorf("%w: simulated", errBatchExpired)
 		},
 	}
 	inner := &stubProvider{
@@ -434,12 +434,24 @@ type mockBatchTransport struct {
 	mu       sync.Mutex
 	emitted  []types.HarnessEvent
 	handlers []func(types.ControlEvent)
+	// emitErr, when non-nil and emitErrTypes is empty, causes every
+	// Emit call to fail with that error. When emitErrTypes is populated,
+	// only matching event types fail; others succeed. This lets a test
+	// drive submission failures while still observing later cancel
+	// emits, etc.
+	emitErr      error
+	emitErrTypes map[string]bool
 }
 
 func (m *mockBatchTransport) Emit(event types.HarnessEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.emitted = append(m.emitted, event)
+	if m.emitErr != nil {
+		if len(m.emitErrTypes) == 0 || m.emitErrTypes[event.Type] {
+			return m.emitErr
+		}
+	}
 	return nil
 }
 
@@ -481,7 +493,7 @@ func (m *mockBatchTransport) emittedSnapshot() []types.HarnessEvent {
 
 func TestControlPlaneBatchClient_SubmitAndResult(t *testing.T) {
 	tr := &mockBatchTransport{}
-	c := NewControlPlaneBatchClient(tr, 5*time.Second)
+	c := NewControlPlaneBatchClient(tr, 5*time.Second, false)
 
 	entry := BatchEntry{
 		CustomID: "run-test-turn-1",
@@ -542,7 +554,7 @@ func TestControlPlaneBatchClient_SubmitAndResult(t *testing.T) {
 
 func TestControlPlaneBatchClient_SubmitMultiEntryRejected(t *testing.T) {
 	tr := &mockBatchTransport{}
-	c := NewControlPlaneBatchClient(tr, time.Second)
+	c := NewControlPlaneBatchClient(tr, time.Second, false)
 	_, err := c.Submit(context.Background(), []BatchEntry{{}, {}})
 	if err == nil || !strings.Contains(err.Error(), "expected exactly 1 entry") {
 		t.Errorf("expected single-entry contract error, got: %v", err)
@@ -551,7 +563,7 @@ func TestControlPlaneBatchClient_SubmitMultiEntryRejected(t *testing.T) {
 
 func TestControlPlaneBatchClient_Result_Timeout(t *testing.T) {
 	tr := &mockBatchTransport{}
-	c := NewControlPlaneBatchClient(tr, 50*time.Millisecond)
+	c := NewControlPlaneBatchClient(tr, 50*time.Millisecond, false)
 
 	batchID, err := c.Submit(context.Background(), []BatchEntry{{
 		CustomID: "run-test-turn-1",
@@ -566,14 +578,14 @@ func TestControlPlaneBatchClient_Result_Timeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
-	if !strings.Contains(err.Error(), "batch_expired") {
-		t.Errorf("expected batch_expired in error, got %q", err.Error())
+	if !errors.Is(err, errBatchExpired) {
+		t.Errorf("expected errBatchExpired in chain, got %v", err)
 	}
 }
 
 func TestControlPlaneBatchClient_Result_ContextCancel(t *testing.T) {
 	tr := &mockBatchTransport{}
-	c := NewControlPlaneBatchClient(tr, time.Hour)
+	c := NewControlPlaneBatchClient(tr, time.Hour, false)
 
 	batchID, err := c.Submit(context.Background(), []BatchEntry{{
 		CustomID: "run-test-turn-1",
@@ -600,7 +612,7 @@ func TestControlPlaneBatchClient_BatchWaitingHeartbeat(t *testing.T) {
 	t.Cleanup(func() { setBatchWaitingHeartbeatInterval(prev) })
 
 	tr := &mockBatchTransport{}
-	c := NewControlPlaneBatchClient(tr, time.Second)
+	c := NewControlPlaneBatchClient(tr, time.Second, false)
 
 	batchID, err := c.Submit(context.Background(), []BatchEntry{{
 		CustomID: "run-test-turn-1",
@@ -643,7 +655,7 @@ func TestControlPlaneBatchClient_BatchWaitingHeartbeat(t *testing.T) {
 
 func TestControlPlaneBatchClient_IgnoresUnrelatedControlEvents(t *testing.T) {
 	tr := &mockBatchTransport{}
-	c := NewControlPlaneBatchClient(tr, time.Second)
+	c := NewControlPlaneBatchClient(tr, time.Second, false)
 
 	batchID, err := c.Submit(context.Background(), []BatchEntry{{
 		CustomID: "run-test-turn-1",
@@ -675,5 +687,219 @@ func TestControlPlaneBatchClient_IgnoresUnrelatedControlEvents(t *testing.T) {
 	}
 	if got.Err == nil || got.Err.Type != "invalid_request_error" {
 		t.Errorf("expected synthetic invalid_request_error, got %+v", got.Err)
+	}
+}
+
+// TestControlPlaneBatchClient_DeliverBeforeResult exercises the B1
+// race: handleControl delivers a batch_result before Result is even
+// called. With the fix, Result must return the buffered value rather
+// than spuriously surfacing "no pending submission".
+func TestControlPlaneBatchClient_DeliverBeforeResult(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Second, false)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	// Deliver the result before Result is called; the buffered channel
+	// holds the value until Result drains it.
+	tr.deliver(types.ControlEvent{
+		Type:      "batch_result",
+		RequestID: batchID,
+		Content:   `{"response":{"content":[],"stop_reason":"end_turn","usage":{"output_tokens":0}}}`,
+	})
+
+	results, err := c.Result(context.Background(), batchID)
+	if err != nil {
+		t.Fatalf("Result after early delivery: %v", err)
+	}
+	got, ok := results["run-test-turn-1"]
+	if !ok || got == nil {
+		t.Fatalf("expected entry keyed by custom_id, got %+v", results)
+	}
+	if got.Err != nil {
+		t.Errorf("expected success, got err %+v", got.Err)
+	}
+
+	// Cleanup proof: a second Result returns "no pending submission".
+	if _, err := c.Result(context.Background(), batchID); err == nil ||
+		!strings.Contains(err.Error(), "no pending submission") {
+		t.Errorf("expected 'no pending submission' on second Result, got %v", err)
+	}
+}
+
+// TestControlPlaneBatchClient_CancelBundle_TimeoutEmits asserts B3: a
+// timeout exit emits a batch_cancel_request when cancelBundleOnExit=true.
+func TestControlPlaneBatchClient_CancelBundle_TimeoutEmits(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, 30*time.Millisecond, true)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	if _, err := c.Result(context.Background(), batchID); !errors.Is(err, errBatchExpired) {
+		t.Fatalf("expected errBatchExpired, got %v", err)
+	}
+
+	var cancel int
+	for _, ev := range tr.emittedSnapshot() {
+		if ev.Type == "batch_cancel_request" && ev.RequestID == batchID {
+			cancel++
+		}
+	}
+	if cancel != 1 {
+		t.Errorf("expected exactly 1 batch_cancel_request, got %d (emitted=%+v)", cancel, tr.emittedSnapshot())
+	}
+}
+
+// TestControlPlaneBatchClient_CancelBundle_CtxCancelEmits asserts B3 on
+// the ctx-cancel arm.
+func TestControlPlaneBatchClient_CancelBundle_CtxCancelEmits(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Hour, true)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := c.Result(ctx, batchID); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	var cancelEvents int
+	for _, ev := range tr.emittedSnapshot() {
+		if ev.Type == "batch_cancel_request" && ev.RequestID == batchID {
+			cancelEvents++
+		}
+	}
+	if cancelEvents != 1 {
+		t.Errorf("expected exactly 1 batch_cancel_request, got %d", cancelEvents)
+	}
+}
+
+// TestControlPlaneBatchClient_CancelBundle_DisabledNoEmit asserts B3:
+// when cancelBundleOnExit=false, the cancel/timeout arms emit nothing
+// beyond the original batch_submission.
+func TestControlPlaneBatchClient_CancelBundle_DisabledNoEmit(t *testing.T) {
+	tr := &mockBatchTransport{}
+	c := NewControlPlaneBatchClient(tr, time.Hour, false)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Result(ctx, batchID); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	for _, ev := range tr.emittedSnapshot() {
+		if ev.Type == "batch_cancel_request" {
+			t.Errorf("unexpected batch_cancel_request emitted with cancelBundleOnExit=false: %+v", ev)
+		}
+	}
+}
+
+// TestDecodeBatchResult_MalformedJSON (B6) asserts a non-JSON content
+// surfaces as a synthetic invalid_request_error rather than panicking.
+func TestDecodeBatchResult_MalformedJSON(t *testing.T) {
+	got := decodeBatchResult(types.ControlEvent{
+		Type:      "batch_result",
+		RequestID: "batch-1",
+		Content:   "{not-json",
+	})
+	if got == nil || got.Err == nil {
+		t.Fatalf("expected synthetic error, got %+v", got)
+	}
+	if got.Err.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", got.Err.Type)
+	}
+	if !strings.Contains(got.Err.Message, "decode batch_result") {
+		t.Errorf("message: got %q, want substring 'decode batch_result'", got.Err.Message)
+	}
+}
+
+// TestDecodeBatchResult_SizeCap (B6) asserts a Content payload above
+// maxBatchResponseBytes surfaces as a synthetic invalid_request_error
+// without attempting to decode the oversized blob.
+func TestDecodeBatchResult_SizeCap(t *testing.T) {
+	oversized := strings.Repeat("a", maxBatchResponseBytes+1)
+	got := decodeBatchResult(types.ControlEvent{
+		Type:      "batch_result",
+		RequestID: "batch-1",
+		Content:   oversized,
+	})
+	if got == nil || got.Err == nil {
+		t.Fatalf("expected synthetic error, got %+v", got)
+	}
+	if got.Err.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", got.Err.Type)
+	}
+	if !strings.Contains(got.Err.Message, "exceeds") {
+		t.Errorf("message: got %q, want substring 'exceeds'", got.Err.Message)
+	}
+}
+
+// TestControlPlaneBatchClient_SubmitEmitFailureCleansUp (B7) drives an
+// Emit failure on batch_submission and asserts the pending entry was
+// dropped (no leak; subsequent Result reports "no pending submission").
+func TestControlPlaneBatchClient_SubmitEmitFailureCleansUp(t *testing.T) {
+	tr := &mockBatchTransport{
+		emitErr:      errors.New("simulated emit failure"),
+		emitErrTypes: map[string]bool{"batch_submission": true},
+	}
+	c := NewControlPlaneBatchClient(tr, time.Second, false)
+
+	batchID, err := c.Submit(context.Background(), []BatchEntry{{
+		CustomID: "run-test-turn-1",
+		Provider: "anthropic",
+		Body:     json.RawMessage(`{}`),
+	}})
+	if err == nil {
+		t.Fatal("expected emit error from Submit")
+	}
+	if !strings.Contains(err.Error(), "simulated emit failure") {
+		t.Errorf("expected wrapped emit error, got %v", err)
+	}
+	if batchID != "" {
+		t.Errorf("Submit returned non-empty batchID on failure: %q", batchID)
+	}
+	emitted := tr.emittedSnapshot()
+	if len(emitted) != 1 || emitted[0].Type != "batch_submission" {
+		t.Fatalf("expected single batch_submission emit, got %+v", emitted)
+	}
+	requestID := emitted[0].RequestID
+
+	if _, err := c.Result(context.Background(), requestID); err == nil ||
+		!strings.Contains(err.Error(), "no pending submission") {
+		t.Errorf("expected 'no pending submission' after Submit failure, got %v", err)
 	}
 }

--- a/harness/internal/provider/batch_test.go
+++ b/harness/internal/provider/batch_test.go
@@ -208,7 +208,7 @@ func TestBatchAdapter_Stream_HappyPath(t *testing.T) {
 	client := &fakeBatchClient{
 		resultFn: func(batchID string) (map[string]*BatchResult, error) {
 			return map[string]*BatchResult{
-				"run-test-turn-1": {Response: response},
+				"stirrup-run-test-turn-1": {Response: response},
 			}, nil
 		},
 	}
@@ -235,8 +235,8 @@ func TestBatchAdapter_Stream_HappyPath(t *testing.T) {
 	if len(client.submitted) != 1 || len(client.submitted[0]) != 1 {
 		t.Fatalf("expected one single-entry submit, got %+v", client.submitted)
 	}
-	if client.submitted[0][0].CustomID != "run-test-turn-1" {
-		t.Errorf("custom_id: got %q, want run-test-turn-1", client.submitted[0][0].CustomID)
+	if client.submitted[0][0].CustomID != "stirrup-run-test-turn-1" {
+		t.Errorf("custom_id: got %q, want stirrup-run-test-turn-1", client.submitted[0][0].CustomID)
 	}
 	if client.submitted[0][0].Provider != "anthropic" {
 		t.Errorf("provider: got %q, want anthropic", client.submitted[0][0].Provider)
@@ -267,7 +267,7 @@ func TestBatchAdapter_Stream_TurnCounterIncrements(t *testing.T) {
 		t.Fatalf("expected 3 submits, got %d", len(client.submitted))
 	}
 	for i, batch := range client.submitted {
-		want := fmt.Sprintf("run-test-turn-%d", i+1)
+		want := fmt.Sprintf("stirrup-run-test-turn-%d", i+1)
 		if batch[0].CustomID != want {
 			t.Errorf("submit %d: custom_id %q, want %q", i, batch[0].CustomID, want)
 		}
@@ -298,7 +298,7 @@ func TestBatchAdapter_Stream_ResultError(t *testing.T) {
 	client := &fakeBatchClient{
 		resultFn: func(_ string) (map[string]*BatchResult, error) {
 			return map[string]*BatchResult{
-				"run-test-turn-1": {Err: &BatchResultError{Type: "batch_cancelled", Message: "user aborted"}},
+				"stirrup-run-test-turn-1": {Err: &BatchResultError{Type: "batch_cancelled", Message: "user aborted"}},
 			}, nil
 		},
 	}

--- a/harness/internal/transport/stdio_test.go
+++ b/harness/internal/transport/stdio_test.go
@@ -146,6 +146,66 @@ func TestStdioTransport_EmitFiresSecretRedactedInOutput(t *testing.T) {
 	}
 }
 
+// TestStdioTransport_RoundTripsBatchEventTypes confirms the stdio
+// transport carries the phase-2 batch event-type discriminators through
+// without dropping or remapping them. The transport is pass-through on
+// Type (no allowlist), so the test guards against a future regression
+// that would add one.
+func TestStdioTransport_RoundTripsBatchEventTypes(t *testing.T) {
+	var buf bytes.Buffer
+	tr := NewStdioTransport(&buf, strings.NewReader(""))
+
+	outbound := []types.HarnessEvent{
+		{Type: "batch_submission", RequestID: "batch-1", Input: []byte(`{"provider_type":"anthropic"}`)},
+		{Type: "batch_waiting", RequestID: "batch-1"},
+		{Type: "batch_cancel_request", RequestID: "batch-1"},
+	}
+	for _, ev := range outbound {
+		if err := tr.Emit(ev); err != nil {
+			t.Fatalf("Emit %s: %v", ev.Type, err)
+		}
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != len(outbound) {
+		t.Fatalf("expected %d lines, got %d: %q", len(outbound), len(lines), buf.String())
+	}
+	for i, line := range lines {
+		var got types.HarnessEvent
+		if err := json.Unmarshal([]byte(line), &got); err != nil {
+			t.Fatalf("unmarshal line %d: %v", i, err)
+		}
+		if got.Type != outbound[i].Type {
+			t.Errorf("line %d: got type %q, want %q", i, got.Type, outbound[i].Type)
+		}
+		if got.RequestID != outbound[i].RequestID {
+			t.Errorf("line %d: got requestID %q, want %q", i, got.RequestID, outbound[i].RequestID)
+		}
+	}
+
+	// Inbound batch_result via the read path.
+	inbound := `{"type":"batch_result","requestId":"batch-1","content":"{\"response\":null,\"err\":{\"type\":\"batch_expired\"}}"}` + "\n"
+	tr2 := NewStdioTransport(&bytes.Buffer{}, strings.NewReader(inbound))
+	received := make(chan types.ControlEvent, 1)
+	tr2.OnControl(func(event types.ControlEvent) {
+		received <- event
+	})
+	select {
+	case ev := <-received:
+		if ev.Type != "batch_result" {
+			t.Errorf("got type %q, want batch_result", ev.Type)
+		}
+		if ev.RequestID != "batch-1" {
+			t.Errorf("got requestID %q, want batch-1", ev.RequestID)
+		}
+		if ev.Content == "" {
+			t.Error("expected non-empty content on batch_result")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for batch_result control event")
+	}
+}
+
 func TestStdioTransport_EmitNoEventWhenNoSecret(t *testing.T) {
 	var buf bytes.Buffer
 	tr := NewStdioTransport(&buf, strings.NewReader(""))

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -83,11 +83,32 @@ service HarnessService {
 //     - (no additional fields) Sent every 30 seconds during execution to
 //       signal liveness. The control plane should treat absence of heartbeats
 //       as a potential hang.
+//
+//   "batch_submission"
+//     - request_id: correlation ID; the control plane must echo this in
+//                   the corresponding batch_result ControlEvent.
+//     - input:      JSON-encoded BatchSubmission payload (provider_type,
+//                   custom_id, body). The body is the marshalled provider
+//                   request the streaming adapter would have POSTed.
+//
+//   "batch_waiting"
+//     - request_id: the originating batch_submission request_id.
+//     (Heartbeat-style event emitted every 5 minutes during the wait so
+//     the control plane can distinguish "still pending" from a stalled
+//     harness. Reuses the run-level heartbeat as a liveness signal of
+//     last resort.)
+//
+//   "batch_cancel_request"
+//     - request_id: the originating batch_submission request_id.
+//     (Best-effort signal; the control plane should call the provider's
+//     batch-cancel endpoint. The harness does not retry or block on a
+//     response — cancellation is fire-and-forget.)
 message HarnessEvent {
   // Required. The event type discriminator.
   // Valid values: "text_delta", "tool_call", "tool_result", "done", "error",
   //              "warning", "heartbeat", "ready", "permission_request",
-  //              "tool_result_request".
+  //              "tool_result_request", "batch_submission", "batch_waiting",
+  //              "batch_cancel_request".
   string type = 1;
 
   // Incremental text fragment from the model. Set on "text_delta" events.
@@ -174,10 +195,18 @@ message HarnessEvent {
 //       final "done" HarnessEvent carries stop_reason="cancelled". If the
 //       harness is in the follow-up grace window (no active run), the
 //       stream closes promptly without an additional "done" event.
+//
+//   "batch_result"
+//     - request_id: must match a previously received batch_submission
+//                   HarnessEvent.request_id.
+//     - content:    JSON-encoded BatchResult payload (response or err).
+//     - is_error:   true for non-success result types (batch_expired,
+//                   batch_cancelled, invalid_request_error, server_error).
 message ControlEvent {
   // Required. The event type discriminator.
   // Valid values: "task_assignment", "user_response", "cancel",
-  //              "permission_response", "tool_result_response".
+  //              "permission_response", "tool_result_response",
+  //              "batch_result".
   string type = 1;
 
   // The run configuration. Set on "task_assignment" events only. This is the

--- a/types/events.go
+++ b/types/events.go
@@ -93,6 +93,17 @@ func Float64Ptr(v float64) *float64 {
 //     tool defers its result; correlated by RequestID with the incoming
 //     "tool_result_response" ControlEvent. Carries ToolUseID, ToolName and
 //     Input so the control plane can correlate to the original tool_call.
+//   - "batch_submission"     — emitted by the gRPC BatchAdapter for a turn
+//     it wants the control plane to dispatch as a batch entry; Input carries
+//     the provider-shaped request body, RequestID correlates the matching
+//     "batch_result" ControlEvent.
+//   - "batch_waiting"        — periodic heartbeat from the BatchAdapter
+//     while a "batch_submission" is in flight; RequestID echoes the
+//     originating submission so the control plane can keep its slot alive.
+//   - "batch_cancel_request" — emitted by the BatchAdapter when the run
+//     cancels or its wall-clock cap fires and the operator opted into
+//     CancelBundleOnRunCancel; RequestID echoes the submission so the
+//     control plane can cancel the matching provider-side batch entry.
 type HarnessEvent struct {
 	Type           string          `json:"type"`
 	Text           string          `json:"text,omitempty"`
@@ -121,6 +132,10 @@ type HarnessEvent struct {
 //     for an async tool. RequestID echoes the originating request; Content
 //     carries the result payload; IsError, when set, marks the result as a
 //     tool failure (the model sees IsError=true on the ToolResult).
+//   - "batch_result"          — completes a "batch_submission" HarnessEvent.
+//     RequestID echoes the originating submission; Content carries the JSON
+//     BatchResult (provider response on success, BatchResultError on failure)
+//     consumed by harness/internal/provider.decodeBatchResult.
 type ControlEvent struct {
 	Type         string     `json:"type"`
 	Task         *RunConfig `json:"task,omitempty"`


### PR DESCRIPTION
## Summary

Core of the batch-API stack: `BatchAdapter` wraps any streaming `ProviderAdapter` and fabricates streaming events from completed batch results; `controlPlaneBatchClient` submits over the existing gRPC transport, correlated by request ID; factory wires the adapter when `provider.batch.enabled && transport.type == "grpc"`. PR 3 of 7. Stack base: PR #208 (`gh-134-batch-phase-1`).

## Changes

- `harness/internal/provider/batch.go` (new):
  - `BatchClient` interface (Submit / Result), `BatchEntry`/`BatchResult`/`BatchResultError` types.
  - `BatchAdapter` implementing `types.ProviderAdapter` — six-step Stream flow: build via the phase-0 `build*Request` helpers, marshal, Submit, block on Result, fabricate or fall back, close.
  - `fabricateStream` decodes the Anthropic batch response and emits the canonical event sequence (text_delta per text block, tool_call per tool_use, message_complete with assembled `Content`/`StopReason`/`OutputTokens`). OpenAI variants emit an explicit "not yet implemented" error event — phase 6 hook.
  - `controlPlaneBatchClient`: emits `batch_submission` HarnessEvents, blocks on matching `batch_result` ControlEvents via a local pending-map (typed `map[string]chan *BatchResult`). Emits `batch_waiting` heartbeats every 5 min during the wait. Emits `batch_cancel_request` on ctx-cancel/timeout when `CancelBundleOnRunCancel=true`. `errBatchExpired` sentinel gates the FallbackOnTimeout path via `errors.Is`. 4 MB cap on decoded `batch_result` content.
- `harness/internal/core/factory.go`: wires `BatchAdapter` over the base provider when `Batch.Enabled && Transport.Type == "grpc"`, overwriting both the top-level `prov` and `providers[type]` map entry (so the model-router lookup doesn't bypass the wrapper).
- `proto/harness/v1/harness.proto`: comment-only update documenting the four new event discriminators (`batch_submission`, `batch_waiting`, `batch_cancel_request`, `batch_result`) on `HarnessEvent`/`ControlEvent`.
- `types/events.go`: docstring updates for the same.
- `harness/internal/transport/stdio_test.go`: regression test asserting the new event types round-trip pass-through on stdio.

## Tests

`harness/internal/provider/batch_test.go` (new): 25+ tests covering fabricate sequence + parity check, BatchAdapter happy path / submit error / result error / ctx cancel / timeout fallback / fallback inner error / OpenAI not-implemented, controlPlaneBatchClient submit-and-result / timeout / ctx-cancel / heartbeat firing / heartbeat ctx-cancel exit / Submit Emit-failure cleanup / size-cap rejection / malformed-JSON path / cancel-request emit gated on flag.

`harness/internal/core/factory_test.go`: `TestBuildLoopWithTransport_BatchAdapterWiredWhenEnabled` proves wrapping happens for grpc and is correctly absent for stdio (until phase 4).

`go test -race ./harness/internal/provider/... ./harness/internal/transport/... ./harness/internal/core/...` → PASS. `golangci-lint`: clean.

## Review wave

Five-reviewer cycle ran (code, security, spec-compliance, test-coverage, api-design). Synthesised brief: 8 blocking + 10 recommended. All resolved across commits 5e136f9, 4cc813a, fbdf243, 7e8fcbf, ccdd623.

Blocking resolved:
- `handleControl`/`Result` race that silently turned successful batches into failures on a fast control plane (transferred pending-map ownership to `Result`).
- `isBatchTimeout` substring-matching `"batch_expired"` (replaced with `errBatchExpired` sentinel).
- `CancelBundleOnRunCancel` silent no-op + `batch_cancel_request` phantom contract (single fix: client emits the event when the flag is true).
- Untyped event discriminator strings + stale `types/events.go` docs (extracted constants + updated docstrings).
- Factory wiring entirely untested (`TestBuildLoopWithTransport_BatchAdapterWiredWhenEnabled` added).
- `decodeBatchResult` malformed JSON test gap + no size cap (4 MB cap + decode-error path tested).
- `Submit` Emit-failure pending-map cleanup untested (test added).
- `CustomID` missing `"stirrup-"` prefix (added per spec).

7 deferred items + handful of NITs noted for follow-up issues after merge.

## Test plan

- [x] `go build ./harness/... ./types/... ./eval/... ./gen/...`
- [x] `go test -race -count=1 ./harness/internal/provider/... ./harness/internal/transport/... ./harness/internal/core/...`
- [x] `golangci-lint run ./harness/internal/provider/... ./harness/internal/core/...`
- [ ] CI green

Closes #135.