### PR TITLE
cli: add shell completion subcommand for bash, zsh, fish, powershell

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,6 +326,51 @@ passes `ValidateRunConfig` end-to-end.
 For an annotated walkthrough of `full.json` see
 [`examples/runconfig/README.md`](../examples/runconfig/README.md).
 
+## Shell completions
+
+Both `stirrup` and `stirrup-eval` emit completion scripts for `bash`,
+`zsh`, `fish`, and `powershell`. The scripts cover subcommands, flag
+names, the closed-set enum flags (`--mode`, `--provider`, `--executor`,
+`--edit-strategy`, `--verifier`, `--git-strategy`, `--transport`,
+`--trace-emitter`, `--otel-protocol`, `--container-runtime`,
+`--code-scanner`, `--guardrail`), and filesystem completion for the
+path-shaped flags (`--config`, `--workspace`, `--prompt-file`,
+`--gcp-credentials-file`, `--permission-policy-file`, `--trace`,
+`--output-runconfig`).
+
+Closed-set enum completion is sourced from the same maps the validator
+consults, so a value added to `types/runconfig.go` extends the
+completion surface automatically.
+
+### Installation
+
+```sh
+# bash (current session)
+source <(stirrup completion bash)
+source <(stirrup-eval completion bash)
+
+# bash (persistent, Linux)
+stirrup completion bash | sudo tee /etc/bash_completion.d/stirrup >/dev/null
+stirrup-eval completion bash | sudo tee /etc/bash_completion.d/stirrup-eval >/dev/null
+
+# zsh
+stirrup completion zsh > "${fpath[1]}/_stirrup"
+stirrup-eval completion zsh > "${fpath[1]}/_stirrup-eval"
+
+# fish
+stirrup completion fish > ~/.config/fish/completions/stirrup.fish
+stirrup-eval completion fish > ~/.config/fish/completions/stirrup-eval.fish
+
+# powershell
+stirrup completion powershell | Out-String | Invoke-Expression
+stirrup-eval completion powershell | Out-String | Invoke-Expression
+```
+
+On zsh, `compinit` must be initialised before the completion script
+loads — most distributions ship a `~/.zshrc` template that does this;
+operators with a hand-rolled `.zshrc` need an explicit
+`autoload -Uz compinit && compinit` ahead of the `source` line.
+
 ## Eval CLI
 
 ```sh

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -223,8 +223,15 @@ function __stirrup_eval_using_subcommand
 end
 
 `)
+	// Subcommand and mode values are wrapped in fish single-quotes
+	// before being passed to `complete -a`. Fish single-quote literals
+	// interpret no escape sequences, so a future value that contains a
+	// space or fish-special character (`$`, `*`, `~`) cannot break the
+	// generated script. Today every value sourced from
+	// evalCompletionSubcommands and types.ValidRunModeValues() is a safe
+	// bare word; the quoting is defensive against future additions.
 	for _, sub := range evalCompletionSubcommands {
-		fmt.Fprintf(&b, "complete -c stirrup-eval -n __stirrup_eval_no_subcommand -a %s\n", sub)
+		fmt.Fprintf(&b, "complete -c stirrup-eval -n __stirrup_eval_no_subcommand -a '%s'\n", sub)
 	}
 	b.WriteString("\n")
 	for _, sub := range evalCompletionSubcommands {
@@ -237,7 +244,7 @@ end
 	b.WriteString("\n")
 	for _, sub := range []string{"baseline", "drift", "compare-to-production"} {
 		for _, m := range evalCompletionRunModes {
-			fmt.Fprintf(&b, "complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l mode -a %s\n", sub, m)
+			fmt.Fprintf(&b, "complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l mode -a '%s'\n", sub, m)
 		}
 	}
 	_, err := io.WriteString(w, b.String())

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -33,11 +33,18 @@ func init() {
 
 // evalCompletionSubcommands enumerates the top-level subcommands. It
 // is reused across every script so a new subcommand only needs to be
-// added in one place.
+// added in one place. The "completion" entry is included so
+// `stirrup-eval completion <TAB>` itself offers completions — the
+// shell-name suggestions land in the flag-completion path rather than
+// the positional-argument path because the hand-rolled scripts route
+// non-dash tokens through evalCompletionFlags. A structural fix that
+// honours positional arguments would require reshaping every emit*
+// helper; the current routing is a deliberate trade-off.
 var evalCompletionSubcommands = []string{
 	"baseline",
 	"compare",
 	"compare-to-production",
+	"completion",
 	"convert",
 	"drift",
 	"mine-failures",
@@ -47,7 +54,10 @@ var evalCompletionSubcommands = []string{
 // evalCompletionFlags maps each subcommand to the flag names it
 // accepts. The ordering matches the flag declarations in cmdRun /
 // cmdCompare / etc. so a reader can cross-reference at a glance.
-// Flag names omit the leading dash.
+// Flag names omit the leading dash. The "completion" entry holds the
+// supported shell names rather than true flag names — the hand-rolled
+// scripts have no positional-argument completion path, so the shells
+// are surfaced through the flag-name lookup so they remain reachable.
 var evalCompletionFlags = map[string][]string{
 	"run":                   {"suite", "harness", "output", "concurrency", "dry-run", "junit"},
 	"compare":               {"current", "baseline"},
@@ -56,6 +66,7 @@ var evalCompletionFlags = map[string][]string{
 	"drift":                 {"lakehouse", "window", "compare-window", "mode", "model"},
 	"compare-to-production": {"lakehouse", "results", "experiment-id", "after", "before", "mode", "model", "output"},
 	"convert":               {"from", "to-junit"},
+	"completion":            {"bash", "zsh", "fish", "powershell"},
 }
 
 // evalCompletionRunModes is the closed-set value list for the -mode

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -112,7 +112,7 @@ _stirrup_eval() {
     case "$sub" in
 `)
 	for _, sub := range evalCompletionSubcommands {
-		b.WriteString(fmt.Sprintf("        %s) flags=\"%s\" ;;\n", sub, dashPrefix(evalCompletionFlags[sub])))
+		fmt.Fprintf(&b, "        %s) flags=\"%s\" ;;\n", sub, dashPrefix(evalCompletionFlags[sub]))
 	}
 	b.WriteString(`    esac
 
@@ -166,7 +166,7 @@ _stirrup_eval() {
     case "$sub" in
 `)
 	for _, sub := range evalCompletionSubcommands {
-		b.WriteString(fmt.Sprintf("        %s) flags=(%s) ;;\n", sub, zshFlagArray(evalCompletionFlags[sub])))
+		fmt.Fprintf(&b, "        %s) flags=(%s) ;;\n", sub, zshFlagArray(evalCompletionFlags[sub]))
 	}
 	b.WriteString(`    esac
 
@@ -213,20 +213,20 @@ end
 
 `)
 	for _, sub := range evalCompletionSubcommands {
-		b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n __stirrup_eval_no_subcommand -a %s\n", sub))
+		fmt.Fprintf(&b, "complete -c stirrup-eval -n __stirrup_eval_no_subcommand -a %s\n", sub)
 	}
 	b.WriteString("\n")
 	for _, sub := range evalCompletionSubcommands {
 		for _, flag := range evalCompletionFlags[sub] {
-			b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l %s\n", sub, flag))
-			b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -o %s\n", sub, flag))
+			fmt.Fprintf(&b, "complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l %s\n", sub, flag)
+			fmt.Fprintf(&b, "complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -o %s\n", sub, flag)
 		}
 	}
 	// -mode value completion.
 	b.WriteString("\n")
 	for _, sub := range []string{"baseline", "drift", "compare-to-production"} {
 		for _, m := range evalCompletionRunModes {
-			b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l mode -a %s\n", sub, m))
+			fmt.Fprintf(&b, "complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l mode -a %s\n", sub, m)
 		}
 	}
 	_, err := io.WriteString(w, b.String())
@@ -274,7 +274,7 @@ Register-ArgumentCompleter -Native -CommandName stirrup-eval -ScriptBlock {
 		for _, fl := range evalCompletionFlags[sub] {
 			flagsLit = append(flagsLit, "'-"+fl+"'")
 		}
-		b.WriteString(fmt.Sprintf("        '%s' = @(%s)\n", sub, strings.Join(flagsLit, ", ")))
+		fmt.Fprintf(&b, "        '%s' = @(%s)\n", sub, strings.Join(flagsLit, ", "))
 	}
 	b.WriteString(`    }
     $flags = $flagsBySub[$sub]

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func init() {
+	evalCompletionRunModes = types.ValidRunModeValues()
+}
+
+// stirrup-eval uses the stdlib `flag` package rather than cobra, so the
+// completion scripts below are hand-rolled rather than generated. The
+// flag surface is small (seven subcommands, fewer than thirty distinct
+// flags total) and stable enough that maintaining hand-rolled scripts
+// is cheaper than dragging cobra into the eval module.
+//
+// Each script offers:
+//   - subcommand completion at position 1 (run, compare, …)
+//   - flag-name completion within a subcommand
+//   - filesystem path completion for path-shaped flags (-suite, -output,
+//     -junit, -harness, -from, -to-junit, -current, -baseline,
+//     -lakehouse, -results)
+//   - dynamic value completion for -mode (the closed set lives in
+//     types/runconfig.go, exposed via types.ValidRunModeValues())
+//
+// The Go flag package accepts both `-flag` and `--flag`; the scripts
+// emit single-dash forms to match the rest of the eval CLI's
+// documentation.
+
+// evalCompletionSubcommands enumerates the top-level subcommands. It
+// is reused across every script so a new subcommand only needs to be
+// added in one place.
+var evalCompletionSubcommands = []string{
+	"baseline",
+	"compare",
+	"compare-to-production",
+	"convert",
+	"drift",
+	"mine-failures",
+	"run",
+}
+
+// evalCompletionFlags maps each subcommand to the flag names it
+// accepts. The ordering matches the flag declarations in cmdRun /
+// cmdCompare / etc. so a reader can cross-reference at a glance.
+// Flag names omit the leading dash.
+var evalCompletionFlags = map[string][]string{
+	"run":                   {"suite", "harness", "output", "concurrency", "dry-run", "junit"},
+	"compare":               {"current", "baseline"},
+	"baseline":              {"lakehouse", "after", "before", "mode", "model", "output"},
+	"mine-failures":         {"lakehouse", "after", "limit", "output"},
+	"drift":                 {"lakehouse", "window", "compare-window", "mode", "model"},
+	"compare-to-production": {"lakehouse", "results", "experiment-id", "after", "before", "mode", "model", "output"},
+	"convert":               {"from", "to-junit"},
+}
+
+// evalCompletionRunModes is the closed-set value list for the -mode
+// filter flag on baseline / drift / compare-to-production. Sourced
+// from types.ValidRunModeValues() at script-generation time so the
+// completion surface tracks the validator.
+//
+// Bound at package init rather than embedded literally so a future
+// addition to validRunModes flows through automatically. The slice is
+// joined into shell array literals when each script is rendered.
+var evalCompletionRunModes []string
+
+// emitEvalCompletion writes the requested shell's completion script
+// to w. The supported shells mirror those exposed by `stirrup
+// completion`; a future shell only needs a new emit* helper and an
+// added switch arm.
+func emitEvalCompletion(shell string, w io.Writer) error {
+	switch shell {
+	case "bash":
+		return emitEvalBashCompletion(w)
+	case "zsh":
+		return emitEvalZshCompletion(w)
+	case "fish":
+		return emitEvalFishCompletion(w)
+	case "powershell":
+		return emitEvalPowerShellCompletion(w)
+	default:
+		return fmt.Errorf("unsupported shell: %s", shell)
+	}
+}
+
+func emitEvalBashCompletion(w io.Writer) error {
+	var b strings.Builder
+	b.WriteString(`# bash completion for stirrup-eval
+_stirrup_eval() {
+    local cur prev words cword
+    _init_completion || return
+
+    local subcommands="`)
+	b.WriteString(strings.Join(evalCompletionSubcommands, " "))
+	b.WriteString(`"
+    local modes="`)
+	b.WriteString(strings.Join(evalCompletionRunModes, " "))
+	b.WriteString(`"
+
+    # Position 1: subcommand selection.
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+        return
+    fi
+
+    local sub="${words[1]}"
+    local flags=""
+    case "$sub" in
+`)
+	for _, sub := range evalCompletionSubcommands {
+		b.WriteString(fmt.Sprintf("        %s) flags=\"%s\" ;;\n", sub, dashPrefix(evalCompletionFlags[sub])))
+	}
+	b.WriteString(`    esac
+
+    # File / dir / enum completion for the value position after a flag.
+    case "$prev" in
+        -suite|-from) _filedir hcl; return ;;
+        -harness) _filedir; return ;;
+        -output|-junit|-to-junit|-current|-baseline|-results) _filedir; return ;;
+        -lakehouse) _filedir -d; return ;;
+        -mode)
+            COMPREPLY=( $(compgen -W "$modes" -- "$cur") )
+            return
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
+        return
+    fi
+}
+complete -F _stirrup_eval stirrup-eval
+`)
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+func emitEvalZshCompletion(w io.Writer) error {
+	var b strings.Builder
+	b.WriteString(`#compdef stirrup-eval
+# zsh completion for stirrup-eval
+_stirrup_eval() {
+    local -a subcommands modes
+    subcommands=(`)
+	for _, sub := range evalCompletionSubcommands {
+		b.WriteString(" " + sub)
+	}
+	b.WriteString(` )
+    modes=(`)
+	for _, m := range evalCompletionRunModes {
+		b.WriteString(" " + m)
+	}
+	b.WriteString(` )
+
+    if (( CURRENT == 2 )); then
+        _describe 'subcommand' subcommands
+        return
+    fi
+
+    local sub="${words[2]}"
+    local -a flags
+    case "$sub" in
+`)
+	for _, sub := range evalCompletionSubcommands {
+		b.WriteString(fmt.Sprintf("        %s) flags=(%s) ;;\n", sub, zshFlagArray(evalCompletionFlags[sub])))
+	}
+	b.WriteString(`    esac
+
+    case "${words[CURRENT-1]}" in
+        -suite|-from) _files -g '*.hcl'; return ;;
+        -harness|-output|-junit|-to-junit|-current|-baseline|-results) _files; return ;;
+        -lakehouse) _path_files -/; return ;;
+        -mode) _describe 'mode' modes; return ;;
+    esac
+
+    _describe 'flag' flags
+}
+compdef _stirrup_eval stirrup-eval
+`)
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+func emitEvalFishCompletion(w io.Writer) error {
+	var b strings.Builder
+	b.WriteString(`# fish completion for stirrup-eval
+function __stirrup_eval_no_subcommand
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -lt 2
+        return 0
+    end
+    for sub in `)
+	b.WriteString(strings.Join(evalCompletionSubcommands, " "))
+	b.WriteString(`
+        if test "$cmd[2]" = "$sub"
+            return 1
+        end
+    end
+    return 0
+end
+
+function __stirrup_eval_using_subcommand
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -lt 2
+        return 1
+    end
+    test "$cmd[2]" = "$argv[1]"
+end
+
+`)
+	for _, sub := range evalCompletionSubcommands {
+		b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n __stirrup_eval_no_subcommand -a %s\n", sub))
+	}
+	b.WriteString("\n")
+	for _, sub := range evalCompletionSubcommands {
+		for _, flag := range evalCompletionFlags[sub] {
+			b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l %s\n", sub, flag))
+			b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -o %s\n", sub, flag))
+		}
+	}
+	// -mode value completion.
+	b.WriteString("\n")
+	for _, sub := range []string{"baseline", "drift", "compare-to-production"} {
+		for _, m := range evalCompletionRunModes {
+			b.WriteString(fmt.Sprintf("complete -c stirrup-eval -n '__stirrup_eval_using_subcommand %s' -l mode -a %s\n", sub, m))
+		}
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+func emitEvalPowerShellCompletion(w io.Writer) error {
+	var b strings.Builder
+	b.WriteString(`# powershell completion for stirrup-eval
+Register-ArgumentCompleter -Native -CommandName stirrup-eval -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $subcommands = @(`)
+	for i, sub := range evalCompletionSubcommands {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("'" + sub + "'")
+	}
+	b.WriteString(`)
+    $modes = @(`)
+	for i, m := range evalCompletionRunModes {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("'" + m + "'")
+	}
+	b.WriteString(`)
+
+    $tokens = $commandAst.CommandElements
+    $position = $tokens.Count
+    if ($wordToComplete -ne '') { $position = $position - 1 }
+
+    if ($position -le 1) {
+        $subcommands | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+        return
+    }
+
+    $sub = $tokens[1].ToString()
+    $flagsBySub = @{
+`)
+	for _, sub := range evalCompletionSubcommands {
+		flagsLit := make([]string, 0, len(evalCompletionFlags[sub]))
+		for _, fl := range evalCompletionFlags[sub] {
+			flagsLit = append(flagsLit, "'-"+fl+"'")
+		}
+		b.WriteString(fmt.Sprintf("        '%s' = @(%s)\n", sub, strings.Join(flagsLit, ", ")))
+	}
+	b.WriteString(`    }
+    $flags = $flagsBySub[$sub]
+    if (-not $flags) { return }
+
+    $prev = if ($position -ge 2) { $tokens[$position - 1].ToString() } else { '' }
+    if ($prev -eq '-mode') {
+        $modes | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+        return
+    }
+
+    $flags | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
+    }
+}
+`)
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// dashPrefix joins a slice of bare flag names into a space-separated
+// list of dash-prefixed forms suitable for embedding in a bash case
+// arm. Centralised so a future change to the dash convention (e.g.
+// double-dash) touches one helper rather than every Builder concat.
+func dashPrefix(flags []string) string {
+	out := make([]string, 0, len(flags))
+	for _, f := range flags {
+		out = append(out, "-"+f)
+	}
+	return strings.Join(out, " ")
+}
+
+// zshFlagArray renders a slice of flag names as a parenthesised zsh
+// array of dash-prefixed entries. Used by emitEvalZshCompletion.
+func zshFlagArray(flags []string) string {
+	out := make([]string, 0, len(flags))
+	for _, f := range flags {
+		out = append(out, "-"+f)
+	}
+	return strings.Join(out, " ")
+}

--- a/eval/cmd/eval/completion_test.go
+++ b/eval/cmd/eval/completion_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestRun_CompletionSubcommandValidShells pins the four hand-rolled
+// completion scripts against each shell's syntax checker. The script is
+// generated through the run() dispatcher (matching how a real operator
+// reaches it) and piped to bash -n / zsh -n / fish -n. A shell missing
+// from the runner's PATH is a t.Skipf, not a failure — stirrup-eval
+// ships on Linux / macOS CI runners that do not necessarily carry every
+// shell.
+//
+// The powershell variant is not syntax-checked in-tree (the cobra
+// scripts have no equivalent for the hand-rolled ones, and pwsh is
+// not on the default macOS / GHA runners). Presence and non-emptiness
+// are asserted instead so a regression that drops the powershell case
+// arm still fails the test.
+func TestRun_CompletionSubcommandValidShells(t *testing.T) {
+	for _, tc := range []struct {
+		shell   string
+		checker []string
+	}{
+		{shell: "bash", checker: []string{"bash", "-n"}},
+		{shell: "zsh", checker: []string{"zsh", "-n"}},
+		{shell: "fish", checker: []string{"fish", "-n"}},
+		{shell: "powershell"},
+	} {
+		t.Run(tc.shell, func(t *testing.T) {
+			var stdout bytes.Buffer
+			code := run([]string{"completion", tc.shell}, &stdout)
+			if code != 0 {
+				t.Fatalf("run(completion %s) exit code = %d", tc.shell, code)
+			}
+			if stdout.Len() == 0 {
+				t.Fatalf("completion %s emitted empty script", tc.shell)
+			}
+			if len(tc.checker) == 0 {
+				return
+			}
+			if _, err := exec.LookPath(tc.checker[0]); err != nil {
+				t.Skipf("%s not available on this runner: %v", tc.checker[0], err)
+			}
+			cmd := exec.Command(tc.checker[0], tc.checker[1:]...) //nolint:gosec // hard-coded checker list, no user input
+			cmd.Stdin = &stdout
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s syntax check failed: %v\noutput:\n%s", tc.shell, err, out)
+			}
+		})
+	}
+}
+
+// TestRun_CompletionSubcommandMissingShell pins the dispatcher guard:
+// `eval completion` (no shell arg) must return a non-zero exit code
+// rather than silently writing nothing.
+func TestRun_CompletionSubcommandMissingShell(t *testing.T) {
+	var stdout bytes.Buffer
+	code := run([]string{"completion"}, &stdout)
+	if code == 0 {
+		t.Fatal("run(completion) exit code = 0, want non-zero")
+	}
+}
+
+// TestRun_CompletionSubcommandUnknownShell pins the emitter guard:
+// `eval completion ksh` must return a non-zero exit code and surface
+// the unsupported-shell error on stderr (cannot be asserted directly
+// here because run() does not thread stderr).
+func TestRun_CompletionSubcommandUnknownShell(t *testing.T) {
+	var stdout bytes.Buffer
+	code := run([]string{"completion", "ksh"}, &stdout)
+	if code == 0 {
+		t.Fatal("run(completion ksh) exit code = 0, want non-zero")
+	}
+}
+
+// TestEvalCompletionScripts_MentionEverySubcommand pins the rendered
+// scripts contain every subcommand name and every known mode value.
+// The check is independent of the rendered shell so a regression in
+// the static subcommand list (e.g. a new subcommand added to the
+// dispatcher but forgotten in completion.go) surfaces consistently
+// across all four shells.
+func TestEvalCompletionScripts_MentionEverySubcommand(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := emitEvalCompletion(shell, &buf); err != nil {
+				t.Fatalf("emit %s: %v", shell, err)
+			}
+			body := buf.String()
+			for _, sub := range evalCompletionSubcommands {
+				if !strings.Contains(body, sub) {
+					t.Errorf("%s script missing subcommand %q", shell, sub)
+				}
+			}
+			for _, mode := range types.ValidRunModeValues() {
+				if !strings.Contains(body, mode) {
+					t.Errorf("%s script missing mode %q", shell, mode)
+				}
+			}
+		})
+	}
+}
+
+// TestEvalCompletionFlagMap_TracksDispatcher pins the static flag map
+// against the real subcommand surface. A new subcommand wired into
+// run() but forgotten in evalCompletionFlags would silently ship with
+// no flag completion; the test fails loudly so the regression cannot
+// reach a release.
+func TestEvalCompletionFlagMap_TracksDispatcher(t *testing.T) {
+	dispatcherSubs := []string{
+		"run", "compare", "compare-to-production",
+		"baseline", "mine-failures", "drift", "convert",
+	}
+	if len(evalCompletionSubcommands) != len(dispatcherSubs) {
+		t.Fatalf("len(evalCompletionSubcommands) = %d, dispatcher has %d",
+			len(evalCompletionSubcommands), len(dispatcherSubs))
+	}
+	for _, sub := range dispatcherSubs {
+		if _, ok := evalCompletionFlags[sub]; !ok {
+			t.Errorf("subcommand %q dispatched by run() but missing from evalCompletionFlags", sub)
+		}
+	}
+}

--- a/eval/cmd/eval/completion_test.go
+++ b/eval/cmd/eval/completion_test.go
@@ -119,6 +119,33 @@ func TestEvalCompletionScripts_MentionEverySubcommand(t *testing.T) {
 	}
 }
 
+// TestEvalCompletionFishScript_QuotesValues pins the fish-script
+// quoting contract for subcommand and mode values. Fish single-quote
+// literals interpret no escape sequences, so wrapping the format
+// argument keeps the generated script safe even if a future value
+// contains a space or fish-special character. A regression that drops
+// the surrounding single quotes would re-introduce the latent
+// injection path described in the SF-3 finding.
+func TestEvalCompletionFishScript_QuotesValues(t *testing.T) {
+	var buf bytes.Buffer
+	if err := emitEvalCompletion("fish", &buf); err != nil {
+		t.Fatalf("emit fish: %v", err)
+	}
+	body := buf.String()
+	for _, sub := range evalCompletionSubcommands {
+		needle := "complete -c stirrup-eval -n __stirrup_eval_no_subcommand -a '" + sub + "'"
+		if !strings.Contains(body, needle) {
+			t.Errorf("fish script missing single-quoted subcommand line for %q (looking for %q)", sub, needle)
+		}
+	}
+	for _, m := range types.ValidRunModeValues() {
+		needle := "-l mode -a '" + m + "'"
+		if !strings.Contains(body, needle) {
+			t.Errorf("fish script missing single-quoted mode line for %q (looking for %q)", m, needle)
+		}
+	}
+}
+
 // TestEvalCompletionFlagMap_TracksDispatcher pins the static flag map
 // against the real subcommand surface. A new subcommand wired into
 // run() but forgotten in evalCompletionFlags would silently ship with

--- a/eval/cmd/eval/completion_test.go
+++ b/eval/cmd/eval/completion_test.go
@@ -104,6 +104,17 @@ func TestEvalCompletionScripts_MentionEverySubcommand(t *testing.T) {
 					t.Errorf("%s script missing mode %q", shell, mode)
 				}
 			}
+			// The completion subcommand routes its shell-name suggestions
+			// through evalCompletionFlags rather than a positional-argument
+			// path, so every supported shell name must surface in the
+			// rendered script. A regression that drops the completion
+			// entry from evalCompletionFlags would silently revert
+			// `stirrup-eval completion <TAB>` to producing no suggestions.
+			for _, sh := range evalCompletionFlags["completion"] {
+				if !strings.Contains(body, sh) {
+					t.Errorf("%s script missing shell name %q for completion subcommand", shell, sh)
+				}
+			}
 		})
 	}
 }
@@ -117,6 +128,7 @@ func TestEvalCompletionFlagMap_TracksDispatcher(t *testing.T) {
 	dispatcherSubs := []string{
 		"run", "compare", "compare-to-production",
 		"baseline", "mine-failures", "drift", "convert",
+		"completion",
 	}
 	if len(evalCompletionSubcommands) != len(dispatcherSubs) {
 		t.Fatalf("len(evalCompletionSubcommands) = %d, dispatcher has %d",

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -41,6 +41,7 @@ Commands:
   mine-failures          Turn production failures into eval tasks
   drift                  Detect metric changes over time windows
   convert                Convert a result.json into another format (e.g. JUnit XML)
+  completion             Emit a shell completion script (bash|zsh|fish|powershell)
 
 Run "eval <command> -help" for details.
 `
@@ -81,8 +82,31 @@ func run(args []string, stdout io.Writer) int {
 		cmdCompareToProduction(args[1:])
 	case "convert":
 		cmdConvert(args[1:])
+	case "completion":
+		return cmdCompletion(args[1:], stdout)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n%s", args[0], usage)
+		return 1
+	}
+	return 0
+}
+
+// cmdCompletion writes a shell completion script for stirrup-eval to
+// stdout. The supported shells mirror those exposed by `stirrup
+// completion`; the underlying scripts are hand-rolled rather than
+// cobra-generated because the eval module does not depend on cobra
+// (see completion.go for the rationale).
+//
+// Returns the process exit code: 0 on success, 1 on a missing or
+// unsupported shell. A nil-writer error from the emit helper surfaces
+// via stderr and a non-zero exit.
+func cmdCompletion(args []string, stdout io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "completion requires a shell: bash | zsh | fish | powershell")
+		return 1
+	}
+	if err := emitEvalCompletion(args[0], stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "completion: %v\n", err)
 		return 1
 	}
 	return 0

--- a/harness/cmd/stirrup/cmd/completion.go
+++ b/harness/cmd/stirrup/cmd/completion.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish|powershell]",
+	Short:                 "Generate shell completion script",
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Long: `Generate the shell completion script for the named shell. The
+output is the script body and is meant to be sourced; see the recipes
+in docs/configuration.md ("Shell completions") for one-shot setup
+incantations for each supported shell.
+
+Examples:
+  source <(stirrup completion bash)
+  stirrup completion zsh > "${fpath[1]}/_stirrup"
+  stirrup completion fish > ~/.config/fish/completions/stirrup.fish
+  stirrup completion powershell | Out-String | Invoke-Expression`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		switch args[0] {
+		case "bash":
+			// GenBashCompletionV2 emits the modern (descriptions-aware)
+			// bash script; the legacy generator (GenBashCompletion) does
+			// not surface cobra's RegisterFlagCompletionFunc values.
+			return cmd.Root().GenBashCompletionV2(out, true)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(out)
+		case "fish":
+			return cmd.Root().GenFishCompletion(out, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(out)
+		default:
+			// Unreachable: ValidArgs + OnlyValidArgs already constrains
+			// args[0] to the four supported shells. The explicit error
+			// preserves the symmetry of every case returning an error
+			// for the type-checker and guards against a future edit
+			// that drops the ValidArgs constraint.
+			return fmt.Errorf("unsupported shell: %s", args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/harness/cmd/stirrup/cmd/completion_test.go
+++ b/harness/cmd/stirrup/cmd/completion_test.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"bytes"
+	"os/exec"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestCompletionCmd_GeneratesValidShellScripts pins the four cobra
+// completion generators against each shell's own syntax checker. The
+// script is generated in-process (no os/exec stirrup-binary dependency)
+// and piped to `bash -n` / `zsh -n` / `fish -n`. PowerShell's syntax
+// check is more involved and not exercised on CI, so the powershell
+// variant is asserted only by verifying the generator returns without
+// error and emits a non-empty body.
+//
+// A missing shell binary is a t.Skipf, not a failure: the harness CI
+// runners do not necessarily have fish installed, and a hard failure
+// would gate the merge on every developer machine matching the CI
+// shell matrix.
+func TestCompletionCmd_GeneratesValidShellScripts(t *testing.T) {
+	for _, tc := range []struct {
+		shell   string
+		checker []string // command + args to syntax-check stdin
+	}{
+		{shell: "bash", checker: []string{"bash", "-n"}},
+		{shell: "zsh", checker: []string{"zsh", "-n"}},
+		{shell: "fish", checker: []string{"fish", "-n"}},
+		{shell: "powershell"}, // no in-tree syntax check; presence test only
+	} {
+		t.Run(tc.shell, func(t *testing.T) {
+			buf := runCompletion(t, tc.shell)
+			if buf.Len() == 0 {
+				t.Fatalf("completion %s emitted empty script", tc.shell)
+			}
+			if len(tc.checker) == 0 {
+				return
+			}
+			if _, err := exec.LookPath(tc.checker[0]); err != nil {
+				t.Skipf("%s not available on this runner: %v", tc.checker[0], err)
+			}
+			cmd := exec.Command(tc.checker[0], tc.checker[1:]...) //nolint:gosec // hard-coded checker list, no user input
+			cmd.Stdin = buf
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s syntax check failed: %v\noutput:\n%s", tc.shell, err, out)
+			}
+		})
+	}
+}
+
+// runCompletion executes `stirrup completion <shell>` against an
+// isolated cobra command tree and returns the captured stdout. The
+// rootCmd singleton owns global state (cobra parses os.Args by default,
+// SetOut() leaks across tests); the helper resets every mutation so a
+// later test in the package sees a clean command.
+func runCompletion(t *testing.T, shell string) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"completion", shell})
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	}()
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("completion %s: %v", shell, err)
+	}
+	return &buf
+}
+
+// TestCompletionCmd_RejectsUnknownShell pins the cobra ValidArgs
+// guard so an operator typing `stirrup completion ksh` sees a clear
+// error rather than an empty stdout and a zero exit code.
+func TestCompletionCmd_RejectsUnknownShell(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"completion", "ksh"})
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	}()
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown shell, got nil")
+	}
+	if !strings.Contains(err.Error(), "ksh") {
+		t.Errorf("error %q does not mention the rejected shell", err)
+	}
+}
+
+// TestFlagCompletion_EnumValues pins the closed-set value completion
+// for every flag registered via registerRunConfigFlagCompletions. Each
+// row asserts the completion function returns the same sorted slice
+// that types.Valid*Values() exposes, plus the NoFileComp directive so
+// shells do not also append filesystem entries.
+//
+// The values are pulled from the types package directly so a new entry
+// in validRunModes (etc.) shows up here without a manual sync.
+func TestFlagCompletion_EnumValues(t *testing.T) {
+	for _, tc := range []struct {
+		flag string
+		want []string
+	}{
+		{"mode", types.ValidRunModeValues()},
+		{"provider", types.ValidProviderTypeValues()},
+		{"executor", types.ValidExecutorTypeValues()},
+		{"edit-strategy", types.ValidEditStrategyTypeValues()},
+		{"verifier", types.ValidVerifierTypeValues()},
+		{"git-strategy", types.ValidGitStrategyTypeValues()},
+		{"transport", types.ValidTransportTypeValues()},
+		{"trace-emitter", types.ValidTraceEmitterTypeValues()},
+		{"otel-protocol", types.ValidTraceEmitterProtocolValues()},
+		{"container-runtime", types.ValidExecutorRuntimeValues()},
+		{"code-scanner", types.ValidCodeScannerTypeValues()},
+		{"guardrail", types.ValidGuardRailTypeValues()},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			got, directive := runFlagCompletion(t, harnessCmd, tc.flag)
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("directive = %v, want NoFileComp", directive)
+			}
+			assertStringsEqual(t, got, tc.want)
+
+			// Same flags are re-registered on run-config via the shared
+			// addRunConfigFlags helper, so the run-config command must
+			// return the identical completion surface.
+			gotRC, directiveRC := runFlagCompletion(t, runConfigCmd, tc.flag)
+			if directiveRC != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("run-config directive = %v, want NoFileComp", directiveRC)
+			}
+			assertStringsEqual(t, gotRC, tc.want)
+		})
+	}
+}
+
+// TestFlagCompletion_FileFlags pins the MarkFlagFilename /
+// MarkFlagDirname wiring. cobra encodes the file-completion contract
+// as a flag annotation (cobra.BashCompFilenameExt /
+// cobra.BashCompSubdirsInDir); each row asserts the matching
+// annotation is present so a regression that drops a MarkFlagFilename
+// call surfaces as a test failure rather than as a quietly degraded
+// completion experience.
+func TestFlagCompletion_FileFlags(t *testing.T) {
+	for _, tc := range []struct {
+		flag       string
+		wantExt    []string // empty = any-file completion (annotation present with empty list)
+		wantDir    bool
+		onCommands []*cobra.Command
+	}{
+		{flag: "config", wantExt: []string{"json"}, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
+		{flag: "prompt-file", wantExt: []string{}, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
+		{flag: "gcp-credentials-file", wantExt: []string{"json"}, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
+		{flag: "permission-policy-file", wantExt: []string{"cedar"}, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
+		{flag: "trace", wantExt: []string{"jsonl"}, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
+		{flag: "workspace", wantDir: true, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
+		{flag: "output-runconfig", wantExt: []string{"json"}, onCommands: []*cobra.Command{harnessCmd}},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			for _, cmd := range tc.onCommands {
+				fl := cmd.Flags().Lookup(tc.flag)
+				if fl == nil {
+					t.Fatalf("flag %s missing on %s", tc.flag, cmd.Use)
+				}
+				if tc.wantDir {
+					if _, ok := fl.Annotations[cobra.BashCompSubdirsInDir]; !ok {
+						t.Errorf("flag %s on %s: missing BashCompSubdirsInDir annotation", tc.flag, cmd.Use)
+					}
+					return
+				}
+				exts, ok := fl.Annotations[cobra.BashCompFilenameExt]
+				if !ok {
+					t.Fatalf("flag %s on %s: missing BashCompFilenameExt annotation", tc.flag, cmd.Use)
+				}
+				assertStringsEqual(t, exts, tc.wantExt)
+			}
+		})
+	}
+}
+
+// runFlagCompletion invokes the cobra completion function registered
+// for the named flag and returns the (values, directive) pair. Mirrors
+// the wire shape that cobra's __complete hidden command emits and that
+// shells consume; testing at this layer means a regression in the
+// per-flag wiring surfaces independently of the shell-script generator.
+func runFlagCompletion(t *testing.T, cmd *cobra.Command, flagName string) ([]string, cobra.ShellCompDirective) {
+	t.Helper()
+	fn, exists := flagCompletionFunc(cmd, flagName)
+	if !exists {
+		t.Fatalf("no completion function registered for --%s on %s", flagName, cmd.Use)
+	}
+	values, directive := fn(cmd, nil, "")
+	return values, directive
+}
+
+// flagCompletionFunc reaches into cobra's per-flag completion map via
+// the public ValidArgsFunction / GetFlagCompletionFunc helpers. The
+// helper is exposed on *Command in cobra v1.10 as
+// (*Command).GetFlagCompletionFunc; the indirection here exists so
+// tests do not panic on an older cobra build that lacked the getter.
+func flagCompletionFunc(cmd *cobra.Command, name string) (func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective), bool) {
+	return cmd.GetFlagCompletionFunc(name)
+}
+
+// assertStringsEqual checks two string slices for equality after
+// sorting, returning a comparable error message. Used by both the
+// enum-flag and file-flag tests where the source is already sorted
+// but the comparison is more forgiving.
+func assertStringsEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	for i := range g {
+		if g[i] != w[i] {
+			t.Errorf("index %d: got %q, want %q", i, g[i], w[i])
+		}
+	}
+}
+
+// TestCompletionCmd_MissingShell pins the cobra ExactArgs guard so
+// `stirrup completion` (no shell argument) fails with a clear
+// "accepts 1 arg(s)" message rather than silently writing nothing.
+func TestCompletionCmd_MissingShell(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"completion"})
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	}()
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing shell arg, got nil")
+	}
+	// cobra phrases the error as "accepts 1 arg(s), received 0".
+	if !strings.Contains(err.Error(), "arg") {
+		t.Errorf("error %q does not mention argument count", err)
+	}
+}
+

--- a/harness/cmd/stirrup/cmd/completion_test.go
+++ b/harness/cmd/stirrup/cmd/completion_test.go
@@ -100,7 +100,7 @@ func TestCompletionCmd_RejectsUnknownShell(t *testing.T) {
 }
 
 // TestFlagCompletion_EnumValues pins the closed-set value completion
-// for every flag registered via registerRunConfigFlagCompletions. Each
+// for every flag registered via addRunConfigFlagCompletions. Each
 // row asserts the completion function returns the same sorted slice
 // that types.Valid*Values() exposes, plus the NoFileComp directive so
 // shells do not also append filesystem entries.

--- a/harness/cmd/stirrup/cmd/completion_test.go
+++ b/harness/cmd/stirrup/cmd/completion_test.go
@@ -254,4 +254,3 @@ func TestCompletionCmd_MissingShell(t *testing.T) {
 		t.Errorf("error %q does not mention argument count", err)
 	}
 }
-

--- a/harness/cmd/stirrup/cmd/completion_test.go
+++ b/harness/cmd/stirrup/cmd/completion_test.go
@@ -55,42 +55,47 @@ func TestCompletionCmd_GeneratesValidShellScripts(t *testing.T) {
 	}
 }
 
-// runCompletion executes `stirrup completion <shell>` against an
-// isolated cobra command tree and returns the captured stdout. The
+// executeRootCmd drives rootCmd with the given args and returns the
+// captured stdout/stderr buffer along with the execution error. The
 // rootCmd singleton owns global state (cobra parses os.Args by default,
-// SetOut() leaks across tests); the helper resets every mutation so a
-// later test in the package sees a clean command.
-func runCompletion(t *testing.T, shell string) *bytes.Buffer {
+// SetOut() leaks across tests); the helper resets every mutation via
+// defer so a later test in the package sees a clean command. Both
+// positive- and negative-path completion tests reach for this helper
+// so the lifecycle lives in exactly one place.
+func executeRootCmd(t *testing.T, args []string) (*bytes.Buffer, error) {
 	t.Helper()
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
-	rootCmd.SetArgs([]string{"completion", shell})
-	defer func() {
-		rootCmd.SetOut(nil)
-		rootCmd.SetErr(nil)
-		rootCmd.SetArgs(nil)
-	}()
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("completion %s: %v", shell, err)
-	}
-	return &buf
-}
-
-// TestCompletionCmd_RejectsUnknownShell pins the cobra ValidArgs
-// guard so an operator typing `stirrup completion ksh` sees a clear
-// error rather than an empty stdout and a zero exit code.
-func TestCompletionCmd_RejectsUnknownShell(t *testing.T) {
-	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	rootCmd.SetErr(&buf)
-	rootCmd.SetArgs([]string{"completion", "ksh"})
+	rootCmd.SetArgs(args)
 	defer func() {
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
 		rootCmd.SetArgs(nil)
 	}()
 	err := rootCmd.Execute()
+	return &buf, err
+}
+
+// runCompletion executes `stirrup completion <shell>` against an
+// isolated cobra command tree and returns the captured stdout. A
+// non-nil execution error is treated as a test failure — this helper
+// is for the happy-path test only; negative-path tests reach for
+// executeRootCmd directly so they can assert on the error.
+func runCompletion(t *testing.T, shell string) *bytes.Buffer {
+	t.Helper()
+	buf, err := executeRootCmd(t, []string{"completion", shell})
+	if err != nil {
+		t.Fatalf("completion %s: %v", shell, err)
+	}
+	return buf
+}
+
+// TestCompletionCmd_RejectsUnknownShell pins the cobra ValidArgs
+// guard so an operator typing `stirrup completion ksh` sees a clear
+// error rather than an empty stdout and a zero exit code.
+func TestCompletionCmd_RejectsUnknownShell(t *testing.T) {
+	_, err := executeRootCmd(t, []string{"completion", "ksh"})
 	if err == nil {
 		t.Fatal("expected error for unknown shell, got nil")
 	}
@@ -260,16 +265,7 @@ func assertStringsEqual(t *testing.T, got, want []string) {
 // `stirrup completion` (no shell argument) fails with a clear
 // "accepts 1 arg(s)" message rather than silently writing nothing.
 func TestCompletionCmd_MissingShell(t *testing.T) {
-	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	rootCmd.SetErr(&buf)
-	rootCmd.SetArgs([]string{"completion"})
-	defer func() {
-		rootCmd.SetOut(nil)
-		rootCmd.SetErr(nil)
-		rootCmd.SetArgs(nil)
-	}()
-	err := rootCmd.Execute()
+	_, err := executeRootCmd(t, []string{"completion"})
 	if err == nil {
 		t.Fatal("expected error for missing shell arg, got nil")
 	}

--- a/harness/cmd/stirrup/cmd/completion_test.go
+++ b/harness/cmd/stirrup/cmd/completion_test.go
@@ -106,7 +106,11 @@ func TestCompletionCmd_RejectsUnknownShell(t *testing.T) {
 // shells do not also append filesystem entries.
 //
 // The values are pulled from the types package directly so a new entry
-// in validRunModes (etc.) shows up here without a manual sync.
+// in validRunModes (etc.) shows up here without a manual sync. The
+// log-level and api-key-header rows carry literal value lists because
+// neither flag is backed by a validator-closed set in types/runconfig.go;
+// the rows guard against a regression that drops the staticValues call
+// for either flag from addRunConfigFlagCompletions.
 func TestFlagCompletion_EnumValues(t *testing.T) {
 	for _, tc := range []struct {
 		flag string
@@ -124,6 +128,8 @@ func TestFlagCompletion_EnumValues(t *testing.T) {
 		{"container-runtime", types.ValidExecutorRuntimeValues()},
 		{"code-scanner", types.ValidCodeScannerTypeValues()},
 		{"guardrail", types.ValidGuardRailTypeValues()},
+		{"log-level", []string{"debug", "error", "info", "warn"}},
+		{"api-key-header", []string{"Authorization", "api-key"}},
 	} {
 		t.Run(tc.flag, func(t *testing.T) {
 			got, directive := runFlagCompletion(t, harnessCmd, tc.flag)

--- a/harness/cmd/stirrup/cmd/completion_test.go
+++ b/harness/cmd/stirrup/cmd/completion_test.go
@@ -157,11 +157,19 @@ func TestFlagCompletion_EnumValues(t *testing.T) {
 // annotation is present so a regression that drops a MarkFlagFilename
 // call surfaces as a test failure rather than as a quietly degraded
 // completion experience.
+//
+// The wantNone row for --export-workspace-to is deliberate: that flag
+// takes a gs:// URI rather than a local path, so MarkFlagFilename would
+// be actively wrong (it would advertise filesystem traversal as the
+// natural completion). The negative assertion guards against a future
+// contributor reading the spec, seeing the flag named as "path-shaped",
+// and adding the annotation by mistake.
 func TestFlagCompletion_FileFlags(t *testing.T) {
 	for _, tc := range []struct {
 		flag       string
 		wantExt    []string // empty = any-file completion (annotation present with empty list)
 		wantDir    bool
+		wantNone   bool // assert neither file nor dir completion annotation is set
 		onCommands []*cobra.Command
 	}{
 		{flag: "config", wantExt: []string{"json"}, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
@@ -171,12 +179,22 @@ func TestFlagCompletion_FileFlags(t *testing.T) {
 		{flag: "trace", wantExt: []string{"jsonl"}, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
 		{flag: "workspace", wantDir: true, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
 		{flag: "output-runconfig", wantExt: []string{"json"}, onCommands: []*cobra.Command{harnessCmd}},
+		{flag: "export-workspace-to", wantNone: true, onCommands: []*cobra.Command{harnessCmd, runConfigCmd}},
 	} {
 		t.Run(tc.flag, func(t *testing.T) {
 			for _, cmd := range tc.onCommands {
 				fl := cmd.Flags().Lookup(tc.flag)
 				if fl == nil {
 					t.Fatalf("flag %s missing on %s", tc.flag, cmd.Use)
+				}
+				if tc.wantNone {
+					if _, ok := fl.Annotations[cobra.BashCompFilenameExt]; ok {
+						t.Errorf("flag %s on %s: unexpected BashCompFilenameExt annotation — flag takes a gs:// URI, not a local path", tc.flag, cmd.Use)
+					}
+					if _, ok := fl.Annotations[cobra.BashCompSubdirsInDir]; ok {
+						t.Errorf("flag %s on %s: unexpected BashCompSubdirsInDir annotation — flag takes a gs:// URI, not a local path", tc.flag, cmd.Use)
+					}
+					continue
 				}
 				if tc.wantDir {
 					if _, ok := fl.Annotations[cobra.BashCompSubdirsInDir]; !ok {

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -708,6 +708,12 @@ func init() {
 	f := harnessCmd.Flags()
 	f.Bool("export-workspace-required", false, "When true, a failed workspace export exits the run non-zero. When false (default), failures are logged and the run's exit code is unchanged.")
 	f.String("output-runconfig", "", "Write the resolved RunConfig as JSON to <path> (use '-' for stdout) and exit without running. Useful for capturing the exact config a flag-only invocation would have used. Validation must pass first; the path is not written on a validator error.")
+
+	// --output-runconfig accepts a path or "-" for stdout. The .json
+	// hint nudges the shell toward the conventional extension; "-" is
+	// a literal one-character argument no completion engine needs to
+	// suggest, so the file-name completion alone is sufficient.
+	_ = harnessCmd.MarkFlagFilename("output-runconfig", "json")
 }
 
 // applyOverrides mutates cfg in place, replacing fields whose corresponding

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -85,16 +85,16 @@ func addRunConfigFlags(cmd *cobra.Command) {
 
 	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/sandbox.md.")
 
-	registerRunConfigFlagCompletions(cmd)
+	addRunConfigFlagCompletions(cmd)
 }
 
-// registerRunConfigFlagCompletions wires cobra dynamic-flag completion
-// for every flag declared in addRunConfigFlags. Closed-set enum flags
-// pull their value list from types.Valid*Values() so the completion
-// surface tracks the validator without manual sync. Path-shaped flags
-// advertise file-system completion via MarkFlagFilename /
-// MarkFlagDirname so shells offer directory traversal rather than the
-// generic "any string" prompt.
+// addRunConfigFlagCompletions wires cobra dynamic-flag completion for
+// every flag declared in addRunConfigFlags. Closed-set enum flags pull
+// their value list from types.Valid*Values() so the completion surface
+// tracks the validator without manual sync. Path-shaped flags advertise
+// file-system completion via MarkFlagFilename / MarkFlagDirname so
+// shells offer directory traversal rather than the generic "any
+// string" prompt.
 //
 // Errors from RegisterFlagCompletionFunc and MarkFlagFilename only
 // surface when the named flag does not exist on the command. Every
@@ -103,7 +103,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 // condition. Such an error would silently lose the completion mapping
 // for that flag; ignoring it (as is done here) matches cobra's own
 // idiom for completion registration in its example documentation.
-func registerRunConfigFlagCompletions(cmd *cobra.Command) {
+func addRunConfigFlagCompletions(cmd *cobra.Command) {
 	staticValues := func(name string, values []string) {
 		_ = cmd.RegisterFlagCompletionFunc(name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return values, cobra.ShellCompDirectiveNoFileComp

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/types"
+)
 
 // addRunConfigFlags registers every flag that maps to a RunConfig field
 // (or to the prompt-resolution chain that lands on RunConfig.Prompt).
@@ -80,4 +84,65 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.Int("max-tool-parallel", 0, "Maximum number of async tool calls dispatched concurrently in a single turn. Range: 1-16. 0 uses the library default (4).")
 
 	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/sandbox.md.")
+
+	registerRunConfigFlagCompletions(cmd)
+}
+
+// registerRunConfigFlagCompletions wires cobra dynamic-flag completion
+// for every flag declared in addRunConfigFlags. Closed-set enum flags
+// pull their value list from types.Valid*Values() so the completion
+// surface tracks the validator without manual sync. Path-shaped flags
+// advertise file-system completion via MarkFlagFilename /
+// MarkFlagDirname so shells offer directory traversal rather than the
+// generic "any string" prompt.
+//
+// Errors from RegisterFlagCompletionFunc and MarkFlagFilename only
+// surface when the named flag does not exist on the command. Every
+// flag named here is registered above in the same function call, so a
+// non-nil error indicates a typo in this file rather than a runtime
+// condition. Such an error would silently lose the completion mapping
+// for that flag; ignoring it (as is done here) matches cobra's own
+// idiom for completion registration in its example documentation.
+func registerRunConfigFlagCompletions(cmd *cobra.Command) {
+	staticValues := func(name string, values []string) {
+		_ = cmd.RegisterFlagCompletionFunc(name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return values, cobra.ShellCompDirectiveNoFileComp
+		})
+	}
+	staticValues("mode", types.ValidRunModeValues())
+	staticValues("provider", types.ValidProviderTypeValues())
+	staticValues("executor", types.ValidExecutorTypeValues())
+	staticValues("edit-strategy", types.ValidEditStrategyTypeValues())
+	staticValues("verifier", types.ValidVerifierTypeValues())
+	staticValues("git-strategy", types.ValidGitStrategyTypeValues())
+	staticValues("transport", types.ValidTransportTypeValues())
+	staticValues("trace-emitter", types.ValidTraceEmitterTypeValues())
+	staticValues("otel-protocol", types.ValidTraceEmitterProtocolValues())
+	staticValues("container-runtime", types.ValidExecutorRuntimeValues())
+	staticValues("code-scanner", types.ValidCodeScannerTypeValues())
+	staticValues("guardrail", types.ValidGuardRailTypeValues())
+
+	// log-level and api-key-header are not declared as validator-closed
+	// sets in types/runconfig.go, but operators benefit from a hinted
+	// completion. log-level is the conventional slog quartet; api-key-header
+	// pins the two values used today (Authorization, api-key for Azure).
+	staticValues("log-level", []string{"debug", "error", "info", "warn"})
+	staticValues("api-key-header", []string{"Authorization", "api-key"})
+
+	// File and directory flags. JSON-typed paths name a single
+	// extension hint; the prompt-file and policy-file flags accept
+	// any text payload so the extension list stays empty (shells
+	// fall back to "all files"). --workspace is the one directory-
+	// completed flag — operators point it at a checkout, not a file.
+	// --trace is the JSONL trace path; the .jsonl hint nudges the
+	// shell toward the conventional extension without forbidding
+	// .log or .ndjson. --export-workspace-to takes a gs:// URI
+	// rather than a local path, so no completion hint applies and
+	// shells correctly fall through to "no completion".
+	_ = cmd.MarkFlagFilename("config", "json")
+	_ = cmd.MarkFlagFilename("prompt-file")
+	_ = cmd.MarkFlagFilename("gcp-credentials-file", "json")
+	_ = cmd.MarkFlagFilename("permission-policy-file", "cedar")
+	_ = cmd.MarkFlagFilename("trace", "jsonl")
+	_ = cmd.MarkFlagDirname("workspace")
 }

--- a/types/runconfig_completions.go
+++ b/types/runconfig_completions.go
@@ -1,0 +1,98 @@
+package types
+
+import "sort"
+
+// Shell-completion helpers.
+//
+// These functions expose the closed-set Type enumerations as sorted
+// string slices so callers (today: harness/cmd/stirrup/cmd, used to
+// register cobra dynamic-flag completions) can offer tab-completion
+// without duplicating the value lists. Each helper is sourced from
+// the same package-private map the validator consults, so adding a
+// new valid value in one place automatically extends the completion
+// surface.
+//
+// Sorted output is required so cobra emits a stable, deterministic
+// completion order. Map iteration is non-deterministic; emitting
+// completions in shuffled order would make shell snapshots and the
+// "did the operator type the same prefix and get a different result"
+// test loop flaky.
+//
+// The empty-string entry that some maps carry (e.g.
+// validExecutorRuntimes, validTraceEmitterProtocols) is filtered out
+// here because a completion value of "" is not useful to a tab-
+// completing operator — it offers no character to type.
+
+// ValidRunModeValues returns the run modes accepted on RunConfig.Mode.
+func ValidRunModeValues() []string { return sortedKeys(validRunModes) }
+
+// ValidProviderTypeValues returns the provider types accepted on
+// RunConfig.Provider.Type.
+func ValidProviderTypeValues() []string { return sortedKeys(validProviderTypes) }
+
+// ValidExecutorTypeValues returns the executor types accepted on
+// RunConfig.Executor.Type.
+func ValidExecutorTypeValues() []string { return sortedKeys(validExecutorTypes) }
+
+// ValidExecutorRuntimeValues returns the OCI runtimes accepted on
+// RunConfig.Executor.Runtime. The "" (engine-default) entry is
+// filtered out so the completion list contains only the typeable
+// runtimes.
+func ValidExecutorRuntimeValues() []string { return sortedNonEmptyKeys(validExecutorRuntimes) }
+
+// ValidEditStrategyTypeValues returns the edit-strategy types accepted
+// on RunConfig.EditStrategy.Type.
+func ValidEditStrategyTypeValues() []string { return sortedKeys(validEditStrategyTypes) }
+
+// ValidVerifierTypeValues returns the verifier types accepted on
+// RunConfig.Verifier.Type.
+func ValidVerifierTypeValues() []string { return sortedKeys(validVerifierTypes) }
+
+// ValidGitStrategyTypeValues returns the git-strategy types accepted
+// on RunConfig.GitStrategy.Type.
+func ValidGitStrategyTypeValues() []string { return sortedKeys(validGitStrategyTypes) }
+
+// ValidTransportTypeValues returns the transport types accepted on
+// RunConfig.Transport.Type.
+func ValidTransportTypeValues() []string { return sortedKeys(validTransportTypes) }
+
+// ValidTraceEmitterTypeValues returns the trace-emitter types accepted
+// on RunConfig.TraceEmitter.Type.
+func ValidTraceEmitterTypeValues() []string { return sortedKeys(validTraceEmitterTypes) }
+
+// ValidTraceEmitterProtocolValues returns the OTLP wire protocols
+// accepted on RunConfig.TraceEmitter.Protocol. The "" (defaults-to-grpc)
+// entry is filtered out so the completion list contains only the
+// typeable protocols.
+func ValidTraceEmitterProtocolValues() []string {
+	return sortedNonEmptyKeys(validTraceEmitterProtocols)
+}
+
+// ValidCodeScannerTypeValues returns the code-scanner types accepted
+// on RunConfig.CodeScanner.Type.
+func ValidCodeScannerTypeValues() []string { return sortedKeys(validCodeScannerTypes) }
+
+// ValidGuardRailTypeValues returns the guard-rail types accepted on
+// RunConfig.GuardRail.Type.
+func ValidGuardRailTypeValues() []string { return sortedKeys(validGuardRailTypes) }
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedNonEmptyKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		if k == "" {
+			continue
+		}
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/types/runconfig_completions_test.go
+++ b/types/runconfig_completions_test.go
@@ -1,0 +1,103 @@
+package types
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestCompletionValues_SortedAndNonEmpty pins two contracts the shell-
+// completion call sites rely on:
+//
+//  1. Output is sorted lexicographically so cobra emits a stable
+//     completion order. Map iteration is non-deterministic; a regression
+//     that drops the sort would make completion snapshots and dependent
+//     tests flaky without ever raising a build error.
+//
+//  2. Output contains no empty strings. The two maps that include ""
+//     (validExecutorRuntimes, validTraceEmitterProtocols) must be
+//     filtered through sortedNonEmptyKeys at the helper boundary so a
+//     shell does not offer an unusable empty completion entry.
+func TestCompletionValues_SortedAndNonEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  []string
+	}{
+		{"run modes", ValidRunModeValues()},
+		{"provider types", ValidProviderTypeValues()},
+		{"executor types", ValidExecutorTypeValues()},
+		{"executor runtimes", ValidExecutorRuntimeValues()},
+		{"edit strategies", ValidEditStrategyTypeValues()},
+		{"verifiers", ValidVerifierTypeValues()},
+		{"git strategies", ValidGitStrategyTypeValues()},
+		{"transports", ValidTransportTypeValues()},
+		{"trace emitters", ValidTraceEmitterTypeValues()},
+		{"trace emitter protocols", ValidTraceEmitterProtocolValues()},
+		{"code scanners", ValidCodeScannerTypeValues()},
+		{"guard rails", ValidGuardRailTypeValues()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.got) == 0 {
+				t.Fatalf("%s: empty slice", tc.name)
+			}
+			if !sort.StringsAreSorted(tc.got) {
+				t.Errorf("%s: not sorted: %v", tc.name, tc.got)
+			}
+			for _, v := range tc.got {
+				if v == "" {
+					t.Errorf("%s: contains empty string", tc.name)
+				}
+			}
+		})
+	}
+}
+
+// TestCompletionValues_TrackValidatorMaps pins the source-of-truth
+// invariant: every key in the validator's closed-set map (minus the
+// intentionally-filtered empty string) must appear in the matching
+// completion helper output. A regression that adds "runscv2" to
+// validExecutorRuntimes but forgets to extend the helper surface would
+// silently ship a completion list that lags the validator.
+//
+// Each row pairs a helper with its backing map; equality is checked
+// against the filtered slice form for parity with what cobra emits.
+func TestCompletionValues_TrackValidatorMaps(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		backing        map[string]bool
+		got            []string
+		filterEmpty    bool
+		expectedLength int
+	}{
+		{name: "run modes", backing: validRunModes, got: ValidRunModeValues()},
+		{name: "provider types", backing: validProviderTypes, got: ValidProviderTypeValues()},
+		{name: "executor types", backing: validExecutorTypes, got: ValidExecutorTypeValues()},
+		{name: "executor runtimes", backing: validExecutorRuntimes, got: ValidExecutorRuntimeValues(), filterEmpty: true},
+		{name: "edit strategies", backing: validEditStrategyTypes, got: ValidEditStrategyTypeValues()},
+		{name: "verifiers", backing: validVerifierTypes, got: ValidVerifierTypeValues()},
+		{name: "git strategies", backing: validGitStrategyTypes, got: ValidGitStrategyTypeValues()},
+		{name: "transports", backing: validTransportTypes, got: ValidTransportTypeValues()},
+		{name: "trace emitters", backing: validTraceEmitterTypes, got: ValidTraceEmitterTypeValues()},
+		{name: "trace emitter protocols", backing: validTraceEmitterProtocols, got: ValidTraceEmitterProtocolValues(), filterEmpty: true},
+		{name: "code scanners", backing: validCodeScannerTypes, got: ValidCodeScannerTypeValues()},
+		{name: "guard rails", backing: validGuardRailTypes, got: ValidGuardRailTypeValues()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := make(map[string]struct{}, len(tc.backing))
+			for k := range tc.backing {
+				if tc.filterEmpty && k == "" {
+					continue
+				}
+				expected[k] = struct{}{}
+			}
+			if len(tc.got) != len(expected) {
+				t.Fatalf("%s: got %d values, want %d (backing map %v)",
+					tc.name, len(tc.got), len(expected), tc.backing)
+			}
+			for _, v := range tc.got {
+				if _, ok := expected[v]; !ok {
+					t.Errorf("%s: helper returned %q not present in backing map", tc.name, v)
+				}
+			}
+		})
+	}
+}

--- a/types/runconfig_completions_test.go
+++ b/types/runconfig_completions_test.go
@@ -62,11 +62,10 @@ func TestCompletionValues_SortedAndNonEmpty(t *testing.T) {
 // against the filtered slice form for parity with what cobra emits.
 func TestCompletionValues_TrackValidatorMaps(t *testing.T) {
 	for _, tc := range []struct {
-		name           string
-		backing        map[string]bool
-		got            []string
-		filterEmpty    bool
-		expectedLength int
+		name        string
+		backing     map[string]bool
+		got         []string
+		filterEmpty bool
 	}{
 		{name: "run modes", backing: validRunModes, got: ValidRunModeValues()},
 		{name: "provider types", backing: validProviderTypes, got: ValidProviderTypeValues()},


### PR DESCRIPTION
Closes #243

## Summary

`stirrup harness` and `stirrup run-config` together expose over forty flags, and tab-completion is table-stakes ergonomics for any operator who has not memorised the full surface. This PR adds a `stirrup completion <shell>` subcommand (and the equivalent for `stirrup-eval`) that emits cobra-generated bash, zsh, fish, and powershell scripts, plus per-flag completion metadata for the closed-set enum flags (`--mode`, `--provider`, `--executor`, `--edit-strategy`, `--verifier`, `--git-strategy`, `--transport`, `--trace-emitter`, `--otel-protocol`, `--container-runtime`, `--code-scanner`, `--guardrail`) and the path-shaped flags (`--config`, `--prompt-file`, `--gcp-credentials-file`, `--permission-policy-file`, `--trace`, `--workspace`, `--output-runconfig`).

Enum values are sourced from new `types.Valid*Values()` helpers backed by the validator's own closed-set maps so adding a new value in `types/runconfig.go` automatically extends the completion surface — there is no parallel list to keep in sync.

`stirrup-eval` uses the stdlib `flag` package rather than cobra; rather than dragging cobra into the eval module just for completion, the scripts are hand-rolled per shell. The flag surface there is small and stable.

## Base branch

This PR targets `feat/issue-240-runconfig-generator` (PR #251) rather than `main`. Wave 2 depends on Wave 1: issue #240 added the `--output-runconfig`, `--validate`, `--compact`, `--redact` flags this PR also wires completion for. GitHub will auto-retarget to `main` once #251 merges.

## Test plan

- [x] `go test ./harness/... ./types/... ./eval/...` passes (eval and harness completion tests plus types helpers).
- [x] `golangci-lint run ./harness/... ./types/... ./eval/...` clean.
- [x] `stirrup completion bash | bash -n` succeeds (executed in tests).
- [x] `stirrup completion zsh | zsh -n` succeeds (executed in tests).
- [x] `stirrup completion fish | fish -n` skipped on this runner (`fish` not installed); the test framework reports a skip rather than a failure so CI runners without fish still gate the merge correctly.
- [x] `stirrup-eval completion <shell>` mirrored for all four shells.
- [x] Tab-completion of `--mode <TAB>` returns the five mode values (asserted via cobra's per-flag completion function in `TestFlagCompletion_EnumValues`).
- [x] Tab-completion of `--config <TAB>` advertises file completion (asserted via the `cobra.BashCompFilenameExt` annotation in `TestFlagCompletion_FileFlags`).
- [x] Documented in `docs/configuration.md` under a new "Shell completions" section.