### PR TITLE
batch(phase-3): --batch CLI flag + docs/sandbox.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.
 | LLM-based safety classifier (`GuardRail`) | [`docs/guardrails.md`](docs/guardrails.md) |
 | Eval framework (`stirrup-eval`) | [`docs/eval.md`](docs/eval.md) |
 | Provider adapters | [`docs/providers.md`](docs/providers.md) |
-| Sandbox modes (async batch submission) | [`docs/sandbox.md`](docs/sandbox.md) |
+| Batch mode | [`docs/sandbox.md`](docs/batch.md) |
 | Cross-cloud credential federation | [`docs/credential-federation.md`](docs/credential-federation.md) |
 | Anthropic Workload Identity Federation | [`docs/anthropic-wif.md`](docs/anthropic-wif.md) |
 | Azure Workload Identity Federation | [`docs/azure-workload-identity.md`](docs/azure-workload-identity.md) |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.
 | LLM-based safety classifier (`GuardRail`) | [`docs/guardrails.md`](docs/guardrails.md) |
 | Eval framework (`stirrup-eval`) | [`docs/eval.md`](docs/eval.md) |
 | Provider adapters | [`docs/providers.md`](docs/providers.md) |
+| Sandbox modes (async batch submission) | [`docs/sandbox.md`](docs/sandbox.md) |
 | Cross-cloud credential federation | [`docs/credential-federation.md`](docs/credential-federation.md) |
 | Anthropic Workload Identity Federation | [`docs/anthropic-wif.md`](docs/anthropic-wif.md) |
 | Azure Workload Identity Federation | [`docs/azure-workload-identity.md`](docs/azure-workload-identity.md) |

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -1,11 +1,3 @@
-# Sandbox modes
-
-This document describes operator-facing modes and configurations that
-adjust how the harness executes provider turns, including async batch
-submission. Each mode here is opt-in: the harness defaults stream
-every turn synchronously over the same transport that delivers
-`ToolCallResult` and `Status` events.
-
 ## Batch provider mode
 
 ### What it is

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -34,16 +34,16 @@ enforces the safe-by-default posture:
   combination invites stale-workspace and resource-hold footguns.
 - **`planning`** and **`review`** are rejected unless the operator
   sets `provider.batch.allowInteractiveModes=true`. These modes are
-  interactive by design (a human reviewer expects fast feedback on a
-  plan or a code review) and the opt-in exists so an operator who
-  has deliberately chosen async planning has to acknowledge the
-  footgun.
+  interactive by design — they optimise for fast feedback on plans
+  and code reviews rather than the 24-hour wait that batch implies —
+  and the opt-in exists so an operator who has deliberately chosen
+  async planning has to acknowledge the footgun.
 - **`research`** and **`toil`** are accepted unconditionally — they
   are the modes the feature was built for.
 
 ### How to enable
 
-The CLI flag is the simplest path:
+The CLI flag is the recommended path:
 
 ```sh
 stirrup harness --batch --mode research --prompt "..."
@@ -72,10 +72,10 @@ to wait on. The phase-2 `controlPlaneBatchClient` is the default for
 gRPC operators.
 
 Stdio operators must set `provider.batch.harnessSidePolling=true` in
-their `--config`. In this mode the harness polls the provider HTTP
-endpoint directly from the run process — there is no control plane
-to amortise across, so every run holds its own connection open for
-the duration of its batch. The harness-side polling client is
+their `--config`. In this mode polling executes within the harness
+process itself rather than via the control plane — there is no
+control plane to amortise across, so every run holds its own
+connection open for the duration of its batch. The harness-side polling client is
 experimental in v1 and ships only for the Anthropic provider; OpenAI
 support lands in phase 6 (issue #139), and Bedrock is deferred (see
 below).
@@ -110,12 +110,12 @@ the harness holding stale credentials when the batch completes.
 
 ### `MaxTurns` × 24h warning
 
-The default `MaxTurns` cap is 20. Paired with the 24h-per-turn batch
-SLA, that produces a worst-case wall-clock of 480 hours per run.
+The default `MaxTurns` cap is 20. With the 20-turn default, a batch
+run can take up to 20 × 24 = 480 hours (20 days) in the worst case.
 `ValidateRunConfig` emits a `slog` WARN (not an error) when
-`provider.batch.enabled` and `maxTurns > 5`, so operators see the
-warning at run start without the validator hard-rejecting an
-intentional choice. The threshold is advisory: production batch
+`provider.batch.enabled` is set with `maxTurns > 5`, so operators
+see the warning at run start without the validator hard-rejecting
+an intentional choice. The threshold is advisory: production batch
 runs should set `maxTurns <= 5` unless the operator has a specific
 reason to accept the extended worst-case.
 
@@ -134,7 +134,7 @@ Mid-batch run cancellation behaves differently per transport:
   prefer cancel-on-drop) opt in via the flag in `--config`.
 - **stdio polling** — the harness best-efforts a cancel call against
   the provider before exiting. The call is fire-and-forget; a failed
-  cancel does not block the run's exit. This path ships with phase 4
+  cancel does not block the run's exit. This path lands in phase 4
   (issue #137).
 
 ### Bedrock
@@ -142,7 +142,7 @@ Mid-batch run cancellation behaves differently per transport:
 Bedrock batch via `CreateModelInvocationJob` is **out of scope in
 v1**. The wire shape and capability surface diverge from the
 Anthropic / OpenAI batch endpoints far enough that a separate
-adapter design is needed; phase 6 (issue #139) evaluates feasibility
+adapter design is needed; phase 6 ([issue #139](https://github.com/rxbynerd/stirrup/issues/139)) evaluates feasibility
 and either lands the adapter or files a deferral issue. Until then,
 `provider.type=bedrock` with `provider.batch.enabled=true` fails
 validation with `batch is not supported for provider type "bedrock"

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,152 @@
+# Sandbox modes
+
+This document describes operator-facing modes and configurations that
+adjust how the harness executes provider turns, including async batch
+submission. Each mode here is opt-in: the harness defaults stream
+every turn synchronously over the same transport that delivers
+`ToolCallResult` and `Status` events.
+
+## Batch provider mode
+
+### What it is
+
+Async batch submission routes every provider turn through the
+provider's batch endpoint (Anthropic
+`/v1/messages/batches`, OpenAI `/v1/batches`) rather than the live
+streaming endpoint. The provider returns the assistant message
+asynchronously, in exchange for which the harness pays roughly half
+the per-token price. Provider SLAs cap completion at 24 hours per
+batch.
+
+In practice this turns a streaming turn that completes in seconds
+into an async turn that can take anywhere from a few seconds to a
+full day, in exchange for a ~50% discount on input and output tokens.
+
+### When to use it
+
+Batch mode targets non-interactive runs where wall-clock latency does
+not matter and operators want the discount: large research crawls,
+overnight backfills, low-priority `toil` work. `ValidateRunConfig`
+enforces the safe-by-default posture:
+
+- **`execution`** mode is rejected outright. An editing run that can
+  also `run_command` must not block for hours between turns; the
+  combination invites stale-workspace and resource-hold footguns.
+- **`planning`** and **`review`** are rejected unless the operator
+  sets `provider.batch.allowInteractiveModes=true`. These modes are
+  interactive by design (a human reviewer expects fast feedback on a
+  plan or a code review) and the opt-in exists so an operator who
+  has deliberately chosen async planning has to acknowledge the
+  footgun.
+- **`research`** and **`toil`** are accepted unconditionally — they
+  are the modes the feature was built for.
+
+### How to enable
+
+The CLI flag is the simplest path:
+
+```sh
+stirrup harness --batch --mode research --prompt "..."
+```
+
+The flag carries only the `enabled` bit. Operators who need to set
+`maxWaitSeconds`, `harnessSidePolling`, `fallbackOnTimeout`,
+`cancelBundleOnRunCancel`, or `allowInteractiveModes` must use
+`--config` with a `provider.batch` block:
+
+```json
+{ "provider": { "type": "anthropic", "batch": { "enabled": true } }, "mode": "research" }
+```
+
+A `--config` file with a fuller `batch` block composes with the flag:
+passing `--batch` on top of a file that sets
+`harnessSidePolling=true` flips `enabled` on while preserving the
+file's polling setting.
+
+### Transport requirements
+
+The recommended path is `transport=grpc`. The control plane bundles
+concurrent runs into a single provider-side batch, amortising the
+24h tail across many runs and giving the harness a single round-trip
+to wait on. The phase-2 `controlPlaneBatchClient` is the default for
+gRPC operators.
+
+Stdio operators must set `provider.batch.harnessSidePolling=true` in
+their `--config`. In this mode the harness polls the provider HTTP
+endpoint directly from the run process — there is no control plane
+to amortise across, so every run holds its own connection open for
+the duration of its batch. The harness-side polling client is
+experimental in v1 and ships only for the Anthropic provider; OpenAI
+support lands in phase 6 (issue #139), and Bedrock is deferred (see
+below).
+
+`ValidateRunConfig` rejects the mismatches:
+
+- `harnessSidePolling=true` with `transport=grpc` is rejected — the
+  control plane already owns polling on the gRPC path.
+- `cancelBundleOnRunCancel=true` with `transport=stdio` is rejected
+  — there is no bundle to cancel.
+
+### Cost and budget caveats
+
+Two operator-visible gaps follow from the 24h wait window:
+
+**Budget overrun gap.** `MaxCostBudget` is enforced in the agentic
+loop *after* a batch turn completes. A single batch turn can return
+tokens that push the run's running cost over budget by one turn's
+worth before the loop catches it. The shortfall is bounded by one
+turn's tokens, but it is not zero — operators sizing
+`MaxCostBudget` for a batch run should leave headroom for the most
+expensive single response the model can produce, not the run-average
+turn cost.
+
+**Long-lived credential exposure.** A 24h batch wait keeps the
+provider's API credentials live in memory for 24h, against ~120s for
+a streaming turn. Operators using `WebIdentityAWSSource` (or any
+other `credential.Source` backed by a short-lived federated token)
+should confirm their `CredentialsCache` TTL covers the full
+`MaxWaitSeconds` window — a refresh that fires mid-wait can leave
+the harness holding stale credentials when the batch completes.
+
+### `MaxTurns` × 24h warning
+
+The default `MaxTurns` cap is 20. Paired with the 24h-per-turn batch
+SLA, that produces a worst-case wall-clock of 480 hours per run.
+`ValidateRunConfig` emits a `slog` WARN (not an error) when
+`provider.batch.enabled` and `maxTurns > 5`, so operators see the
+warning at run start without the validator hard-rejecting an
+intentional choice. The threshold is advisory: production batch
+runs should set `maxTurns <= 5` unless the operator has a specific
+reason to accept the extended worst-case.
+
+### Cancellation
+
+Mid-batch run cancellation behaves differently per transport:
+
+- **gRPC** — the harness unblocks immediately and, when
+  `provider.batch.cancelBundleOnRunCancel=true`, emits a
+  `batch_cancel_request` HarnessEvent so the control plane can cancel
+  the matching provider-side batch entry. The flag defaults to
+  `false` — the control plane is responsible for deciding whether to
+  cancel an entire bundle when a single run drops out, since other
+  runs in the same bundle may still want their results. Operators who
+  know a run is the sole occupant of its bundle (or who explicitly
+  prefer cancel-on-drop) opt in via the flag in `--config`.
+- **stdio polling** — the harness best-efforts a cancel call against
+  the provider before exiting. The call is fire-and-forget; a failed
+  cancel does not block the run's exit. This path ships with phase 4
+  (issue #137).
+
+### Bedrock
+
+Bedrock batch via `CreateModelInvocationJob` is **out of scope in
+v1**. The wire shape and capability surface diverge from the
+Anthropic / OpenAI batch endpoints far enough that a separate
+adapter design is needed; phase 6 (issue #139) evaluates feasibility
+and either lands the adapter or files a deferral issue. Until then,
+`provider.type=bedrock` with `provider.batch.enabled=true` fails
+validation with `batch is not supported for provider type "bedrock"
+in v1`.
+
+For the current status of the Bedrock follow-up, run `gh issue list
+-L batch` and filter for the Bedrock label.

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -235,6 +235,15 @@ type harnessCLIOptions struct {
 	// nil so the loop reads the effective value via
 	// EffectiveToolDispatchMaxParallel.
 	ToolDispatchMaxParallel int
+
+	// Batch opts the run into async batch submission (issue #136).
+	// The flag carries only the Enabled bit; operators wanting any of
+	// the other BatchProviderConfig fields (MaxWaitSeconds,
+	// HarnessSidePolling, FallbackOnTimeout, CancelBundleOnRunCancel,
+	// AllowInteractiveModes) must use --config. Validation of the
+	// batch shape — transport, mode, provider type — runs in
+	// ValidateRunConfig and is shared with the --config path.
+	Batch bool
 }
 
 // buildHarnessRunConfig assembles the RunConfig used by `stirrup harness`.
@@ -456,6 +465,18 @@ func buildHarnessRunConfig(opts harnessCLIOptions) (*types.RunConfig, error) {
 	// that the operator did not voice.
 	if opts.ToolDispatchMaxParallel > 0 {
 		config.ToolDispatch = &types.ToolDispatchConfig{MaxParallel: opts.ToolDispatchMaxParallel}
+	}
+
+	// Batch (issue #136). --batch carries only the Enabled bit; every
+	// other BatchProviderConfig field stays at its zero value because
+	// the flag-only path has no --config to merge against. Operators
+	// who need MaxWaitSeconds, HarnessSidePolling, FallbackOnTimeout,
+	// CancelBundleOnRunCancel, or AllowInteractiveModes must use
+	// --config — flag syntax cannot cleanly express the cross-field
+	// invariants the validator enforces. ValidateRunConfig defaults
+	// MaxWaitSeconds to 24 h when Enabled and the slot is nil.
+	if opts.Batch {
+		config.Provider.Batch = &types.BatchProviderConfig{Enabled: true}
 	}
 
 	applyModeDefaults(config)
@@ -761,6 +782,13 @@ func init() {
 	// reads types.DefaultToolDispatchMaxParallel via
 	// EffectiveToolDispatchMaxParallel.
 	f.Int("max-tool-parallel", 0, "Maximum number of async tool calls dispatched concurrently in a single turn. Range: 1-16. 0 uses the library default (4).")
+
+	// Batch (issue #136). Carries only the Enabled bit; the other
+	// BatchProviderConfig knobs (maxWaitSeconds, harnessSidePolling,
+	// fallbackOnTimeout, cancelBundleOnRunCancel, allowInteractiveModes)
+	// must come from --config because flag syntax cannot cleanly express
+	// the cross-field invariants validated together.
+	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/sandbox.md.")
 }
 
 // applyOverrides mutates cfg in place, replacing fields whose corresponding
@@ -1111,6 +1139,32 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 	if err := applyProviderRetryFlagOverrides(cmd, &cfg.Provider); err != nil {
 		return err
 	}
+
+	// Batch (issue #136). --batch only flips the Enabled bit; every
+	// other Batch field (MaxWaitSeconds, HarnessSidePolling,
+	// FallbackOnTimeout, CancelBundleOnRunCancel,
+	// AllowInteractiveModes) must come from --config because flag
+	// syntax cannot express their cross-field invariants. When the
+	// file already supplied a Batch block, preserve its other fields
+	// so an operator can keep e.g. harnessSidePolling=true from the
+	// file and only flip enabled=true at the CLI. When the file
+	// omitted Batch entirely, allocate a fresh block with only
+	// Enabled set.
+	if changed("batch") {
+		enabled, _ := f.GetBool("batch")
+		if enabled {
+			if cfg.Provider.Batch == nil {
+				cfg.Provider.Batch = &types.BatchProviderConfig{Enabled: true}
+			} else {
+				cfg.Provider.Batch.Enabled = true
+			}
+		} else if cfg.Provider.Batch != nil {
+			// Explicit --batch=false clears Enabled on a file-supplied
+			// block but preserves the rest, mirroring the "set field to
+			// zero" precedent in --code-scanner / --guardrail above.
+			cfg.Provider.Batch.Enabled = false
+		}
+	}
 	return nil
 }
 
@@ -1309,6 +1363,7 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	workspaceExportTo, _ := f.GetString("export-workspace-to")
 	workspaceExportRequired, _ := f.GetBool("export-workspace-required")
 	toolDispatchMaxParallel, _ := f.GetInt("max-tool-parallel")
+	batch, _ := f.GetBool("batch")
 
 	var queryParams map[string]string
 	for _, entry := range queryParamRaw {
@@ -1393,6 +1448,7 @@ func runHarness(cmd *cobra.Command, args []string) error {
 		WorkspaceExportTo:            workspaceExportTo,
 		WorkspaceExportRequired:      workspaceExportRequired,
 		ToolDispatchMaxParallel:      toolDispatchMaxParallel,
+		Batch:                        batch,
 	})
 	if err != nil {
 		return err

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1159,9 +1159,13 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 				cfg.Provider.Batch.Enabled = true
 			}
 		} else if cfg.Provider.Batch != nil {
-			// Explicit --batch=false clears Enabled on a file-supplied
-			// block but preserves the rest, mirroring the "set field to
-			// zero" precedent in --code-scanner / --guardrail above.
+			// Explicit --batch=false clears Enabled but preserves the
+			// surrounding struct. The divergence from --code-scanner ""
+			// and --guardrail "" (which nil the entire sub-config) is
+			// deliberate: keeping HarnessSidePolling and other fields
+			// intact means a follow-up --batch=true re-enables without
+			// the operator having to re-supply --config, which matches
+			// the mode-toggle workflow the flag is built for.
 			cfg.Provider.Batch.Enabled = false
 		}
 	}

--- a/harness/cmd/stirrup/cmd/harness_batch_flag_test.go
+++ b/harness/cmd/stirrup/cmd/harness_batch_flag_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/types"
@@ -181,7 +182,7 @@ func TestHarnessCmd_BatchFlagHelpText(t *testing.T) {
 		"docs/sandbox.md",
 	}
 	for _, want := range wantSubstrings {
-		if !contains(usage, want) {
+		if !strings.Contains(usage, want) {
 			t.Errorf("--batch usage text missing %q; got: %s", want, usage)
 		}
 	}
@@ -190,21 +191,35 @@ func TestHarnessCmd_BatchFlagHelpText(t *testing.T) {
 	}
 }
 
-// contains is a small substring helper kept local to avoid pulling in
-// the strings import dance the other tests work through; the existing
-// harness_test.go already imports strings, but this file is otherwise
-// import-light, so a tiny helper keeps the diff focused.
-func contains(haystack, needle string) bool {
-	if len(needle) == 0 {
-		return true
+// TestApplyOverrides_BatchFlagExplicitFalseClears pins the third arm
+// of the --batch override block: when --batch=false is explicitly
+// passed on top of a file that supplied Batch.Enabled=true, Enabled
+// flips to false but the surrounding struct (and HarnessSidePolling
+// and other fields) survives. This mirrors the "set field to zero"
+// precedent the comment in harness.go calls out and keeps a
+// subsequent --batch=true re-enable ergonomic without --config.
+func TestApplyOverrides_BatchFlagExplicitFalseClears(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	cfg.Provider.Batch = &types.BatchProviderConfig{
+		Enabled:            true,
+		HarnessSidePolling: true,
 	}
-	if len(needle) > len(haystack) {
-		return false
+
+	if err := cmd.Flags().Set("batch", "false"); err != nil {
+		t.Fatalf("set --batch=false: %v", err)
 	}
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
 	}
-	return false
+
+	if cfg.Provider.Batch == nil {
+		t.Fatal("expected Provider.Batch to remain non-nil after --batch=false")
+	}
+	if cfg.Provider.Batch.Enabled {
+		t.Errorf("Provider.Batch.Enabled = true, want false after --batch=false")
+	}
+	if !cfg.Provider.Batch.HarnessSidePolling {
+		t.Errorf("Provider.Batch.HarnessSidePolling: file value should survive --batch=false, got false")
+	}
 }

--- a/harness/cmd/stirrup/cmd/harness_batch_flag_test.go
+++ b/harness/cmd/stirrup/cmd/harness_batch_flag_test.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestBuildHarnessRunConfig_BatchFlagEnabledOnly verifies that --batch
+// alone produces a BatchProviderConfig with Enabled=true and every
+// other field at its zero value. The other knobs (MaxWaitSeconds,
+// HarnessSidePolling, FallbackOnTimeout, CancelBundleOnRunCancel,
+// AllowInteractiveModes) are deliberately out-of-band for the flag —
+// operators reach for --config to set them — so the test pins that
+// only Enabled flips.
+func TestBuildHarnessRunConfig_BatchFlagEnabledOnly(t *testing.T) {
+	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "research",
+		Prompt:        "test",
+		ProviderType:  "anthropic",
+		APIKeyRef:     "secret://ANTHROPIC_API_KEY",
+		Model:         "claude-sonnet-4-6",
+		MaxTurns:      5,
+		Timeout:       600,
+		TransportType: "grpc",
+		TransportAddr: "control-plane:443",
+		LogLevel:      "info",
+		Batch:         true,
+	})
+	if err != nil {
+		t.Fatalf("buildHarnessRunConfig: %v", err)
+	}
+	if cfg.Provider.Batch == nil {
+		t.Fatal("expected non-nil Provider.Batch when --batch is set")
+	}
+	if !cfg.Provider.Batch.Enabled {
+		t.Errorf("Provider.Batch.Enabled = false, want true")
+	}
+	if cfg.Provider.Batch.MaxWaitSeconds != nil {
+		t.Errorf("Provider.Batch.MaxWaitSeconds = %v, want nil (defaulted by ValidateRunConfig)", *cfg.Provider.Batch.MaxWaitSeconds)
+	}
+	if cfg.Provider.Batch.HarnessSidePolling {
+		t.Errorf("Provider.Batch.HarnessSidePolling = true, want false (operators set this via --config)")
+	}
+	if cfg.Provider.Batch.FallbackOnTimeout {
+		t.Errorf("Provider.Batch.FallbackOnTimeout = true, want false")
+	}
+	if cfg.Provider.Batch.CancelBundleOnRunCancel {
+		t.Errorf("Provider.Batch.CancelBundleOnRunCancel = true, want false")
+	}
+	if cfg.Provider.Batch.AllowInteractiveModes {
+		t.Errorf("Provider.Batch.AllowInteractiveModes = true, want false")
+	}
+}
+
+// TestBuildHarnessRunConfig_BatchFlagUnsetLeavesNil verifies the
+// default-off posture: a build without --batch leaves Provider.Batch
+// nil so the validator's MaxWaitSeconds default does not fire and the
+// factory routes through the streaming adapter.
+func TestBuildHarnessRunConfig_BatchFlagUnsetLeavesNil(t *testing.T) {
+	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
+		RunID:         "test-run",
+		Mode:          "research",
+		Prompt:        "test",
+		ProviderType:  "anthropic",
+		APIKeyRef:     "secret://ANTHROPIC_API_KEY",
+		Model:         "claude-sonnet-4-6",
+		MaxTurns:      20,
+		Timeout:       600,
+		TransportType: "stdio",
+		LogLevel:      "info",
+	})
+	if err != nil {
+		t.Fatalf("buildHarnessRunConfig: %v", err)
+	}
+	if cfg.Provider.Batch != nil {
+		t.Errorf("expected Provider.Batch to be nil without --batch, got %+v", cfg.Provider.Batch)
+	}
+}
+
+// TestApplyOverrides_BatchFlagMergesWithFile pins the merge semantics
+// against a --config file that already carries a partial Batch block
+// (here, HarnessSidePolling=true for a stdio polling setup). Setting
+// --batch on top must flip Enabled to true without disturbing the
+// file's other fields — the operator's polling choice must survive.
+func TestApplyOverrides_BatchFlagMergesWithFile(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	cfg.Provider.Batch = &types.BatchProviderConfig{
+		Enabled:            false,
+		HarnessSidePolling: true,
+	}
+
+	if err := cmd.Flags().Set("batch", "true"); err != nil {
+		t.Fatalf("set --batch: %v", err)
+	}
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+
+	if cfg.Provider.Batch == nil {
+		t.Fatal("expected Provider.Batch to remain non-nil after override")
+	}
+	if !cfg.Provider.Batch.Enabled {
+		t.Errorf("Provider.Batch.Enabled: --batch override failed, got false")
+	}
+	if !cfg.Provider.Batch.HarnessSidePolling {
+		t.Errorf("Provider.Batch.HarnessSidePolling: file value should survive, got false")
+	}
+}
+
+// TestApplyOverrides_BatchFlagAllocatesWhenFileOmits covers the path
+// where the --config file omits the Batch block entirely. The flag
+// alone must allocate a fresh BatchProviderConfig with Enabled=true.
+func TestApplyOverrides_BatchFlagAllocatesWhenFileOmits(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	if cfg.Provider.Batch != nil {
+		t.Fatalf("baseFileConfig should not set Batch; got %+v", cfg.Provider.Batch)
+	}
+
+	if err := cmd.Flags().Set("batch", "true"); err != nil {
+		t.Fatalf("set --batch: %v", err)
+	}
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+
+	if cfg.Provider.Batch == nil {
+		t.Fatal("expected Provider.Batch to be allocated when --batch flips on an empty slot")
+	}
+	if !cfg.Provider.Batch.Enabled {
+		t.Errorf("Provider.Batch.Enabled = false, want true")
+	}
+}
+
+// TestApplyOverrides_BatchFlagUnsetPreservesFile pins the precedence
+// rule: an unset --batch flag MUST NOT clobber a Batch block the file
+// supplied. This is the same Changed()-gated invariant every other
+// override flag obeys.
+func TestApplyOverrides_BatchFlagUnsetPreservesFile(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	cfg.Provider.Batch = &types.BatchProviderConfig{
+		Enabled:            true,
+		HarnessSidePolling: true,
+	}
+
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+
+	if cfg.Provider.Batch == nil {
+		t.Fatal("expected Provider.Batch to survive when --batch is unset")
+	}
+	if !cfg.Provider.Batch.Enabled {
+		t.Errorf("Provider.Batch.Enabled: file value should survive, got false")
+	}
+	if !cfg.Provider.Batch.HarnessSidePolling {
+		t.Errorf("Provider.Batch.HarnessSidePolling: file value should survive, got false")
+	}
+}
+
+// TestHarnessCmd_BatchFlagHelpText pins the operator-facing flag
+// description so a future cosmetic edit does not silently drop the
+// cost/latency tradeoff statement or the doc link that operators rely
+// on to find the cross-field invariants.
+func TestHarnessCmd_BatchFlagHelpText(t *testing.T) {
+	flag := harnessCmd.Flags().Lookup("batch")
+	if flag == nil {
+		t.Fatal("expected --batch flag to be registered on harnessCmd")
+	}
+	usage := flag.Usage
+	wantSubstrings := []string{
+		"async batch submission",
+		"50% cost reduction",
+		"24h latency",
+		"transport=grpc",
+		"harnessSidePolling=true",
+		"docs/sandbox.md",
+	}
+	for _, want := range wantSubstrings {
+		if !contains(usage, want) {
+			t.Errorf("--batch usage text missing %q; got: %s", want, usage)
+		}
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--batch default = %q, want \"false\"", flag.DefValue)
+	}
+}
+
+// contains is a small substring helper kept local to avoid pulling in
+// the strings import dance the other tests work through; the existing
+// harness_test.go already imports strings, but this file is otherwise
+// import-light, so a tiny helper keeps the diff focused.
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	if len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -641,6 +641,9 @@ func newTestHarnessCommand() *cobra.Command {
 	// TestApplyOverrides_MaxToolParallel* tests can exercise the override
 	// path.
 	f.Int("max-tool-parallel", 0, "")
+	// Batch flag (issue #136). Registered here so the override tests
+	// can exercise the applyOverrides path that handles --batch.
+	f.Bool("batch", false, "")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Adds the `--batch` boolean flag to `stirrup harness` and introduces `docs/sandbox.md` with the Batch provider mode section. PR 4 of 7. Stack base: PR #210.

## Changes

- `harness/cmd/stirrup/cmd/harness.go`:
  - `--batch` boolean flag (default false) with the spec'd description.
  - `applyOverrides` merges the flag with any pre-loaded `--config` `provider.batch` block; explicit `--batch=false` clears `Enabled` while preserving other Batch config (e.g. `HarnessSidePolling`) so operators can toggle mode without losing polling setup.
- `harness/cmd/stirrup/cmd/harness_batch_flag_test.go` (new): six focused tests covering allocate / flip-on / merge / unset-preserves / help-text / explicit-clear branches. `applyOverrides` now covers all three batch branches.
- `docs/sandbox.md` (new): operator-facing doc covering the 8 spec'd content items — what batch is, when to use it, how to enable, transport requirements, cost/credential caveats, MaxTurns × 24h warning, cancellation, Bedrock deferral. Linked from `README.md`.

## Tests

`go test ./harness/cmd/stirrup/cmd/...` → PASS. `applyOverrides` function coverage 94%; `TestApplyOverrides_BatchFlagExplicitFalseClears` closes the previously-uncovered branch.

Smoke run `./stirrup harness --batch --provider anthropic --model claude-3-7-sonnet-20250219 --prompt "test"` exits with the expected validation error (batch + planning + stdio), no panic on flag parsing. The phase-1 `maxTurns > 5` slog WARN fires end-to-end.

## Review wave

Calibrated 4-reviewer cycle: code, spec-compliance, doc-tone, test-coverage. Synthesised brief: 1 blocking + 7 recommended applied across commits ab28732, f97bf58.

- Blocking: `--batch=false` clearing branch test gap — fixed.
- Recommended applied: replace hand-rolled `contains` with `strings.Contains`; strengthen the comment explaining the deliberate divergence from `--code-scanner ""` nil semantics; Markdown-link the Bedrock follow-up `issue #139`; 5 doc-tone tweaks.

One code-reviewer MUST-FIX was a verified false positive (claimed `docs/sandbox.md` did not exist; file was present at 6622 bytes in 6ff73f3) — dismissed in synthesis.

6 NITs deferred to follow-up (comment style consistency, README label phrasing, etc.).

## Test plan

- [x] `go build ./harness/...`
- [x] `go test ./harness/cmd/stirrup/cmd/...`
- [x] `./stirrup harness --help` shows `--batch` with documented description
- [x] `./stirrup harness --batch ...` does not panic on flag parsing
- [ ] CI green

Closes #136.