### PR TITLE
core: make sampling temperature configurable (#217)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,7 @@ the same flags grouped by concern.
 | `--workspace`, `-w` | cwd | Workspace directory. |
 | `--max-turns` | `20` | Hard-capped at 100. |
 | `--timeout` | `600` | Wall-clock seconds; capped at 3600. |
+| `--temperature` | (unset → `0.1`) | Sampling temperature forwarded to the provider on every turn. Range `0.0`–`2.0` (the union of provider-side ranges; see [Limits and budgets](#limits-and-budgets)). Omit the flag to inherit the harness default; pass an explicit `0` for greedy decoding. The runtime distinguishes "flag absent" from `--temperature=0` via cobra's `Changed()` bit. |
 | `--log-level` | `info` | One of `debug`, `info`, `warn`, `error`. |
 
 ### Provider
@@ -226,8 +227,20 @@ be unbounded:
 | `followUpGrace` | 3600 s |
 | `maxTokenBudget` | 50 M |
 | `maxCostBudget` | $100 |
+| `temperature` | `0.0` ≤ `t` ≤ `2.0` |
 
 Read-only modes additionally require the tool list to be set.
+
+`temperature` accepts the union of provider-side ranges (Anthropic
+`[0, 1]`, OpenAI / Gemini `[0, 2]`). A value inside the union may
+still be rejected by the chosen provider's narrower range; the
+adapter surfaces that rejection at request time rather than at
+validation, so a single config can target multiple providers. Nil /
+omitted means "use the harness default" (currently `0.1`); the
+agentic loop forwards a non-nil value verbatim, including explicit
+`0.0` for greedy decoding. Reasoning models that reject `temperature`
+on the wire are handled separately by the provider adapter — the
+field on the run config still represents intent.
 
 ## RunConfig examples
 

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -588,7 +588,20 @@ type RunConfig struct {
 	// library default (currently 4 concurrent calls per turn). Neither
 	// means "disable concurrency". The hard ceiling is 16; values
 	// outside [0, 16] are rejected by ValidateRunConfig.
-	ToolDispatch  *ToolDispatchConfig `protobuf:"bytes,30,opt,name=tool_dispatch,json=toolDispatch,proto3" json:"tool_dispatch,omitempty"`
+	ToolDispatch *ToolDispatchConfig `protobuf:"bytes,30,opt,name=tool_dispatch,json=toolDispatch,proto3" json:"tool_dispatch,omitempty"`
+	// Optional. Sampling temperature forwarded to the provider on every
+	// turn. Unset means "use the harness default" (currently 0.1, a low
+	// value that biases for determinism on coding tasks). A set value is
+	// forwarded verbatim, including an explicit 0.0 for greedy decoding.
+	//
+	// Validated against the union of provider ranges (Anthropic [0, 1],
+	// OpenAI / Gemini [0, 2]) → [0.0, 2.0]. A value inside the union may
+	// still be rejected by the chosen provider's narrower range; the
+	// adapter surfaces that rejection at request time. Declared `optional`
+	// so unset is wire-distinguishable from explicit 0.0 (proto3's scalar
+	// default would otherwise silently coerce greedy decoding to the
+	// harness default).
+	Temperature   *float64 `protobuf:"fixed64,31,opt,name=temperature,proto3,oneof" json:"temperature,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -831,6 +844,13 @@ func (x *RunConfig) GetToolDispatch() *ToolDispatchConfig {
 		return x.ToolDispatch
 	}
 	return nil
+}
+
+func (x *RunConfig) GetTemperature() float64 {
+	if x != nil && x.Temperature != nil {
+		return *x.Temperature
+	}
+	return 0
 }
 
 // DynamicContextValue is a single dynamic-context value with metadata.
@@ -3521,7 +3541,7 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\acontent\x18\a \x01(\tR\acontent\x12;\n" +
 	"\bis_error\x18\b \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aisError\"$\n" +
 	"\fOptionalBool\x12\x14\n" +
-	"\x05value\x18\x01 \x01(\bR\x05value\"\xb0\x10\n" +
+	"\x05value\x18\x01 \x01(\bR\x05value\"\xe7\x10\n" +
 	"\tRunConfig\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\tR\x04mode\x12\x16\n" +
@@ -3554,7 +3574,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\n" +
 	"guard_rail\x18\x1c \x01(\v2#.stirrup.harness.v1.GuardRailConfigR\tguardRail\x12M\n" +
 	"\robservability\x18\x1d \x01(\v2'.stirrup.harness.v1.ObservabilityConfigR\robservability\x12K\n" +
-	"\rtool_dispatch\x18\x1e \x01(\v2&.stirrup.harness.v1.ToolDispatchConfigR\ftoolDispatch\x1aj\n" +
+	"\rtool_dispatch\x18\x1e \x01(\v2&.stirrup.harness.v1.ToolDispatchConfigR\ftoolDispatch\x12%\n" +
+	"\vtemperature\x18\x1f \x01(\x01H\x06R\vtemperature\x88\x01\x01\x1aj\n" +
 	"\x13DynamicContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12=\n" +
 	"\x05value\x18\x02 \x01(\v2'.stirrup.harness.v1.DynamicContextValueR\x05value:\x028\x01\x1a`\n" +
@@ -3567,7 +3588,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\b_timeoutB\x12\n" +
 	"\x10_follow_up_graceB\x0f\n" +
 	"\r_session_nameB\x11\n" +
-	"\x0f_sensitive_data\"I\n" +
+	"\x0f_sensitive_dataB\x0e\n" +
+	"\f_temperature\"I\n" +
 	"\x13DynamicContextValue\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\tR\x05value\x12\x1c\n" +
 	"\tsensitive\x18\x02 \x01(\bR\tsensitive\"7\n" +

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -121,6 +121,14 @@ type harnessCLIOptions struct {
 	FollowUpGrace int
 	LogLevel      string
 
+	// Temperature overrides the loop's default sampling temperature.
+	// Nil means "do not override" (the harness default applies). A
+	// pointer is used so an explicit --temperature=0 (greedy decoding)
+	// is distinguishable from the flag being absent — cobra's Float64
+	// store is a plain float64, so the disambiguation has to happen at
+	// the flags.Changed() check site upstream.
+	Temperature *float64
+
 	// Vertex AI Gemini provider fields. Only meaningful when
 	// ProviderType == "gemini"; ValidateRunConfig rejects them on
 	// every other provider type, so the flag-only path safely
@@ -334,6 +342,10 @@ func buildHarnessRunConfig(opts harnessCLIOptions) (*types.RunConfig, error) {
 	if opts.FollowUpGrace > 0 {
 		grace := opts.FollowUpGrace
 		config.FollowUpGrace = &grace
+	}
+	if opts.Temperature != nil {
+		t := *opts.Temperature
+		config.Temperature = &t
 	}
 
 	// Vertex AI Gemini fields. The validator rejects these on every
@@ -664,6 +676,7 @@ func init() {
 	f.String("transport", "stdio", "Transport type: stdio, grpc")
 	f.String("transport-addr", "", "gRPC target address (required when transport is grpc)")
 	f.Int("followup-grace", 0, "Seconds to keep gRPC transport open for follow-up requests (0 = disabled; env: STIRRUP_FOLLOWUP_GRACE)")
+	f.Float64("temperature", 0, "Sampling temperature forwarded to the provider on every turn. Range 0.0-2.0 (union of provider ranges). Unset leaves the harness default (0.1); explicit 0 sets greedy decoding.")
 	f.String("log-level", "info", "Log level: debug, info, warn, error")
 	f.String("prompt", "", "User prompt (can also be passed as a positional argument; falls back to --prompt-file then STIRRUP_PROMPT env var, then a prompt field in --config)")
 	f.String("prompt-file", "", "Path to a file whose contents become the prompt. Read from CWD when relative. Trailing newlines are trimmed; the file is capped at 10 MiB and must be non-empty. Lower precedence than --prompt and the positional argument; higher than STIRRUP_PROMPT.")
@@ -796,6 +809,15 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 		} else {
 			cfg.FollowUpGrace = nil
 		}
+	}
+	if changed("temperature") {
+		// flags.Changed() lets us distinguish an explicit
+		// --temperature=0 (greedy decoding) from the flag being
+		// absent. The plain Float64 store would coerce both to 0.0,
+		// silently overriding any file-provided value with greedy
+		// decoding on every run that omitted the flag.
+		t, _ := f.GetFloat64("temperature")
+		cfg.Temperature = &t
 	}
 	if changed("log-level") {
 		cfg.LogLevel, _ = f.GetString("log-level")
@@ -1292,6 +1314,16 @@ func runHarness(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Distinguish --temperature unset from --temperature=0. The
+	// cobra Float64 store has no way to express absence, so the
+	// flag's Changed() bit is the only safe way to preserve
+	// "use harness default" when the flag is omitted.
+	var temperature *float64
+	if f.Changed("temperature") {
+		t, _ := f.GetFloat64("temperature")
+		temperature = &t
+	}
+
 	config, err := buildHarnessRunConfig(harnessCLIOptions{
 		RunID:                        generateRunID(),
 		Mode:                         mode,
@@ -1321,6 +1353,7 @@ func runHarness(cmd *cobra.Command, args []string) error {
 		TransportType:                transportType,
 		TransportAddr:                transportAddr,
 		FollowUpGrace:                followUpGrace,
+		Temperature:                  temperature,
 		LogLevel:                     logLevel,
 		ExecutorType:                 executorType,
 		EditStrategyType:             editStrategyType,

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -509,6 +509,24 @@ func applyProviderRetryOverrides(pc *types.ProviderConfig, opts harnessCLIOption
 	return nil
 }
 
+// optionalFloat64Flag returns a heap-allocated copy of the named Float64
+// flag's value iff the operator set it on the command line, and nil
+// otherwise. cobra's Float64 store cannot represent absence — both an
+// unset flag and an explicit --foo=0 read back as 0.0 — so the
+// Changed() bit is the only safe way to preserve "use the default"
+// versus "the operator chose 0". Used by --temperature on both the
+// --config-path (applyOverrides) and the flag-only (runHarness) entry
+// points; centralising the pattern keeps the two paths from drifting
+// when a future env-var fallback (e.g. STIRRUP_TEMPERATURE) lands.
+func optionalFloat64Flag(cmd *cobra.Command, name string) *float64 {
+	f := cmd.Flags()
+	if !f.Changed(name) {
+		return nil
+	}
+	v, _ := f.GetFloat64(name)
+	return &v
+}
+
 // retryDurationToMs converts a positive Duration to whole milliseconds
 // for the provider-retry CLI flags, rejecting any non-zero value below
 // 1ms. A zero input (the flag's default sentinel) returns zero with no
@@ -810,14 +828,13 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 			cfg.FollowUpGrace = nil
 		}
 	}
-	if changed("temperature") {
-		// flags.Changed() lets us distinguish an explicit
-		// --temperature=0 (greedy decoding) from the flag being
-		// absent. The plain Float64 store would coerce both to 0.0,
-		// silently overriding any file-provided value with greedy
-		// decoding on every run that omitted the flag.
-		t, _ := f.GetFloat64("temperature")
-		cfg.Temperature = &t
+	// optionalFloat64Flag distinguishes an explicit --temperature=0
+	// (greedy decoding) from the flag being absent: cobra's Float64
+	// store coerces both to 0.0, so without the Changed() check every
+	// run that omitted --temperature would silently rewrite a
+	// file-provided non-zero value to greedy decoding.
+	if t := optionalFloat64Flag(cmd, "temperature"); t != nil {
+		cfg.Temperature = t
 	}
 	if changed("log-level") {
 		cfg.LogLevel, _ = f.GetString("log-level")
@@ -1317,12 +1334,10 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	// Distinguish --temperature unset from --temperature=0. The
 	// cobra Float64 store has no way to express absence, so the
 	// flag's Changed() bit is the only safe way to preserve
-	// "use harness default" when the flag is omitted.
-	var temperature *float64
-	if f.Changed("temperature") {
-		t, _ := f.GetFloat64("temperature")
-		temperature = &t
-	}
+	// "use harness default" when the flag is omitted. Shared with
+	// applyOverrides via optionalFloat64Flag to keep the two paths
+	// from drifting.
+	temperature := optionalFloat64Flag(cmd, "temperature")
 
 	config, err := buildHarnessRunConfig(harnessCLIOptions{
 		RunID:                        generateRunID(),

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -1816,6 +1816,89 @@ func TestApplyOverrides_TemperatureChangedDisambiguatesZero(t *testing.T) {
 	})
 }
 
+// TestBuildHarnessRunConfig_Temperature pins the temperature propagation
+// inside buildHarnessRunConfig itself. The applyOverrides tests cover the
+// --config-path branch, but buildHarnessRunConfig has its own three-line
+// "if opts.Temperature != nil { copy }" block on the flag-only path —
+// a regression there (e.g. unconditional assignment, or always
+// dereferencing) would be invisible to the applyOverrides suite because
+// the two code paths never intersect. Mirrors the shape of
+// TestBuildHarnessRunConfig_SessionNamePropagates.
+func TestBuildHarnessRunConfig_Temperature(t *testing.T) {
+	base := func() harnessCLIOptions {
+		return harnessCLIOptions{
+			RunID:         "test-run",
+			Mode:          "execution",
+			Prompt:        "test",
+			ProviderType:  "anthropic",
+			APIKeyRef:     "secret://ANTHROPIC_API_KEY",
+			Model:         "claude-sonnet-4-6",
+			MaxTurns:      20,
+			Timeout:       600,
+			TransportType: "stdio",
+			LogLevel:      "info",
+		}
+	}
+
+	t.Run("nil opts.Temperature stays nil on the config", func(t *testing.T) {
+		opts := base()
+		opts.Temperature = nil
+		cfg, err := buildHarnessRunConfig(opts)
+		if err != nil {
+			t.Fatalf("buildHarnessRunConfig: %v", err)
+		}
+		if cfg.Temperature != nil {
+			t.Errorf("nil opts.Temperature must yield nil cfg.Temperature, got %v", *cfg.Temperature)
+		}
+	})
+
+	t.Run("explicit zero propagates as *0.0", func(t *testing.T) {
+		opts := base()
+		opts.Temperature = types.Float64Ptr(0.0)
+		cfg, err := buildHarnessRunConfig(opts)
+		if err != nil {
+			t.Fatalf("buildHarnessRunConfig: %v", err)
+		}
+		if cfg.Temperature == nil {
+			t.Fatalf("explicit *float64(0.0) must yield non-nil cfg.Temperature")
+		}
+		if *cfg.Temperature != 0.0 {
+			t.Errorf("cfg.Temperature: got %v, want 0.0", *cfg.Temperature)
+		}
+	})
+
+	t.Run("non-zero value propagates", func(t *testing.T) {
+		opts := base()
+		opts.Temperature = types.Float64Ptr(0.7)
+		cfg, err := buildHarnessRunConfig(opts)
+		if err != nil {
+			t.Fatalf("buildHarnessRunConfig: %v", err)
+		}
+		if cfg.Temperature == nil {
+			t.Fatalf("non-nil opts.Temperature must yield non-nil cfg.Temperature")
+		}
+		if *cfg.Temperature != 0.7 {
+			t.Errorf("cfg.Temperature: got %v, want 0.7", *cfg.Temperature)
+		}
+	})
+
+	t.Run("opts.Temperature is copied, not aliased", func(t *testing.T) {
+		opts := base()
+		opts.Temperature = types.Float64Ptr(0.4)
+		cfg, err := buildHarnessRunConfig(opts)
+		if err != nil {
+			t.Fatalf("buildHarnessRunConfig: %v", err)
+		}
+		// Mutating opts.Temperature post-build must not bleed through
+		// into the constructed RunConfig — the harness contract is that
+		// buildHarnessRunConfig snapshots the value.
+		*opts.Temperature = 1.5
+		if cfg.Temperature == nil || *cfg.Temperature != 0.4 {
+			t.Errorf("cfg.Temperature should be a copy snapshot of 0.4, got %v", cfg.Temperature)
+		}
+	})
+}
+
 // TestRunHarness_ConfigPathFollowupGraceFromEnv verifies that the
 // STIRRUP_FOLLOWUP_GRACE environment variable populates FollowUpGrace in
 // the --config code path when the file omits the field. This mirrors the

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -603,6 +603,7 @@ func newTestHarnessCommand() *cobra.Command {
 	f.String("transport", "stdio", "")
 	f.String("transport-addr", "", "")
 	f.Int("followup-grace", 0, "")
+	f.Float64("temperature", 0, "")
 	f.String("log-level", "info", "")
 	f.String("prompt", "", "")
 	f.String("prompt-file", "", "")
@@ -1753,6 +1754,66 @@ func TestApplyOverrides_FollowupGraceZeroClears(t *testing.T) {
 	if cfg.FollowUpGrace != nil {
 		t.Errorf("explicit --followup-grace=0 should clear FollowUpGrace, got %v", *cfg.FollowUpGrace)
 	}
+}
+
+// TestApplyOverrides_TemperatureChangedDisambiguatesZero exercises the
+// unset-vs-explicit-zero distinction for --temperature. The flag store
+// is a plain Float64, so cobra cannot represent "absence" — the
+// override path must rely on flags.Changed() instead, or every run
+// that omits the flag silently rewrites a file-provided non-zero
+// value to greedy decoding.
+func TestApplyOverrides_TemperatureChangedDisambiguatesZero(t *testing.T) {
+	t.Run("unset leaves file value alone", func(t *testing.T) {
+		cmd := newTestHarnessCommand()
+		cfg := baseFileConfig()
+		want := 0.5
+		cfg.Temperature = &want
+		// Do NOT set --temperature on the command line.
+
+		if err := applyOverrides(cmd, cfg, nil); err != nil {
+			t.Fatalf("applyOverrides: %v", err)
+		}
+		if cfg.Temperature == nil || *cfg.Temperature != want {
+			t.Errorf("unset --temperature must preserve file value 0.5, got %v", cfg.Temperature)
+		}
+	})
+
+	t.Run("explicit zero is greedy override", func(t *testing.T) {
+		cmd := newTestHarnessCommand()
+		cfg := baseFileConfig()
+		filed := 0.5
+		cfg.Temperature = &filed
+
+		if err := cmd.Flags().Set("temperature", "0"); err != nil {
+			t.Fatalf("set temperature: %v", err)
+		}
+		if err := applyOverrides(cmd, cfg, nil); err != nil {
+			t.Fatalf("applyOverrides: %v", err)
+		}
+		if cfg.Temperature == nil {
+			t.Fatalf("explicit --temperature=0 should set greedy decoding, got nil")
+		}
+		if *cfg.Temperature != 0 {
+			t.Errorf("--temperature=0 should set 0.0, got %v", *cfg.Temperature)
+		}
+	})
+
+	t.Run("explicit non-zero overrides file value", func(t *testing.T) {
+		cmd := newTestHarnessCommand()
+		cfg := baseFileConfig()
+		filed := 0.5
+		cfg.Temperature = &filed
+
+		if err := cmd.Flags().Set("temperature", "1.2"); err != nil {
+			t.Fatalf("set temperature: %v", err)
+		}
+		if err := applyOverrides(cmd, cfg, nil); err != nil {
+			t.Fatalf("applyOverrides: %v", err)
+		}
+		if cfg.Temperature == nil || *cfg.Temperature != 1.2 {
+			t.Errorf("--temperature=1.2 override failed, got %v", cfg.Temperature)
+		}
+	})
 }
 
 // TestRunHarness_ConfigPathFollowupGraceFromEnv verifies that the

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -42,6 +42,13 @@ const (
 	// model's response within the context window.
 	defaultReserveForResponse = 64_000
 
+	// defaultTemperature is the sampling temperature applied to every
+	// provider call when RunConfig.Temperature is nil. A low value
+	// biases for determinism on coding tasks — the historical
+	// hardcoded value, preserved as the harness default so unset
+	// configs see no behaviour change.
+	defaultTemperature = 0.1
+
 	// tokenEstimationDivisor is the approximate character-to-token ratio
 	// used by token estimation functions (≈4 characters per token).
 	tokenEstimationDivisor = 4
@@ -563,13 +570,24 @@ func (l *AgenticLoop) runInnerLoop(
 			),
 		)
 
+		// Resolve sampling temperature. Forward an explicit override
+		// verbatim (including 0.0 for greedy decoding); fall back to
+		// the harness default when the config left it nil. The
+		// invariant — loop must never silently forward a nil
+		// temperature to providers that would otherwise fall through
+		// to their own (higher) service defaults — is preserved by
+		// the fallback branch.
+		temperature := config.Temperature
+		if temperature == nil {
+			temperature = types.Float64Ptr(defaultTemperature)
+		}
 		ch, err := selectedProvider.Stream(spanCtx, types.StreamParams{
 			Model:       selection.Model,
 			System:      systemPrompt,
 			Messages:    preparedMessages,
 			Tools:       l.Tools.List(),
 			MaxTokens:   defaultReserveForResponse,
-			Temperature: types.Float64Ptr(0.1),
+			Temperature: temperature,
 		})
 		if err != nil {
 			// Scrub the status string before it lands on the OTel span.

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -145,11 +145,53 @@ func TestLoop_SimpleTextResponse(t *testing.T) {
 	if runTrace.Turns != 1 {
 		t.Errorf("expected 1 turn, got %d", runTrace.Turns)
 	}
-	// The loop pins Temperature=Float64Ptr(0.1) on every provider call
-	// (see loop.go). If that producer regresses to nil, downstream
-	// callers will silently receive the service-default temperature.
-	if prov.lastParams.Temperature == nil || *prov.lastParams.Temperature != 0.1 {
-		t.Errorf("loop temperature = %v, want *=0.1", prov.lastParams.Temperature)
+}
+
+// TestLoop_ForwardsConfiguredTemperature exercises the three temperature
+// cases the loop must distinguish:
+//
+//   - unset RunConfig.Temperature falls back to the harness default
+//     (0.1). The "loop never silently forwards nil to the provider"
+//     property — historically guarded inline in
+//     TestLoop_SimpleTextResponse — lives in this case. A regression
+//     that drops the fallback re-introduces the silent-provider-default
+//     bug the original assertion was written to catch.
+//   - a non-zero override is forwarded verbatim.
+//   - an explicit 0.0 override (greedy decoding) is forwarded as 0.0,
+//     not coerced back to the default. This is the case the pointer
+//     indirection on RunConfig.Temperature exists to preserve.
+func TestLoop_ForwardsConfiguredTemperature(t *testing.T) {
+	cases := []struct {
+		name     string
+		override *float64
+		want     float64
+	}{
+		{name: "unset falls back to default", override: nil, want: 0.1},
+		{name: "non-zero override forwarded", override: types.Float64Ptr(0.7), want: 0.7},
+		{name: "explicit zero override forwarded", override: types.Float64Ptr(0.0), want: 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := &mockProvider{
+				events: []types.StreamEvent{
+					{Type: "text_delta", Text: "Hi"},
+					{Type: "message_complete", StopReason: "end_turn"},
+				},
+			}
+			loop := buildTestLoop(prov)
+			config := buildTestConfig()
+			config.Temperature = tc.override
+
+			if _, err := loop.Run(context.Background(), config); err != nil {
+				t.Fatalf("Run() error: %v", err)
+			}
+			if prov.lastParams.Temperature == nil {
+				t.Fatalf("loop temperature = nil, want *=%v (loop must never forward nil)", tc.want)
+			}
+			if *prov.lastParams.Temperature != tc.want {
+				t.Errorf("loop temperature = %v, want *=%v", *prov.lastParams.Temperature, tc.want)
+			}
+		})
 	}
 }
 

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -90,6 +90,9 @@ func runConfigFromProto(pc *pb.RunConfig) types.RunConfig {
 	if pc.MaxCostBudget != nil {
 		rc.MaxCostBudget = pc.MaxCostBudget
 	}
+	if pc.Temperature != nil {
+		rc.Temperature = pc.Temperature
+	}
 	if pc.Timeout != nil {
 		v := int(*pc.Timeout)
 		rc.Timeout = &v

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -757,3 +757,37 @@ func TestRunConfigFromProto_BatchProviderConfigPreserved(t *testing.T) {
 		}
 	})
 }
+
+// TestRunConfigFromProto_TemperatureRoundTrip pins the pointer-vs-nil
+// distinction across the wire boundary for RunConfig.Temperature
+// (issue #217). The control plane must be able to (a) leave the field
+// unset and inherit the harness default, (b) request a non-zero
+// temperature, and (c) request greedy decoding by sending an explicit
+// 0.0. Without the optional-double field on the proto side, case (c)
+// is wire-indistinguishable from case (a) — exactly the failure mode
+// the proto's `optional` keyword exists to prevent.
+func TestRunConfigFromProto_TemperatureRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		set  *float64
+	}{
+		{name: "nil_unset", set: nil},
+		{name: "explicit_zero_greedy", set: proto.Float64(0.0)},
+		{name: "mid_range", set: proto.Float64(0.7)},
+		{name: "above_anthropic_ceiling", set: proto.Float64(1.5)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := &pb.RunConfig{Temperature: tc.set}
+			rc := runConfigFromProto(pc)
+			switch {
+			case tc.set == nil && rc.Temperature != nil:
+				t.Fatalf("nil-on-wire translated to non-nil internal: got %v", *rc.Temperature)
+			case tc.set != nil && rc.Temperature == nil:
+				t.Fatalf("set-on-wire (%v) dropped to nil internal", *tc.set)
+			case tc.set != nil && *rc.Temperature != *tc.set:
+				t.Errorf("Temperature: got %v, want %v", *rc.Temperature, *tc.set)
+			}
+		})
+	}
+}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -397,6 +397,20 @@ message RunConfig {
   // outside [0, 16] are rejected by ValidateRunConfig.
   ToolDispatchConfig tool_dispatch = 30;
 
+  // Optional. Sampling temperature forwarded to the provider on every
+  // turn. Unset means "use the harness default" (currently 0.1, a low
+  // value that biases for determinism on coding tasks). A set value is
+  // forwarded verbatim, including an explicit 0.0 for greedy decoding.
+  //
+  // Validated against the union of provider ranges (Anthropic [0, 1],
+  // OpenAI / Gemini [0, 2]) → [0.0, 2.0]. A value inside the union may
+  // still be rejected by the chosen provider's narrower range; the
+  // adapter surfaces that rejection at request time. Declared `optional`
+  // so unset is wire-distinguishable from explicit 0.0 (proto3's scalar
+  // default would otherwise silently coerce greedy decoding to the
+  // harness default).
+  optional double temperature = 31;
+
 }
 
 // DynamicContextValue is a single dynamic-context value with metadata.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -1618,14 +1619,21 @@ func ValidateRunConfig(config *RunConfig) error {
 
 	// temperature must lie inside the union of provider ranges. Negative
 	// values are nonsensical (all providers reject them); >2 is outside
-	// every provider's documented ceiling.
+	// every provider's documented ceiling. NaN/Inf must be rejected
+	// before the ordered comparisons: IEEE 754 NaN compares false against
+	// both bounds, so without an explicit finite-number guard a
+	// `--temperature=NaN` would slip past validation and reach providers.
 	if config.Temperature != nil {
 		t := *config.Temperature
-		if t < 0 {
-			errs = append(errs, "temperature must be >= 0.0")
-		}
-		if t > maxTemperature {
-			errs = append(errs, fmt.Sprintf("temperature must be <= %.1f", maxTemperature))
+		if math.IsNaN(t) || math.IsInf(t, 0) {
+			errs = append(errs, "temperature must be a finite number")
+		} else {
+			if t < 0 {
+				errs = append(errs, "temperature must be >= 0.0")
+			}
+			if t > maxTemperature {
+				errs = append(errs, fmt.Sprintf("temperature must be <= %.1f", maxTemperature))
+			}
 		}
 	}
 

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -25,6 +25,14 @@ const (
 	// maxTokenBudget is the maximum allowed token budget.
 	maxTokenBudget = 50_000_000
 
+	// maxTemperature is the upper bound on RunConfig.Temperature.
+	// Chosen as the union of provider-side ranges: Anthropic accepts
+	// [0, 1], OpenAI and Gemini accept [0, 2]. Values inside the union
+	// validate cleanly here so a single config can target multiple
+	// providers; the adapter still surfaces the provider's own rejection
+	// when a value lands above that provider's narrower range.
+	maxTemperature = 2.0
+
 	// maxSessionNameLength is the maximum allowed length, in bytes, of
 	// SessionName. Capped to keep log lines, OTel attribute values, and
 	// trace JSON predictable; well above any genuine human-readable label.
@@ -108,6 +116,23 @@ type RunConfig struct {
 	MaxTokenBudget *int     `json:"maxTokenBudget,omitempty"`
 	MaxCostBudget  *float64 `json:"maxCostBudget,omitempty"`
 	Timeout        *int     `json:"timeout,omitempty"`
+
+	// Temperature is the sampling temperature forwarded to the provider
+	// on every turn. Nil means "use the harness default" (0.1 — a low
+	// value that biases for determinism on coding tasks). A non-nil value
+	// is forwarded verbatim, including an explicit 0.0 for greedy
+	// decoding; this is the only way to override the default downwards.
+	//
+	// Validated against [0.0, maxTemperature]. The union of provider
+	// ranges (Anthropic [0, 1], OpenAI/Gemini [0, 2]) means a value
+	// inside the union may still be rejected by the chosen provider's
+	// own API; the adapter surfaces that rejection at request time
+	// rather than at validation.
+	//
+	// Reasoning models that reject temperature on the wire are a
+	// separate concern: the provider adapter is responsible for
+	// stripping the field when the selected model requires it.
+	Temperature *float64 `json:"temperature,omitempty"`
 
 	// FollowUpGrace is the number of seconds to keep the transport open after
 	// the primary run completes, waiting for follow-up user_response events.
@@ -1589,6 +1614,19 @@ func ValidateRunConfig(config *RunConfig) error {
 	// maxTokenBudget must be bounded
 	if config.MaxTokenBudget != nil && *config.MaxTokenBudget > maxTokenBudget {
 		errs = append(errs, fmt.Sprintf("maxTokenBudget must be <= %d", maxTokenBudget))
+	}
+
+	// temperature must lie inside the union of provider ranges. Negative
+	// values are nonsensical (all providers reject them); >2 is outside
+	// every provider's documented ceiling.
+	if config.Temperature != nil {
+		t := *config.Temperature
+		if t < 0 {
+			errs = append(errs, "temperature must be >= 0.0")
+		}
+		if t > maxTemperature {
+			errs = append(errs, fmt.Sprintf("temperature must be <= %.1f", maxTemperature))
+		}
 	}
 
 	validateRuleOfTwo(config, &errs)

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"strings"
 	"testing"
 )
@@ -559,6 +560,34 @@ func TestValidateRunConfig_TemperatureBounds(t *testing.T) {
 	err = ValidateRunConfig(c)
 	if err == nil || !strings.Contains(err.Error(), "temperature") {
 		t.Fatalf("expected temperature error for value > 2.0, got: %v", err)
+	}
+
+	// Non-finite values must be rejected explicitly. IEEE 754 NaN
+	// compares false against both bounds, so without a finite-number
+	// guard `--temperature=NaN` (strconv.ParseFloat accepts "NaN")
+	// would slip past the range checks and reach the provider. +Inf
+	// is caught by the > maxTemperature comparison today, but the
+	// finite-number guard is the contract — assert it directly so a
+	// later refactor cannot regress it.
+	nan := math.NaN()
+	c.Temperature = &nan
+	err = ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "finite") {
+		t.Fatalf("expected finite-number temperature error for NaN, got: %v", err)
+	}
+
+	posInf := math.Inf(1)
+	c.Temperature = &posInf
+	err = ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "finite") {
+		t.Fatalf("expected finite-number temperature error for +Inf, got: %v", err)
+	}
+
+	negInf := math.Inf(-1)
+	c.Temperature = &negInf
+	err = ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "finite") {
+		t.Fatalf("expected finite-number temperature error for -Inf, got: %v", err)
 	}
 
 	// In-range and boundary values must validate cleanly. 0.0 is the

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -543,6 +543,47 @@ func TestValidateRunConfig_NilBudgetsPass(t *testing.T) {
 	}
 }
 
+func TestValidateRunConfig_TemperatureBounds(t *testing.T) {
+	// Out-of-range: negative.
+	c := validConfig()
+	neg := -0.01
+	c.Temperature = &neg
+	err := ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "temperature") {
+		t.Fatalf("expected temperature error for negative value, got: %v", err)
+	}
+
+	// Out-of-range: above ceiling.
+	high := 2.01
+	c.Temperature = &high
+	err = ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "temperature") {
+		t.Fatalf("expected temperature error for value > 2.0, got: %v", err)
+	}
+
+	// In-range and boundary values must validate cleanly. 0.0 is the
+	// greedy-decoding case the spec calls out explicitly; 1.0 is the
+	// Anthropic ceiling; 2.0 is the OpenAI/Gemini ceiling.
+	for _, v := range []float64{0.0, 1.0, 2.0} {
+		t.Run(fmt.Sprintf("v=%v", v), func(t *testing.T) {
+			c := validConfig()
+			x := v
+			c.Temperature = &x
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("expected no error for temperature=%v, got: %v", v, err)
+			}
+		})
+	}
+
+	// Nil temperature falls back to the harness default and must
+	// validate cleanly. The "no temperature override" baseline.
+	c = validConfig()
+	c.Temperature = nil
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("expected no error for nil temperature, got: %v", err)
+	}
+}
+
 func TestValidateRunConfig_SessionNameEmpty(t *testing.T) {
 	c := validConfig()
 	c.SessionName = ""


### PR DESCRIPTION
Closes #217.

## Summary

Exposes the agentic loop's sampling temperature as a run-level setting on three surfaces:

- `RunConfig.Temperature *float64` (Go) — nil means "use the harness default"; non-nil is forwarded verbatim, including explicit `0.0` for greedy decoding.
- `--temperature` CLI flag on `stirrup` — unset is distinguished from explicit zero via `cmd.Flags().Changed("temperature")`, mirroring the `FollowUpGrace` / `MaxCostBudget` precedent.
- `optional double temperature = 31` on the gRPC `HarnessJobConfig` — round-trips through `grpc_translate.go` preserving the nil-vs-explicit-zero distinction.

The previously hardcoded `Temperature: types.Float64Ptr(0.1)` in `harness/internal/core/loop.go:572` is replaced by `cfg.Temperature` with a named-constant fallback (`defaultTemperature = 0.1`). The default value is unchanged — operators who want a different value set it explicitly.

## Why

Three motivations called out in #217:

1. **Reasoning-model wire shape.** `StreamParams.Temperature` already documents nil-means-provider-default semantics (used by the OpenAI Responses adapter per #200), but the loop unconditionally sent `0.1`, so operators had no way to request the nil pathway end-to-end.
2. **Eval reproducibility.** Greedy decoding (`0.0`) for deterministic grading and higher values for creative research runs are now expressible in a `RunConfig` (and therefore in an eval spec) without source patches.
3. **gRPC surface symmetry.** With `temperature` on `HarnessJobConfig`, a Cloud Run job can pin the value via its serialized config.

## Validation

`ValidateRunConfig` rejects any temperature that is:

- Not finite (`math.IsNaN(t) || math.IsInf(t, 0)`) — guards against `--temperature NaN`, `+Inf`, `-Inf` reaching the provider where behaviour is undefined or opaque.
- Negative.
- Greater than `2.0` (union of Anthropic 0–1, OpenAI 0–2, Gemini 0–2; providers may still reject values their own API does not accept).

`nil` is accepted (use the harness default).

## Non-goals (explicit)

- Per-turn / per-tool temperature — out of scope for a run-level setting.
- The summariser's `Float64Ptr(0.0)` at `harness/internal/context/summarise.go:187` is untouched; its greedy decoding is a context-component invariant, not a loop sampling parameter.
- The default is unchanged at `0.1`.
- No `top_p` / `top_k` / sampling-bundle flag.

## Commit walk

| Commit | Area |
|---|---|
| `8ddb593` | `types`: `RunConfig.Temperature` field + `0.0`–`2.0` validation |
| `2b490a6` | `proto`: `optional double temperature = 31` on `HarnessJobConfig` (+ regenerated `pb.go`) |
| `4774fae` | `core`: thread `RunConfig.Temperature` through the loop; `defaultTemperature = 0.1` constant |
| `e435959` | `transport`: round-trip `RunConfig.Temperature` in `grpc_translate` |
| `424ecfb` | `cli`: `--temperature` flag with unset-vs-zero distinction |
| `22a8d2b` | `docs`: document the flag and field in `docs/configuration.md` |
| `8be53e6` | `types`: reject NaN / Inf with a finite-number guard (post-review) |
| `a769536` | `cli`: direct `buildHarnessRunConfig` test for temperature plumbing (post-review) |
| `aeb5a02` | `cli`: extract `optionalFloat64Flag` helper shared between callers (post-review) |

## Test plan

- [x] `just build` — clean.
- [x] `just test` — clean (added 5 test functions covering loop forwarding, validation bounds, NaN/Inf, gRPC round-trip, CLI plumbing).
- [x] `just lint` — `0 issues`.
- [x] `RunConfig.Redact()` unaffected (temperature is not sensitive).
- [x] `harnessapi/` public surface unchanged beyond the new `RunConfig` field.
- [x] Summariser greedy decoding (`harness/internal/context/summarise.go:187`) untouched.
- [x] Loop regression-guard preserved: the unset case still pins `StreamParams.Temperature == 0.1` so the "loop never silently forwards nil to the provider" property is testable.
- [x] CLI: `--temperature 0` produces `*float64 → 0.0` (not nil); omitting the flag produces nil; `--temperature 0.7` produces `*float64 → 0.7`.
- [x] gRPC translate preserves explicit zero across the round-trip.

## Review context for the human reviewer

The implementation passed through a five-agent review wave (code, security, spec-compliance, test-coverage, api-design) plus a synthesizer pass. Findings classified by the synthesizer:

**Blocking — fixed in `8be53e6`:**
- NaN bypass in `ValidateRunConfig`: `t < 0` and `t > 2.0` both return `false` for IEEE 754 NaN, and `strconv.ParseFloat` accepts the literal `"NaN"`. Flagged independently by security-reviewer (MEDIUM) and test-coverage-auditor (CRITICAL). Fix adds `math.IsNaN(t) || math.IsInf(t, 0)` as the first guard with a dedicated error and three new test cases.

**Should-fix — fixed in `a769536` and `aeb5a02`:**
- `buildHarnessRunConfig` had no direct temperature test (transitive coverage only). Added `TestBuildHarnessRunConfig_Temperature` covering unset, explicit zero, explicit non-zero, and the alias-copy property.
- `runHarness` and `applyOverrides` duplicated the `flags.Changed` + `GetFloat64` pattern. Extracted to `optionalFloat64Flag` helper; pure refactor with no observable behaviour change.

**Deferred (Nice-to-have / Defer — not addressed in this PR):**

1. `grpc_translate.go` aliases the proto `*float64` pointer directly into `RunConfig` rather than copying the value. Inherited from the pre-existing `MaxCostBudget` path; fixing for temperature alone would create inconsistency. Worth a separate sweep across all optional-scalar fields if pursued.
2. Add gRPC round-trip test case at the exact `2.0` boundary (current tests cover `0.0`, `0.7`, `1.5`).
3. Add `100.0` to the validation rejection cases (current tests reject `2.01` and rely on the same boundary code path).
4. `Temperature` field placement in `types/runconfig.go` sits between `Timeout` and `FollowUpGrace` without a comment-group label — could join a `// Limits` block or get a `// Sampling` separator (cosmetic).
5. `--temperature` is in the "Run identity and shape" table in `docs/configuration.md` rather than near the limit/budget flags (cosmetic, no missing information).
6. Reviewer-noted asymmetry between `Timeout` / `FollowUpGrace` (which copy through the proto translation) and `MaxCostBudget` / `Temperature` (which pointer-alias) — covered by deferred item 1.

If any of the deferred items should be in-scope, happy to fold them into this PR or open a follow-up.

## References

- Issue: #217
- Related reasoning-model wire-shape constraint: #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)