### PR TITLE
cli: add run-config subcommand and --output-runconfig

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,21 @@ Requires `ANTHROPIC_API_KEY` environment variable for the default Anthropic prov
 | `--transport-addr` | (none) | gRPC target address, required when transport is grpc |
 | `--followup-grace` | `0` | Seconds to keep gRPC open for follow-ups (env: `STIRRUP_FOLLOWUP_GRACE`) |
 | `--log-level` | `info` | Log level: debug, info, warn, error |
+| `--config` | (none) | JSON `RunConfig` path. Use `-` for stdin; auto-detected on a non-TTY pipe. |
+| `--output-runconfig` | (none) | Write the resolved `RunConfig` JSON to `<path>` (or `-` for stdout) and exit without running. Dry-run capture for replay or post-mortem. |
+
+### CLI Flags (`stirrup run-config`)
+
+Emits a fully-resolved `RunConfig` JSON document without invoking the
+loop. Accepts every `RunConfig`-producing flag from `stirrup harness`
+plus a base via stdin or `--config <path>`. See
+[`docs/configuration.md`](docs/configuration.md#building-runconfigs-interactively).
+
+| Flag | Default | Description |
+|---|---|---|
+| `--validate` | `false` | Run `types.ValidateRunConfig` and exit non-zero on failure. |
+| `--compact` | `false` | Single-line JSON instead of indented (2-space). |
+| `--redact` | `false` | Apply `RunConfig.Redact()` before emit (rewrites `secret://` references). |
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,10 @@ Quick map for "I need to change X" lookups:
 | Result sink (RunResult payload) | `harness/internal/resultsink/` |
 | Workspace GCS export | `harness/internal/workspaceexport/` |
 | `RunConfig` validation | `types/runconfig.go` |
-| CLI flag definitions | `harness/cmd/stirrup/cmd/harness.go` |
+| CLI flag definitions (shared between `harness` and `run-config`) | `harness/cmd/stirrup/cmd/runconfigflags.go` |
+| CLI flag definitions (`harness`-only behaviour: `--export-workspace-required`, `--output-runconfig`) | `harness/cmd/stirrup/cmd/harness.go` |
+| Resolved-config builder (file/stdin/flags → RunConfig) | `harness/cmd/stirrup/cmd/runconfigbuilder.go` |
+| `stirrup run-config` subcommand | `harness/cmd/stirrup/cmd/runconfig.go` |
 | gRPC schema | `proto/harness/v1/harness.proto` (then `buf generate`) |
 | Eval suite parser | `eval/spec/` |
 | Eval CLI subcommands | `eval/cmd/eval/main.go` |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ OPENAI_KEY="$(op read "op://Private/qeu6gafabhkpsm6hhzattx6p4m/credential")" ./s
 
 ```
 
+### Composing configs in a pipeline
+
+For development workflows that build up a `RunConfig` incrementally,
+`stirrup run-config` emits the resolved JSON document without
+invoking the loop, and `stirrup harness` reads a base config from
+stdin so each stage layers one more adjustment before the final stage
+runs the agent:
+
+```sh
+stirrup run-config --model claude-opus-4-7 \
+  | stirrup run-config --max-turns 100 \
+  | stirrup run-config --mode execution --executor container \
+  | stirrup harness --prompt "refactor module X"
+```
+
+`stirrup harness --output-runconfig <path>` captures the exact
+config a flag-only invocation *would* have used — useful for
+post-mortem replays or pinning a stable configuration. See
+[`docs/configuration.md`](docs/configuration.md#building-runconfigs-interactively).
+
 ### In GitHub Actions
 
 See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.yml) for an example of using `stirrup harness` in a GitHub Actions workflow via [Anthropic Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,20 +21,83 @@ fails fast with a clear error rather than being silently dropped.
 
 ## Precedence
 
-When both `--config` and explicit flags are passed, the order of
-precedence is:
+When `--config`, piped stdin, or explicit flags are passed, the order
+of precedence is:
 
-1. **File** — `--config` populates the full `RunConfig`.
+1. **Base config** — either `--config <path>` (file) or stdin
+   (`--config -`, or auto-detected on a non-TTY pipe). Mutually
+   exclusive: passing both is a hard error so the operator never
+   has to guess which source won.
 2. **Explicit flags** — flags whose `cmd.Flags().Changed(...)` bit is
-   set replace the corresponding file-provided field.
+   set replace the corresponding base field.
 3. **Defaults** — flags left at their default value do **not**
-   override the file. This is what makes `--config` ergonomic: you
-   do not have to clear every default to keep the file's intent.
+   override the base. This is what makes `--config` ergonomic:
+   defaults can stay defaults while the file's intent is preserved.
 
 The positional `prompt` argument is a fallback only. It fills the
-prompt slot when the file omits it and `--prompt` is not set, but
-neither the file's `prompt` nor an explicit `--prompt` is overridden
+prompt slot when the base omits it and `--prompt` is not set, but
+neither the base's `prompt` nor an explicit `--prompt` is overridden
 by a positional.
+
+## Building RunConfigs interactively
+
+For development workflows that compose a `RunConfig` incrementally —
+or just to capture what a flag-only invocation *would* have run — the
+harness ships two surfaces that complement `--config <path>`:
+
+- `stirrup run-config` emits a fully-resolved `RunConfig` JSON
+  document to stdout without invoking the agentic loop. Every
+  RunConfig-producing flag from `stirrup harness` is honoured; a
+  base config can arrive via stdin (the pipeline pattern) or
+  `--config <path>`.
+- `stirrup harness --output-runconfig <path>` writes the resolved
+  RunConfig as JSON to `<path>` (use `-` for stdout) and exits
+  without running. The captured document is exactly what would have
+  been handed to the loop, so it can be checked into source control
+  for replay or compared with `diff` between runs.
+
+The two surfaces together support a UNIX-style pipeline where each
+stage layers one more adjustment before the final stage runs the
+agent:
+
+```sh
+stirrup run-config --model claude-opus-4-7 \
+  | stirrup run-config --max-turns 100 \
+  | stirrup run-config --mode execution --executor container \
+  | stirrup harness --prompt "refactor X"
+```
+
+`stirrup run-config` exposes three subcommand-specific flags:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--validate` | `false` | Run `types.ValidateRunConfig` on the resolved document and exit non-zero on failure. Without this flag, partial / chained configs are emitted as-is so a downstream stage can complete them. |
+| `--compact` | `false` | Emit single-line JSON instead of indented (2-space). |
+| `--redact` | `false` | Apply `RunConfig.Redact()` before emit. Rewrites `secret://` references to `secret://[REDACTED]`. The result is share-safe but no longer runnable as-is — operators who need a runnable replay should omit the flag. |
+
+`stirrup harness --output-runconfig` always emits the unredacted form
+because its purpose is exact replay; pipe through
+`stirrup run-config --redact` when a share-safe artifact is wanted.
+
+### Reading from stdin
+
+`stirrup harness` accepts a base `RunConfig` from stdin in two shapes:
+
+- **`--config -`** is the explicit, scripted opt-in. It always
+  reads stdin and fails loudly if stdin is a terminal or carries no
+  data.
+- **Auto-detection on a non-TTY pipe** triggers when `--config` is
+  unset and stdin is a named pipe (`|`) or a regular-file
+  redirection (`< config.json`). Other non-TTY shapes — including
+  `< /dev/null` and the stdin handed to tests by `go test` — fall
+  through to flag-only construction so the harness does not trap
+  noninteractive automation.
+
+Piping a config into `stirrup harness` consumes stdin at startup,
+before transport initialisation, so the stdio transport sees EOF for
+any subsequent control-event input. This matches the batch shape the
+pipeline pattern targets — operators who need interactive control
+should use `--transport grpc`.
 
 ## CLI flags
 

--- a/examples/runconfig/README.md
+++ b/examples/runconfig/README.md
@@ -42,20 +42,12 @@ fails fast with a clear error rather than being silently dropped.
 
 ## Precedence
 
-When the user passes both `--config <path>` and individual flags, the
-order of precedence is:
-
-1. **File** — `--config` populates the full `RunConfig`.
-2. **Explicit flags** — flags whose `cmd.Flags().Changed(...)` bit is
-   set replace the corresponding file-provided field.
-3. **Defaults** — flags left at their default value do **not**
-   override the file. This is what makes `--config` ergonomic:
-   defaults can stay defaults while the file's intent is preserved.
-
-The positional `prompt` argument is a fallback only. It fills the
-prompt slot when the file omits it and `--prompt` is not set, but
-neither the file's `prompt` nor an explicit `--prompt` is overridden
-by a positional.
+The canonical resolution table — covering `--config <path>`, piped
+stdin (`--config -` or auto-detected on a non-TTY pipe), explicit
+flag overrides, and the positional prompt fallback — lives in
+[`docs/configuration.md`](../../docs/configuration.md#building-runconfigs-interactively).
+The same section documents the `stirrup run-config | stirrup harness`
+pipeline pattern these examples plug into.
 
 ## Annotated example walkthrough
 

--- a/examples/runconfig/README.md
+++ b/examples/runconfig/README.md
@@ -3,6 +3,13 @@
 This directory contains example `RunConfig` JSON files for the
 `stirrup harness --config <path>` flag.
 
+To produce one of these from scratch — either from a flag-only
+invocation or by composing several `run-config` stages — see
+`stirrup run-config --help` and the pipeline pattern documented in
+[`docs/configuration.md`](../../docs/configuration.md#building-runconfigs-interactively).
+The same file format is consumed by `--config` and emitted by
+`run-config`, so a captured config round-trips into a replay run.
+
 ## Source of truth
 
 The canonical schema for these files is the protobuf definition at

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -846,13 +846,10 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 		}
 	}
 
-	// Anthropic Workload Identity Federation overrides (issue #117).
-	// Encapsulated for readability; the helper handles the four ID
-	// fields, the inferred credential.type, the token-source inference
-	// chain, and the apiKeyRef mutual-exclusion guard.
-	if err := applyAnthropicWIFOverrides(cmd, cfg); err != nil {
-		return err
-	}
+	// Anthropic WIF folding lives in BuildRunConfig as a single
+	// post-override step (see runconfigbuilder.go). Calling it again
+	// here would double-invoke its slog.Warn diagnostics and silently
+	// double-count any future non-idempotent additions.
 
 	// Azure Entra ID Workload Identity Federation (issue #118). The three
 	// --azure-* flags compose: --azure-tenant-id alone is enough to imply

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1187,8 +1187,26 @@ func writeOutputRunConfig(path string, cfg *types.RunConfig) error {
 	if err != nil {
 		return fmt.Errorf("opening --output-runconfig %q: %w", path, err)
 	}
-	defer func() { _ = f.Close() }()
-	return writeRunConfigJSON(f, cfg, false)
+	return writeAndCloseRunConfig(f, path, cfg)
+}
+
+// writeAndCloseRunConfig is the testable seam writeOutputRunConfig
+// delegates to once a writer is available. Tests inject a synthetic
+// io.WriteCloser whose Close returns an error to pin the deferred-
+// flush diagnostic path.
+//
+// Linux's buffered file I/O can defer kernel page flushes until
+// Close. A successful writeRunConfigJSON but a failed Close (ENOSPC,
+// EIO, NFS commit failure) would otherwise hand the operator a
+// zero-exit run with a corrupt or empty capture file and no
+// diagnostic. Surface the close error when the prior write
+// succeeded.
+func writeAndCloseRunConfig(wc io.WriteCloser, path string, cfg *types.RunConfig) error {
+	writeErr := writeRunConfigJSON(wc, cfg, false)
+	if cerr := wc.Close(); cerr != nil && writeErr == nil {
+		return fmt.Errorf("closing --output-runconfig %q: %w", path, cerr)
+	}
+	return writeErr
 }
 
 // applyAnthropicWIFOverrides folds the Anthropic-WIF flag surface and

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -257,7 +256,27 @@ type harnessCLIOptions struct {
 // would silently truncate to zero). Most validation still happens later
 // in `ValidateRunConfig`; the checks here exist where the truncation
 // would erase operator intent before the validator ever sees it.
+//
+// Internally delegates to buildHarnessRunConfigCore for the field-by-
+// field shape, then runs applyModeDefaults so the returned config is
+// ready for the validator. Splitting the two lets BuildRunConfig hand
+// run-config's ResolveBase path a config without the mode-default
+// mutations applied, matching the spec's "leave the document minimally
+// mutated" contract for chained pipeline stages.
 func buildHarnessRunConfig(opts harnessCLIOptions) (*types.RunConfig, error) {
+	cfg, err := buildHarnessRunConfigCore(opts)
+	if err != nil {
+		return nil, err
+	}
+	applyModeDefaults(cfg)
+	return cfg, nil
+}
+
+// buildHarnessRunConfigCore is buildHarnessRunConfig without the trailing
+// applyModeDefaults call. BuildRunConfig uses this directly so the
+// run-config subcommand's ResolveBase path can emit a minimally-mutated
+// document for downstream pipeline stages.
+func buildHarnessRunConfigCore(opts harnessCLIOptions) (*types.RunConfig, error) {
 	timeout := opts.Timeout
 
 	executorType := opts.ExecutorType
@@ -479,7 +498,6 @@ func buildHarnessRunConfig(opts harnessCLIOptions) (*types.RunConfig, error) {
 		config.Provider.Batch = &types.BatchProviderConfig{Enabled: true}
 	}
 
-	applyModeDefaults(config)
 	return config, nil
 }
 
@@ -680,115 +698,16 @@ default first-touch posture.`,
 func init() {
 	rootCmd.AddCommand(harnessCmd)
 
+	// All RunConfig-producing flags live in addRunConfigFlags so the
+	// run-config subcommand can register the same set without drifting.
+	// CLI-behaviour flags that do not round-trip through RunConfig
+	// (--export-workspace-required, --output-runconfig) remain on the
+	// harness command directly.
+	addRunConfigFlags(harnessCmd)
+
 	f := harnessCmd.Flags()
-	f.String("config", "", "Path to a JSON RunConfig file (mirrors proto/harness/v1/harness.proto). Explicit flags still override individual fields; unset flags do not.")
-	f.StringP("mode", "m", "planning", "Run mode: execution, planning, review, research, toil. Default is the read-only `planning` mode (no edits, no shell, deny-side-effects policy); pass `--mode execution` for editable runs with shell access.")
-	f.String("model", "claude-sonnet-4-6", "Model to use (sets ModelRouter.Model; for dynamic/per-mode routers in --config files this only sets the default-model field, not the cheap/expensive override)")
-	f.String("provider", "anthropic", "Provider type: anthropic, bedrock, gemini (Vertex AI), openai-compatible (Chat Completions), openai-responses (Responses API). The two OpenAI variants speak different wire formats and must be selected explicitly.")
-	f.String("api-key-ref", "secret://ANTHROPIC_API_KEY", "Secret reference for API key")
-	f.String("base-url", "", "API base URL for openai-compatible / openai-responses providers (e.g. https://<resource>.openai.azure.com/openai/v1)")
-	f.String("api-key-header", "", "Header name for sending the API key. Empty = Authorization: Bearer (default). Set to \"api-key\" for Azure OpenAI key auth.")
-	f.StringArray("query-param", nil, "Repeatable key=value query parameter appended to every provider request URL (e.g. api-version=preview). Used by the openai-* adapters.")
-	f.String("gcp-project", "", "GCP project ID hosting the Vertex AI usage. Required when --provider=gemini.")
-	f.String("gcp-location", "global", "Vertex AI location: \"global\" or a region (e.g. us-central1). Determines the URL host and project location segment.")
-	f.String("gcp-credentials-file", "", "Path to a Google service account JSON key file. When set, implies credential.type=gcp-service-account.")
-
-	// Anthropic Workload Identity Federation flags (issue #117). Setting
-	// any of the four ID flags implies credential.type=anthropic-wif when
-	// the credential type is otherwise unset; the JWT source is selected
-	// by --anthropic-from-github-actions or the ANTHROPIC_IDENTITY_TOKEN*
-	// env vars (precedence documented in the operator walkthrough).
-	f.String("anthropic-federation-rule-id", "", "Anthropic federation rule ID (`fdrl_...`). Implies `credential.type=anthropic-wif` when set. Env fallback: ANTHROPIC_FEDERATION_RULE_ID.")
-	f.String("anthropic-organization-id", "", "Anthropic organization UUID. Required with WIF. Env fallback: ANTHROPIC_ORGANIZATION_ID.")
-	f.String("anthropic-service-account-id", "", "Anthropic service account ID (`svac_...`). Required with WIF. Env fallback: ANTHROPIC_SERVICE_ACCOUNT_ID.")
-	f.String("anthropic-workspace-id", "", "Anthropic workspace ID (`wrkspc_...`) or `default`. Conditional. Env fallback: ANTHROPIC_WORKSPACE_ID.")
-	f.Bool("anthropic-from-github-actions", false, "Enable GitHub Actions OIDC token source for Anthropic WIF. Reads ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN from the runner environment. Ignored (with a warning) if `--config` already sets `credential.tokenSource`.")
-
-	// Azure Entra ID Workload Identity Federation flags (issue #118).
-	f.String("azure-tenant-id", "", "Azure AD tenant UUID hosting the App Registration. When set, implies credential.type=azure-workload-identity. Use with --provider=openai-compatible or openai-responses against Azure OpenAI / Foundry.")
-	f.String("azure-client-id", "", "App Registration / federated identity credential client ID (UUID). Required with --azure-tenant-id.")
-	f.String("azure-scope", "https://cognitiveservices.azure.com/.default", "OAuth2 scope for the Entra access token. Override only for non-default Azure audiences (custom AAD app registrations, sovereign clouds).")
-	f.StringP("workspace", "w", "", "Workspace directory (default: current directory)")
-	f.Int("max-turns", 20, "Maximum agentic loop turns")
-	f.Int("timeout", 600, "Wall-clock timeout in seconds")
-	f.String("trace", "", "Path to JSONL trace file (sets --trace-emitter to jsonl unless --trace-emitter is explicitly set)")
-	f.String("transport", "stdio", "Transport type: stdio, grpc")
-	f.String("transport-addr", "", "gRPC target address (required when transport is grpc)")
-	f.Int("followup-grace", 0, "Seconds to keep gRPC transport open for follow-up requests (0 = disabled; env: STIRRUP_FOLLOWUP_GRACE)")
-	f.Float64("temperature", 0, "Sampling temperature forwarded to the provider on every turn. Range 0.0-2.0 (union of provider ranges). Unset leaves the harness default (0.1); explicit 0 sets greedy decoding.")
-	f.String("log-level", "info", "Log level: debug, info, warn, error")
-	f.String("prompt", "", "User prompt (can also be passed as a positional argument; falls back to --prompt-file then STIRRUP_PROMPT env var, then a prompt field in --config)")
-	f.String("prompt-file", "", "Path to a file whose contents become the prompt. Read from CWD when relative. Trailing newlines are trimmed; the file is capped at 10 MiB and must be non-empty. Lower precedence than --prompt and the positional argument; higher than STIRRUP_PROMPT.")
-	f.String("name", "", "Human-readable session label (metadata only, not injected into prompt)")
-
-	// Component-selection flags. Escape hatches for callers who don't want
-	// a full --config file but need to switch a single component. These
-	// are still honoured (as overrides) when --config is set.
-	f.String("executor", "local", "Executor: local, container, api")
-	f.String("edit-strategy", "multi", "Edit strategy: whole-file, search-replace, udiff, multi (composite available only via --config)")
-	f.String("verifier", "none", "Verifier: none, test-runner, llm-judge (composite available only via --config)")
-	f.String("git-strategy", "none", "Git strategy: none, deterministic")
-	f.String("trace-emitter", "jsonl", "Trace emitter: jsonl, otel, gcs")
-	f.String("otel-endpoint", "", "OTLP endpoint for the otel trace emitter (default: localhost:4317 for grpc; full URL ending in the gateway base path for http/protobuf, e.g. https://otlp-gateway-prod-us-east-0.grafana.net/otlp)")
-	f.String("otel-protocol", "", "OTLP wire protocol for the otel trace emitter: \"\" (default — grpc), grpc, http/protobuf. HTTP/JSON is not supported; managed gateways like Grafana Cloud use http/protobuf. See docs/observability-cloud.md.")
-
-	// Safety-ring flags (issue #42). Each maps to a single RunConfig
-	// field; precedence with --config is the same as the rest of the
-	// override surface (file -> flag -> default; unset flags don't
-	// override the file).
-	f.String("container-runtime", "", "OCI runtime for the container executor: runc, runsc (gVisor), kata, kata-qemu, kata-fc. Empty means engine default (typically runc). Requires the runtime to be registered with the host Docker/Podman daemon — see docs/safety-rings.md.")
-	f.String("permission-policy-file", "", "Path to a Cedar policy file for the policy-engine PermissionPolicy. When set and --permission-policy is unset elsewhere, also implies permissionPolicy.type=policy-engine. See examples/policies/ for starters.")
-	f.String("code-scanner", "", "CodeScanner type: none, patterns, semgrep, composite. Composite requires --config (codeScanner.scanners). Empty defers to the mode-aware default (patterns for execution, none for read-only modes).")
-
-	// GuardRail flags (issue #43). The composite layering used by the
-	// operator escape hatch requires per-stage phase restrictions, which
-	// flag syntax cannot express; composite stacks therefore round-trip
-	// only through --config (see docs/guardrails.md).
-	f.String("guardrail", "", "GuardRail type: none, granite-guardian, composite, cloud-judge. Composite requires --config (guardRail.stages).")
-	f.String("guardrail-endpoint", "", "Endpoint URL for the granite-guardian or cloud-judge adapter.")
-	f.String("guardrail-model", "", "Model identifier for the GuardRail classifier. Granite-guardian default: ibm-granite/granite-guardian-4.1-8b. Cloud-judge default: claude-haiku-4-5-20251001 (Anthropic API format) — when the primary provider is Bedrock, use the Bedrock-format ID (e.g. us.anthropic.claude-haiku-4-5-20251001-v1:0).")
-	f.Bool("guardrail-fail-open", false, "When true, transport errors / timeouts produce VerdictAllow with a security event rather than blocking. Default false (fail closed).")
-
-	// Observability resource attributes (issue #95). No default at the
-	// flag level — empty values fall through to env-var fallbacks
-	// (OTEL_DEPLOYMENT_ENVIRONMENT, OTEL_SERVICE_NAMESPACE) and finally
-	// to defaults ("local" / "stirrup") at resource construction time.
-	f.String("deployment-environment", "", "OTel deployment.environment resource attribute (e.g. production, staging). Empty falls through to OTEL_DEPLOYMENT_ENVIRONMENT, then to \"local\".")
-	f.String("service-namespace", "", "OTel service.namespace resource attribute (e.g. stirrup-eval, team-a). Empty falls through to OTEL_SERVICE_NAMESPACE, then to \"stirrup\".")
-
-	// Provider retry policy (issue #197). No flag-level default — when
-	// a flag is left unset its corresponding Provider.Retry field stays
-	// at the zero value and ValidateRunConfig fills the documented
-	// default (MaxAttempts=3, InitialDelay=500ms, MaxDelay=16s,
-	// WallClockBudget=90s). Per-named-provider retry policy requires
-	// --config; these flags apply only to the default provider.
-	f.Int("provider-retry-max-attempts", 0, "Maximum HTTP attempts (including the first) for the default provider. 1 disables retry. Hard ceiling: 5. Default (when unset): 3. Currently honoured only by the openai-compatible adapter; the other adapters fall through unconditionally pending their own wire-ups.")
-	f.Duration("provider-retry-initial-delay", 0, "Base delay for exponential backoff before jitter, applied between retries on the default provider. Accepts Go duration syntax (e.g. 500ms, 1s). Default (when unset): 500ms.")
-	f.Duration("provider-retry-max-delay", 0, "Per-attempt sleep ceiling for the default provider (also caps Retry-After hints). Applies only to the default provider; per-named-provider retry policy requires --config. Hard ceiling: 60s. Default (when unset): 16s.")
-	f.Duration("provider-retry-wall-clock", 0, "Wall-clock budget for the entire retry sequence on the default provider. Applies only to the default provider; per-named-provider retry policy requires --config. Hard ceiling: 300s. Default (when unset): 90s.")
-
-	// Workspace export flags (issue #164). --export-workspace-to mirrors
-	// executor.workspaceExportTo in the RunConfig; an explicit flag
-	// overrides whatever the --config file set. --export-workspace-required
-	// controls error semantics on upload failure (default: log and
-	// continue; required: fail the run). Validation is delegated to
-	// types.ValidateRunConfig which already accepts only gs:// URIs.
-	f.String("export-workspace-to", "", "Upload the executor workspace as a gzipped tarball to this URI at end-of-run (e.g. gs://bucket/runs/<runId>/workspace.tar.gz). Only gs:// is supported in v1. Mirrors executor.workspaceExportTo.")
 	f.Bool("export-workspace-required", false, "When true, a failed workspace export exits the run non-zero. When false (default), failures are logged and the run's exit code is unchanged.")
-
-	// Parallel async-tool dispatch (issue #184). Default 0 means "use
-	// the library default" so a flag-only run without
-	// --max-tool-parallel leaves config.ToolDispatch nil and the loop
-	// reads types.DefaultToolDispatchMaxParallel via
-	// EffectiveToolDispatchMaxParallel.
-	f.Int("max-tool-parallel", 0, "Maximum number of async tool calls dispatched concurrently in a single turn. Range: 1-16. 0 uses the library default (4).")
-
-	// Batch (issue #136). Carries only the Enabled bit; the other
-	// BatchProviderConfig knobs (maxWaitSeconds, harnessSidePolling,
-	// fallbackOnTimeout, cancelBundleOnRunCancel, allowInteractiveModes)
-	// must come from --config because flag syntax cannot cleanly express
-	// the cross-field invariants validated together.
-	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/sandbox.md.")
+	f.String("output-runconfig", "", "Write the resolved RunConfig as JSON to <path> (use '-' for stdout) and exit without running. Useful for capturing the exact config a flag-only invocation would have used. Validation must pass first; the path is not written on a validator error.")
 }
 
 // applyOverrides mutates cfg in place, replacing fields whose corresponding
@@ -1227,250 +1146,52 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	f := cmd.Flags()
 	configPath, _ := f.GetString("config")
 
-	// Path 1: --config file is the base; explicitly-set flags override it.
-	if configPath != "" {
-		cfg, err := loadRunConfigFile(configPath)
-		if err != nil {
-			return err
-		}
-		if err := applyOverrides(cmd, cfg, args); err != nil {
-			return err
-		}
-
-		// After overrides, derive any unset mode-driven defaults
-		// (PermissionPolicy, read-only Tools.BuiltIn). Mirrors what
-		// buildHarnessRunConfig does in the flag-only path so the two
-		// code paths produce architecturally consistent configs.
-		applyModeDefaults(cfg)
-
-		// Generate a RunID if the file omitted one. We never let the file
-		// dictate identity, but we do honour an explicit RunID for replay
-		// scenarios.
-		if cfg.RunID == "" {
-			cfg.RunID = generateRunID()
-		}
-		// Resolve env var for follow-up grace if neither flag nor file set it.
-		if cfg.FollowUpGrace == nil {
-			if v := os.Getenv("STIRRUP_FOLLOWUP_GRACE"); v != "" {
-				if n, err := strconv.Atoi(v); err == nil && n > 0 {
-					cfg.FollowUpGrace = &n
-				}
-			}
-		}
-		// --prompt-file and STIRRUP_PROMPT fall in below --prompt /
-		// positional / file-prompt (applyOverrides has already resolved
-		// those three by this point). Inlined rather than extracted into
-		// a resolvePrompt helper per the house-style preference for
-		// minimal-diff changes — the two call sites read the same five
-		// sources in the same order, and a tiny duplication keeps the
-		// resolution chain visible at both decision points.
-		if cfg.Prompt == "" {
-			if promptFile, _ := f.GetString("prompt-file"); promptFile != "" {
-				p, err := readPromptFile(promptFile)
-				if err != nil {
-					return err
-				}
-				cfg.Prompt = p
-			}
-		}
-		if cfg.Prompt == "" {
-			if v := os.Getenv("STIRRUP_PROMPT"); v != "" {
-				cfg.Prompt = v
-			}
-		}
-		if cfg.Prompt == "" {
-			return fmt.Errorf("prompt is required: pass via --prompt flag, as a positional argument, --prompt-file, STIRRUP_PROMPT env var, or the prompt field in --config")
-		}
-		if err := types.ValidateRunConfig(cfg); err != nil {
-			return fmt.Errorf("invalid config from %q: %w", configPath, err)
-		}
-		exportRequired, _ := f.GetBool("export-workspace-required")
-		return runWithConfig(cfg, runOptions{exportWorkspaceRequired: exportRequired})
-	}
-
-	// Path 2: no --config file. Build the RunConfig from flags + defaults.
-	prompt, _ := f.GetString("prompt")
-	if prompt == "" && len(args) > 0 {
-		prompt = args[0]
-	}
-	// --prompt-file and STIRRUP_PROMPT fall in below --prompt and the
-	// positional argument. Inlined rather than extracted into a
-	// resolvePrompt helper per the house-style preference for
-	// minimal-diff changes; the chain is short and reads top-to-bottom
-	// in precedence order, which is easier to audit than a separate
-	// function with its own ordering.
-	if prompt == "" {
-		if promptFile, _ := f.GetString("prompt-file"); promptFile != "" {
-			p, err := readPromptFile(promptFile)
-			if err != nil {
-				return err
-			}
-			prompt = p
-		}
-	}
-	if prompt == "" {
-		if v := os.Getenv("STIRRUP_PROMPT"); v != "" {
-			prompt = v
-		}
-	}
-	if prompt == "" {
-		return fmt.Errorf("prompt is required: pass via --prompt flag, as a positional argument, --prompt-file, STIRRUP_PROMPT env var, or the prompt field in --config")
-	}
-
-	mode, _ := f.GetString("mode")
-	sessionName, _ := f.GetString("name")
-	model, _ := f.GetString("model")
-	providerType, _ := f.GetString("provider")
-	apiKeyRef, _ := f.GetString("api-key-ref")
-	baseURL, _ := f.GetString("base-url")
-	apiKeyHeader, _ := f.GetString("api-key-header")
-	queryParamRaw, _ := f.GetStringArray("query-param")
-	gcpProject, _ := f.GetString("gcp-project")
-	gcpLocation, _ := f.GetString("gcp-location")
-	gcpCredentialsFile, _ := f.GetString("gcp-credentials-file")
-	anthropicFederationRuleID, _ := f.GetString("anthropic-federation-rule-id")
-	anthropicOrganizationID, _ := f.GetString("anthropic-organization-id")
-	anthropicServiceAccountID, _ := f.GetString("anthropic-service-account-id")
-	anthropicWorkspaceID, _ := f.GetString("anthropic-workspace-id")
-	anthropicFromGitHubActions, _ := f.GetBool("anthropic-from-github-actions")
-	azureTenantID, _ := f.GetString("azure-tenant-id")
-	azureClientID, _ := f.GetString("azure-client-id")
-	azureScope, _ := f.GetString("azure-scope")
-	workspace, _ := f.GetString("workspace")
-	maxTurns, _ := f.GetInt("max-turns")
-	timeout, _ := f.GetInt("timeout")
-	tracePath, _ := f.GetString("trace")
-	transportType, _ := f.GetString("transport")
-	transportAddr, _ := f.GetString("transport-addr")
-	followUpGrace, _ := f.GetInt("followup-grace")
-	logLevel, _ := f.GetString("log-level")
-	executorType, _ := f.GetString("executor")
-	editStrategyType, _ := f.GetString("edit-strategy")
-	verifierType, _ := f.GetString("verifier")
-	gitStrategyType, _ := f.GetString("git-strategy")
-	traceEmitterType, _ := f.GetString("trace-emitter")
-	otelEndpoint, _ := f.GetString("otel-endpoint")
-	otelProtocol, _ := f.GetString("otel-protocol")
-	containerRuntime, _ := f.GetString("container-runtime")
-	permissionPolicyFile, _ := f.GetString("permission-policy-file")
-	codeScannerType, _ := f.GetString("code-scanner")
-	guardRailType, _ := f.GetString("guardrail")
-	guardRailEndpoint, _ := f.GetString("guardrail-endpoint")
-	guardRailModel, _ := f.GetString("guardrail-model")
-	guardRailFailOpen, _ := f.GetBool("guardrail-fail-open")
-	deploymentEnvironment, _ := f.GetString("deployment-environment")
-	serviceNamespace, _ := f.GetString("service-namespace")
-	providerRetryMaxAttempts, _ := f.GetInt("provider-retry-max-attempts")
-	providerRetryInitialDelay, _ := f.GetDuration("provider-retry-initial-delay")
-	providerRetryMaxDelay, _ := f.GetDuration("provider-retry-max-delay")
-	providerRetryWallClockBudget, _ := f.GetDuration("provider-retry-wall-clock")
-	workspaceExportTo, _ := f.GetString("export-workspace-to")
-	workspaceExportRequired, _ := f.GetBool("export-workspace-required")
-	toolDispatchMaxParallel, _ := f.GetInt("max-tool-parallel")
-	batch, _ := f.GetBool("batch")
-
-	var queryParams map[string]string
-	for _, entry := range queryParamRaw {
-		k, v, err := parseQueryParam(entry)
-		if err != nil {
-			return fmt.Errorf("--query-param %q: %w", entry, err)
-		}
-		if queryParams == nil {
-			queryParams = map[string]string{}
-		}
-		queryParams[k] = v
-	}
-
-	// Allow the env var to set the follow-up grace when the flag is not provided.
-	if followUpGrace == 0 {
-		if v := os.Getenv("STIRRUP_FOLLOWUP_GRACE"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				followUpGrace = n
-			}
-		}
-	}
-
-	// Distinguish --temperature unset from --temperature=0. The
-	// cobra Float64 store has no way to express absence, so the
-	// flag's Changed() bit is the only safe way to preserve
-	// "use harness default" when the flag is omitted. Shared with
-	// applyOverrides via optionalFloat64Flag to keep the two paths
-	// from drifting.
-	temperature := optionalFloat64Flag(cmd, "temperature")
-
-	config, err := buildHarnessRunConfig(harnessCLIOptions{
-		RunID:                        generateRunID(),
-		Mode:                         mode,
-		SessionName:                  sessionName,
-		Prompt:                       prompt,
-		ProviderType:                 providerType,
-		BaseURL:                      baseURL,
-		APIKeyHeader:                 apiKeyHeader,
-		QueryParams:                  queryParams,
-		APIKeyRef:                    apiKeyRef,
-		GCPProject:                   gcpProject,
-		GCPLocation:                  gcpLocation,
-		GCPCredentialsFile:           gcpCredentialsFile,
-		AnthropicFederationRuleID:    anthropicFederationRuleID,
-		AnthropicOrganizationID:      anthropicOrganizationID,
-		AnthropicServiceAccountID:    anthropicServiceAccountID,
-		AnthropicWorkspaceID:         anthropicWorkspaceID,
-		AnthropicFromGitHubActions:   anthropicFromGitHubActions,
-		AzureTenantID:                azureTenantID,
-		AzureClientID:                azureClientID,
-		AzureScope:                   azureScope,
-		Model:                        model,
-		Workspace:                    workspace,
-		MaxTurns:                     maxTurns,
-		Timeout:                      timeout,
-		TracePath:                    tracePath,
-		TransportType:                transportType,
-		TransportAddr:                transportAddr,
-		FollowUpGrace:                followUpGrace,
-		Temperature:                  temperature,
-		LogLevel:                     logLevel,
-		ExecutorType:                 executorType,
-		EditStrategyType:             editStrategyType,
-		VerifierType:                 verifierType,
-		GitStrategyType:              gitStrategyType,
-		TraceEmitterType:             traceEmitterType,
-		OTelEndpoint:                 otelEndpoint,
-		OTelProtocol:                 otelProtocol,
-		ContainerRuntime:             containerRuntime,
-		PermissionPolicyFile:         permissionPolicyFile,
-		CodeScannerType:              codeScannerType,
-		GuardRailType:                guardRailType,
-		GuardRailEndpoint:            guardRailEndpoint,
-		GuardRailModel:               guardRailModel,
-		GuardRailFailOpen:            guardRailFailOpen,
-		DeploymentEnvironment:        deploymentEnvironment,
-		ServiceNamespace:             serviceNamespace,
-		ProviderRetryMaxAttempts:     providerRetryMaxAttempts,
-		ProviderRetryInitialDelay:    providerRetryInitialDelay,
-		ProviderRetryMaxDelay:        providerRetryMaxDelay,
-		ProviderRetryWallClockBudget: providerRetryWallClockBudget,
-		WorkspaceExportTo:            workspaceExportTo,
-		WorkspaceExportRequired:      workspaceExportRequired,
-		ToolDispatchMaxParallel:      toolDispatchMaxParallel,
-		Batch:                        batch,
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:      os.Stdin,
+		ConfigPath: configPath,
+		Cmd:        cmd,
+		Args:       args,
+		Resolve:    ResolveAll,
 	})
 	if err != nil {
 		return err
 	}
 
-	// Anthropic WIF env-var fallbacks and token-source inference run
-	// after buildHarnessRunConfig so the flag-only path mirrors the
-	// --config path's resolution chain. Errors here surface with the
-	// offending flag name rather than as an opaque ValidateRunConfig
-	// rejection.
-	if err := applyAnthropicWIFOverrides(cmd, config); err != nil {
-		return err
+	// --output-runconfig is a dry-run capture: write the validated
+	// RunConfig to the named path (or stdout) and exit without
+	// invoking the loop. The validator has already run inside
+	// BuildRunConfig, so reaching this branch with an invalid config
+	// is structurally impossible — that is what the spec means by
+	// "never writes on validation failure".
+	if outPath, _ := f.GetString("output-runconfig"); outPath != "" {
+		return writeOutputRunConfig(outPath, cfg)
 	}
 
-	if err := types.ValidateRunConfig(config); err != nil {
-		return fmt.Errorf("invalid config: %w", err)
+	exportRequired, _ := f.GetBool("export-workspace-required")
+	return runWithConfig(cfg, runOptions{exportWorkspaceRequired: exportRequired})
+}
+
+// writeOutputRunConfig emits the resolved RunConfig as pretty-printed
+// JSON to the named path. The special value "-" writes to stdout so
+// `--output-runconfig=-` composes with `stirrup run-config` for
+// pipeline replay. Non-stdout paths open with 0600 — a captured
+// RunConfig may carry secret:// references whose names are operationally
+// sensitive even though the references themselves are not secrets, and
+// the conservative mode matches how the rest of the harness writes
+// operator-facing artifacts (trace files, prompt files).
+func writeOutputRunConfig(path string, cfg *types.RunConfig) error {
+	if path == "-" {
+		return writeRunConfigJSON(os.Stdout, cfg, false)
 	}
-	return runWithConfig(config, runOptions{exportWorkspaceRequired: workspaceExportRequired})
+	// O_TRUNC because a captured config replaces any previous one at
+	// the same path; the alternative ("append") would silently corrupt
+	// a replay file.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("opening --output-runconfig %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return writeRunConfigJSON(f, cfg, false)
 }
 
 // applyAnthropicWIFOverrides folds the Anthropic-WIF flag surface and

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -4384,3 +4384,226 @@ func TestRunHarness_OutputRunConfigReplaysIdentically(t *testing.T) {
 		t.Logf("RunIDs happen to match (clock resolution); harmless")
 	}
 }
+
+// withPipedStdin swaps os.Stdin for a pipe whose read end the helper
+// returns to the caller; the supplied content is written to the
+// write end and the writer is closed so EOF reaches the reader. The
+// returned cleanup is registered with t.Cleanup so tests do not need
+// to thread the restore call themselves. Used by the MF-2 stdin
+// integration tests to drive runHarness without launching a subprocess.
+func withPipedStdin(t *testing.T, content string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+	})
+	if _, err := w.Write([]byte(content)); err != nil {
+		_ = w.Close()
+		t.Fatalf("write to pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+}
+
+// captureStdout swaps os.Stdout for a pipe and returns a function the
+// caller invokes once the test action has completed to retrieve the
+// captured bytes. Used by MF-2 tests that drive runHarness via
+// --output-runconfig=- (the dry-run capture sentinel) so the test can
+// observe the resolved RunConfig without invoking the provider.
+func captureStdout(t *testing.T) func() string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+	return func() string {
+		os.Stdout = orig
+		_ = w.Close()
+		out := <-done
+		_ = r.Close()
+		return out
+	}
+}
+
+// minimalStdinRunConfig is the smallest RunConfig the runHarness stdin
+// integration tests pipe through os.Stdin. ResolveAll still runs after
+// the read so every required field for the validator must be set —
+// the minimalRunConfigJSON helper in runconfigbuilder_test.go is the
+// ResolveBase shape, which omits Tools.BuiltIn / PermissionPolicy
+// values ResolveAll would reject on the execution path.
+func minimalStdinRunConfig(t *testing.T) string {
+	t.Helper()
+	timeout := 300
+	cfg := types.RunConfig{
+		RunID:  "from-stdin",
+		Mode:   "planning",
+		Prompt: "prompt from stdin",
+		Provider: types.ProviderConfig{
+			Type:      "anthropic",
+			APIKeyRef: "secret://STDIN_KEY",
+		},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
+		Executor:        types.ExecutorConfig{Type: "local"},
+		EditStrategy:    types.EditStrategyConfig{Type: "multi"},
+		Verifier:        types.VerifierConfig{Type: "none"},
+		GitStrategy:     types.GitStrategyConfig{Type: "none"},
+		Transport:       types.TransportConfig{Type: "stdio"},
+		TraceEmitter:    types.TraceEmitterConfig{Type: "jsonl"},
+		PermissionPolicy: types.PermissionPolicyConfig{
+			Type: "deny-side-effects",
+		},
+		Tools: types.ToolsConfig{
+			BuiltIn: types.DefaultReadOnlyBuiltInTools(),
+		},
+		MaxTurns: 10,
+		Timeout:  &timeout,
+		LogLevel: "info",
+	}
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(body)
+}
+
+// TestRunHarness_StdinExplicitDashReadsConfig pins MF-2 scenario 1:
+// `stirrup harness --config -` consumes a piped RunConfig from
+// os.Stdin and resolves through ResolveAll into a writable capture.
+// --output-runconfig=- short-circuits the provider invocation so the
+// test can assert on the resolved shape without booting the loop.
+func TestRunHarness_StdinExplicitDashReadsConfig(t *testing.T) {
+	withPipedStdin(t, minimalStdinRunConfig(t))
+	getOut := captureStdout(t)
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("config", "-"); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	if err := cmd.Flags().Set("output-runconfig", "-"); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+
+	runErr := runHarness(cmd, nil)
+	out := getOut()
+
+	if runErr != nil {
+		t.Fatalf("runHarness with --config -: %v\nstdout: %s", runErr, out)
+	}
+
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("captured output should be parseable JSON: %v\n%s", err, out)
+	}
+	if cfg.Prompt != "prompt from stdin" {
+		t.Errorf("Prompt = %q, want %q", cfg.Prompt, "prompt from stdin")
+	}
+	if cfg.Provider.APIKeyRef != "secret://STDIN_KEY" {
+		t.Errorf("APIKeyRef = %q, want secret://STDIN_KEY", cfg.Provider.APIKeyRef)
+	}
+}
+
+// TestRunHarness_StdinAutoDetectsPipe pins MF-2 scenario 2: a piped
+// stdin (no --config flag) is auto-detected and treated as the base
+// RunConfig. The shape mirrors the canonical `run-config | harness`
+// pipeline.
+func TestRunHarness_StdinAutoDetectsPipe(t *testing.T) {
+	withPipedStdin(t, minimalStdinRunConfig(t))
+	getOut := captureStdout(t)
+
+	cmd := newTestHarnessCommand()
+	// Deliberately no --config flag set. The pipe's named-pipe mode
+	// bit triggers isStdinPiped, which makes BuildRunConfig consume
+	// stdin as the base.
+	if err := cmd.Flags().Set("output-runconfig", "-"); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+
+	runErr := runHarness(cmd, nil)
+	out := getOut()
+
+	if runErr != nil {
+		t.Fatalf("runHarness with auto-stdin: %v\nstdout: %s", runErr, out)
+	}
+
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("captured output should be parseable JSON: %v\n%s", err, out)
+	}
+	if cfg.Prompt != "prompt from stdin" {
+		t.Errorf("auto-detected stdin Prompt = %q, want %q", cfg.Prompt, "prompt from stdin")
+	}
+}
+
+// TestRunHarness_StdinAndConfigFileAreAmbiguous pins MF-2 scenario 3:
+// `--config <path>` alongside a non-TTY stdin must fail loudly. Silent
+// precedence would surprise pipeline authors debugging which source
+// landed which field.
+func TestRunHarness_StdinAndConfigFileAreAmbiguous(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalStdinRunConfig(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	withPipedStdin(t, minimalStdinRunConfig(t))
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("config", path); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	err := runHarness(cmd, nil)
+	if err == nil {
+		t.Fatal("expected runHarness to reject --config <path> + piped stdin")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error should describe ambiguity, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error should mention config path, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "stdin") {
+		t.Errorf("error should mention stdin, got: %v", err)
+	}
+}
+
+// TestRunHarness_StdinDashWithoutPipeErrors pins MF-2 scenario 4:
+// `--config -` with no piped stdin (the TTY / `go test` char-device
+// shape) returns a non-nil error with a clear "no piped input"
+// message rather than blocking on a phantom read.
+func TestRunHarness_StdinDashWithoutPipeErrors(t *testing.T) {
+	// Deliberately do NOT swap os.Stdin — the `go test` default is a
+	// char device that isStdinPiped rejects.
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("config", "-"); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	err := runHarness(cmd, nil)
+	if err == nil {
+		t.Fatal("expected runHarness to reject --config - with no piped stdin")
+	}
+	if !strings.Contains(err.Error(), "--config -") {
+		t.Errorf("error should cite --config -, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "terminal") && !strings.Contains(err.Error(), "piped") {
+		t.Errorf("error should explain the missing pipe, got: %v", err)
+	}
+}

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -574,79 +574,17 @@ func TestLoadRunConfigFile_InvalidJSON(t *testing.T) {
 
 // newTestHarnessCommand builds a cobra command with the same flag surface
 // as the real harnessCmd. Used to exercise applyOverrides under realistic
-// conditions where Changed() reflects only what the test sets.
+// conditions where Changed() reflects only what the test sets. Delegates
+// the RunConfig-producing flag surface to addRunConfigFlags so a flag
+// added to the shared registry is automatically picked up here — this
+// is the same factory the run-config subcommand uses.
 func newTestHarnessCommand() *cobra.Command {
 	cmd := &cobra.Command{Use: "harness"}
+	addRunConfigFlags(cmd)
 	f := cmd.Flags()
-	f.String("config", "", "")
-	f.StringP("mode", "m", "planning", "")
-	f.String("model", "claude-sonnet-4-6", "")
-	f.String("provider", "anthropic", "")
-	f.String("api-key-ref", "secret://ANTHROPIC_API_KEY", "")
-	f.String("base-url", "", "")
-	f.String("api-key-header", "", "")
-	f.StringArray("query-param", nil, "")
-	f.String("gcp-project", "", "")
-	f.String("gcp-location", "global", "")
-	f.String("gcp-credentials-file", "", "")
-	f.String("anthropic-federation-rule-id", "", "")
-	f.String("anthropic-organization-id", "", "")
-	f.String("anthropic-service-account-id", "", "")
-	f.String("anthropic-workspace-id", "", "")
-	f.Bool("anthropic-from-github-actions", false, "")
-	f.String("azure-tenant-id", "", "")
-	f.String("azure-client-id", "", "")
-	f.String("azure-scope", "https://cognitiveservices.azure.com/.default", "")
-	f.StringP("workspace", "w", "", "")
-	f.Int("max-turns", 20, "")
-	f.Int("timeout", 600, "")
-	f.String("trace", "", "")
-	f.String("transport", "stdio", "")
-	f.String("transport-addr", "", "")
-	f.Int("followup-grace", 0, "")
-	f.Float64("temperature", 0, "")
-	f.String("log-level", "info", "")
-	f.String("prompt", "", "")
-	f.String("prompt-file", "", "")
-	f.String("name", "", "")
-	f.String("executor", "local", "")
-	f.String("edit-strategy", "multi", "")
-	f.String("verifier", "none", "")
-	f.String("git-strategy", "none", "")
-	f.String("trace-emitter", "jsonl", "")
-	f.String("otel-endpoint", "", "")
-	f.String("otel-protocol", "", "")
-	f.String("container-runtime", "", "")
-	f.String("permission-policy-file", "", "")
-	f.String("code-scanner", "", "")
-	f.String("guardrail", "", "")
-	f.String("guardrail-endpoint", "", "")
-	f.String("guardrail-model", "", "")
-	f.Bool("guardrail-fail-open", false, "")
-	f.String("deployment-environment", "", "")
-	f.String("service-namespace", "", "")
-	// Provider retry policy flags (issue #197). Registered here so
-	// f.Changed("...") can fire in TestApplyOverrides_ProviderRetry*
-	// tests — without these registrations applyProviderRetryFlagOverrides
-	// hits its early-return guard unconditionally.
-	f.Int("provider-retry-max-attempts", 0, "")
-	f.Duration("provider-retry-initial-delay", 0, "")
-	f.Duration("provider-retry-max-delay", 0, "")
-	f.Duration("provider-retry-wall-clock", 0, "")
-	// Workspace export flags (issue #164). Registered here so the
-	// override tests can exercise the applyOverrides path that handles
-	// --export-workspace-to.
-	f.String("export-workspace-to", "", "")
+	// Harness-only behaviour flags that do not round-trip through
+	// RunConfig. Mirrors the registration in harness.go init().
 	f.Bool("export-workspace-required", false, "")
-	// Parallel async-tool dispatch flag (issue #184). Registered here so
-	// TestApplyOverrides_MaxToolParallel* tests can exercise the override
-	// path.
-	f.Int("max-tool-parallel", 0, "")
-	// Batch flag (issue #136). Registered here so the override tests
-	// can exercise the applyOverrides path that handles --batch.
-	f.Bool("batch", false, "")
-	// --output-runconfig (issue #240). Registered here so runHarness
-	// can read the flag when its dry-run capture path runs in tests.
 	f.String("output-runconfig", "", "")
 	return cmd
 }

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1845,9 +1847,14 @@ func TestBuildHarnessRunConfig_Temperature(t *testing.T) {
 }
 
 // TestRunHarness_ConfigPathFollowupGraceFromEnv verifies that the
-// STIRRUP_FOLLOWUP_GRACE environment variable populates FollowUpGrace in
-// the --config code path when the file omits the field. This mirrors the
-// flag-only path's env-var handling so the two paths behave alike.
+// STIRRUP_FOLLOWUP_GRACE environment variable populates FollowUpGrace
+// in the --config code path when the file omits the field. The
+// env-var resolution now lives inside BuildRunConfig's ResolveAll
+// branch (runconfigbuilder.go), so the test drives that path through
+// the shared builder rather than re-implementing the resolution
+// inline. The pre-refactor version called loadRunConfigFile and
+// manually applied the env var — that test would have passed even if
+// BuildRunConfig's branch were deleted.
 func TestRunHarness_ConfigPathFollowupGraceFromEnv(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
@@ -1881,21 +1888,17 @@ func TestRunHarness_ConfigPathFollowupGraceFromEnv(t *testing.T) {
 
 	t.Setenv("STIRRUP_FOLLOWUP_GRACE", "45")
 
-	loaded, err := loadRunConfigFile(path)
+	cmd := newTestHarnessCommand()
+	resolved, err := BuildRunConfig(RunConfigSources{
+		ConfigPath: path,
+		Cmd:        cmd,
+		Resolve:    ResolveAll,
+	})
 	if err != nil {
-		t.Fatalf("loadRunConfigFile: %v", err)
+		t.Fatalf("BuildRunConfig: %v", err)
 	}
-	// Replicate runHarness's --config-path env-var handling. Keeps the
-	// test focused on the env-var resolution logic without booting the
-	// full agentic loop.
-	if loaded.FollowUpGrace == nil {
-		if v := os.Getenv("STIRRUP_FOLLOWUP_GRACE"); v != "" {
-			n := 45
-			loaded.FollowUpGrace = &n
-		}
-	}
-	if loaded.FollowUpGrace == nil || *loaded.FollowUpGrace != 45 {
-		t.Errorf("STIRRUP_FOLLOWUP_GRACE should fill FollowUpGrace when file omits it, got %v", loaded.FollowUpGrace)
+	if resolved.FollowUpGrace == nil || *resolved.FollowUpGrace != 45 {
+		t.Errorf("STIRRUP_FOLLOWUP_GRACE should fill FollowUpGrace when file omits it, got %v", resolved.FollowUpGrace)
 	}
 }
 
@@ -4607,3 +4610,98 @@ func TestRunHarness_StdinDashWithoutPipeErrors(t *testing.T) {
 		t.Errorf("error should explain the missing pipe, got: %v", err)
 	}
 }
+
+// TestRunHarness_OutputRunConfigBadPathErrors pins SF-3: an
+// --output-runconfig path whose parent directory does not exist must
+// surface as a non-nil error mentioning the path. The OpenFile error
+// branch previously had no coverage.
+func TestRunHarness_OutputRunConfigBadPathErrors(t *testing.T) {
+	badPath := filepath.Join(t.TempDir(), "does-not-exist", "out.json")
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("output-runconfig", badPath); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+	if err := cmd.Flags().Set("prompt", "test prompt"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+
+	err := runHarness(cmd, nil)
+	if err == nil {
+		t.Fatal("expected OpenFile error for missing parent directory")
+	}
+	if !strings.Contains(err.Error(), badPath) {
+		t.Errorf("error should mention the bad path %q, got: %v", badPath, err)
+	}
+	if !strings.Contains(err.Error(), "opening") {
+		t.Errorf("error should mention the open failure, got: %v", err)
+	}
+}
+
+// failCloseWriter writes successfully but its Close returns the
+// configured error. Used to drive writeAndCloseRunConfig's
+// deferred-flush diagnostic path without depending on filesystem
+// conditions.
+type failCloseWriter struct {
+	bytes.Buffer
+	closeErr error
+}
+
+func (f *failCloseWriter) Close() error { return f.closeErr }
+
+// TestWriteOutputRunConfig_CloseError pins SF-1: a Close error from
+// the captured-config writer (e.g. ENOSPC manifesting only at kernel
+// flush time) must propagate as a non-nil error wrapping the
+// underlying cause. The pre-fix `defer _ = f.Close()` silently
+// discarded the failure.
+func TestWriteOutputRunConfig_CloseError(t *testing.T) {
+	cfg := &types.RunConfig{
+		RunID:        "x",
+		Mode:         "planning",
+		Provider:     types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://K"},
+		ModelRouter:  types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		Transport:    types.TransportConfig{Type: "stdio"},
+		Executor:     types.ExecutorConfig{Type: "local"},
+		EditStrategy: types.EditStrategyConfig{Type: "multi"},
+		MaxTurns:     5,
+	}
+
+	t.Run("close error surfaces", func(t *testing.T) {
+		w := &failCloseWriter{closeErr: io.ErrClosedPipe}
+		err := writeAndCloseRunConfig(w, "/tmp/captured.json", cfg)
+		if err == nil {
+			t.Fatal("expected close error to propagate")
+		}
+		if !errors.Is(err, io.ErrClosedPipe) {
+			t.Errorf("error should wrap io.ErrClosedPipe, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "/tmp/captured.json") {
+			t.Errorf("error should mention path, got: %v", err)
+		}
+	})
+
+	t.Run("write error wins over close error", func(t *testing.T) {
+		// When writeRunConfigJSON has already failed, the prior
+		// error must take precedence — the close error is irrelevant
+		// noise at that point.
+		w := &failWriteCloseWriter{closeErr: io.ErrClosedPipe, writeErr: io.ErrShortWrite}
+		err := writeAndCloseRunConfig(w, "/tmp/captured.json", cfg)
+		if err == nil {
+			t.Fatal("expected write error to propagate")
+		}
+		if !errors.Is(err, io.ErrShortWrite) {
+			t.Errorf("write error should take precedence over close error, got: %v", err)
+		}
+	})
+}
+
+// failWriteCloseWriter fails on Write with writeErr and on Close with
+// closeErr; used to assert the write-error precedence in
+// writeAndCloseRunConfig.
+type failWriteCloseWriter struct {
+	closeErr error
+	writeErr error
+}
+
+func (f *failWriteCloseWriter) Write(p []byte) (int, error) { return 0, f.writeErr }
+func (f *failWriteCloseWriter) Close() error                { return f.closeErr }

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -644,6 +645,9 @@ func newTestHarnessCommand() *cobra.Command {
 	// Batch flag (issue #136). Registered here so the override tests
 	// can exercise the applyOverrides path that handles --batch.
 	f.Bool("batch", false, "")
+	// --output-runconfig (issue #240). Registered here so runHarness
+	// can read the flag when its dry-run capture path runs in tests.
+	f.String("output-runconfig", "", "")
 	return cmd
 }
 
@@ -4252,5 +4256,193 @@ func TestApplyOverrides_ToolDispatchMaxParallelDefaultDoesNotOverride(t *testing
 	if cfg.ToolDispatch.MaxParallel != 8 {
 		t.Errorf("file ToolDispatch.MaxParallel should survive default flag, got %d, want 8",
 			cfg.ToolDispatch.MaxParallel)
+	}
+}
+
+// TestRunHarness_OutputRunConfigWritesFile pins the dry-run capture
+// surface from issue #240: --output-runconfig writes the resolved
+// RunConfig to disk, the loop is not invoked, and the process exits
+// cleanly. The written file must be parseable JSON; round-tripping it
+// back through loadRunConfigFile asserts the wire shape.
+func TestRunHarness_OutputRunConfigWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.json")
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("output-runconfig", outPath); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+	if err := cmd.Flags().Set("prompt", "test prompt"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+
+	if err := runHarness(cmd, nil); err != nil {
+		t.Fatalf("runHarness with --output-runconfig should exit cleanly, got: %v", err)
+	}
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	// 0600 is the documented contract: captured configs may carry
+	// secret:// references whose names are operationally sensitive even
+	// though the references themselves are not secrets.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Errorf("output file should be 0600, got %v", info.Mode().Perm())
+	}
+
+	cfg, err := loadRunConfigFile(outPath)
+	if err != nil {
+		t.Fatalf("captured config should round-trip through loadRunConfigFile: %v", err)
+	}
+	if cfg.Prompt != "test prompt" {
+		t.Errorf("captured Prompt = %q, want %q", cfg.Prompt, "test prompt")
+	}
+	if cfg.RunID == "" {
+		t.Errorf("captured config should have a RunID (ResolveAll mints one)")
+	}
+}
+
+// TestRunHarness_OutputRunConfigToStdout pins the "-" sentinel: a
+// captured config can flow straight back into another `stirrup
+// run-config` or `stirrup harness --config -` without a temp file
+// hop. We cannot easily capture the live os.Stdout here, but we can
+// at least confirm runHarness does not return an error for the
+// stdout-sentinel branch and does not try to invoke the loop.
+func TestRunHarness_OutputRunConfigToStdout(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("output-runconfig", "-"); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+	if err := cmd.Flags().Set("prompt", "test prompt"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+
+	// Redirect os.Stdout for the duration so the test output stays
+	// clean. The exact stdout contents are exercised by
+	// TestWriteRunConfigJSON_RoundTrip and TestRunRunConfig_*; here we
+	// only need to confirm the dry-run branch doesn't fall through to
+	// runWithConfig.
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = origStdout
+		_ = r.Close()
+	}()
+
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+
+	runErr := runHarness(cmd, nil)
+	_ = w.Close()
+	out := <-done
+
+	if runErr != nil {
+		t.Fatalf("runHarness with --output-runconfig=-: %v", runErr)
+	}
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("stdout should be parseable JSON: %v\n%s", err, out)
+	}
+	if cfg.Prompt != "test prompt" {
+		t.Errorf("captured Prompt = %q, want %q", cfg.Prompt, "test prompt")
+	}
+}
+
+// TestRunHarness_OutputRunConfigDoesNotWriteOnValidationFailure pins
+// the spec's "never writes on validation failure" contract for
+// --output-runconfig. We pick the same bedrock + sonnet-4-6 trap that
+// powers TestBuildHarnessRunConfig_BedrockDefaultModelFailsValidation
+// because the validator rejects it deterministically and ahead of any
+// other path that might write the file.
+func TestRunHarness_OutputRunConfigDoesNotWriteOnValidationFailure(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.json")
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("output-runconfig", outPath); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+	if err := cmd.Flags().Set("prompt", "test prompt"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+	if err := cmd.Flags().Set("provider", "bedrock"); err != nil {
+		t.Fatalf("set provider: %v", err)
+	}
+	// --model stays at its CLI default "claude-sonnet-4-6", which is
+	// the issue #65 trap the validator rejects.
+
+	err := runHarness(cmd, nil)
+	if err == nil {
+		t.Fatal("expected validator to reject bedrock + sonnet-4-6 alias")
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Errorf("output file should not exist on validation failure, got stat err: %v", statErr)
+	}
+}
+
+// TestRunHarness_OutputRunConfigReplaysIdentically pins the "save and
+// replay" workflow the spec calls out: a config captured via
+// --output-runconfig, when fed back into `stirrup harness --config
+// <path>`, produces an equivalent resolved config. The check ignores
+// only RunID (a fresh run mints a new ID by design) and Timeout
+// pointer identity (the helper materialises a new *int).
+func TestRunHarness_OutputRunConfigReplaysIdentically(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "captured.json")
+
+	cmd1 := newTestHarnessCommand()
+	if err := cmd1.Flags().Set("output-runconfig", outPath); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+	if err := cmd1.Flags().Set("prompt", "captured prompt"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+	if err := cmd1.Flags().Set("mode", "execution"); err != nil {
+		t.Fatalf("set mode: %v", err)
+	}
+	if err := runHarness(cmd1, nil); err != nil {
+		t.Fatalf("first run capture: %v", err)
+	}
+
+	captured, err := loadRunConfigFile(outPath)
+	if err != nil {
+		t.Fatalf("load captured: %v", err)
+	}
+
+	// Now feed it back via --config and capture the resolved shape.
+	replayPath := filepath.Join(dir, "replay.json")
+	cmd2 := newTestHarnessCommand()
+	if err := cmd2.Flags().Set("config", outPath); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	if err := cmd2.Flags().Set("output-runconfig", replayPath); err != nil {
+		t.Fatalf("set output-runconfig (replay): %v", err)
+	}
+	if err := runHarness(cmd2, nil); err != nil {
+		t.Fatalf("second run capture: %v", err)
+	}
+	replayed, err := loadRunConfigFile(replayPath)
+	if err != nil {
+		t.Fatalf("load replay: %v", err)
+	}
+
+	if captured.Prompt != replayed.Prompt {
+		t.Errorf("Prompt drifted: captured=%q replay=%q", captured.Prompt, replayed.Prompt)
+	}
+	if captured.Mode != replayed.Mode {
+		t.Errorf("Mode drifted: captured=%q replay=%q", captured.Mode, replayed.Mode)
+	}
+	// RunID is allowed to differ — the replay is a new run.
+	if captured.RunID == replayed.RunID {
+		t.Logf("RunIDs happen to match (clock resolution); harmless")
 	}
 }

--- a/harness/cmd/stirrup/cmd/runconfig.go
+++ b/harness/cmd/stirrup/cmd/runconfig.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var runConfigCmd = &cobra.Command{
+	Use:   "run-config [flags]",
+	Short: "Emit a resolved RunConfig as JSON",
+	Long: `Produce a fully-resolved RunConfig JSON document and print it to stdout.
+Does NOT run the agentic loop. Composable via UNIX pipes: stdin is
+treated as a base RunConfig, then explicit flags override individual
+fields, mirroring how ` + "`stirrup harness --config <file>`" + ` already works.
+
+Resolution order (lowest -> highest precedence):
+  1. Defaults (flag DefValues, mode-derived defaults when --validate)
+  2. Base RunConfig from stdin OR --config <path> (mutually exclusive)
+  3. Explicit flags (those whose Changed() bit is set)
+
+Flags: identical to ` + "`stirrup harness`" + ` for every RunConfig-producing
+flag. CLI-only behaviour flags (--export-workspace-required,
+--output-runconfig) are excluded because they do not map to
+RunConfig fields.
+
+Output:
+  - Default: pretty-printed JSON (2-space indent) to stdout
+  - --compact: single-line JSON
+  - --redact: apply RunConfig.Redact() before emit (rewrites
+    secret:// references to secret://[REDACTED] — produces a copy
+    safe to commit / share, but not runnable as-is)`,
+	Args: cobra.NoArgs,
+	RunE: runRunConfig,
+}
+
+func init() {
+	rootCmd.AddCommand(runConfigCmd)
+
+	addRunConfigFlags(runConfigCmd)
+
+	// Subcommand-only flags. None of these map to RunConfig fields;
+	// they control how the resolved document is processed before
+	// emission, so they live on run-config rather than the shared
+	// helper.
+	f := runConfigCmd.Flags()
+	f.Bool("validate", false, "Run types.ValidateRunConfig on the resolved RunConfig and exit non-zero on failure. Without this flag, partial / chained configs are emitted as-is so they can be completed downstream.")
+	f.Bool("compact", false, "Emit single-line JSON instead of indented (2-space) JSON.")
+	f.Bool("redact", false, "Apply RunConfig.Redact() before emit. Rewrites secret:// references to secret://[REDACTED] for share-safe artifacts; the result is no longer runnable as-is.")
+}
+
+func runRunConfig(cmd *cobra.Command, args []string) error {
+	f := cmd.Flags()
+	configPath, _ := f.GetString("config")
+	resolve := ResolveBase
+	if validate, _ := f.GetBool("validate"); validate {
+		resolve = ResolveAll
+	}
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:      os.Stdin,
+		ConfigPath: configPath,
+		Cmd:        cmd,
+		Args:       args,
+		Resolve:    resolve,
+	})
+	if err != nil {
+		return err
+	}
+
+	if redact, _ := f.GetBool("redact"); redact {
+		r := cfg.Redact()
+		cfg = &r
+	}
+
+	compact, _ := f.GetBool("compact")
+	return writeRunConfigJSON(os.Stdout, cfg, compact)
+}

--- a/harness/cmd/stirrup/cmd/runconfig.go
+++ b/harness/cmd/stirrup/cmd/runconfig.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -50,6 +51,16 @@ func init() {
 }
 
 func runRunConfig(cmd *cobra.Command, args []string) error {
+	return runRunConfigWithIO(cmd, args, os.Stdin, os.Stdout)
+}
+
+// runRunConfigWithIO is the testable seam for runRunConfig: it accepts
+// explicit stdin and stdout so tests can drive the cobra flag-reading
+// wiring (validate, redact, compact) through the real entry point
+// instead of replicating the function body. The cobra RunE signature
+// reaches it via runRunConfig, which threads os.Stdin / os.Stdout for
+// the production binary.
+func runRunConfigWithIO(cmd *cobra.Command, args []string, stdin io.Reader, stdout io.Writer) error {
 	f := cmd.Flags()
 	configPath, _ := f.GetString("config")
 	resolve := ResolveBase
@@ -58,7 +69,7 @@ func runRunConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg, err := BuildRunConfig(RunConfigSources{
-		Stdin:      os.Stdin,
+		Stdin:      stdin,
 		ConfigPath: configPath,
 		Cmd:        cmd,
 		Args:       args,
@@ -74,5 +85,5 @@ func runRunConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	compact, _ := f.GetBool("compact")
-	return writeRunConfigJSON(os.Stdout, cfg, compact)
+	return writeRunConfigJSON(stdout, cfg, compact)
 }

--- a/harness/cmd/stirrup/cmd/runconfig_test.go
+++ b/harness/cmd/stirrup/cmd/runconfig_test.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// newTestRunConfigCommand returns a fresh cobra command preloaded with
+// the run-config flag surface. The real runConfigCmd is process-global
+// and a test that calls SetArgs / ParseFlags on it would pollute
+// neighbour tests; a per-test command keeps the Changed() state
+// scoped.
+func newTestRunConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "run-config"}
+	addRunConfigFlags(cmd)
+	cmd.Flags().Bool("validate", false, "")
+	cmd.Flags().Bool("compact", false, "")
+	cmd.Flags().Bool("redact", false, "")
+	return cmd
+}
+
+// runRunConfigForTest invokes runRunConfig with the given args, a
+// stdin reader, and a stdout writer. The real runRunConfig writes to
+// os.Stdout via writeRunConfigJSON; the test bypasses that by
+// replacing os.Stdout for the duration of the call. (Cobra does not
+// expose an os.Stdout-injection seam without re-plumbing every
+// downstream helper, so a swap is the smallest change.)
+func runRunConfigForTest(t *testing.T, args []string, stdin string) (string, error) {
+	t.Helper()
+	cmd := newTestRunConfigCommand()
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	// Build the config ourselves rather than calling runRunConfig:
+	// runRunConfig reads os.Stdin (which we cannot easily replace
+	// across goroutines / cobra layers) and writes to os.Stdout (which
+	// we can but would need to be process-global). This pathway
+	// exercises the same BuildRunConfig + writeRunConfigJSON code the
+	// command does, just with the stdin source threaded explicitly.
+	configPath, _ := cmd.Flags().GetString("config")
+	resolve := ResolveBase
+	if v, _ := cmd.Flags().GetBool("validate"); v {
+		resolve = ResolveAll
+	}
+	var reader io.Reader
+	if stdin != "" {
+		reader = strings.NewReader(stdin)
+	}
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:      reader,
+		ConfigPath: configPath,
+		Cmd:        cmd,
+		Args:       cmd.Flags().Args(),
+		Resolve:    resolve,
+	})
+	if err != nil {
+		return "", err
+	}
+	if redact, _ := cmd.Flags().GetBool("redact"); redact {
+		r := cfg.Redact()
+		cfg = &r
+	}
+	compact, _ := cmd.Flags().GetBool("compact")
+	var buf bytes.Buffer
+	if werr := writeRunConfigJSON(&buf, cfg, compact); werr != nil {
+		return "", werr
+	}
+	return buf.String(), nil
+}
+
+// TestRunRunConfig_FlagOnlyEmitsValidJSON pins acceptance criterion 1:
+// `stirrup run-config --mode execution --provider anthropic` produces
+// a parseable RunConfig.
+func TestRunRunConfig_FlagOnlyEmitsValidJSON(t *testing.T) {
+	out, err := runRunConfigForTest(t, []string{
+		"--mode", "execution",
+		"--provider", "anthropic",
+	}, "")
+	if err != nil {
+		t.Fatalf("runRunConfig: %v", err)
+	}
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("emitted output is not parseable JSON: %v\n%s", err, out)
+	}
+	if cfg.Mode != "execution" {
+		t.Errorf("Mode = %q, want execution", cfg.Mode)
+	}
+	if cfg.Provider.Type != "anthropic" {
+		t.Errorf("Provider.Type = %q, want anthropic", cfg.Provider.Type)
+	}
+}
+
+// TestRunRunConfig_Idempotency pins acceptance criterion 3: piping a
+// config through `stirrup run-config` twice produces byte-identical
+// output the second time. The first pass may apply default mutations;
+// the second pass must not move the document any further.
+func TestRunRunConfig_Idempotency(t *testing.T) {
+	pass1, err := runRunConfigForTest(t, []string{
+		"--mode", "execution",
+		"--model", "claude-opus-4-7",
+	}, "")
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	pass2, err := runRunConfigForTest(t, nil, pass1)
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if pass1 != pass2 {
+		t.Errorf("run-config is not idempotent\npass1:\n%s\npass2:\n%s", pass1, pass2)
+	}
+}
+
+// TestRunRunConfig_ValidateRejectsInvalidConfig pins acceptance
+// criterion 2: --validate causes the subcommand to exit non-zero on a
+// config the validator rejects. We pick a contradiction the validator
+// flags reliably: bedrock + the CLI-default `claude-sonnet-4-6` is
+// the issue #65 trap, which validateBedrockProviderFields rejects
+// with an inference-profile remediation hint.
+func TestRunRunConfig_ValidateRejectsInvalidConfig(t *testing.T) {
+	_, err := runRunConfigForTest(t, []string{
+		"--validate",
+		"--mode", "execution",
+		"--provider", "bedrock",
+		"--prompt", "x",
+	}, "")
+	if err == nil {
+		t.Fatal("expected --validate to reject bedrock + sonnet-4-6 alias")
+	}
+	if !strings.Contains(err.Error(), "bedrock") {
+		t.Errorf("error should mention bedrock, got: %v", err)
+	}
+}
+
+// TestRunRunConfig_ValidateAcceptsValidConfig is the positive
+// complement: --validate on a valid config emits the document with
+// the validator's default-application mutations applied.
+func TestRunRunConfig_ValidateAcceptsValidConfig(t *testing.T) {
+	out, err := runRunConfigForTest(t, []string{
+		"--validate",
+		"--mode", "execution",
+		"--prompt", "x",
+	}, "")
+	if err != nil {
+		t.Fatalf("runRunConfig: %v", err)
+	}
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.RunID == "" {
+		t.Error("--validate path should mint a RunID (ResolveAll)")
+	}
+}
+
+// TestRunRunConfig_CompactProducesSingleLine pins acceptance of the
+// --compact flag: the body is a single JSON line (no indentation),
+// still terminated by a newline so shell pipelines see a clean EOF.
+func TestRunRunConfig_CompactProducesSingleLine(t *testing.T) {
+	out, err := runRunConfigForTest(t, []string{
+		"--compact",
+		"--mode", "planning",
+	}, "")
+	if err != nil {
+		t.Fatalf("runRunConfig: %v", err)
+	}
+	body := strings.TrimRight(out, "\n")
+	if strings.Contains(body, "\n") {
+		t.Errorf("--compact output should be single-line, got: %q", out)
+	}
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(body), &cfg); err != nil {
+		t.Fatalf("compact output not parseable: %v\n%s", err, out)
+	}
+}
+
+// TestRunRunConfig_RedactScrubsSecretRefs pins that --redact rewrites
+// secret:// references but leaves every other field intact. The
+// captured config is no longer runnable as-is — that's the point.
+func TestRunRunConfig_RedactScrubsSecretRefs(t *testing.T) {
+	out, err := runRunConfigForTest(t, []string{
+		"--redact",
+		"--mode", "planning",
+		"--api-key-ref", "secret://CUSTOM_KEY",
+	}, "")
+	if err != nil {
+		t.Fatalf("runRunConfig: %v", err)
+	}
+	if !strings.Contains(out, "secret://[REDACTED]") {
+		t.Errorf("--redact should produce REDACTED placeholder, got: %s", out)
+	}
+	if strings.Contains(out, "CUSTOM_KEY") {
+		t.Errorf("--redact should scrub the original secret reference, got: %s", out)
+	}
+}
+
+// TestRunRunConfig_MalformedStdinJSONErrors pins the parse-error
+// surface. The DisallowUnknownFields decoder reports unknown fields
+// by name; the test asserts on that name to catch a regression that
+// swallows the underlying error.
+func TestRunRunConfig_MalformedStdinJSONErrors(t *testing.T) {
+	_, err := runRunConfigForTest(t, nil, `{"this is not valid JSON`)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parsing config") {
+		t.Errorf("error should describe parse failure, got: %v", err)
+	}
+}
+
+// TestRunRunConfig_RoundTripFromExample is the spec's acceptance
+// criterion 3 against a real example file. It picks the smallest
+// example to keep the diff window narrow if the test breaks; the
+// `cat config.json | stirrup run-config | stirrup run-config | diff -
+// config.json` shape is what the spec calls out for the smoke suite.
+func TestRunRunConfig_RoundTripFromExample(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "examples", "runconfig", "openai_responses.json"))
+	if err != nil {
+		t.Skipf("openai_responses.json example not present: %v", err)
+	}
+	pass1, err := runRunConfigForTest(t, nil, string(body))
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	pass2, err := runRunConfigForTest(t, nil, pass1)
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if pass1 != pass2 {
+		t.Errorf("normalisation pass is not idempotent")
+	}
+}

--- a/harness/cmd/stirrup/cmd/runconfig_test.go
+++ b/harness/cmd/stirrup/cmd/runconfig_test.go
@@ -28,52 +28,24 @@ func newTestRunConfigCommand() *cobra.Command {
 	return cmd
 }
 
-// runRunConfigForTest invokes runRunConfig with the given args, a
-// stdin reader, and a stdout writer. The real runRunConfig writes to
-// os.Stdout via writeRunConfigJSON; the test bypasses that by
-// replacing os.Stdout for the duration of the call. (Cobra does not
-// expose an os.Stdout-injection seam without re-plumbing every
-// downstream helper, so a swap is the smallest change.)
+// runRunConfigForTest invokes the run-config command through its real
+// runRunConfigWithIO entry point so the cobra flag-reading wiring
+// (validate, redact, compact) is exercised end-to-end. The previous
+// implementation replicated the function body inline, which left the
+// production glue at 0% coverage.
 func runRunConfigForTest(t *testing.T, args []string, stdin string) (string, error) {
 	t.Helper()
 	cmd := newTestRunConfigCommand()
 	if err := cmd.ParseFlags(args); err != nil {
 		t.Fatalf("ParseFlags: %v", err)
 	}
-
-	// Build the config ourselves rather than calling runRunConfig:
-	// runRunConfig reads os.Stdin (which we cannot easily replace
-	// across goroutines / cobra layers) and writes to os.Stdout (which
-	// we can but would need to be process-global). This pathway
-	// exercises the same BuildRunConfig + writeRunConfigJSON code the
-	// command does, just with the stdin source threaded explicitly.
-	configPath, _ := cmd.Flags().GetString("config")
-	resolve := ResolveBase
-	if v, _ := cmd.Flags().GetBool("validate"); v {
-		resolve = ResolveAll
-	}
 	var reader io.Reader
 	if stdin != "" {
 		reader = strings.NewReader(stdin)
 	}
-	cfg, err := BuildRunConfig(RunConfigSources{
-		Stdin:      reader,
-		ConfigPath: configPath,
-		Cmd:        cmd,
-		Args:       cmd.Flags().Args(),
-		Resolve:    resolve,
-	})
-	if err != nil {
-		return "", err
-	}
-	if redact, _ := cmd.Flags().GetBool("redact"); redact {
-		r := cfg.Redact()
-		cfg = &r
-	}
-	compact, _ := cmd.Flags().GetBool("compact")
 	var buf bytes.Buffer
-	if werr := writeRunConfigJSON(&buf, cfg, compact); werr != nil {
-		return "", werr
+	if err := runRunConfigWithIO(cmd, cmd.Flags().Args(), reader, &buf); err != nil {
+		return "", err
 	}
 	return buf.String(), nil
 }
@@ -239,5 +211,141 @@ func TestRunRunConfig_RoundTripFromExample(t *testing.T) {
 	}
 	if pass1 != pass2 {
 		t.Errorf("normalisation pass is not idempotent")
+	}
+}
+
+// TestRunRunConfig_WrapperThreadsOSIO pins MF-3's residual line: the
+// runRunConfig cobra RunE thunk threads os.Stdin / os.Stdout into the
+// testable runRunConfigWithIO helper. Without this assertion the
+// one-liner thunk stays at 0% coverage and a future regression that
+// swaps the wiring (e.g. passes nil for stdout) would land silently.
+func TestRunRunConfig_WrapperThreadsOSIO(t *testing.T) {
+	cmd := newTestRunConfigCommand()
+	if err := cmd.ParseFlags([]string{"--mode", "planning"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = origStdout
+		_ = r.Close()
+	}()
+
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+
+	if err := runRunConfig(cmd, cmd.Flags().Args()); err != nil {
+		_ = w.Close()
+		<-done
+		t.Fatalf("runRunConfig: %v", err)
+	}
+	_ = w.Close()
+	out := <-done
+
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("os.Stdout should receive parseable JSON: %v\n%s", err, out)
+	}
+	if cfg.Mode != "planning" {
+		t.Errorf("Mode = %q, want planning", cfg.Mode)
+	}
+}
+
+// TestRunRunConfigWithIO_TableDriven pins MF-3: every cobra
+// flag-reading branch inside runRunConfigWithIO (validate, redact,
+// compact, plain) reaches a passing assertion through the real entry
+// point. Before the WithIO refactor, runRunConfigForTest replicated
+// the function body inline, so a `f.GetBool("compact")` rename would
+// have passed every test. The table exercises one branch per row.
+func TestRunRunConfigWithIO_TableDriven(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		stdin   string
+		wantErr bool
+		check   func(t *testing.T, out string)
+	}{
+		{
+			name: "flag-only emits indented JSON",
+			args: []string{"--mode", "planning", "--prompt", "x"},
+			check: func(t *testing.T, out string) {
+				if !strings.Contains(out, "\n  ") {
+					t.Errorf("default output should be indented, got: %s", out)
+				}
+				var cfg types.RunConfig
+				if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+					t.Fatalf("unparseable JSON: %v\n%s", err, out)
+				}
+				if cfg.Mode != "planning" {
+					t.Errorf("Mode = %q, want planning", cfg.Mode)
+				}
+			},
+		},
+		{
+			name: "compact produces single-line JSON",
+			args: []string{"--compact", "--mode", "planning"},
+			check: func(t *testing.T, out string) {
+				body := strings.TrimRight(out, "\n")
+				if strings.Contains(body, "\n") {
+					t.Errorf("--compact output should be single-line, got: %q", out)
+				}
+				var cfg types.RunConfig
+				if err := json.Unmarshal([]byte(body), &cfg); err != nil {
+					t.Fatalf("compact output not parseable: %v\n%s", err, out)
+				}
+			},
+		},
+		{
+			name: "redact rewrites secret references",
+			args: []string{"--redact", "--mode", "planning", "--api-key-ref", "secret://CUSTOM_KEY"},
+			check: func(t *testing.T, out string) {
+				if !strings.Contains(out, "secret://[REDACTED]") {
+					t.Errorf("--redact should produce REDACTED placeholder, got: %s", out)
+				}
+				if strings.Contains(out, "CUSTOM_KEY") {
+					t.Errorf("--redact should scrub the original secret reference, got: %s", out)
+				}
+			},
+		},
+		{
+			name:    "validate rejects invalid config",
+			args:    []string{"--validate", "--mode", "execution", "--provider", "bedrock", "--prompt", "x"},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newTestRunConfigCommand()
+			if err := cmd.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			var reader io.Reader
+			if tc.stdin != "" {
+				reader = strings.NewReader(tc.stdin)
+			}
+			var buf bytes.Buffer
+			err := runRunConfigWithIO(cmd, cmd.Flags().Args(), reader, &buf)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil; output: %s", buf.String())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("runRunConfigWithIO: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, buf.String())
+			}
+		})
 	}
 }

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -1,0 +1,465 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// ResolveMode controls the late-stage mutation BuildRunConfig applies to
+// the merged document. The harness path uses ResolveAll so the loop
+// receives a validated, prompt-resolved, mode-defaulted config; the
+// run-config subcommand defaults to ResolveBase so intermediate
+// pipeline stages can emit transformable documents without prematurely
+// applying defaults a later stage might override.
+type ResolveMode int
+
+const (
+	// ResolveBase merges sources (file or stdin + flag overrides + WIF
+	// folding) and returns. No mode-default application, no validator
+	// invocation, no prompt-resolution chain, no RunID generation. The
+	// emitted document is intentionally minimally mutated so chained
+	// `stirrup run-config | stirrup run-config | ...` stages remain
+	// idempotent.
+	ResolveBase ResolveMode = iota
+	// ResolveAll applies the full harness-path mutation chain on top of
+	// ResolveBase: applyModeDefaults, prompt resolution (--prompt >
+	// positional > --prompt-file > STIRRUP_PROMPT > config.prompt),
+	// STIRRUP_FOLLOWUP_GRACE env-var fallback, RunID generation when
+	// the source omitted one, and types.ValidateRunConfig. This is what
+	// `stirrup harness` needs before invoking the loop.
+	ResolveAll
+)
+
+// RunConfigSources gathers the inputs BuildRunConfig consumes. Both the
+// harness command and the new run-config command populate this struct
+// and dispatch through the shared builder so flag overrides, base
+// loading, WIF folding, and (optionally) prompt + validation cannot
+// drift between the two surfaces.
+type RunConfigSources struct {
+	// Stdin is the reader treated as a piped base RunConfig. Nil means
+	// "do not consider stdin". When non-nil, the builder checks whether
+	// the underlying fd is a TTY (when Stdin is *os.File) and, if so,
+	// ignores it. Pass a non-file reader (bytes.Reader, strings.Reader)
+	// from tests to force the "piped" code path.
+	Stdin io.Reader
+	// ConfigPath is the --config flag value. Empty means no file; "-"
+	// means stdin (in which case Stdin must be non-nil and reachable).
+	ConfigPath string
+	// Cmd is the cobra command whose flags carry the overrides. The
+	// builder reads both Changed() and the resolved values via
+	// applyOverrides / applyAnthropicWIFOverrides.
+	Cmd *cobra.Command
+	// Args is the positional argument slice (typically the prompt
+	// positional). Only consulted when Resolve == ResolveAll and the
+	// prompt is otherwise unresolved, mirroring runHarness's existing
+	// chain.
+	Args []string
+	// Resolve picks between the chained-pipeline-friendly ResolveBase
+	// and the loop-ready ResolveAll. See the ResolveMode docs.
+	Resolve ResolveMode
+}
+
+// BuildRunConfig is the single resolution path for every flag-set or
+// file/stdin-supplied RunConfig the CLI accepts. It replaces the two
+// inline paths (`--config` + overrides vs flag-only) that used to live
+// in runHarness so any future change to precedence, WIF folding, or
+// prompt resolution lands in one place.
+//
+// Resolution order (lowest -> highest precedence):
+//  1. Defaults supplied by flag DefValues.
+//  2. Base RunConfig from --config <path>, --config -, or piped stdin
+//     when ConfigPath is empty and Stdin is non-TTY. The three base
+//     sources are mutually exclusive; passing both --config <path> and
+//     a piped stdin is a hard error so silent precedence surprises
+//     cannot happen in scripted pipelines.
+//  3. Explicit flag overrides via applyOverrides (Changed()-gated, so
+//     a flag at its default value never clobbers a base field).
+//  4. applyAnthropicWIFOverrides (env-var + flag federation folding
+//     plus the apiKeyRef mutual-exclusion guard from #117).
+//
+// When Resolve == ResolveAll the builder additionally:
+//   - Calls applyModeDefaults so read-only modes get a non-empty Tools.
+//     BuiltIn list and the deny-side-effects policy.
+//   - Generates a RunID when the base omitted one.
+//   - Folds STIRRUP_FOLLOWUP_GRACE when neither the flag nor the file
+//     set FollowUpGrace.
+//   - Walks the prompt resolution chain (--prompt > positional >
+//     --prompt-file > STIRRUP_PROMPT > base.Prompt) and errors if the
+//     result is empty.
+//   - Calls types.ValidateRunConfig and returns its error verbatim.
+//
+// When Resolve == ResolveBase none of the above run; the document is
+// emitted minimally mutated so a downstream `stirrup run-config` stage
+// can layer one more override on top.
+func BuildRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
+	cfg, err := loadBaseRunConfig(sources)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := applyOverrides(sources.Cmd, cfg, sources.Args); err != nil {
+		return nil, err
+	}
+
+	if err := applyAnthropicWIFOverrides(sources.Cmd, cfg); err != nil {
+		return nil, err
+	}
+
+	if sources.Resolve != ResolveAll {
+		return cfg, nil
+	}
+
+	applyModeDefaults(cfg)
+
+	if cfg.RunID == "" {
+		cfg.RunID = generateRunID()
+	}
+
+	if cfg.FollowUpGrace == nil {
+		if v := os.Getenv("STIRRUP_FOLLOWUP_GRACE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.FollowUpGrace = &n
+			}
+		}
+	}
+
+	if err := resolvePromptForRun(sources.Cmd, cfg); err != nil {
+		return nil, err
+	}
+
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	return cfg, nil
+}
+
+// loadBaseRunConfig picks the right base — file, stdin, or
+// flag-derived — and returns a RunConfig pre-population is layered on.
+// The three sources are mutually exclusive: --config <path> with a
+// non-TTY stdin is rejected with both sources cited, because the
+// alternative (silent precedence) would surprise pipeline authors
+// debugging which source landed which field.
+func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
+	stdinPiped := isStdinPiped(sources.Stdin)
+	explicitStdin := sources.ConfigPath == "-"
+	filePath := ""
+	if sources.ConfigPath != "" && !explicitStdin {
+		filePath = sources.ConfigPath
+	}
+
+	if filePath != "" && stdinPiped {
+		return nil, fmt.Errorf("ambiguous config sources: --config %q and piped stdin are both present; pick one", filePath)
+	}
+
+	switch {
+	case explicitStdin:
+		if !stdinPiped {
+			return nil, fmt.Errorf("--config - requires piped stdin but stdin is a terminal")
+		}
+		return readRunConfigFromReader(sources.Stdin, "<stdin>")
+	case stdinPiped && filePath == "":
+		return readRunConfigFromReader(sources.Stdin, "<stdin>")
+	case filePath != "":
+		return loadRunConfigFile(filePath)
+	}
+
+	return buildFlagOnlyRunConfig(sources.Cmd, sources.Args)
+}
+
+// isStdinPiped reports whether the reader looks like a piped or
+// file-redirected stdin source the operator deliberately attached.
+// The detection is deliberately narrow:
+//
+//   - A nil reader returns false (no stdin to consider).
+//   - A non-*os.File reader (bytes.Reader, strings.Reader from tests)
+//     returns true so unit tests can exercise the piped path without
+//     mocking out os.Stdin.
+//   - An *os.File whose fd is a TTY returns false — an interactive
+//     shell must never silently read keystrokes as a JSON RunConfig.
+//   - An *os.File backed by a named pipe (shell `|`) or a regular
+//     file (`< config.json`) returns true.
+//   - An *os.File backed by anything else — character devices
+//     (including `< /dev/null` and the shape `go test` hands its
+//     children), Unix sockets, and the no-redirect case — returns
+//     false and the harness falls through to flag-only construction.
+//
+// This is narrower than the spec's "any non-TTY stdin is piped"
+// because that rule would make `go test ./harness/...` trip the
+// piped-base path for every existing harness_test.go fixture: the
+// test runner inherits stdin as a non-TTY char device from the
+// terminal. Limiting auto-detection to pipes and regular files
+// covers the canonical pipeline example (`run-config | harness`)
+// and explicit redirection from a config file (`harness <
+// config.json`), and leaves the `< /dev/null` "non-TTY but empty"
+// case to the explicit `--config -` form (which always errors on
+// EOF input). The cost is that an operator who pipes `< /dev/null`
+// gets the flag-only path's prompt-required error rather than a
+// "stdin was empty" error — still loud, still actionable, just
+// pointing at the more usual remediation.
+func isStdinPiped(r io.Reader) bool {
+	if r == nil {
+		return false
+	}
+	f, ok := r.(*os.File)
+	if !ok {
+		return true
+	}
+	if term.IsTerminal(int(f.Fd())) {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	mode := info.Mode()
+	if mode&os.ModeNamedPipe != 0 {
+		return true
+	}
+	if mode.IsRegular() {
+		return true
+	}
+	return false
+}
+
+// readRunConfigFromReader mirrors loadRunConfigFile but consumes any
+// io.Reader. Used for both --config - and the auto-detected pipe path
+// in BuildRunConfig. The 1 MiB cap matches the file path (a RunConfig
+// is at most a few KB; megabytes mean a mistake), the
+// DisallowUnknownFields setting matches the file path (typos in piped
+// JSON should fail fast), and the empty-input error is what the spec
+// requires for `stirrup harness < /dev/null`.
+func readRunConfigFromReader(r io.Reader, source string) (*types.RunConfig, error) {
+	// +1 lets us distinguish "exactly at the cap" from "larger than the
+	// cap" so the operator-facing error is accurate. Same shape as the
+	// readPromptFile helper above.
+	data, err := io.ReadAll(io.LimitReader(r, maxConfigFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading config from %s: %w", source, err)
+	}
+	if int64(len(data)) > maxConfigFileBytes {
+		return nil, fmt.Errorf("reading config from %s: exceeds %d byte cap", source, maxConfigFileBytes)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("reading config from %s: input is empty; pass --config <path> or remove the redirection", source)
+	}
+	var cfg types.RunConfig
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing config from %s: %w", source, err)
+	}
+	return &cfg, nil
+}
+
+// buildFlagOnlyRunConfig reads the flag values off cmd and constructs
+// the RunConfig the flag-only base used to start from. This is the
+// no-stdin, no-file branch of BuildRunConfig and corresponds to
+// the second `runHarness` path before the refactor.
+//
+// applyOverrides will run against the returned config too, but most of
+// its overrides are no-ops on a flag-only base because the values are
+// already in place. Running it unconditionally keeps the cross-field
+// inferences (--gcp-credentials-file implying gcp-service-account
+// credential.type, --azure-tenant-id implying azure-workload-identity,
+// --permission-policy-file implying policy-engine) reachable through
+// the single resolution path.
+func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig, error) {
+	f := cmd.Flags()
+
+	prompt, _ := f.GetString("prompt")
+	if prompt == "" && len(args) > 0 {
+		prompt = args[0]
+	}
+
+	mode, _ := f.GetString("mode")
+	sessionName, _ := f.GetString("name")
+	model, _ := f.GetString("model")
+	providerType, _ := f.GetString("provider")
+	apiKeyRef, _ := f.GetString("api-key-ref")
+	baseURL, _ := f.GetString("base-url")
+	apiKeyHeader, _ := f.GetString("api-key-header")
+	queryParamRaw, _ := f.GetStringArray("query-param")
+	gcpProject, _ := f.GetString("gcp-project")
+	gcpLocation, _ := f.GetString("gcp-location")
+	gcpCredentialsFile, _ := f.GetString("gcp-credentials-file")
+	anthropicFederationRuleID, _ := f.GetString("anthropic-federation-rule-id")
+	anthropicOrganizationID, _ := f.GetString("anthropic-organization-id")
+	anthropicServiceAccountID, _ := f.GetString("anthropic-service-account-id")
+	anthropicWorkspaceID, _ := f.GetString("anthropic-workspace-id")
+	anthropicFromGitHubActions, _ := f.GetBool("anthropic-from-github-actions")
+	azureTenantID, _ := f.GetString("azure-tenant-id")
+	azureClientID, _ := f.GetString("azure-client-id")
+	azureScope, _ := f.GetString("azure-scope")
+	workspace, _ := f.GetString("workspace")
+	maxTurns, _ := f.GetInt("max-turns")
+	timeout, _ := f.GetInt("timeout")
+	tracePath, _ := f.GetString("trace")
+	transportType, _ := f.GetString("transport")
+	transportAddr, _ := f.GetString("transport-addr")
+	followUpGrace, _ := f.GetInt("followup-grace")
+	logLevel, _ := f.GetString("log-level")
+	executorType, _ := f.GetString("executor")
+	editStrategyType, _ := f.GetString("edit-strategy")
+	verifierType, _ := f.GetString("verifier")
+	gitStrategyType, _ := f.GetString("git-strategy")
+	traceEmitterType, _ := f.GetString("trace-emitter")
+	otelEndpoint, _ := f.GetString("otel-endpoint")
+	otelProtocol, _ := f.GetString("otel-protocol")
+	containerRuntime, _ := f.GetString("container-runtime")
+	permissionPolicyFile, _ := f.GetString("permission-policy-file")
+	codeScannerType, _ := f.GetString("code-scanner")
+	guardRailType, _ := f.GetString("guardrail")
+	guardRailEndpoint, _ := f.GetString("guardrail-endpoint")
+	guardRailModel, _ := f.GetString("guardrail-model")
+	guardRailFailOpen, _ := f.GetBool("guardrail-fail-open")
+	deploymentEnvironment, _ := f.GetString("deployment-environment")
+	serviceNamespace, _ := f.GetString("service-namespace")
+	providerRetryMaxAttempts, _ := f.GetInt("provider-retry-max-attempts")
+	providerRetryInitialDelay, _ := f.GetDuration("provider-retry-initial-delay")
+	providerRetryMaxDelay, _ := f.GetDuration("provider-retry-max-delay")
+	providerRetryWallClockBudget, _ := f.GetDuration("provider-retry-wall-clock")
+	workspaceExportTo, _ := f.GetString("export-workspace-to")
+	toolDispatchMaxParallel, _ := f.GetInt("max-tool-parallel")
+	batch, _ := f.GetBool("batch")
+
+	var queryParams map[string]string
+	for _, entry := range queryParamRaw {
+		k, v, err := parseQueryParam(entry)
+		if err != nil {
+			return nil, fmt.Errorf("--query-param %q: %w", entry, err)
+		}
+		if queryParams == nil {
+			queryParams = map[string]string{}
+		}
+		queryParams[k] = v
+	}
+
+	temperature := optionalFloat64Flag(cmd, "temperature")
+
+	// buildHarnessRunConfigCore (not buildHarnessRunConfig) is what runs
+	// here so the trailing applyModeDefaults stays gated by Resolve ==
+	// ResolveAll up in BuildRunConfig. A run-config stage that uses
+	// ResolveBase should not silently materialise the read-only mode's
+	// Tools.BuiltIn list because a later stage may pivot to --mode
+	// execution where the read-only defaults do not apply.
+	return buildHarnessRunConfigCore(harnessCLIOptions{
+		// RunID intentionally left empty; ResolveAll generates one when
+		// the base did not supply one, and ResolveBase leaves it empty
+		// so chained stages do not each mint a fresh ID.
+		Mode:                         mode,
+		SessionName:                  sessionName,
+		Prompt:                       prompt,
+		ProviderType:                 providerType,
+		BaseURL:                      baseURL,
+		APIKeyHeader:                 apiKeyHeader,
+		QueryParams:                  queryParams,
+		APIKeyRef:                    apiKeyRef,
+		GCPProject:                   gcpProject,
+		GCPLocation:                  gcpLocation,
+		GCPCredentialsFile:           gcpCredentialsFile,
+		AnthropicFederationRuleID:    anthropicFederationRuleID,
+		AnthropicOrganizationID:      anthropicOrganizationID,
+		AnthropicServiceAccountID:    anthropicServiceAccountID,
+		AnthropicWorkspaceID:         anthropicWorkspaceID,
+		AnthropicFromGitHubActions:   anthropicFromGitHubActions,
+		AzureTenantID:                azureTenantID,
+		AzureClientID:                azureClientID,
+		AzureScope:                   azureScope,
+		Model:                        model,
+		Workspace:                    workspace,
+		MaxTurns:                     maxTurns,
+		Timeout:                      timeout,
+		TracePath:                    tracePath,
+		TransportType:                transportType,
+		TransportAddr:                transportAddr,
+		FollowUpGrace:                followUpGrace,
+		Temperature:                  temperature,
+		LogLevel:                     logLevel,
+		ExecutorType:                 executorType,
+		EditStrategyType:             editStrategyType,
+		VerifierType:                 verifierType,
+		GitStrategyType:              gitStrategyType,
+		TraceEmitterType:             traceEmitterType,
+		OTelEndpoint:                 otelEndpoint,
+		OTelProtocol:                 otelProtocol,
+		ContainerRuntime:             containerRuntime,
+		PermissionPolicyFile:         permissionPolicyFile,
+		CodeScannerType:              codeScannerType,
+		GuardRailType:                guardRailType,
+		GuardRailEndpoint:            guardRailEndpoint,
+		GuardRailModel:               guardRailModel,
+		GuardRailFailOpen:            guardRailFailOpen,
+		DeploymentEnvironment:        deploymentEnvironment,
+		ServiceNamespace:             serviceNamespace,
+		ProviderRetryMaxAttempts:     providerRetryMaxAttempts,
+		ProviderRetryInitialDelay:    providerRetryInitialDelay,
+		ProviderRetryMaxDelay:        providerRetryMaxDelay,
+		ProviderRetryWallClockBudget: providerRetryWallClockBudget,
+		WorkspaceExportTo:            workspaceExportTo,
+		ToolDispatchMaxParallel:      toolDispatchMaxParallel,
+		Batch:                        batch,
+	})
+}
+
+// resolvePromptForRun fills cfg.Prompt from the lower-precedence sources
+// (--prompt-file, STIRRUP_PROMPT) when the higher-precedence ones
+// (--prompt, positional, base RunConfig.prompt) left it empty. Returns
+// the "prompt is required" error verbatim from the pre-refactor paths
+// so harness_test.go's existing fixtures continue to match the message.
+func resolvePromptForRun(cmd *cobra.Command, cfg *types.RunConfig) error {
+	if cfg.Prompt != "" {
+		return nil
+	}
+	if promptFile, _ := cmd.Flags().GetString("prompt-file"); promptFile != "" {
+		p, err := readPromptFile(promptFile)
+		if err != nil {
+			return err
+		}
+		cfg.Prompt = p
+	}
+	if cfg.Prompt == "" {
+		if v := os.Getenv("STIRRUP_PROMPT"); v != "" {
+			cfg.Prompt = v
+		}
+	}
+	if cfg.Prompt == "" {
+		return fmt.Errorf("prompt is required: pass via --prompt flag, as a positional argument, --prompt-file, STIRRUP_PROMPT env var, or the prompt field in --config")
+	}
+	return nil
+}
+
+// writeRunConfigJSON marshals cfg to w with a trailing newline. The
+// pretty form (2-space indent) is the default because the primary
+// consumers are humans inspecting captured configs and `diff` output
+// between pipeline stages; --compact on run-config flips to a single
+// line for tooling that prefers terse JSON.
+func writeRunConfigJSON(w io.Writer, cfg *types.RunConfig, compact bool) error {
+	var (
+		data []byte
+		err  error
+	)
+	if compact {
+		data, err = json.Marshal(cfg)
+	} else {
+		data, err = json.MarshalIndent(cfg, "", "  ")
+	}
+	if err != nil {
+		return fmt.Errorf("marshal RunConfig: %w", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write RunConfig: %w", err)
+	}
+	if _, err := w.Write([]byte("\n")); err != nil {
+		return fmt.Errorf("write RunConfig: %w", err)
+	}
+	return nil
+}

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -110,6 +110,12 @@ func BuildRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 		return nil, err
 	}
 
+	// Anthropic Workload Identity Federation overrides (issue #117).
+	// Encapsulated for readability; the helper handles the four ID
+	// fields, the inferred credential.type, the token-source inference
+	// chain, and the apiKeyRef mutual-exclusion guard. The single call
+	// site here keeps the slog.Warn diagnostics inside the helper from
+	// firing twice per invocation.
 	if err := applyAnthropicWIFOverrides(sources.Cmd, cfg); err != nil {
 		return nil, err
 	}

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -474,5 +475,76 @@ func TestWriteRunConfigJSON_RoundTrip(t *testing.T) {
 	}
 	if !strings.HasSuffix(buf.String(), "\n") {
 		t.Errorf("compact output should still end with a trailing newline")
+	}
+}
+
+// TestBuildRunConfig_AnthropicWIFWarnFiresOnce pins MF-1: BuildRunConfig
+// must invoke applyAnthropicWIFOverrides exactly once. The pre-fix code
+// invoked it both inside applyOverrides AND directly in BuildRunConfig,
+// so the "config already specifies tokenSource" diagnostic was emitted
+// twice per invocation. This test captures slog output and asserts the
+// warning appears once.
+func TestBuildRunConfig_AnthropicWIFWarnFiresOnce(t *testing.T) {
+	prevDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var logBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	// Base config carries an explicit credential.tokenSource so the
+	// helper's "operator opt-in ignored because file already set source"
+	// warning path fires.
+	base := types.RunConfig{
+		RunID:  "from-file",
+		Mode:   "execution",
+		Prompt: "test prompt",
+		Provider: types.ProviderConfig{
+			Type: "anthropic",
+			Credential: &types.CredentialConfig{
+				Type:             "anthropic-wif",
+				FederationRuleID: "fdrl_filerule",
+				OrganizationID:   "11111111-1111-1111-1111-111111111111",
+				ServiceAccountID: "svac_filesa",
+				TokenSource: &types.TokenSourceConfig{
+					Type: "file",
+					Path: "/var/run/file/jwt",
+				},
+			},
+		},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
+		Executor:        types.ExecutorConfig{Type: "local"},
+		EditStrategy:    types.EditStrategyConfig{Type: "multi"},
+		Verifier:        types.VerifierConfig{Type: "none"},
+		GitStrategy:     types.GitStrategyConfig{Type: "none"},
+		Transport:       types.TransportConfig{Type: "stdio"},
+		TraceEmitter:    types.TraceEmitterConfig{Type: "jsonl"},
+		MaxTurns:        10,
+		LogLevel:        "info",
+	}
+	t300 := 300
+	base.Timeout = &t300
+	body, err := json.Marshal(base)
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("anthropic-from-github-actions", "true"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	_, err = BuildRunConfig(RunConfigSources{
+		Stdin:   bytes.NewReader(body),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+
+	count := strings.Count(logBuf.String(), "--anthropic-from-github-actions ignored")
+	if count != 1 {
+		t.Errorf("WIF warn should fire exactly once, got %d:\n%s", count, logBuf.String())
 	}
 }

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -546,5 +547,181 @@ func TestBuildRunConfig_AnthropicWIFWarnFiresOnce(t *testing.T) {
 	count := strings.Count(logBuf.String(), "--anthropic-from-github-actions ignored")
 	if count != 1 {
 		t.Errorf("WIF warn should fire exactly once, got %d:\n%s", count, logBuf.String())
+	}
+}
+
+// failWriter returns an error on the Nth write (1-based). Used to
+// exercise writeRunConfigJSON's two distinct Write call sites.
+type failWriter struct {
+	calls    int
+	failOn   int
+	failWith error
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.calls == w.failOn {
+		return 0, w.failWith
+	}
+	return len(p), nil
+}
+
+// TestWriteRunConfigJSON_WriteError pins SF-5: writeRunConfigJSON must
+// surface a write error from either of its two Write call sites
+// (payload bytes and trailing newline) rather than silently producing
+// a half-written capture file.
+func TestWriteRunConfigJSON_WriteError(t *testing.T) {
+	cfg := &types.RunConfig{
+		RunID:        "x",
+		Mode:         "planning",
+		Provider:     types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://K"},
+		ModelRouter:  types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		Transport:    types.TransportConfig{Type: "stdio"},
+		Executor:     types.ExecutorConfig{Type: "local"},
+		EditStrategy: types.EditStrategyConfig{Type: "multi"},
+		MaxTurns:     5,
+	}
+
+	t.Run("first write (payload) fails", func(t *testing.T) {
+		w := &failWriter{failOn: 1, failWith: io.ErrClosedPipe}
+		err := writeRunConfigJSON(w, cfg, false)
+		if err == nil {
+			t.Fatal("expected write error to propagate")
+		}
+		if !strings.Contains(err.Error(), "write RunConfig") {
+			t.Errorf("error should describe the write failure, got: %v", err)
+		}
+	})
+
+	t.Run("second write (newline) fails", func(t *testing.T) {
+		w := &failWriter{failOn: 2, failWith: io.ErrClosedPipe}
+		err := writeRunConfigJSON(w, cfg, false)
+		if err == nil {
+			t.Fatal("expected newline write error to propagate")
+		}
+		if !strings.Contains(err.Error(), "write RunConfig") {
+			t.Errorf("error should describe the newline write failure, got: %v", err)
+		}
+	})
+}
+
+// TestIsStdinPiped_NamedPipeReturnsTrue pins SF-4: an os.Pipe reader,
+// whose Stat() reports os.ModeNamedPipe, must be treated as piped.
+func TestIsStdinPiped_NamedPipeReturnsTrue(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+	if !isStdinPiped(r) {
+		t.Error("named pipe should be detected as piped")
+	}
+}
+
+// TestIsStdinPiped_RegularFileReturnsTrue pins SF-4: a redirected
+// regular file (`< config.json`) must be treated as piped.
+func TestIsStdinPiped_RegularFileReturnsTrue(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "in-*.json")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if !isStdinPiped(f) {
+		t.Error("regular file should be detected as piped")
+	}
+}
+
+// TestIsStdinPiped_StatErrorReturnsFalse pins SF-4: a closed file fd
+// whose Stat() errors must be treated as non-piped (the conservative
+// default — better to fall through to flag-only than to attempt a
+// read on an unusable fd).
+func TestIsStdinPiped_StatErrorReturnsFalse(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "stat-err-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if isStdinPiped(f) {
+		t.Error("closed file (Stat errors) should not be treated as piped")
+	}
+}
+
+// TestIsStdinPiped_CharDeviceReturnsFalse pins SF-4 and the documented
+// `go test` deviation: a character device (the shape `go test` hands
+// its children as stdin) must NOT be treated as piped. Removing this
+// branch would re-introduce false-positive activation in every
+// harness_test.go fixture.
+func TestIsStdinPiped_CharDeviceReturnsFalse(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open /dev/null: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if isStdinPiped(f) {
+		t.Error("character device (/dev/null) should not be treated as piped")
+	}
+}
+
+// TestBuildRunConfig_ApplyOverridesError pins SF-6: a malformed
+// --query-param entry surfaces through BuildRunConfig as a non-nil
+// error. Before, applyOverrides was only tested directly; this
+// exercises the error-propagation arm of BuildRunConfig itself.
+func TestBuildRunConfig_ApplyOverridesError(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("query-param", "no-equals-sign"); err != nil {
+		t.Fatalf("set query-param: %v", err)
+	}
+	_, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected malformed --query-param to surface as error")
+	}
+	if !strings.Contains(err.Error(), "query-param") {
+		t.Errorf("error should mention query-param, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_WIFOverridesError pins SF-6: a WIF flag set
+// alongside an explicit --api-key-ref surfaces through BuildRunConfig
+// as a non-nil error.
+func TestBuildRunConfig_WIFOverridesError(t *testing.T) {
+	for _, name := range []string{
+		"ANTHROPIC_FEDERATION_RULE_ID",
+		"ANTHROPIC_ORGANIZATION_ID",
+		"ANTHROPIC_SERVICE_ACCOUNT_ID",
+		"ANTHROPIC_WORKSPACE_ID",
+		"ANTHROPIC_IDENTITY_TOKEN_FILE",
+		"ANTHROPIC_IDENTITY_TOKEN",
+	} {
+		t.Setenv(name, "")
+	}
+
+	cmd := newTestHarnessCommand()
+	mustSet := func(name, val string) {
+		if err := cmd.Flags().Set(name, val); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+	}
+	mustSet("anthropic-federation-rule-id", "fdrl_rule")
+	mustSet("anthropic-organization-id", "11111111-1111-1111-1111-111111111111")
+	mustSet("anthropic-service-account-id", "svac_sa")
+	mustSet("api-key-ref", "secret://EXPLICIT_KEY")
+
+	_, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected WIF + explicit api-key-ref to surface as error")
+	}
+	if !strings.Contains(err.Error(), "api-key-ref") {
+		t.Errorf("error should mention api-key-ref, got: %v", err)
 	}
 }

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -1,0 +1,478 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// minimalRunConfigJSON is the smallest base RunConfig the tests pipe
+// through BuildRunConfig. It carries only the fields a downstream
+// pipeline stage cannot reasonably default — provider/credential
+// shape, prompt — so the assertions about flag overrides aren't
+// confused by mode-default mutations.
+func minimalRunConfigJSON(t *testing.T) string {
+	t.Helper()
+	cfg := types.RunConfig{
+		RunID:  "from-file",
+		Mode:   "planning",
+		Prompt: "prompt from file",
+		Provider: types.ProviderConfig{
+			Type:      "anthropic",
+			APIKeyRef: "secret://FILE_KEY",
+		},
+		ModelRouter: types.ModelRouterConfig{
+			Type:     "static",
+			Provider: "anthropic",
+			Model:    "claude-sonnet-4-6",
+		},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
+		Executor:        types.ExecutorConfig{Type: "local"},
+		EditStrategy:    types.EditStrategyConfig{Type: "multi"},
+		Verifier:        types.VerifierConfig{Type: "none"},
+		GitStrategy:     types.GitStrategyConfig{Type: "none"},
+		Transport:       types.TransportConfig{Type: "stdio"},
+		TraceEmitter:    types.TraceEmitterConfig{Type: "jsonl"},
+		PermissionPolicy: types.PermissionPolicyConfig{
+			Type: "deny-side-effects",
+		},
+		Tools: types.ToolsConfig{
+			BuiltIn: types.DefaultReadOnlyBuiltInTools(),
+		},
+		MaxTurns: 10,
+		LogLevel: "info",
+	}
+	t300 := 300
+	cfg.Timeout = &t300
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal minimal RunConfig: %v", err)
+	}
+	return string(b)
+}
+
+// TestBuildRunConfig_FlagOnlyMatchesBuildHarnessRunConfig pins that
+// the shared builder produces a config equivalent to today's
+// buildHarnessRunConfig for the no-base case. Without this assertion
+// the refactor could silently drift the flag-only path (the
+// pre-refactor Path 2) from the rest of the resolver.
+func TestBuildRunConfig_FlagOnlyMatchesBuildHarnessRunConfig(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--mode", "execution",
+		"--model", "claude-opus-4-7",
+		"--max-turns", "42",
+		"--prompt", "do the thing",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:   nil,
+		Cmd:     cmd,
+		Resolve: ResolveAll,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+
+	if cfg.Mode != "execution" {
+		t.Errorf("Mode = %q, want execution", cfg.Mode)
+	}
+	if cfg.ModelRouter.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want claude-opus-4-7", cfg.ModelRouter.Model)
+	}
+	if cfg.MaxTurns != 42 {
+		t.Errorf("MaxTurns = %d, want 42", cfg.MaxTurns)
+	}
+	if cfg.Prompt != "do the thing" {
+		t.Errorf("Prompt = %q, want %q", cfg.Prompt, "do the thing")
+	}
+	if cfg.RunID == "" {
+		t.Errorf("ResolveAll should generate a RunID, got empty")
+	}
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		t.Errorf("ResolveAll output should validate, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_StdinBaseWithFlagOverride exercises the canonical
+// pipeline shape: a JSON RunConfig arrives on stdin and an explicit
+// flag overrides one field. The base survives intact for every field
+// the flag did not touch.
+func TestBuildRunConfig_StdinBaseWithFlagOverride(t *testing.T) {
+	base := minimalRunConfigJSON(t)
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--max-turns", "99",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:   strings.NewReader(base),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+
+	if cfg.MaxTurns != 99 {
+		t.Errorf("MaxTurns = %d, want 99 (flag override)", cfg.MaxTurns)
+	}
+	if cfg.Provider.APIKeyRef != "secret://FILE_KEY" {
+		t.Errorf("APIKeyRef = %q, want secret://FILE_KEY (base preserved)", cfg.Provider.APIKeyRef)
+	}
+	if cfg.Prompt != "prompt from file" {
+		t.Errorf("Prompt = %q, want %q (base preserved)", cfg.Prompt, "prompt from file")
+	}
+	if cfg.RunID != "from-file" {
+		t.Errorf("RunID = %q, want from-file (ResolveBase must not mint a new ID)", cfg.RunID)
+	}
+}
+
+// TestBuildRunConfig_FilePath verifies the file-loading branch. The
+// path coverage matters because loadRunConfigFile already had a code
+// path for file reads pre-refactor — the test confirms BuildRunConfig
+// reaches it the same way.
+func TestBuildRunConfig_FilePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalRunConfigJSON(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	cmd := newTestHarnessCommand()
+	cfg, err := BuildRunConfig(RunConfigSources{
+		ConfigPath: path,
+		Cmd:        cmd,
+		Resolve:    ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.RunID != "from-file" {
+		t.Errorf("RunID = %q, want from-file", cfg.RunID)
+	}
+}
+
+// TestBuildRunConfig_StdinPlusConfigFileAreAmbiguous pins acceptance
+// criterion 6: --config <path> with piped stdin must fail loudly
+// rather than silently picking one base. The error mentions both
+// sources so the operator can fix whichever was unintentional.
+func TestBuildRunConfig_StdinPlusConfigFileAreAmbiguous(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalRunConfigJSON(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Stdin:      strings.NewReader(minimalRunConfigJSON(t)),
+		ConfigPath: path,
+		Cmd:        cmd,
+		Resolve:    ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected error for --config + piped stdin combination")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error should describe ambiguity, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error should mention config path, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "stdin") {
+		t.Errorf("error should mention stdin, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_ExplicitDashRequiresStdin pins the explicit
+// `--config -` failure mode the spec calls out: when stdin is a TTY
+// (or, in our test harness, simulated with a nil Stdin), reading the
+// dash literal as a path is nonsense. The error tells the operator
+// the redirection is missing.
+func TestBuildRunConfig_ExplicitDashRequiresStdin(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Stdin:      nil,
+		ConfigPath: "-",
+		Cmd:        cmd,
+		Resolve:    ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected error for --config - with no piped stdin")
+	}
+	if !strings.Contains(err.Error(), "--config -") {
+		t.Errorf("error should cite --config -, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_ResolveBaseSkipsModeDefaults pins the
+// pipeline-friendly contract: ResolveBase leaves PermissionPolicy and
+// Tools.BuiltIn empty even for a read-only mode because a later
+// pipeline stage may pivot to --mode execution where those defaults
+// would be wrong. ResolveAll, by contrast, populates them — that's
+// what the harness path needs before invoking the loop.
+func TestBuildRunConfig_ResolveBaseSkipsModeDefaults(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--mode", "planning",
+		"--prompt", "x",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	base, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig(ResolveBase): %v", err)
+	}
+	if base.PermissionPolicy.Type != "" {
+		t.Errorf("ResolveBase should leave PermissionPolicy unset on planning, got %q", base.PermissionPolicy.Type)
+	}
+	if len(base.Tools.BuiltIn) != 0 {
+		t.Errorf("ResolveBase should leave Tools.BuiltIn empty on planning, got %v", base.Tools.BuiltIn)
+	}
+
+	all, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveAll,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig(ResolveAll): %v", err)
+	}
+	if all.PermissionPolicy.Type != "deny-side-effects" {
+		t.Errorf("ResolveAll planning should default to deny-side-effects, got %q", all.PermissionPolicy.Type)
+	}
+	if len(all.Tools.BuiltIn) == 0 {
+		t.Error("ResolveAll planning should populate Tools.BuiltIn")
+	}
+}
+
+// TestBuildRunConfig_ResolveAllRequiresPrompt pins that the harness
+// path's existing prompt-required error fires through the shared
+// builder. The message text matches harness_test.go's existing prompt
+// fixtures so the error string is part of the API contract.
+func TestBuildRunConfig_ResolveAllRequiresPrompt(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{"--mode", "execution"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	t.Setenv("STIRRUP_PROMPT", "")
+
+	_, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveAll,
+	})
+	if err == nil {
+		t.Fatal("ResolveAll with no prompt should fail")
+	}
+	if !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("error should be the documented prompt-required message, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_ResolveBaseAllowsEmptyPrompt pins the
+// pipeline-stage contract: a chained `run-config` stage must be
+// allowed to emit a config without a prompt because the final
+// `harness` stage will supply one via --prompt / positional /
+// --prompt-file / STIRRUP_PROMPT.
+func TestBuildRunConfig_ResolveBaseAllowsEmptyPrompt(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{"--mode", "execution"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	t.Setenv("STIRRUP_PROMPT", "")
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.Prompt != "" {
+		t.Errorf("ResolveBase should leave empty prompt as empty, got %q", cfg.Prompt)
+	}
+}
+
+// TestBuildRunConfig_RejectsUnknownStdinFields exercises the
+// DisallowUnknownFields safeguard on the stdin reader. Typos in a
+// piped JSON should fail loudly with a parse error, not silently
+// drop the unknown field.
+func TestBuildRunConfig_RejectsUnknownStdinFields(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Stdin:   strings.NewReader(`{"mode":"planning","not_a_field":true}`),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected DisallowUnknownFields rejection")
+	}
+	if !strings.Contains(err.Error(), "not_a_field") {
+		t.Errorf("error should name the unknown field, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_StdinSizeCap pins that the 1 MiB cap on
+// loadRunConfigFile is reused for stdin so a hostile / runaway piped
+// input cannot OOM the harness.
+func TestBuildRunConfig_StdinSizeCap(t *testing.T) {
+	// 1 MiB + 1 KiB of whitespace-padded JSON. The DisallowUnknownFields
+	// decoder rejects the padding anyway, but the size guard must trip
+	// first — that's what we're pinning.
+	padding := bytes.Repeat([]byte(" "), int(maxConfigFileBytes)+1024)
+	body := append([]byte(`{"mode":"planning"}`), padding...)
+
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Stdin:   bytes.NewReader(body),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected size-cap rejection")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error should mention the size cap, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_EmptyStdinErrors pins the spec's "non-TTY but
+// empty" failure mode for explicit --config -. With ConfigPath = "-"
+// and an empty reader, the builder must error loudly rather than
+// silently falling through to flag-only.
+func TestBuildRunConfig_EmptyStdinErrors(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Stdin:      strings.NewReader(""),
+		ConfigPath: "-",
+		Cmd:        cmd,
+		Resolve:    ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected empty-stdin rejection")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty input, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_FlagOverridesBaseWIFInference exercises one of
+// the cross-field invariants the spec calls out: --azure-tenant-id
+// implies credential.type=azure-workload-identity. Reaching this from
+// a stdin-base path proves the WIF folding step runs for both file/
+// stdin and flag-only bases — without that, an Azure operator piping
+// `run-config --azure-tenant-id ...` into `harness --prompt ...`
+// would get a config without the implied credential block.
+func TestBuildRunConfig_FlagOverridesBaseWIFInference(t *testing.T) {
+	base := minimalRunConfigJSON(t)
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--provider", "openai-responses",
+		"--azure-tenant-id", "11111111-1111-1111-1111-111111111111",
+		"--azure-client-id", "22222222-2222-2222-2222-222222222222",
+		"--base-url", "https://example.openai.azure.com/openai/v1",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:   strings.NewReader(base),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.Provider.Credential == nil {
+		t.Fatal("--azure-tenant-id should imply a Credential block")
+	}
+	if cfg.Provider.Credential.Type != "azure-workload-identity" {
+		t.Errorf("Credential.Type = %q, want azure-workload-identity", cfg.Provider.Credential.Type)
+	}
+	if cfg.Provider.Credential.AzureTenantID == "" {
+		t.Error("Credential.AzureTenantID should be populated")
+	}
+}
+
+// TestBuildRunConfig_PositionalPromptOverlay confirms the positional
+// prompt argument is consumed by ResolveAll's prompt chain even when
+// it arrives via Sources.Args (no --prompt flag, no stdin prompt).
+func TestBuildRunConfig_PositionalPromptOverlay(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{"--mode", "execution"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Args:    []string{"positional prompt"},
+		Resolve: ResolveAll,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.Prompt != "positional prompt" {
+		t.Errorf("Prompt = %q, want %q", cfg.Prompt, "positional prompt")
+	}
+}
+
+// TestWriteRunConfigJSON_RoundTrip pins that the writer emits a
+// document the existing loader can read back. Belt-and-braces against
+// a hypothetical future tweak to the marshal indent / trailing newline
+// that breaks downstream `stirrup run-config` consumers.
+func TestWriteRunConfigJSON_RoundTrip(t *testing.T) {
+	cfg := &types.RunConfig{
+		RunID:        "test-run",
+		Mode:         "planning",
+		Prompt:       "x",
+		Provider:     types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ANTHROPIC_API_KEY"},
+		ModelRouter:  types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		Transport:    types.TransportConfig{Type: "stdio"},
+		Executor:     types.ExecutorConfig{Type: "local"},
+		EditStrategy: types.EditStrategyConfig{Type: "multi"},
+		MaxTurns:     20,
+	}
+	var buf bytes.Buffer
+	if err := writeRunConfigJSON(&buf, cfg, false); err != nil {
+		t.Fatalf("writeRunConfigJSON: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("output should end with a trailing newline")
+	}
+
+	// Re-read it.
+	var rc types.RunConfig
+	if err := json.Unmarshal(buf.Bytes(), &rc); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if rc.RunID != cfg.RunID {
+		t.Errorf("RunID lost in round-trip: got %q want %q", rc.RunID, cfg.RunID)
+	}
+
+	// Compact variant: must NOT contain the indent string, but must
+	// still parse and still end with a newline.
+	buf.Reset()
+	if err := writeRunConfigJSON(&buf, cfg, true); err != nil {
+		t.Fatalf("writeRunConfigJSON(compact): %v", err)
+	}
+	if strings.Contains(buf.String(), "\n  ") {
+		t.Errorf("compact output should not be indented, got %q", buf.String())
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Errorf("compact output should still end with a trailing newline")
+	}
+}

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -1,0 +1,83 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// addRunConfigFlags registers every flag that maps to a RunConfig field
+// (or to the prompt-resolution chain that lands on RunConfig.Prompt).
+// Both `stirrup harness` and `stirrup run-config` call this so the two
+// subcommands cannot drift on default values, help text, or supported
+// fields. Pure CLI-behaviour flags that do not round-trip through
+// RunConfig (--export-workspace-required, --output-runconfig) live on
+// the harness command directly; the run-config subcommand adds its own
+// --validate / --compact / --redact afterwards.
+//
+// Flag defaults are preserved verbatim from the pre-refactor
+// harnessCmd.init() body so a flag-only invocation of either command
+// produces identical RunConfigs.
+func addRunConfigFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+	f.String("config", "", "Path to a JSON RunConfig file (mirrors proto/harness/v1/harness.proto). Use \"-\" to read from stdin. Explicit flags still override individual fields; unset flags do not.")
+	f.StringP("mode", "m", "planning", "Run mode: execution, planning, review, research, toil. Default is the read-only `planning` mode (no edits, no shell, deny-side-effects policy); pass `--mode execution` for editable runs with shell access.")
+	f.String("model", "claude-sonnet-4-6", "Model to use (sets ModelRouter.Model; for dynamic/per-mode routers in --config files this only sets the default-model field, not the cheap/expensive override)")
+	f.String("provider", "anthropic", "Provider type: anthropic, bedrock, gemini (Vertex AI), openai-compatible (Chat Completions), openai-responses (Responses API). The two OpenAI variants speak different wire formats and must be selected explicitly.")
+	f.String("api-key-ref", "secret://ANTHROPIC_API_KEY", "Secret reference for API key")
+	f.String("base-url", "", "API base URL for openai-compatible / openai-responses providers (e.g. https://<resource>.openai.azure.com/openai/v1)")
+	f.String("api-key-header", "", "Header name for sending the API key. Empty = Authorization: Bearer (default). Set to \"api-key\" for Azure OpenAI key auth.")
+	f.StringArray("query-param", nil, "Repeatable key=value query parameter appended to every provider request URL (e.g. api-version=preview). Used by the openai-* adapters.")
+	f.String("gcp-project", "", "GCP project ID hosting the Vertex AI usage. Required when --provider=gemini.")
+	f.String("gcp-location", "global", "Vertex AI location: \"global\" or a region (e.g. us-central1). Determines the URL host and project location segment.")
+	f.String("gcp-credentials-file", "", "Path to a Google service account JSON key file. When set, implies credential.type=gcp-service-account.")
+
+	f.String("anthropic-federation-rule-id", "", "Anthropic federation rule ID (`fdrl_...`). Implies `credential.type=anthropic-wif` when set. Env fallback: ANTHROPIC_FEDERATION_RULE_ID.")
+	f.String("anthropic-organization-id", "", "Anthropic organization UUID. Required with WIF. Env fallback: ANTHROPIC_ORGANIZATION_ID.")
+	f.String("anthropic-service-account-id", "", "Anthropic service account ID (`svac_...`). Required with WIF. Env fallback: ANTHROPIC_SERVICE_ACCOUNT_ID.")
+	f.String("anthropic-workspace-id", "", "Anthropic workspace ID (`wrkspc_...`) or `default`. Conditional. Env fallback: ANTHROPIC_WORKSPACE_ID.")
+	f.Bool("anthropic-from-github-actions", false, "Enable GitHub Actions OIDC token source for Anthropic WIF. Reads ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN from the runner environment. Ignored (with a warning) if `--config` already sets `credential.tokenSource`.")
+
+	f.String("azure-tenant-id", "", "Azure AD tenant UUID hosting the App Registration. When set, implies credential.type=azure-workload-identity. Use with --provider=openai-compatible or openai-responses against Azure OpenAI / Foundry.")
+	f.String("azure-client-id", "", "App Registration / federated identity credential client ID (UUID). Required with --azure-tenant-id.")
+	f.String("azure-scope", "https://cognitiveservices.azure.com/.default", "OAuth2 scope for the Entra access token. Override only for non-default Azure audiences (custom AAD app registrations, sovereign clouds).")
+	f.StringP("workspace", "w", "", "Workspace directory (default: current directory)")
+	f.Int("max-turns", 20, "Maximum agentic loop turns")
+	f.Int("timeout", 600, "Wall-clock timeout in seconds")
+	f.String("trace", "", "Path to JSONL trace file (sets --trace-emitter to jsonl unless --trace-emitter is explicitly set)")
+	f.String("transport", "stdio", "Transport type: stdio, grpc")
+	f.String("transport-addr", "", "gRPC target address (required when transport is grpc)")
+	f.Int("followup-grace", 0, "Seconds to keep gRPC transport open for follow-up requests (0 = disabled; env: STIRRUP_FOLLOWUP_GRACE)")
+	f.Float64("temperature", 0, "Sampling temperature forwarded to the provider on every turn. Range 0.0-2.0 (union of provider ranges). Unset leaves the harness default (0.1); explicit 0 sets greedy decoding.")
+	f.String("log-level", "info", "Log level: debug, info, warn, error")
+	f.String("prompt", "", "User prompt (can also be passed as a positional argument; falls back to --prompt-file then STIRRUP_PROMPT env var, then a prompt field in --config)")
+	f.String("prompt-file", "", "Path to a file whose contents become the prompt. Read from CWD when relative. Trailing newlines are trimmed; the file is capped at 10 MiB and must be non-empty. Lower precedence than --prompt and the positional argument; higher than STIRRUP_PROMPT.")
+	f.String("name", "", "Human-readable session label (metadata only, not injected into prompt)")
+
+	f.String("executor", "local", "Executor: local, container, api")
+	f.String("edit-strategy", "multi", "Edit strategy: whole-file, search-replace, udiff, multi (composite available only via --config)")
+	f.String("verifier", "none", "Verifier: none, test-runner, llm-judge (composite available only via --config)")
+	f.String("git-strategy", "none", "Git strategy: none, deterministic")
+	f.String("trace-emitter", "jsonl", "Trace emitter: jsonl, otel, gcs")
+	f.String("otel-endpoint", "", "OTLP endpoint for the otel trace emitter (default: localhost:4317 for grpc; full URL ending in the gateway base path for http/protobuf, e.g. https://otlp-gateway-prod-us-east-0.grafana.net/otlp)")
+	f.String("otel-protocol", "", "OTLP wire protocol for the otel trace emitter: \"\" (default — grpc), grpc, http/protobuf. HTTP/JSON is not supported; managed gateways like Grafana Cloud use http/protobuf. See docs/observability-cloud.md.")
+
+	f.String("container-runtime", "", "OCI runtime for the container executor: runc, runsc (gVisor), kata, kata-qemu, kata-fc. Empty means engine default (typically runc). Requires the runtime to be registered with the host Docker/Podman daemon — see docs/safety-rings.md.")
+	f.String("permission-policy-file", "", "Path to a Cedar policy file for the policy-engine PermissionPolicy. When set and --permission-policy is unset elsewhere, also implies permissionPolicy.type=policy-engine. See examples/policies/ for starters.")
+	f.String("code-scanner", "", "CodeScanner type: none, patterns, semgrep, composite. Composite requires --config (codeScanner.scanners). Empty defers to the mode-aware default (patterns for execution, none for read-only modes).")
+
+	f.String("guardrail", "", "GuardRail type: none, granite-guardian, composite, cloud-judge. Composite requires --config (guardRail.stages).")
+	f.String("guardrail-endpoint", "", "Endpoint URL for the granite-guardian or cloud-judge adapter.")
+	f.String("guardrail-model", "", "Model identifier for the GuardRail classifier. Granite-guardian default: ibm-granite/granite-guardian-4.1-8b. Cloud-judge default: claude-haiku-4-5-20251001 (Anthropic API format) — when the primary provider is Bedrock, use the Bedrock-format ID (e.g. us.anthropic.claude-haiku-4-5-20251001-v1:0).")
+	f.Bool("guardrail-fail-open", false, "When true, transport errors / timeouts produce VerdictAllow with a security event rather than blocking. Default false (fail closed).")
+
+	f.String("deployment-environment", "", "OTel deployment.environment resource attribute (e.g. production, staging). Empty falls through to OTEL_DEPLOYMENT_ENVIRONMENT, then to \"local\".")
+	f.String("service-namespace", "", "OTel service.namespace resource attribute (e.g. stirrup-eval, team-a). Empty falls through to OTEL_SERVICE_NAMESPACE, then to \"stirrup\".")
+
+	f.Int("provider-retry-max-attempts", 0, "Maximum HTTP attempts (including the first) for the default provider. 1 disables retry. Hard ceiling: 5. Default (when unset): 3. Currently honoured only by the openai-compatible adapter; the other adapters fall through unconditionally pending their own wire-ups.")
+	f.Duration("provider-retry-initial-delay", 0, "Base delay for exponential backoff before jitter, applied between retries on the default provider. Accepts Go duration syntax (e.g. 500ms, 1s). Default (when unset): 500ms.")
+	f.Duration("provider-retry-max-delay", 0, "Per-attempt sleep ceiling for the default provider (also caps Retry-After hints). Applies only to the default provider; per-named-provider retry policy requires --config. Hard ceiling: 60s. Default (when unset): 16s.")
+	f.Duration("provider-retry-wall-clock", 0, "Wall-clock budget for the entire retry sequence on the default provider. Applies only to the default provider; per-named-provider retry policy requires --config. Hard ceiling: 300s. Default (when unset): 90s.")
+
+	f.String("export-workspace-to", "", "Upload the executor workspace as a gzipped tarball to this URI at end-of-run (e.g. gs://bucket/runs/<runId>/workspace.tar.gz). Only gs:// is supported in v1. Mirrors executor.workspaceExportTo.")
+
+	f.Int("max-tool-parallel", 0, "Maximum number of async tool calls dispatched concurrently in a single turn. Range: 1-16. 0 uses the library default (4).")
+
+	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/sandbox.md.")
+}

--- a/harness/go.mod
+++ b/harness/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/term v0.41.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/api v0.36.1
@@ -75,7 +76,6 @@ require (
 	golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/scripts/smoke-runconfig.sh
+++ b/scripts/smoke-runconfig.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# smoke-runconfig.sh — verify `stirrup run-config` emits a parseable
+# RunConfig and the canonical pipeline shape round-trips idempotently.
+#
+# Four checks run sequentially:
+#
+#   1. Flag-only invocation produces JSON with the operator-set mode
+#      and prompt visible. Asserted with `jq -e` so a structural drift
+#      in the emitted JSON trips this script before it lands in
+#      a release.
+#   2. Idempotency: piping a config through `stirrup run-config` twice
+#      produces byte-identical output. The first pass normalises;
+#      the second is a no-op.
+#   3. --validate exits non-zero on a contradictory config.
+#   4. `stirrup harness --output-runconfig <path>` writes a
+#      parseable RunConfig and exits cleanly without invoking the
+#      provider (no ANTHROPIC_API_KEY set; the dry-run branch must
+#      short-circuit before any provider HTTP).
+#
+# Run from the repo root after `just build`:
+#   ./scripts/smoke-runconfig.sh
+#
+# Honours STIRRUP_BIN as an override path (e.g. for CI builds that
+# stage the binary somewhere other than ./stirrup).
+
+set -euo pipefail
+
+STIRRUP_BIN="${STIRRUP_BIN:-./stirrup}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+if [[ ! -x "${STIRRUP_BIN}" ]]; then
+    echo "FAIL: stirrup binary not found at ${STIRRUP_BIN}" >&2
+    echo "  Run \`just build\` first or set STIRRUP_BIN to the binary path." >&2
+    exit 1
+fi
+
+# Check 1: flag-only invocation produces parseable JSON with the
+# operator-set mode visible.
+mode_out=$(${STIRRUP_BIN} run-config --mode execution --prompt "x" \
+    | jq -er '.mode')
+if [[ "${mode_out}" != "execution" ]]; then
+    echo "FAIL: --mode execution did not surface in emitted JSON (got: ${mode_out})" >&2
+    exit 1
+fi
+echo "ok: run-config emits parseable JSON with operator-set mode"
+
+# Check 2: idempotency. Pipe a config through twice and diff the two
+# outputs. The first run may apply default mutations (e.g. cobra
+# defaults); the second must not move the document any further.
+${STIRRUP_BIN} run-config --mode execution --prompt "x" > "${TMP_DIR}/pass1.json"
+${STIRRUP_BIN} run-config < "${TMP_DIR}/pass1.json" > "${TMP_DIR}/pass2.json"
+if ! diff -q "${TMP_DIR}/pass1.json" "${TMP_DIR}/pass2.json" >/dev/null; then
+    echo "FAIL: run-config is not idempotent" >&2
+    diff "${TMP_DIR}/pass1.json" "${TMP_DIR}/pass2.json" >&2 || true
+    exit 1
+fi
+echo "ok: run-config | run-config is idempotent"
+
+# Check 3: --validate rejects a contradictory config. Bedrock + the
+# CLI-default `claude-sonnet-4-6` is the issue #65 trap the validator
+# rejects with an inference-profile remediation hint.
+if ${STIRRUP_BIN} run-config --validate \
+    --mode execution \
+    --provider bedrock \
+    --prompt "x" >/dev/null 2>&1; then
+    echo "FAIL: --validate accepted bedrock + sonnet-4-6 alias" >&2
+    exit 1
+fi
+echo "ok: --validate rejects invalid configs"
+
+# Check 4: --output-runconfig writes a parseable file and exits
+# cleanly without invoking the provider. We rely on the dry-run
+# branch firing before any HTTP would happen; the absence of
+# ANTHROPIC_API_KEY here proves the loop did not start.
+${STIRRUP_BIN} harness --output-runconfig "${TMP_DIR}/captured.json" \
+    --prompt "x" --mode planning
+captured_mode=$(jq -er '.mode' < "${TMP_DIR}/captured.json")
+if [[ "${captured_mode}" != "planning" ]]; then
+    echo "FAIL: --output-runconfig did not capture --mode planning (got: ${captured_mode})" >&2
+    exit 1
+fi
+echo "ok: --output-runconfig captures the resolved RunConfig"
+
+echo "all run-config smoke checks passed"


### PR DESCRIPTION
Closes #240.

## Why

Capturing a fully-resolved `RunConfig` used to mean either
hand-crafting a JSON file or starting a real loop just to inspect
what the flags would have produced. This change adds the
`stirrup run-config` subcommand (emits the resolved document to
stdout without invoking the loop) and the `stirrup harness
--output-runconfig <path>` flag (dry-run capture of what *would* have
run). Together they enable a UNIX-style pipeline where each stage
layers one more adjustment before the final stage runs the agent,
and they give post-mortem replay a stable, file-based artefact. The
two surfaces converge on one resolver — `BuildRunConfig` in
`runconfigbuilder.go` — so the file-loading, stdin-piping,
flag-overriding, WIF-folding, prompt-chaining, and validation steps
are reachable from a single code path instead of the two parallel
branches that used to live in `runHarness`.

## What changed

- **New files**: `runconfigbuilder.go`, `runconfigflags.go`,
  `runconfig.go` (+ tests). `runconfigflags.go` extracts the shared
  flag registration so the two subcommands cannot drift.
- **`runHarness` refactor**: the pre-existing `--config`-with-overrides
  branch and flag-only branch collapse into one `BuildRunConfig`
  call. New `--output-runconfig` and `--config -` / auto-stdin
  handling.
- **`buildHarnessRunConfig` refactor**: split into a `Core` helper
  (no `applyModeDefaults`) and the public wrapper (calls
  `applyModeDefaults` for backward compatibility). `BuildRunConfig`
  uses the core helper so its `ResolveBase` path can emit a
  minimally-mutated document.
- **Docs**: `docs/configuration.md` gains a "Building RunConfigs
  interactively" section; README.md gets a paragraph; AGENTS.md
  picks up the new flag rows and a `run-config` flag table;
  CLAUDE.md's where-things-live table points at the new files;
  `examples/runconfig/README.md` cross-links to the subcommand.
- **Smoke**: `scripts/smoke-runconfig.sh` exercises the four
  offline acceptance criteria (emitter shape, idempotency,
  `--validate`, `--output-runconfig`).

## Deviation from the spec

The spec calls for auto-stdin detection via `IsTerminal(stdin)` —
any non-TTY stdin is treated as a piped base. In practice that
trips every existing `harness_test.go` fixture because the
`go test` runner inherits stdin from the terminal as a non-TTY
character device. The implementation narrows the auto-detection to
named pipes (shell `|`) and regular-file redirects (`<
config.json`); other non-TTY shapes (char devices including
`< /dev/null`, Unix sockets) fall through to flag-only construction.
The explicit `--config -` form continues to enforce the spec's
"non-TTY but empty" failure mode on EOF input, which keeps the
acceptance criterion about `< /dev/null` reachable without trapping
the test suite. The rationale and the cost (operators who
deliberately pipe `< /dev/null` get the prompt-required error rather
than a "stdin was empty" error) is documented in the
`isStdinPiped` comment.

## Test plan

- [x] `just` (build + test) passes — 26 new tests added under
  `harness/cmd/stirrup/cmd/`.
- [x] `just lint` passes (golangci-lint v2).
- [x] Manual smoke: `./scripts/smoke-runconfig.sh` passes
  end-to-end after `just build`.
- [x] Pipeline pattern works end-to-end:
  `stirrup run-config --model X | stirrup run-config --mode execution | stirrup harness --output-runconfig=-`.
- [x] `stirrup harness --config /tmp/x` plus piped stdin fails
  loudly with both sources cited.
- [x] `stirrup harness --output-runconfig=out.json --prompt "x"`
  writes a parseable `RunConfig` and exits 0; re-running with
  `--config out.json` produces an equivalent resolved config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)