### PR TITLE
cli: add STIRRUP_CONFIG env var for default --config path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,23 +21,59 @@ fails fast with a clear error rather than being silently dropped.
 
 ## Precedence
 
-When `--config`, piped stdin, or explicit flags are passed, the order
-of precedence is:
+When `--config`, piped stdin, `STIRRUP_CONFIG`, or explicit flags
+are passed, the order of precedence is:
 
-1. **Base config** — either `--config <path>` (file) or stdin
-   (`--config -`, or auto-detected on a non-TTY pipe). Mutually
-   exclusive: passing both is a hard error so the operator never
-   has to guess which source won.
+1. **Base config** — one of the following, in descending priority:
+
+   | Rank | Source | Notes |
+   |---|---|---|
+   | 1 | `--config <path>` flag | Explicit. Wins outright. |
+   | 2 | `--config -` flag | Reads the base from piped stdin. |
+   | 3 | Auto-detected piped stdin | Triggered when `--config` is absent and stdin is a pipe or a redirected regular file (not a TTY). |
+   | 4 | `STIRRUP_CONFIG` env var | Filesystem path, or the literal `-` to opt into stdin. Consulted only when `--config` is absent. |
+
+   The four sources are mutually exclusive. Combining a path-shaped
+   source (`--config <path>` or `STIRRUP_CONFIG=<path>`) with piped
+   stdin is a hard error so operators never have to guess which
+   source won. `STIRRUP_CONFIG=-` with piped stdin is allowed because
+   the env var is opting into the stdin path, not naming a separate
+   base.
 2. **Explicit flags** — flags whose `cmd.Flags().Changed(...)` bit is
    set replace the corresponding base field.
 3. **Defaults** — flags left at their default value do **not**
    override the base. This is what makes `--config` ergonomic:
    defaults can stay defaults while the file's intent is preserved.
 
+When the env var is the chosen source, the harness emits a single
+`slog.Debug` line naming the path (or `-`) so operators can audit
+precedence at debug log level without grepping the source.
+
 The positional `prompt` argument is a fallback only. It fills the
 prompt slot when the base omits it and `--prompt` is not set, but
 neither the base's `prompt` nor an explicit `--prompt` is overridden
 by a positional.
+
+### `STIRRUP_CONFIG` ergonomics
+
+`STIRRUP_CONFIG` mirrors `KUBECONFIG` and `AWS_CONFIG_FILE`: setting
+it once per shell session removes the need to retype `--config` on
+every invocation, while leaving the flag itself available for ad-hoc
+overrides.
+
+```sh
+export STIRRUP_CONFIG="$HOME/.config/stirrup/default.json"
+
+# Uses the env-var config.
+stirrup harness --prompt "explain this repo"
+
+# Explicit --config wins over the env var for this one invocation.
+stirrup harness --config ./experimental.json --prompt "try the new model"
+
+# Pipe a config in and ignore the env var path; STIRRUP_CONFIG=- opts
+# into stdin without naming a separate source.
+STIRRUP_CONFIG=- some-tool emit-config | stirrup harness --prompt "x"
+```
 
 ## Building RunConfigs interactively
 

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -4705,3 +4705,80 @@ type failWriteCloseWriter struct {
 
 func (f *failWriteCloseWriter) Write(p []byte) (int, error) { return 0, f.writeErr }
 func (f *failWriteCloseWriter) Close() error                { return f.closeErr }
+
+// TestRunHarness_EnvVarConfigLoadsBase pins the integration-level
+// guarantee for #241: STIRRUP_CONFIG, set in the environment with no
+// --config flag, must be threaded through runHarness → BuildRunConfig
+// → os.Getenv and consume the named file as the base RunConfig. The
+// unit tests in runconfigbuilder_test.go cover BuildRunConfig directly;
+// this test catches a future refactor of runHarness that drops the
+// delegation (e.g., reverts to an inline config-load path) which would
+// silently break env-var support without any of the unit tests failing.
+//
+// --output-runconfig=- short-circuits the provider invocation and
+// writes the resolved RunConfig to stdout so the assertion observes
+// the merged shape without booting the loop.
+func TestRunHarness_EnvVarConfigLoadsBase(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env-config.json")
+	envCfg := types.RunConfig{
+		RunID:  "from-env-integration",
+		Mode:   "planning",
+		Prompt: "prompt from STIRRUP_CONFIG",
+		Provider: types.ProviderConfig{
+			Type:      "anthropic",
+			APIKeyRef: "secret://ENV_INTEGRATION_KEY",
+		},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
+		Executor:        types.ExecutorConfig{Type: "local"},
+		EditStrategy:    types.EditStrategyConfig{Type: "multi"},
+		Verifier:        types.VerifierConfig{Type: "none"},
+		GitStrategy:     types.GitStrategyConfig{Type: "none"},
+		Transport:       types.TransportConfig{Type: "stdio"},
+		TraceEmitter:    types.TraceEmitterConfig{Type: "jsonl"},
+		PermissionPolicy: types.PermissionPolicyConfig{
+			Type: "deny-side-effects",
+		},
+		Tools: types.ToolsConfig{
+			BuiltIn: types.DefaultReadOnlyBuiltInTools(),
+		},
+		MaxTurns: 10,
+		LogLevel: "info",
+	}
+	timeout := 300
+	envCfg.Timeout = &timeout
+	body, err := json.Marshal(envCfg)
+	if err != nil {
+		t.Fatalf("marshal env cfg: %v", err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write env config: %v", err)
+	}
+	t.Setenv("STIRRUP_CONFIG", path)
+
+	getOut := captureStdout(t)
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("output-runconfig", "-"); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+
+	runErr := runHarness(cmd, nil)
+	out := getOut()
+
+	if runErr != nil {
+		t.Fatalf("runHarness with STIRRUP_CONFIG: %v\nstdout: %s", runErr, out)
+	}
+
+	var captured types.RunConfig
+	if err := json.Unmarshal([]byte(out), &captured); err != nil {
+		t.Fatalf("captured output should be parseable JSON: %v\n%s", err, out)
+	}
+	if captured.Prompt != "prompt from STIRRUP_CONFIG" {
+		t.Errorf("Prompt = %q, want %q (env-var base should load)", captured.Prompt, "prompt from STIRRUP_CONFIG")
+	}
+	if captured.Provider.APIKeyRef != "secret://ENV_INTEGRATION_KEY" {
+		t.Errorf("APIKeyRef = %q, want secret://ENV_INTEGRATION_KEY", captured.Provider.APIKeyRef)
+	}
+}

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strconv"
 
@@ -76,11 +77,16 @@ type RunConfigSources struct {
 //
 // Resolution order (lowest -> highest precedence):
 //  1. Defaults supplied by flag DefValues.
-//  2. Base RunConfig from --config <path>, --config -, or piped stdin
-//     when ConfigPath is empty and Stdin is non-TTY. The three base
-//     sources are mutually exclusive; passing both --config <path> and
-//     a piped stdin is a hard error so silent precedence surprises
-//     cannot happen in scripted pipelines.
+//  2. Base RunConfig from one of:
+//     a. --config <path> or --config - (explicit flag wins outright).
+//     b. STIRRUP_CONFIG env var (path or "-"; consulted only when the
+//        --config flag was not passed).
+//     c. Piped stdin auto-detected when ConfigPath is empty and Stdin
+//        is non-TTY.
+//     The base sources are mutually exclusive; combining a path-shaped
+//     source (--config or STIRRUP_CONFIG=<path>) with piped stdin is
+//     a hard error so silent precedence surprises cannot happen in
+//     scripted pipelines.
 //  3. Explicit flag overrides via applyOverrides (Changed()-gated, so
 //     a flag at its default value never clobbers a base field).
 //  4. applyAnthropicWIFOverrides (env-var + flag federation folding
@@ -154,6 +160,15 @@ func BuildRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 // non-TTY stdin is rejected with both sources cited, because the
 // alternative (silent precedence) would surprise pipeline authors
 // debugging which source landed which field.
+//
+// STIRRUP_CONFIG is a fourth-precedence fallback that fills the same
+// slot as --config when the flag was not passed. It accepts the same
+// shape as the flag: a filesystem path, or the literal "-" meaning
+// stdin. Combining STIRRUP_CONFIG=<path> with piped stdin is rejected
+// the same way --config <path> + piped stdin is, and the error cites
+// the env var by name so the operator knows which source to remove.
+// A STIRRUP_CONFIG=- + piped-stdin combination is fine because the
+// env var is opting into the stdin path, not naming a separate base.
 func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 	stdinPiped := isStdinPiped(sources.Stdin)
 	explicitStdin := sources.ConfigPath == "-"
@@ -162,13 +177,36 @@ func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 		filePath = sources.ConfigPath
 	}
 
+	// STIRRUP_CONFIG fills the --config slot only when the flag was not
+	// passed; an explicit --config always wins. Logged once at Debug so
+	// operators can audit precedence at runtime without grepping source.
+	envConfigSourced := false
+	if sources.ConfigPath == "" {
+		if envPath := os.Getenv("STIRRUP_CONFIG"); envPath != "" {
+			envConfigSourced = true
+			if envPath == "-" {
+				explicitStdin = true
+				slog.Debug("using STIRRUP_CONFIG=- as base RunConfig source (stdin)")
+			} else {
+				filePath = envPath
+				slog.Debug("using STIRRUP_CONFIG as base RunConfig source", "path", envPath)
+			}
+		}
+	}
+
 	if filePath != "" && stdinPiped {
+		if envConfigSourced {
+			return nil, fmt.Errorf("ambiguous config sources: both env var STIRRUP_CONFIG=%q and piped stdin specify a base config; pick one", filePath)
+		}
 		return nil, fmt.Errorf("ambiguous config sources: --config %q and piped stdin are both present; pick one", filePath)
 	}
 
 	switch {
 	case explicitStdin:
 		if !stdinPiped {
+			if envConfigSourced {
+				return nil, fmt.Errorf("STIRRUP_CONFIG=- requires piped stdin but stdin is a terminal")
+			}
 			return nil, fmt.Errorf("--config - requires piped stdin but stdin is a terminal")
 		}
 		return readRunConfigFromReader(sources.Stdin, "<stdin>")

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -77,16 +77,14 @@ type RunConfigSources struct {
 //
 // Resolution order (lowest -> highest precedence):
 //  1. Defaults supplied by flag DefValues.
-//  2. Base RunConfig from one of:
-//     a. --config <path> or --config - (explicit flag wins outright).
-//     b. STIRRUP_CONFIG env var (path or "-"; consulted only when the
-//        --config flag was not passed).
-//     c. Piped stdin auto-detected when ConfigPath is empty and Stdin
-//        is non-TTY.
-//     The base sources are mutually exclusive; combining a path-shaped
-//     source (--config or STIRRUP_CONFIG=<path>) with piped stdin is
-//     a hard error so silent precedence surprises cannot happen in
-//     scripted pipelines.
+//  2. Base RunConfig from --config <path>, --config -, the
+//     STIRRUP_CONFIG env var (path or "-", consulted only when the
+//     --config flag was not passed), or piped stdin auto-detected
+//     when ConfigPath is empty and Stdin is non-TTY. The base
+//     sources are mutually exclusive; combining a path-shaped source
+//     (--config or STIRRUP_CONFIG=<path>) with piped stdin is a hard
+//     error so silent precedence surprises cannot happen in scripted
+//     pipelines.
 //  3. Explicit flag overrides via applyOverrides (Changed()-gated, so
 //     a flag at its default value never clobbers a base field).
 //  4. applyAnthropicWIFOverrides (env-var + flag federation folding

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -176,18 +177,19 @@ func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 	}
 
 	// STIRRUP_CONFIG fills the --config slot only when the flag was not
-	// passed; an explicit --config always wins. Logged once at Debug so
-	// operators can audit precedence at runtime without grepping source.
+	// passed; an explicit --config always wins. Surrounding whitespace
+	// is trimmed because shell env-var editors and CI secret stores
+	// routinely smuggle in a stray newline or space — silently mapping
+	// `STIRRUP_CONFIG=" /path"` to `open  /path: no such file` would be
+	// a worse failure than treating the trimmed value as authoritative.
 	envConfigSourced := false
 	if sources.ConfigPath == "" {
-		if envPath := os.Getenv("STIRRUP_CONFIG"); envPath != "" {
+		if envPath := strings.TrimSpace(os.Getenv("STIRRUP_CONFIG")); envPath != "" {
 			envConfigSourced = true
 			if envPath == "-" {
 				explicitStdin = true
-				slog.Debug("using STIRRUP_CONFIG=- as base RunConfig source (stdin)")
 			} else {
 				filePath = envPath
-				slog.Debug("using STIRRUP_CONFIG as base RunConfig source", "path", envPath)
 			}
 		}
 	}
@@ -203,15 +205,28 @@ func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 	case explicitStdin:
 		if !stdinPiped {
 			if envConfigSourced {
+				if sources.Stdin == nil {
+					return nil, fmt.Errorf("STIRRUP_CONFIG=- requires piped stdin but no stdin reader was provided")
+				}
 				return nil, fmt.Errorf("STIRRUP_CONFIG=- requires piped stdin but stdin is a terminal")
 			}
 			return nil, fmt.Errorf("--config - requires piped stdin but stdin is a terminal")
+		}
+		if envConfigSourced {
+			slog.Debug("using STIRRUP_CONFIG as base RunConfig source", "path", "-")
 		}
 		return readRunConfigFromReader(sources.Stdin, "<stdin>")
 	case stdinPiped && filePath == "":
 		return readRunConfigFromReader(sources.Stdin, "<stdin>")
 	case filePath != "":
-		return loadRunConfigFile(filePath)
+		if envConfigSourced {
+			slog.Debug("using STIRRUP_CONFIG as base RunConfig source", "path", filePath)
+		}
+		cfg, err := loadRunConfigFile(filePath)
+		if err != nil && envConfigSourced {
+			return nil, fmt.Errorf("STIRRUP_CONFIG: %w", err)
+		}
+		return cfg, err
 	}
 
 	return buildFlagOnlyRunConfig(sources.Cmd, sources.Args)

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -725,3 +725,221 @@ func TestBuildRunConfig_WIFOverridesError(t *testing.T) {
 		t.Errorf("error should mention api-key-ref, got: %v", err)
 	}
 }
+
+// TestBuildRunConfig_EnvVarSuppliesBasePath pins the #241 fourth-rank
+// fallback: when --config is absent and stdin is not piped,
+// STIRRUP_CONFIG=<path> loads the file the flag would have loaded.
+// This is the "set once per shell session" ergonomic the env var
+// exists to provide.
+func TestBuildRunConfig_EnvVarSuppliesBasePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalRunConfigJSON(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("STIRRUP_CONFIG", path)
+
+	cmd := newTestHarnessCommand()
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.RunID != "from-file" {
+		t.Errorf("RunID = %q, want from-file (env-var base should load)", cfg.RunID)
+	}
+}
+
+// TestBuildRunConfig_ExplicitConfigBeatsEnvVar pins acceptance
+// criterion 2: when both --config and STIRRUP_CONFIG name a file, the
+// explicit flag wins. The env var must not silently leak its base
+// into a flag-driven invocation, or operators with the env var set
+// in their shell profile cannot override it ad-hoc.
+func TestBuildRunConfig_ExplicitConfigBeatsEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "env.json")
+	flagPath := filepath.Join(dir, "flag.json")
+
+	envCfg := types.RunConfig{
+		RunID:           "from-env",
+		Mode:            "planning",
+		Prompt:          "env prompt",
+		Provider:        types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://ENV_KEY"},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
+		Executor:        types.ExecutorConfig{Type: "local"},
+		EditStrategy:    types.EditStrategyConfig{Type: "multi"},
+		Verifier:        types.VerifierConfig{Type: "none"},
+		GitStrategy:     types.GitStrategyConfig{Type: "none"},
+		Transport:       types.TransportConfig{Type: "stdio"},
+		TraceEmitter:    types.TraceEmitterConfig{Type: "jsonl"},
+		PermissionPolicy: types.PermissionPolicyConfig{
+			Type: "deny-side-effects",
+		},
+		Tools:    types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		MaxTurns: 10,
+		LogLevel: "info",
+	}
+	envBytes, err := json.Marshal(envCfg)
+	if err != nil {
+		t.Fatalf("marshal env cfg: %v", err)
+	}
+	if err := os.WriteFile(envPath, envBytes, 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+	if err := os.WriteFile(flagPath, []byte(minimalRunConfigJSON(t)), 0o600); err != nil {
+		t.Fatalf("write flag file: %v", err)
+	}
+	t.Setenv("STIRRUP_CONFIG", envPath)
+
+	cmd := newTestHarnessCommand()
+	cfg, err := BuildRunConfig(RunConfigSources{
+		ConfigPath: flagPath,
+		Cmd:        cmd,
+		Resolve:    ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.RunID != "from-file" {
+		t.Errorf("RunID = %q, want from-file (explicit --config must beat STIRRUP_CONFIG)", cfg.RunID)
+	}
+}
+
+// TestBuildRunConfig_EnvVarDashOptsIntoStdin pins acceptance
+// criterion 3: STIRRUP_CONFIG=- treats the env var as a stdin opt-in,
+// mirroring `--config -`. Combined with a piped stdin, this loads the
+// base from the pipe rather than failing as ambiguous — the env var
+// is opting *into* the stdin path, not naming a separate source.
+func TestBuildRunConfig_EnvVarDashOptsIntoStdin(t *testing.T) {
+	t.Setenv("STIRRUP_CONFIG", "-")
+
+	cmd := newTestHarnessCommand()
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:   strings.NewReader(minimalRunConfigJSON(t)),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.RunID != "from-file" {
+		t.Errorf("RunID = %q, want from-file (stdin should load via STIRRUP_CONFIG=-)", cfg.RunID)
+	}
+}
+
+// TestBuildRunConfig_EnvVarPathPlusStdinIsAmbiguous pins acceptance
+// criterion 4: STIRRUP_CONFIG=<path> plus piped stdin must fail
+// loudly, the same way --config <path> + piped stdin already does.
+// The error must cite both sources — the env var by name and the
+// pipe — so the operator knows which source to remove.
+func TestBuildRunConfig_EnvVarPathPlusStdinIsAmbiguous(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalRunConfigJSON(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("STIRRUP_CONFIG", path)
+
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Stdin:   strings.NewReader(minimalRunConfigJSON(t)),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected STIRRUP_CONFIG=<path> + piped stdin to be rejected")
+	}
+	if !strings.Contains(err.Error(), "STIRRUP_CONFIG") {
+		t.Errorf("error should name STIRRUP_CONFIG, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "stdin") {
+		t.Errorf("error should cite stdin, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error should cite the env-var path, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_EnvVarDashRequiresStdin pins the mirror of
+// `--config -` without a pipe: STIRRUP_CONFIG=- with a TTY stdin is
+// nonsense (nothing to read). The error must name the env var so the
+// operator knows the env var, not the absent --config flag, is the
+// source of the failure.
+func TestBuildRunConfig_EnvVarDashRequiresStdin(t *testing.T) {
+	t.Setenv("STIRRUP_CONFIG", "-")
+
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Stdin:   nil,
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected STIRRUP_CONFIG=- with no piped stdin to be rejected")
+	}
+	if !strings.Contains(err.Error(), "STIRRUP_CONFIG=-") {
+		t.Errorf("error should cite STIRRUP_CONFIG=-, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_EnvVarEmptyIgnored pins that an empty
+// STIRRUP_CONFIG="" behaves identically to an unset env var — the
+// builder falls through to flag-only construction. An empty value
+// must not be treated as a path (loadRunConfigFile would error on
+// the empty string) nor as the stdin opt-in.
+func TestBuildRunConfig_EnvVarEmptyIgnored(t *testing.T) {
+	t.Setenv("STIRRUP_CONFIG", "")
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--mode", "execution",
+		"--prompt", "x",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveAll,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.Mode != "execution" {
+		t.Errorf("Mode = %q, want execution (empty env var should be ignored)", cfg.Mode)
+	}
+}
+
+// TestBuildRunConfig_EnvVarDebugLogged pins the spec's "single
+// slog.Debug line so operators can audit precedence" requirement: when
+// the env var is the chosen source, BuildRunConfig must emit a Debug
+// log entry that mentions STIRRUP_CONFIG.
+func TestBuildRunConfig_EnvVarDebugLogged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalRunConfigJSON(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("STIRRUP_CONFIG", path)
+
+	prevDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var logBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	cmd := newTestHarnessCommand()
+	if _, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	}); err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+
+	out := logBuf.String()
+	if !strings.Contains(out, "STIRRUP_CONFIG") {
+		t.Errorf("debug log should mention STIRRUP_CONFIG, got:\n%s", out)
+	}
+}

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -836,6 +836,11 @@ func TestBuildRunConfig_EnvVarDashOptsIntoStdin(t *testing.T) {
 // loudly, the same way --config <path> + piped stdin already does.
 // The error must cite both sources — the env var by name and the
 // pipe — so the operator knows which source to remove.
+//
+// Additionally pins B1: no debug log line claiming STIRRUP_CONFIG
+// was the chosen source may fire on the ambiguity path. Emitting
+// such a trace immediately before returning the ambiguity error
+// would directly contradict the error message.
 func TestBuildRunConfig_EnvVarPathPlusStdinIsAmbiguous(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cfg.json")
@@ -843,6 +848,11 @@ func TestBuildRunConfig_EnvVarPathPlusStdinIsAmbiguous(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 	t.Setenv("STIRRUP_CONFIG", path)
+
+	prevDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var logBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
 	cmd := newTestHarnessCommand()
 	_, err := BuildRunConfig(RunConfigSources{
@@ -862,6 +872,9 @@ func TestBuildRunConfig_EnvVarPathPlusStdinIsAmbiguous(t *testing.T) {
 	if !strings.Contains(err.Error(), path) {
 		t.Errorf("error should cite the env-var path, got: %v", err)
 	}
+	if strings.Contains(logBuf.String(), "STIRRUP_CONFIG") {
+		t.Errorf("ambiguity path must not emit a chosen-source debug trace, got:\n%s", logBuf.String())
+	}
 }
 
 // TestBuildRunConfig_EnvVarDashRequiresStdin pins the mirror of
@@ -869,6 +882,11 @@ func TestBuildRunConfig_EnvVarPathPlusStdinIsAmbiguous(t *testing.T) {
 // nonsense (nothing to read). The error must name the env var so the
 // operator knows the env var, not the absent --config flag, is the
 // source of the failure.
+//
+// Pins S2: when sources.Stdin is nil (embedded-API path with no
+// reader threaded through), the error must NOT claim "stdin is a
+// terminal" because that diagnosis is wrong — nil means no reader
+// was provided, not that a TTY is attached.
 func TestBuildRunConfig_EnvVarDashRequiresStdin(t *testing.T) {
 	t.Setenv("STIRRUP_CONFIG", "-")
 
@@ -883,6 +901,12 @@ func TestBuildRunConfig_EnvVarDashRequiresStdin(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "STIRRUP_CONFIG=-") {
 		t.Errorf("error should cite STIRRUP_CONFIG=-, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "terminal") {
+		t.Errorf("nil Stdin must not be diagnosed as a terminal, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no stdin reader") {
+		t.Errorf("error should describe the missing reader, got: %v", err)
 	}
 }
 
@@ -916,7 +940,8 @@ func TestBuildRunConfig_EnvVarEmptyIgnored(t *testing.T) {
 // TestBuildRunConfig_EnvVarDebugLogged pins the spec's "single
 // slog.Debug line so operators can audit precedence" requirement: when
 // the env var is the chosen source, BuildRunConfig must emit a Debug
-// log entry that mentions STIRRUP_CONFIG.
+// log entry that mentions STIRRUP_CONFIG and carries the structured
+// "path" field so log consumers can filter on a stable key.
 func TestBuildRunConfig_EnvVarDebugLogged(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cfg.json")
@@ -941,5 +966,90 @@ func TestBuildRunConfig_EnvVarDebugLogged(t *testing.T) {
 	out := logBuf.String()
 	if !strings.Contains(out, "STIRRUP_CONFIG") {
 		t.Errorf("debug log should mention STIRRUP_CONFIG, got:\n%s", out)
+	}
+	if !strings.Contains(out, "path=") {
+		t.Errorf("debug log should carry structured path field, got:\n%s", out)
+	}
+}
+
+// TestBuildRunConfig_EnvVarDashDebugLogged mirrors the path-branch
+// log assertion for the STIRRUP_CONFIG=- form: the same message and
+// the same structured "path" key (value "-") must fire so log
+// consumers can filter on a single key regardless of which env-var
+// shape the operator chose.
+func TestBuildRunConfig_EnvVarDashDebugLogged(t *testing.T) {
+	t.Setenv("STIRRUP_CONFIG", "-")
+
+	prevDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var logBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	cmd := newTestHarnessCommand()
+	if _, err := BuildRunConfig(RunConfigSources{
+		Stdin:   strings.NewReader(minimalRunConfigJSON(t)),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	}); err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+
+	out := logBuf.String()
+	if !strings.Contains(out, "STIRRUP_CONFIG") {
+		t.Errorf("debug log should mention STIRRUP_CONFIG, got:\n%s", out)
+	}
+	if !strings.Contains(out, "path=-") {
+		t.Errorf("debug log should carry path=- structured field, got:\n%s", out)
+	}
+}
+
+// TestBuildRunConfig_EnvVarPathNotFound pins S1: when STIRRUP_CONFIG
+// names a file that does not exist, the error must name the env var
+// so the operator can tell whether the bad path came from --config or
+// the env var. Without this wrap an operator with both --config in
+// muscle memory and STIRRUP_CONFIG in their shell profile would chase
+// the wrong source.
+func TestBuildRunConfig_EnvVarPathNotFound(t *testing.T) {
+	t.Setenv("STIRRUP_CONFIG", "/no/such/stirrup/config/file.json")
+
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err == nil {
+		t.Fatal("expected STIRRUP_CONFIG with non-existent path to fail")
+	}
+	if !strings.Contains(err.Error(), "STIRRUP_CONFIG") {
+		t.Errorf("error should name STIRRUP_CONFIG so operator knows the source, got: %v", err)
+	}
+}
+
+// TestBuildRunConfig_EnvVarLeadingWhitespaceTrimmed pins S5: a
+// STIRRUP_CONFIG value with leading or trailing whitespace must be
+// trimmed before use. Shell env-var editors and CI secret stores
+// routinely smuggle in a stray newline or space; the alternative
+// behaviour ("open  /path: no such file" with a spurious leading
+// space) is a worse failure than treating the trimmed value as
+// authoritative. This test pins the trim contract so the choice
+// cannot silently regress.
+func TestBuildRunConfig_EnvVarLeadingWhitespaceTrimmed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalRunConfigJSON(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("STIRRUP_CONFIG", "  "+path+"\n")
+
+	cmd := newTestHarnessCommand()
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig should trim whitespace and load file, got: %v", err)
+	}
+	if cfg.RunID != "from-file" {
+		t.Errorf("RunID = %q, want from-file (trimmed env path should resolve)", cfg.RunID)
 	}
 }


### PR DESCRIPTION
Closes #241

## Summary

Adds `STIRRUP_CONFIG` as a fourth-rank fallback in the `BuildRunConfig` precedence chain, mirroring `KUBECONFIG` / `AWS_CONFIG_FILE`. Operators who use one RunConfig across many invocations can set it once per shell session instead of retyping `--config` or wrapping the binary in an alias. An explicit `--config` always wins over the env var, so an ad-hoc override is still a one-flag affair; combining `STIRRUP_CONFIG=<path>` with piped stdin is rejected the same way `--config <path>` + piped stdin already is, with an error that cites the env var by name so the source of the failure is unambiguous.

The change layers cleanly into the #240 precedence work: the entire env-var read lives inside `loadBaseRunConfig` so all four base-source decisions stay in one switch statement rather than splitting across `runHarness` and the helper.

A single `slog.Debug` line fires when the env var is the chosen source so operators can audit precedence at debug log level.

## Base branch

This PR targets `feat/issue-240-runconfig-generator`, not `main`. PR #251 (the #240 PR) is open but unmerged; targeting it as the base keeps the diff scoped to only #241's changes. GitHub will auto-retarget this PR to `main` when #251 merges.

## Test plan

- [x] `STIRRUP_CONFIG=/path stirrup harness --output-runconfig -` emits the env-var config
- [x] `STIRRUP_CONFIG=/path stirrup harness --config /other.json --output-runconfig -` emits `/other.json` (flag wins)
- [x] `STIRRUP_CONFIG=- stirrup harness --output-runconfig - < cfg.json` reads from stdin
- [x] `STIRRUP_CONFIG=/path stirrup harness --output-runconfig - < cfg.json` exits 1 with `ambiguous config sources: both env var STIRRUP_CONFIG="..." and piped stdin specify a base config`
- [x] `just test` (`go test ./harness/... ./types/... ./eval/...`) green
- [x] `golangci-lint run ./harness/cmd/stirrup/cmd/...` clean
- [x] Six new test cases in `runconfigbuilder_test.go` cover env-var supplies-base, explicit-flag-wins, dash-opts-into-stdin, path+stdin-ambiguous, dash-requires-stdin, empty-ignored, and debug-logged paths