### PR TITLE
cli: add --output flag for harness run summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ config a flag-only invocation *would* have used — useful for
 post-mortem replays or pinning a stable configuration. See
 [`docs/configuration.md`](docs/configuration.md#building-runconfigs-interactively).
 
+`stirrup harness --output <text|json|none>` (alias `-o`) selects the
+post-run summary surface. `text` (default) prints today's stderr
+summary, `json` emits a single `STIRRUP_RESULT` line on stdout
+parseable as [`types.RunResult`](types/result.go), and `none`
+suppresses both. The structured shape reuses the existing
+`resultSink.type=stdout-json` payload, so a `--output=json` invocation
+and a `resultSink`-configured run produce the same wire format. See
+[`docs/configuration.md`](docs/configuration.md#run-output).
+
 ### In GitHub Actions
 
 See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.yml) for an example of using `stirrup harness` in a GitHub Actions workflow via [Anthropic Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,6 +276,33 @@ Walkthrough: [`azure-workload-identity.md`](azure-workload-identity.md).
 | `--deployment-environment` | (none) | OTel `deployment.environment` resource attribute (e.g. `production`, `staging`). Empty falls through to env `OTEL_DEPLOYMENT_ENVIRONMENT`, then to `local`. |
 | `--service-namespace` | (none) | OTel `service.namespace` resource attribute (e.g. `stirrup-eval`, `team-a`). Empty falls through to env `OTEL_SERVICE_NAMESPACE`, then to `stirrup`. |
 
+### Run output
+
+At end-of-run the harness emits a post-run summary. The `--output`
+flag selects the surface:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--output`, `-o` | `text` | One of `text`, `json`, `none`. `text` (default) prints the freeform human-readable summary to stderr. `json` emits a single `STIRRUP_RESULT <json>` line on stdout (parseable as [`types.RunResult`](../types/result.go)) and suppresses the stderr summary. `none` suppresses both surfaces. |
+
+When `--output=json` is set alongside `resultSink.type=stdout-json`,
+the harness emits the `STIRRUP_RESULT` line exactly once — the flag
+wins because it is the more explicit signal. The wire shape is
+identical between the two paths, so consumers do not need to detect
+which surface produced the line.
+
+The exit code reflects the run outcome regardless of `--output`: a
+failed or cancelled run still exits non-zero. A cancellation
+mid-flight emits a partial `RunResult` carrying the cancellation
+outcome rather than nothing, so callers parsing the JSON line always
+see a structured record.
+
+Pair `--output=json` with a trace emitter that does not target
+stdout. The default JSONL trace writes to a file (or to nothing when
+`--trace` is unset), so the stdout channel stays reserved for the
+`STIRRUP_RESULT` line. A future JSONL emitter that writes to stdout
+would conflict with `--output=json`.
+
 ## Component-selection limits
 
 The CLI deliberately exposes only a subset of each component's

--- a/harness/cmd/stirrup/cmd/completion_test.go
+++ b/harness/cmd/stirrup/cmd/completion_test.go
@@ -118,23 +118,31 @@ func TestCompletionCmd_RejectsUnknownShell(t *testing.T) {
 // for either flag from addRunConfigFlagCompletions.
 func TestFlagCompletion_EnumValues(t *testing.T) {
 	for _, tc := range []struct {
-		flag string
-		want []string
+		flag           string
+		want           []string
+		harnessCmdOnly bool // when true, --run-config does not register this flag
 	}{
-		{"mode", types.ValidRunModeValues()},
-		{"provider", types.ValidProviderTypeValues()},
-		{"executor", types.ValidExecutorTypeValues()},
-		{"edit-strategy", types.ValidEditStrategyTypeValues()},
-		{"verifier", types.ValidVerifierTypeValues()},
-		{"git-strategy", types.ValidGitStrategyTypeValues()},
-		{"transport", types.ValidTransportTypeValues()},
-		{"trace-emitter", types.ValidTraceEmitterTypeValues()},
-		{"otel-protocol", types.ValidTraceEmitterProtocolValues()},
-		{"container-runtime", types.ValidExecutorRuntimeValues()},
-		{"code-scanner", types.ValidCodeScannerTypeValues()},
-		{"guardrail", types.ValidGuardRailTypeValues()},
-		{"log-level", []string{"debug", "error", "info", "warn"}},
-		{"api-key-header", []string{"Authorization", "api-key"}},
+		{flag: "mode", want: types.ValidRunModeValues()},
+		{flag: "provider", want: types.ValidProviderTypeValues()},
+		{flag: "executor", want: types.ValidExecutorTypeValues()},
+		{flag: "edit-strategy", want: types.ValidEditStrategyTypeValues()},
+		{flag: "verifier", want: types.ValidVerifierTypeValues()},
+		{flag: "git-strategy", want: types.ValidGitStrategyTypeValues()},
+		{flag: "transport", want: types.ValidTransportTypeValues()},
+		{flag: "trace-emitter", want: types.ValidTraceEmitterTypeValues()},
+		{flag: "otel-protocol", want: types.ValidTraceEmitterProtocolValues()},
+		{flag: "container-runtime", want: types.ValidExecutorRuntimeValues()},
+		{flag: "code-scanner", want: types.ValidCodeScannerTypeValues()},
+		{flag: "guardrail", want: types.ValidGuardRailTypeValues()},
+		{flag: "log-level", want: []string{"debug", "error", "info", "warn"}},
+		{flag: "api-key-header", want: []string{"Authorization", "api-key"}},
+		// --output is harness-only: a closed three-value set surfaced via
+		// a hand-rolled RegisterFlagCompletionFunc rather than a
+		// types.Valid*Values() call. Pin the list here so a future drift
+		// between validateOutputMode and the completion registration
+		// surfaces as a test failure rather than as stale shell
+		// completions offered to operators.
+		{flag: "output", want: []string{"json", "none", "text"}, harnessCmdOnly: true},
 	} {
 		t.Run(tc.flag, func(t *testing.T) {
 			got, directive := runFlagCompletion(t, harnessCmd, tc.flag)
@@ -142,6 +150,10 @@ func TestFlagCompletion_EnumValues(t *testing.T) {
 				t.Errorf("directive = %v, want NoFileComp", directive)
 			}
 			assertStringsEqual(t, got, tc.want)
+
+			if tc.harnessCmdOnly {
+				return
+			}
 
 			// Same flags are re-registered on run-config via the shared
 			// addRunConfigFlags helper, so the run-config command must

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -708,12 +708,33 @@ func init() {
 	f := harnessCmd.Flags()
 	f.Bool("export-workspace-required", false, "When true, a failed workspace export exits the run non-zero. When false (default), failures are logged and the run's exit code is unchanged.")
 	f.String("output-runconfig", "", "Write the resolved RunConfig as JSON to <path> (use '-' for stdout) and exit without running. Useful for capturing the exact config a flag-only invocation would have used. Validation must pass first; the path is not written on a validator error.")
+	f.StringP("output", "o", "text", "Post-run summary format: text (default human-readable summary on stderr), json (structured RunResult JSON on stdout, suppresses stderr summary), none (suppresses both). When json is set together with resultSink.type=stdout-json the line is emitted once (the flag wins); pair json with a trace emitter that does not target stdout (the default jsonl file path is fine).")
 
 	// --output-runconfig accepts a path or "-" for stdout. The .json
 	// hint nudges the shell toward the conventional extension; "-" is
 	// a literal one-character argument no completion engine needs to
 	// suggest, so the file-name completion alone is sufficient.
 	_ = harnessCmd.MarkFlagFilename("output-runconfig", "json")
+
+	// --output is a closed three-value set; pin the completion list so
+	// shells surface the same values the validator enforces.
+	_ = harnessCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"text", "json", "none"}, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
+// validateOutputMode rejects any --output value outside the closed
+// three-value set. The check fires before the agentic loop builds so a
+// typo surfaces with a clear operator-facing error rather than as a
+// missing summary at end-of-run (which would otherwise be silently
+// ignored when the resolved value did not match any branch downstream).
+func validateOutputMode(mode string) error {
+	switch mode {
+	case "text", "json", "none":
+		return nil
+	default:
+		return fmt.Errorf("--output: invalid value %q (expected one of: text, json, none)", mode)
+	}
 }
 
 // applyOverrides mutates cfg in place, replacing fields whose corresponding
@@ -1171,7 +1192,14 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	}
 
 	exportRequired, _ := f.GetBool("export-workspace-required")
-	return runWithConfig(cfg, runOptions{exportWorkspaceRequired: exportRequired})
+	outputMode, _ := f.GetString("output")
+	if err := validateOutputMode(outputMode); err != nil {
+		return err
+	}
+	return runWithConfig(cfg, runOptions{
+		exportWorkspaceRequired: exportRequired,
+		outputMode:              outputMode,
+	})
 }
 
 // writeOutputRunConfig emits the resolved RunConfig as pretty-printed
@@ -1376,12 +1404,15 @@ func applyAnthropicWIFOverrides(cmd *cobra.Command, cfg *types.RunConfig) error 
 }
 
 // runOptions carries CLI-only behaviour that doesn't fit on RunConfig.
-// Today this is just exportWorkspaceRequired — a flag that controls
-// whether a failed workspace export propagates a non-zero exit code.
-// Threading it through here (rather than embedding it on RunConfig)
-// keeps the wire schema free of CLI-shaped knobs.
+// exportWorkspaceRequired controls whether a failed workspace export
+// propagates a non-zero exit code. outputMode selects the post-run
+// summary surface: "text" prints the human-readable stderr summary,
+// "json" emits a single STIRRUP_RESULT line on stdout, "none"
+// suppresses both. Threading them through here (rather than embedding
+// them on RunConfig) keeps the wire schema free of CLI-shaped knobs.
 type runOptions struct {
 	exportWorkspaceRequired bool
+	outputMode              string
 }
 
 // runWithConfig is the shared run path for both --config and flag-only
@@ -1403,13 +1434,7 @@ func runWithConfig(config *types.RunConfig, opts runOptions) error {
 	if err != nil {
 		return fmt.Errorf("running harness: %w", err)
 	}
-	printRunSummary(runTrace)
-	// resultSink emission is the last thing on stdout for the run, so
-	// a Cloud Logging grep / shell pipeline can extract the
-	// "STIRRUP_RESULT <json>" line deterministically. Failures are
-	// logged inside emitRunResult and never fatal — the trace and the
-	// stderr summary already reflect outcome.
-	emitRunResult(ctx, config, runTrace)
+	emitRunOutput(ctx, config, runTrace, opts.outputMode)
 
 	// Workspace export (issue #164). Called after the trace and
 	// resultSink so a failed upload's slog warning lands after the

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1170,6 +1170,19 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	f := cmd.Flags()
 	configPath, _ := f.GetString("config")
 
+	// Validate --output before any side effects: BuildRunConfig reads
+	// files and resolves env-var-shaped credentials, and the
+	// --output-runconfig dry-run branch below exits without running
+	// the loop. A bad --output value should not silently coexist with
+	// either path — operators expect closed-set violations to surface
+	// before the harness commits to a config-resolution or capture
+	// outcome. --output is not a RunConfig field, so this check has no
+	// dependency on BuildRunConfig.
+	outputMode, _ := f.GetString("output")
+	if err := validateOutputMode(outputMode); err != nil {
+		return err
+	}
+
 	cfg, err := BuildRunConfig(RunConfigSources{
 		Stdin:      os.Stdin,
 		ConfigPath: configPath,
@@ -1192,10 +1205,6 @@ func runHarness(cmd *cobra.Command, args []string) error {
 	}
 
 	exportRequired, _ := f.GetBool("export-workspace-required")
-	outputMode, _ := f.GetString("output")
-	if err := validateOutputMode(outputMode); err != nil {
-		return err
-	}
 	return runWithConfig(cfg, runOptions{
 		exportWorkspaceRequired: exportRequired,
 		outputMode:              outputMode,

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1434,14 +1434,32 @@ func runWithConfig(config *types.RunConfig, opts runOptions) error {
 	if err != nil {
 		return fmt.Errorf("running harness: %w", err)
 	}
-	emitRunOutput(ctx, config, runTrace, opts.outputMode)
+
+	// emitRunOutput must not inherit ctx: by the time we reach here ctx
+	// may already be cancelled (signal handler fired, or the per-run
+	// timeout elapsed). StdoutJSONSink ignores its context today, but
+	// any future sink that respects cancellation — gcp-pubsub, gcs —
+	// would silently fail to emit the structured result on every
+	// cancelled run, and emitRunResult logs-and-discards sink errors.
+	// Use a fresh, short-deadline context for post-run emission so
+	// cancellation does not eat the run's answer. Mirrors the
+	// bestEffortCancel pattern in batchpoll.go.
+	emitCtx, emitCancel := context.WithTimeout(context.Background(), postRunEmitTimeout)
+	defer emitCancel()
+	emitRunOutput(emitCtx, config, runTrace, opts.outputMode)
 
 	// Workspace export (issue #164). Called after the trace and
 	// resultSink so a failed upload's slog warning lands after the
 	// run's structured outcome — easier to correlate during
 	// post-mortem. When required, the error here propagates and
-	// becomes the process exit status.
-	if err := exportWorkspace(ctx, config, opts.exportWorkspaceRequired); err != nil {
+	// becomes the process exit status. Uses an independent context for
+	// the same reason as emitRunOutput above — a signal-cancelled run
+	// must still upload its workspace if the operator opted in — with
+	// a longer deadline because the GCS PUT can carry many MB of
+	// tarball.
+	exportCtx, exportCancel := context.WithTimeout(context.Background(), postRunExportTimeout)
+	defer exportCancel()
+	if err := exportWorkspace(exportCtx, config, opts.exportWorkspaceRequired); err != nil {
 		return err
 	}
 

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/resultsink"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -5119,6 +5120,106 @@ func TestEmitRunOutput_JSONWithNilTraceLogsWarning(t *testing.T) {
 	logs := logBuf.String()
 	if !strings.Contains(logs, "nil RunTrace") {
 		t.Errorf("expected slog.Warn about nil RunTrace, got: %q", logs)
+	}
+}
+
+// stubResultSink records every Emit invocation so tests can assert
+// that the configured resultSink fires when --output=json or
+// --output=none is paired with a non-stdout sink (the
+// forward-compatibility surface for gcp-pubsub / gcs). Distinct from
+// resultsink.NoneSink because the latter discards silently and gives
+// the test no observable signal.
+type stubResultSink struct {
+	calls []types.RunResult
+}
+
+func (s *stubResultSink) Emit(_ context.Context, r types.RunResult) error {
+	s.calls = append(s.calls, r)
+	return nil
+}
+
+// installStubResultSink rewires the newResultSink seam to return the
+// supplied stub for the duration of the test. Returns nothing because
+// the stub itself is the assertion surface.
+func installStubResultSink(t *testing.T, stub *stubResultSink) {
+	t.Helper()
+	prev := newResultSink
+	t.Cleanup(func() { newResultSink = prev })
+	newResultSink = func(_ *types.ResultSinkConfig) (resultsinkInterface, error) {
+		return stub, nil
+	}
+}
+
+// resultsinkInterface is the local alias of resultsink.ResultSink so
+// the stub does not introduce a direct import on every test file
+// (harness_test.go already pulls in the package via the cfg.ResultSink
+// type, but the stub doesn't use any concrete type from there).
+// Renamed alias keeps newResultSink's signature compatible with the
+// production type without copying it.
+type resultsinkInterface = resultsink.ResultSink
+
+// TestEmitRunOutput_JSONWithNonStdoutSinkAlsoFires pins the
+// forward-compatibility surface for a future gcp-pubsub / gcs sink
+// under --output=json. The flag's STIRRUP_RESULT line goes to stdout,
+// and the configured sink (a different channel) also fires. Today the
+// only way to exercise this branch is via the newResultSink seam
+// because resultsink.NewResultSink rejects gcp-pubsub / gcs as
+// "reserved but not yet implemented".
+func TestEmitRunOutput_JSONWithNonStdoutSinkAlsoFires(t *testing.T) {
+	stub := &stubResultSink{}
+	installStubResultSink(t, stub)
+
+	rt := outputModeRunTrace()
+	// Type set to a future-shaped value so the conditional in
+	// emitRunOutput skips the stdout-json short-circuit and falls
+	// through to emitRunResult.
+	cfg := &types.RunConfig{ResultSink: &types.ResultSinkConfig{Type: "gcp-pubsub"}}
+
+	stdoutDone := captureStdout(t)
+	emitRunOutput(context.Background(), cfg, rt, "json")
+	stdout := stdoutDone()
+
+	if !strings.HasPrefix(stdout, "STIRRUP_RESULT ") {
+		t.Errorf("stdout should still carry STIRRUP_RESULT under --output=json, got: %q", stdout)
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected configured sink to fire exactly once, got %d calls", len(stub.calls))
+	}
+	if stub.calls[0].RunID != rt.ID {
+		t.Errorf("sink received RunID %q, want %q", stub.calls[0].RunID, rt.ID)
+	}
+}
+
+// TestEmitRunOutput_NoneWithNonStdoutSinkStillFires pins the
+// forward-compatibility surface under --output=none: the stderr
+// summary and stdout STIRRUP_RESULT are both suppressed, but a sink
+// targeting a non-stdout destination still fires because it
+// represents a separate operator-configured channel with its own
+// intent.
+func TestEmitRunOutput_NoneWithNonStdoutSinkStillFires(t *testing.T) {
+	stub := &stubResultSink{}
+	installStubResultSink(t, stub)
+
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{ResultSink: &types.ResultSinkConfig{Type: "gcp-pubsub"}}
+
+	stdoutDone := captureStdout(t)
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "none")
+	stdout := stdoutDone()
+	stderr := stderrDone()
+
+	if stdout != "" {
+		t.Errorf("stdout should be empty under --output=none, got: %q", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("stderr should be empty under --output=none, got: %q", stderr)
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected configured sink to fire exactly once, got %d calls", len(stub.calls))
+	}
+	if stub.calls[0].RunID != rt.ID {
+		t.Errorf("sink received RunID %q, want %q", stub.calls[0].RunID, rt.ID)
 	}
 }
 

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -5135,3 +5135,39 @@ func TestRunHarness_OutputFlagRejectsInvalidValue(t *testing.T) {
 		t.Errorf("error should name --output, got: %v", err)
 	}
 }
+
+// TestRunHarness_OutputFlagRejectsInvalidValueBeforeOutputRunconfig
+// pins the S1 fix: --output must be validated before the
+// --output-runconfig dry-run branch exits, otherwise
+// `stirrup harness --output-runconfig=- --output=yaml` returns 0 and
+// captures a config the operator cannot replay (the bad flag was
+// silently dropped). Pins the ordering so a refactor that moves
+// validateOutputMode below the dry-run branch surfaces here.
+func TestRunHarness_OutputFlagRejectsInvalidValueBeforeOutputRunconfig(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("prompt", "test prompt"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+	if err := cmd.Flags().Set("output", "yaml"); err != nil {
+		t.Fatalf("set output: %v", err)
+	}
+	if err := cmd.Flags().Set("output-runconfig", "-"); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+
+	// Capture stdout so a regression that lets the dry-run branch fire
+	// surfaces as a captured config rather than a silently dropped
+	// failure.
+	getOut := captureStdout(t)
+	err := runHarness(cmd, nil)
+	stdout := getOut()
+	if err == nil {
+		t.Fatal("runHarness should reject --output=yaml even with --output-runconfig=-")
+	}
+	if !strings.Contains(err.Error(), "--output") {
+		t.Errorf("error should name --output, got: %v", err)
+	}
+	if stdout != "" {
+		t.Errorf("--output-runconfig=- should not have written to stdout when --output is invalid, got: %q", stdout)
+	}
+}

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -4781,5 +4782,288 @@ func TestRunHarness_EnvVarConfigLoadsBase(t *testing.T) {
 	}
 	if captured.Provider.APIKeyRef != "secret://ENV_INTEGRATION_KEY" {
 		t.Errorf("APIKeyRef = %q, want secret://ENV_INTEGRATION_KEY", captured.Provider.APIKeyRef)
+	}
+}
+
+// captureStderr mirrors captureStdout for fd 2. Used by the --output
+// flag tests to assert that --output=json / --output=none suppress the
+// human-readable stderr summary that --output=text (the default)
+// continues to print.
+func captureStderr(t *testing.T) func() string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+	return func() string {
+		os.Stderr = orig
+		_ = w.Close()
+		out := <-done
+		_ = r.Close()
+		return out
+	}
+}
+
+// outputModeRunTrace builds a fixed RunTrace the emitRunOutput tests
+// reuse so each test exercises the same payload through a different
+// mode. The fields are deliberately non-zero (turn count, token usage,
+// duration) so a buggy mode that drops the payload is detectable.
+func outputModeRunTrace() *types.RunTrace {
+	started := time.Now()
+	return &types.RunTrace{
+		ID:          "run-output-test",
+		StartedAt:   started,
+		CompletedAt: started.Add(2 * time.Second),
+		Turns:       4,
+		Outcome:     "success",
+		TokenUsage:  types.TokenUsage{Input: 1234, Output: 567},
+	}
+}
+
+// TestEmitRunOutput_TextDefaultMatchesLegacyBehaviour pins the
+// acceptance-criterion "--output=text matches today's behaviour
+// exactly": the stderr summary is printed and the configured (default)
+// resultSink — "none" — emits nothing. No STIRRUP_RESULT line should
+// appear on stdout because no sink is configured.
+func TestEmitRunOutput_TextDefaultMatchesLegacyBehaviour(t *testing.T) {
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{} // ResultSink nil ≡ NoneSink
+
+	stdoutDone := captureStdout(t)
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "text")
+	stdout := stdoutDone()
+	stderr := stderrDone()
+
+	if !strings.Contains(stderr, "--- Run complete ---") {
+		t.Errorf("stderr should contain the legacy summary header, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Outcome: success") {
+		t.Errorf("stderr should contain Outcome line, got: %q", stderr)
+	}
+	if strings.Contains(stdout, "STIRRUP_RESULT") {
+		t.Errorf("stdout should be empty (no stdout-json sink configured), got: %q", stdout)
+	}
+}
+
+// TestEmitRunOutput_JSONEmitsSingleStdoutLine pins the acceptance
+// criterion that --output=json writes exactly one STIRRUP_RESULT line
+// on stdout and prints nothing on stderr (the legacy summary is
+// suppressed). The JSON payload must be parseable as RunResult.
+func TestEmitRunOutput_JSONEmitsSingleStdoutLine(t *testing.T) {
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{} // ResultSink nil ≡ NoneSink
+
+	stdoutDone := captureStdout(t)
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "json")
+	stdout := stdoutDone()
+	stderr := stderrDone()
+
+	if strings.Contains(stderr, "--- Run complete ---") {
+		t.Errorf("stderr should NOT contain the legacy summary when --output=json, got: %q", stderr)
+	}
+	if !strings.HasPrefix(stdout, "STIRRUP_RESULT ") {
+		t.Fatalf("stdout should start with STIRRUP_RESULT sentinel, got: %q", stdout)
+	}
+	if strings.Count(stdout, "STIRRUP_RESULT ") != 1 {
+		t.Errorf("expected exactly one STIRRUP_RESULT line, got: %q", stdout)
+	}
+	// Strip the sentinel and the trailing newline before parsing.
+	payload := strings.TrimSpace(strings.TrimPrefix(stdout, "STIRRUP_RESULT "))
+	var got types.RunResult
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("STIRRUP_RESULT payload should parse as RunResult: %v\npayload: %s", err, payload)
+	}
+	if got.RunID != "run-output-test" {
+		t.Errorf("RunResult.RunID = %q, want run-output-test", got.RunID)
+	}
+	if got.Outcome != "success" {
+		t.Errorf("RunResult.Outcome = %q, want success", got.Outcome)
+	}
+	if got.Turns != 4 {
+		t.Errorf("RunResult.Turns = %d, want 4", got.Turns)
+	}
+}
+
+// TestEmitRunOutput_NoneSuppressesBoth pins the acceptance criterion
+// that --output=none produces no post-run summary on either stream.
+// Workspace export, follow-up grace, and exit code are exercised
+// elsewhere — this test scopes to the summary surfaces only.
+func TestEmitRunOutput_NoneSuppressesBoth(t *testing.T) {
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{}
+
+	stdoutDone := captureStdout(t)
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "none")
+	stdout := stdoutDone()
+	stderr := stderrDone()
+
+	if stderr != "" {
+		t.Errorf("stderr should be empty when --output=none, got: %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout should be empty when --output=none, got: %q", stdout)
+	}
+}
+
+// TestEmitRunOutput_JSONWithStdoutJSONSinkEmitsOnce pins the
+// deduplication rule from the issue: --output=json and
+// resultSink.type=stdout-json together must produce exactly one
+// STIRRUP_RESULT line, not two. The flag wins because it is the more
+// explicit signal.
+func TestEmitRunOutput_JSONWithStdoutJSONSinkEmitsOnce(t *testing.T) {
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{
+		ResultSink: &types.ResultSinkConfig{Type: "stdout-json"},
+	}
+
+	stdoutDone := captureStdout(t)
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "json")
+	stdout := stdoutDone()
+	stderr := stderrDone()
+
+	if strings.Contains(stderr, "--- Run complete ---") {
+		t.Errorf("stderr should NOT contain the legacy summary, got: %q", stderr)
+	}
+	if got := strings.Count(stdout, "STIRRUP_RESULT "); got != 1 {
+		t.Errorf("expected exactly one STIRRUP_RESULT line, got %d: %q", got, stdout)
+	}
+}
+
+// TestEmitRunOutput_TextWithStdoutJSONSinkUnchanged pins the legacy
+// behaviour when --output is left at "text" and the operator has
+// configured resultSink.type=stdout-json: the stderr summary prints
+// AND the configured sink emits its STIRRUP_RESULT line. This is the
+// pre-#242 surface the regression-tested acceptance criterion relies
+// on.
+func TestEmitRunOutput_TextWithStdoutJSONSinkUnchanged(t *testing.T) {
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{
+		ResultSink: &types.ResultSinkConfig{Type: "stdout-json"},
+	}
+
+	stdoutDone := captureStdout(t)
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "text")
+	stdout := stdoutDone()
+	stderr := stderrDone()
+
+	if !strings.Contains(stderr, "--- Run complete ---") {
+		t.Errorf("stderr should contain the legacy summary on --output=text, got: %q", stderr)
+	}
+	if got := strings.Count(stdout, "STIRRUP_RESULT "); got != 1 {
+		t.Errorf("expected exactly one STIRRUP_RESULT line from configured sink, got %d: %q", got, stdout)
+	}
+}
+
+// TestEmitRunOutput_JSONPartialTraceEmitsCancellationOutcome pins the
+// edge case from the issue: a run cancelled mid-flight should produce
+// a partial RunResult with the cancellation outcome rather than
+// nothing. emitRunOutput is the dispatch site; here we hand it a
+// RunTrace whose Outcome is "cancelled" and assert the JSON line
+// surfaces it.
+func TestEmitRunOutput_JSONPartialTraceEmitsCancellationOutcome(t *testing.T) {
+	started := time.Now()
+	rt := &types.RunTrace{
+		ID:          "run-cancelled",
+		StartedAt:   started,
+		CompletedAt: started.Add(750 * time.Millisecond),
+		Turns:       1,
+		Outcome:     "cancelled",
+	}
+	cfg := &types.RunConfig{}
+
+	stdoutDone := captureStdout(t)
+	emitRunOutput(context.Background(), cfg, rt, "json")
+	stdout := stdoutDone()
+
+	if !strings.HasPrefix(stdout, "STIRRUP_RESULT ") {
+		t.Fatalf("stdout should start with STIRRUP_RESULT sentinel even on cancellation, got: %q", stdout)
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(stdout, "STIRRUP_RESULT "))
+	var got types.RunResult
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("STIRRUP_RESULT payload should parse as RunResult on cancellation: %v\npayload: %s", err, payload)
+	}
+	if got.Outcome != "cancelled" {
+		t.Errorf("RunResult.Outcome = %q, want cancelled", got.Outcome)
+	}
+}
+
+// TestEmitRunOutput_EmptyModeMatchesText pins the runJob entry-point's
+// implicit dependency on the default branch: the job command does not
+// thread --output, so it passes outputMode="" and expects the legacy
+// "print summary + emit configured sink" behaviour. This guards
+// against a refactor that would otherwise silently break the job path.
+func TestEmitRunOutput_EmptyModeMatchesText(t *testing.T) {
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{}
+
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "")
+	stderr := stderrDone()
+
+	if !strings.Contains(stderr, "--- Run complete ---") {
+		t.Errorf("empty outputMode should default to text behaviour, got stderr: %q", stderr)
+	}
+}
+
+// TestValidateOutputMode_AcceptsClosedSet pins the closed three-value
+// set surfaced via --output. A new value would need a corresponding
+// branch in emitRunOutput; this test forces the two to evolve
+// together by failing if validateOutputMode silently accepts an
+// unsupported value.
+func TestValidateOutputMode_AcceptsClosedSet(t *testing.T) {
+	for _, mode := range []string{"text", "json", "none"} {
+		if err := validateOutputMode(mode); err != nil {
+			t.Errorf("validateOutputMode(%q) = %v, want nil", mode, err)
+		}
+	}
+}
+
+// TestValidateOutputMode_RejectsUnsupported pins the operator-facing
+// failure mode: a typo at the CLI surfaces as a clear error rather
+// than being silently swallowed and ignored at the dispatch site.
+func TestValidateOutputMode_RejectsUnsupported(t *testing.T) {
+	cases := []string{"", "json5", "yaml", "TEXT", "jsonl"}
+	for _, mode := range cases {
+		if err := validateOutputMode(mode); err == nil {
+			t.Errorf("validateOutputMode(%q) returned nil, want error", mode)
+		}
+	}
+}
+
+// TestRunHarness_OutputFlagRejectsInvalidValue is the end-to-end
+// integration test for the closed-set validation: an invalid --output
+// value must surface as an error from runHarness rather than being
+// silently dropped. Pairs with TestValidateOutputMode_RejectsUnsupported
+// (which pins the helper directly) to catch a regression that would
+// stop calling validateOutputMode at all.
+func TestRunHarness_OutputFlagRejectsInvalidValue(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("prompt", "test prompt"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+	if err := cmd.Flags().Set("output", "yaml"); err != nil {
+		t.Fatalf("set output: %v", err)
+	}
+
+	err := runHarness(cmd, nil)
+	if err == nil {
+		t.Fatal("runHarness should reject --output=yaml")
+	}
+	if !strings.Contains(err.Error(), "--output") {
+		t.Errorf("error should name --output, got: %v", err)
 	}
 }

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -5084,6 +5085,68 @@ func TestEmitRunOutput_TextWithNilTracePrintsNoTrace(t *testing.T) {
 	stderr := stderrDone()
 	if !strings.Contains(stderr, "no trace") {
 		t.Errorf("stderr should describe nil-trace condition, got: %q", stderr)
+	}
+}
+
+// TestEmitRunOutput_JSONWithNilTraceLogsWarning pins the S3 fix: a
+// nil trace under --output=json produces a structurally valid
+// STIRRUP_RESULT line with Outcome="internal-error", but operators
+// consuming only the JSON stream would otherwise have no diagnostic
+// for the underlying nil-trace condition. The slog.Warn at the top
+// of emitRunOutput surfaces the diagnostic in process logs.
+func TestEmitRunOutput_JSONWithNilTraceLogsWarning(t *testing.T) {
+	prevDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var logBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	cfg := &types.RunConfig{}
+	stdoutDone := captureStdout(t)
+	emitRunOutput(context.Background(), cfg, nil, "json")
+	stdout := stdoutDone()
+
+	if !strings.HasPrefix(stdout, "STIRRUP_RESULT ") {
+		t.Fatalf("stdout should start with STIRRUP_RESULT sentinel even on nil trace, got: %q", stdout)
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(stdout, "STIRRUP_RESULT "))
+	var got types.RunResult
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("STIRRUP_RESULT payload should parse as RunResult: %v\npayload: %s", err, payload)
+	}
+	if got.Outcome != "internal-error" {
+		t.Errorf("Outcome = %q, want internal-error", got.Outcome)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "nil RunTrace") {
+		t.Errorf("expected slog.Warn about nil RunTrace, got: %q", logs)
+	}
+}
+
+// TestEmitRunOutput_UnrecognisedModeLogsAndDefaultsToText pins the
+// S2 fix: an unrecognised mode reached at this layer (the CLI
+// validator catches them earlier, so reaching here means a new caller
+// or a new mode that didn't update both switches) must surface a
+// diagnostic and fall through to the text behaviour rather than
+// silently dropping the summary.
+func TestEmitRunOutput_UnrecognisedModeLogsAndDefaultsToText(t *testing.T) {
+	prevDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var logBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{}
+
+	stderrDone := captureStderr(t)
+	emitRunOutput(context.Background(), cfg, rt, "yaml")
+	stderr := stderrDone()
+
+	if !strings.Contains(stderr, "--- Run complete ---") {
+		t.Errorf("unrecognised mode should fall through to text, stderr: %q", stderr)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "unrecognised mode") {
+		t.Errorf("expected slog.Warn about unrecognised mode, got: %q", logs)
 	}
 }
 

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -5019,6 +5019,45 @@ func TestEmitRunOutput_EmptyModeMatchesText(t *testing.T) {
 	}
 }
 
+// TestPrintRunSummary_NilTraceDoesNotPanic pins the nil guard added in
+// M1. A nil RunTrace would otherwise dereference at the Outcome field
+// and crash the process before any structured output is emitted —
+// buildRunResult already returns a documented "internal-error"
+// sentinel for the same condition, and printRunSummary now mirrors
+// that defensive shape on stderr.
+func TestPrintRunSummary_NilTraceDoesNotPanic(t *testing.T) {
+	stderrDone := captureStderr(t)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("printRunSummary(nil) panicked: %v", r)
+		}
+	}()
+	printRunSummary(nil)
+	stderr := stderrDone()
+	if !strings.Contains(stderr, "no trace") {
+		t.Errorf("stderr should describe the nil-trace condition, got: %q", stderr)
+	}
+}
+
+// TestEmitRunOutput_TextWithNilTracePrintsNoTrace pins the
+// emitRunOutput dispatch path under --output=text when the loop
+// produced no trace at all. The text branch must surface the nil-trace
+// diagnostic on stderr rather than panicking.
+func TestEmitRunOutput_TextWithNilTracePrintsNoTrace(t *testing.T) {
+	cfg := &types.RunConfig{}
+	stderrDone := captureStderr(t)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("emitRunOutput with nil trace panicked: %v", r)
+		}
+	}()
+	emitRunOutput(context.Background(), cfg, nil, "text")
+	stderr := stderrDone()
+	if !strings.Contains(stderr, "no trace") {
+		t.Errorf("stderr should describe nil-trace condition, got: %q", stderr)
+	}
+}
+
 // TestValidateOutputMode_AcceptsClosedSet pins the closed three-value
 // set surfaced via --output. A new value would need a corresponding
 // branch in emitRunOutput; this test forces the two to evolve

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -588,6 +588,7 @@ func newTestHarnessCommand() *cobra.Command {
 	// RunConfig. Mirrors the registration in harness.go init().
 	f.Bool("export-workspace-required", false, "")
 	f.String("output-runconfig", "", "")
+	f.StringP("output", "o", "text", "")
 	return cmd
 }
 

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -5039,6 +5039,35 @@ func TestPrintRunSummary_NilTraceDoesNotPanic(t *testing.T) {
 	}
 }
 
+// TestEmitRunOutput_CancelledContextStillEmits pins the M2 fix:
+// emitRunOutput must be reachable with a usable context even when the
+// run's primary context has already been cancelled. The synthesizer's
+// concern is that a future remote sink (gcp-pubsub, gcs) honouring
+// ctx would otherwise drop every signal-cancelled run's STIRRUP_RESULT
+// silently. Today the StdoutJSONSink ignores ctx, so this test only
+// guards the dispatch site: passing a pre-cancelled ctx must still
+// produce the STIRRUP_RESULT line under --output=json. The
+// runWithConfig and runJob caller sites have been updated to build a
+// fresh context before invoking emitRunOutput; this test pins the
+// observable behaviour so a regression that re-introduces the
+// cancelled context surfaces in the test suite rather than only
+// when a remote sink ships.
+func TestEmitRunOutput_CancelledContextStillEmits(t *testing.T) {
+	rt := outputModeRunTrace()
+	cfg := &types.RunConfig{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	stdoutDone := captureStdout(t)
+	emitRunOutput(ctx, cfg, rt, "json")
+	stdout := stdoutDone()
+
+	if !strings.HasPrefix(stdout, "STIRRUP_RESULT ") {
+		t.Fatalf("stdout should start with STIRRUP_RESULT even with cancelled ctx (StdoutJSONSink does not honour ctx), got: %q", stdout)
+	}
+}
+
 // TestEmitRunOutput_TextWithNilTracePrintsNoTrace pins the
 // emitRunOutput dispatch path under --output=text when the loop
 // produced no trace at all. The text branch must surface the nil-trace

--- a/harness/cmd/stirrup/cmd/job.go
+++ b/harness/cmd/stirrup/cmd/job.go
@@ -132,8 +132,14 @@ func runJob(cmd *cobra.Command, args []string) error {
 	// resultSink emission mirrors the harness command path so a Cloud
 	// Run / Kubernetes job can be configured with
 	// resultSink.type=stdout-json and have its answer scraped from the
-	// pod's stdout regardless of which entrypoint launched it.
-	emitRunResult(ctx, config, runTrace)
+	// pod's stdout regardless of which entrypoint launched it. Uses a
+	// fresh context for the same reason as runWithConfig: ctx may
+	// already be cancelled here when a SIGTERM triggered the job to
+	// stop, and a future remote sink would silently drop the result
+	// line on every cancelled run. See postRunEmitTimeout in root.go.
+	emitCtx, emitCancel := context.WithTimeout(context.Background(), postRunEmitTimeout)
+	defer emitCancel()
+	emitRunResult(emitCtx, config, runTrace)
 
 	// Workspace export. The job entrypoint has no equivalent of the
 	// CLI's --export-workspace-required, so the control plane decides
@@ -141,8 +147,11 @@ func runJob(cmd *cobra.Command, args []string) error {
 	// upload failures as non-fatal: an exit-failing job would lose
 	// the run's trace and resultSink before the operator could
 	// correlate it. Operators who need a hard requirement should
-	// guard the URI on the control-plane side.
-	if err := exportWorkspace(ctx, config, false); err != nil {
+	// guard the URI on the control-plane side. Independent post-run
+	// context — see runWithConfig for the same rationale.
+	exportCtx, exportCancel := context.WithTimeout(context.Background(), postRunExportTimeout)
+	defer exportCancel()
+	if err := exportWorkspace(exportCtx, config, false); err != nil {
 		// exportWorkspace returns nil in the non-required path, so
 		// reaching here is impossible given the false above. The
 		// guard keeps the signature compatible if the contract ever

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -37,8 +37,17 @@ func generateRunID() string {
 	return fmt.Sprintf("run-%d", time.Now().UnixNano())
 }
 
-// printRunSummary writes a brief run summary to stderr.
+// printRunSummary writes a brief run summary to stderr. Mirrors the nil
+// guard in buildRunResult: a nil RunTrace means the loop produced no
+// trace at all, and dereferencing the fields below would panic before
+// any structured output is emitted. The "no trace" line is the
+// stderr-side counterpart to the "internal-error" sentinel buildRunResult
+// returns so operators see a diagnostic on whichever surface they watch.
 func printRunSummary(runTrace *types.RunTrace) {
+	if runTrace == nil {
+		fmt.Fprintf(os.Stderr, "\n--- Run complete (no trace) ---\n")
+		return
+	}
 	fmt.Fprintf(os.Stderr, "\n--- Run complete ---\n")
 	fmt.Fprintf(os.Stderr, "Outcome: %s\n", runTrace.Outcome)
 	fmt.Fprintf(os.Stderr, "Turns: %d\n", runTrace.Turns)

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -121,6 +121,14 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 	return res
 }
 
+// newResultSink is the seam tests use to inject a stub ResultSink so
+// the forward-compatibility branches in emitRunOutput (non-stdout-json
+// sink paths under --output=json and --output=none) can be exercised
+// before the gcp-pubsub / gcs sinks ship. Production code retains the
+// resultsink.NewResultSink factory; tests overwrite the variable for
+// the duration of a test and restore it on cleanup.
+var newResultSink = resultsink.NewResultSink
+
 // emitRunResult builds and emits a RunResult through the configured
 // resultSink. Failures are logged but never fatal — the trace and the
 // stderr summary already carry the run's outcome, so a transient sink
@@ -129,7 +137,7 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 // line is the last thing on stdout (per the issue's Cloud Logging
 // extraction contract).
 func emitRunResult(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace) {
-	sink, err := resultsink.NewResultSink(cfg.ResultSink)
+	sink, err := newResultSink(cfg.ResultSink)
 	if err != nil {
 		slog.Warn("build resultSink", "err", err)
 		return

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -142,10 +142,14 @@ func emitRunResult(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace
 // emitRunOutput dispatches the post-run summary surfaces selected by
 // --output (issue #242). Three modes are supported:
 //
-//   - "text" (or "" for backward compatibility with callers that bypass
-//     the flag — only the job command today): print the human-readable
-//     stderr summary AND emit through the configured resultSink. This
-//     matches the pre-#242 behaviour exactly.
+//   - "text": print the human-readable stderr summary AND emit through
+//     the configured resultSink. This matches the pre-#242 behaviour
+//     exactly. The empty string "" is also accepted and treated as
+//     "text" for backward compatibility — runJob historically called
+//     this path with mode unset, and while runJob today calls
+//     printRunSummary + emitRunResult directly, accepting "" here
+//     keeps the function safe for a future caller that copies the
+//     runWithConfig shape without threading outputMode.
 //   - "json": skip the stderr summary; emit a single STIRRUP_RESULT line
 //     on stdout. When resultSink.type=stdout-json is also configured,
 //     the line is emitted once — the flag wins because it is the more
@@ -160,7 +164,22 @@ func emitRunResult(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace
 // All emissions go through buildRunResult so a partial RunResult (e.g.
 // a cancelled run) round-trips identically through every mode. Sink
 // failures are logged via emitRunResult and never fatal.
+//
+// An unrecognised mode reached here is treated as "text" but logs a
+// slog.Warn — runHarness validates the closed set at the CLI layer, so
+// reaching the default arm indicates either a new caller or a new mode
+// that did not update both switches. The warning surfaces the
+// regression in process logs without dropping the run's summary.
 func emitRunOutput(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace, mode string) {
+	if rt == nil {
+		// buildRunResult maps this case to an "internal-error" RunResult
+		// sentinel. Operators consuming --output=json alone would
+		// otherwise see a structurally valid line with no diagnostic
+		// linking the outcome back to "the loop produced no trace at
+		// all". Emit a slog.Warn so the diagnostic lands in process
+		// logs regardless of which output mode suppresses stderr.
+		slog.Warn("emitRunOutput: nil RunTrace, RunResult will carry the internal-error sentinel", "mode", mode)
+	}
 	switch mode {
 	case "json":
 		// Always emit a STIRRUP_RESULT line to stdout. When the
@@ -184,7 +203,11 @@ func emitRunOutput(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace
 			return
 		}
 		emitRunResult(ctx, cfg, rt)
+	case "text", "":
+		printRunSummary(rt)
+		emitRunResult(ctx, cfg, rt)
 	default:
+		slog.Warn("emitRunOutput: unrecognised mode, defaulting to text", "mode", mode)
 		printRunSummary(rt)
 		emitRunResult(ctx, cfg, rt)
 	}

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -37,6 +37,26 @@ func generateRunID() string {
 	return fmt.Sprintf("run-%d", time.Now().UnixNano())
 }
 
+// postRunEmitTimeout bounds the fresh context used for emitRunOutput
+// after the agentic loop returns. The loop's primary context is already
+// cancelled by the time we reach here when a signal triggered the run
+// to stop, so future remote sinks (gcp-pubsub, gcs) would otherwise
+// silently fail to emit their STIRRUP_RESULT — emitRunResult
+// logs-and-discards sink errors, hiding the loss. 10 s is the same
+// shape as the bestEffortCancel deadline in batchpoll.go: enough for a
+// single remote RPC, short enough that operators see process exit
+// without an apparent hang.
+const postRunEmitTimeout = 10 * time.Second
+
+// postRunExportTimeout bounds the fresh context used for
+// exportWorkspace after the agentic loop returns. Larger than
+// postRunEmitTimeout because the upload carries a tarball that can run
+// into the tens of MB; the GCS exporter's per-request HTTP client
+// already enforces a 5-minute upload ceiling, so this context only
+// gates the orchestration around the call. 6 minutes leaves room for
+// the exporter's internal 5 m and a small amount of setup overhead.
+const postRunExportTimeout = 6 * time.Minute
+
 // printRunSummary writes a brief run summary to stderr. Mirrors the nil
 // guard in buildRunResult: a nil RunTrace means the loop produced no
 // trace at all, and dereferencing the fields below would panic before

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -95,9 +95,10 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 // emitRunResult builds and emits a RunResult through the configured
 // resultSink. Failures are logged but never fatal — the trace and the
 // stderr summary already carry the run's outcome, so a transient sink
-// error must not mask a successful run. Called from runWithConfig and
-// runJob after the stderr summary so the structured line is the last
-// thing on stdout (per the issue's Cloud Logging extraction contract).
+// error must not mask a successful run. Called from runWithConfig (via
+// emitRunOutput) and runJob after the stderr summary so the structured
+// line is the last thing on stdout (per the issue's Cloud Logging
+// extraction contract).
 func emitRunResult(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace) {
 	sink, err := resultsink.NewResultSink(cfg.ResultSink)
 	if err != nil {
@@ -106,6 +107,57 @@ func emitRunResult(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace
 	}
 	if err := sink.Emit(ctx, buildRunResult(rt)); err != nil {
 		slog.Warn("emit resultSink", "err", err)
+	}
+}
+
+// emitRunOutput dispatches the post-run summary surfaces selected by
+// --output (issue #242). Three modes are supported:
+//
+//   - "text" (or "" for backward compatibility with callers that bypass
+//     the flag — only the job command today): print the human-readable
+//     stderr summary AND emit through the configured resultSink. This
+//     matches the pre-#242 behaviour exactly.
+//   - "json": skip the stderr summary; emit a single STIRRUP_RESULT line
+//     on stdout. When resultSink.type=stdout-json is also configured,
+//     the line is emitted once — the flag wins because it is the more
+//     explicit signal. When the configured sink targets a different
+//     surface (a future gcp-pubsub or gcs adapter), that sink also fires
+//     because it represents a separate channel with its own intent.
+//   - "none": suppress the stderr summary AND any emission that would
+//     write to stdout. The configured sink still fires when it targets a
+//     non-stdout surface, on the same "different channel, different
+//     intent" rationale.
+//
+// All emissions go through buildRunResult so a partial RunResult (e.g.
+// a cancelled run) round-trips identically through every mode. Sink
+// failures are logged via emitRunResult and never fatal.
+func emitRunOutput(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace, mode string) {
+	switch mode {
+	case "json":
+		// Always emit a STIRRUP_RESULT line to stdout. When the
+		// configured sink is also stdout-json, swap it out for "none"
+		// before delegating so emitRunResult does not produce a second
+		// line. Any non-stdout sink stays untouched (different channel).
+		stdoutSink := resultsink.NewStdoutJSONSink()
+		if err := stdoutSink.Emit(ctx, buildRunResult(rt)); err != nil {
+			slog.Warn("emit --output=json", "err", err)
+		}
+		if cfg.ResultSink == nil || cfg.ResultSink.Type == "stdout-json" {
+			return
+		}
+		emitRunResult(ctx, cfg, rt)
+	case "none":
+		// Skip the stderr summary. The configured sink is invoked only
+		// when it targets a non-stdout destination so --output=none
+		// genuinely suppresses every stdout / stderr summary surface
+		// regardless of which sink the run config selected.
+		if cfg.ResultSink == nil || cfg.ResultSink.Type == "" || cfg.ResultSink.Type == "none" || cfg.ResultSink.Type == "stdout-json" {
+			return
+		}
+		emitRunResult(ctx, cfg, rt)
+	default:
+		printRunSummary(rt)
+		emitRunResult(ctx, cfg, rt)
 	}
 }
 


### PR DESCRIPTION
Closes #242.

The harness wrote two post-run summaries on every run — a freeform
stderr block (`printRunSummary`) and an optional `STIRRUP_RESULT`
line via `resultSink` — with no single switch to select between them.
Operators parsing the output had to either scrape the stderr text or
configure `resultSink.type=stdout-json`; neither was discoverable from
`--help`, and the stderr summary remained noise on a structured-output
run. The new `--output` (`-o`) flag exposes three modes — `text` (the
default, today's behaviour exactly), `json` (single `STIRRUP_RESULT`
line on stdout, stderr suppressed), and `none` (suppresses both) —
and collapses the `--output=json` + `resultSink.type=stdout-json`
overlap into a single emission so log-extraction pipelines never see
duplicate result lines.

## Test plan

- [x] `just` passes (build + full test suite).
- [x] `just lint` passes (golangci-lint v2, 0 issues).
- [x] New unit tests cover all three `--output` modes, the dedup rule,
  the cancellation edge case, and the closed-set validator.
- [ ] Manual smoke: `./stirrup harness --output=json --prompt "say hi"`
  emits a single `STIRRUP_RESULT` line and no stderr summary.
- [ ] Manual smoke: `./stirrup harness --output=none --prompt "say hi"`
  emits nothing on either stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)