### PR TITLE
cli: add stirrup trace subcommand family

### DIFF
--- a/docs/observability-cloud.md
+++ b/docs/observability-cloud.md
@@ -11,6 +11,10 @@ model — what spans, metrics, and resource attributes Stirrup emits —
 see [`safety-rings.md`](safety-rings.md) and the
 "OpenTelemetry trace emitter" section of the repo-root `CLAUDE.md`.
 
+For operators inspecting the JSONL trace emitter's output (offline
+pretty-print, follow-tail, aggregate stats, JSON-path filtering),
+see [`trace-inspection.md`](trace-inspection.md).
+
 ## Quick choice
 
 | Where do you want telemetry to land? | Use |

--- a/docs/trace-inspection.md
+++ b/docs/trace-inspection.md
@@ -78,6 +78,14 @@ SIGINT (Ctrl-C) terminates the follow loop cleanly. `tail -f -` reads
 from stdin — the follow flag is redundant in that mode because stdin
 already blocks until more bytes are written.
 
+> **Truncation and rotation are not followed.** `tail -f` keeps the
+> same file handle open. If the file is truncated or rotated out
+> from under it, the offset stays past the new EOF and the follow
+> loop appears to stall with no further output and no error.
+> Restart the command to pick up the rotated file. Full
+> `tail --follow=name` semantics (inode-tracking) are out of scope
+> — stirrup's own traces are append-only.
+
 ## `trace stats`
 
 ```sh

--- a/docs/trace-inspection.md
+++ b/docs/trace-inspection.md
@@ -1,0 +1,254 @@
+# Inspecting JSONL trace files
+
+A run configured with `traceEmitter.type=jsonl` writes a newline-delimited
+JSON document describing the run's turns, tool calls, token usage,
+verification results, and final outcome. The `stirrup trace`
+subcommand family inspects those files first-party so operators do
+not have to reinvent the wheel with `cat`, `jq`, and ad-hoc shell.
+
+This page is the operator walkthrough. For the wire schema, see the
+`types.RunTrace`, `types.TurnTrace`, and `types.ToolCallSummary`
+definitions in [`types/runtrace.go`](../types/runtrace.go).
+
+## Quick choice
+
+| Want to… | Use |
+|---|---|
+| Read a finished trace end-to-end | `stirrup trace show <file>` |
+| Watch a still-running trace | `stirrup trace tail -f <file>` |
+| Pull aggregate counters into a dashboard | `stirrup trace stats <file> --output=json` |
+| Pull every record matching a predicate | `stirrup trace grep --jq '<path> <op> <value>' <file>` |
+
+Every subcommand accepts `-` as the file argument to read from stdin,
+so the family composes with shell pipelines:
+
+```sh
+tail -F live.jsonl | stirrup trace show -
+gunzip -c archived.jsonl.gz | stirrup trace stats - --output=json
+```
+
+A `.gz` archive is read by piping through `gunzip` or `zcat`; the
+subcommands themselves are uncompressed-only and do not embed a
+gzip dependency.
+
+## `trace show`
+
+```sh
+stirrup trace show example.jsonl
+```
+
+Pretty-prints the trace in chronological order: the run metadata
+header, every tool call in the order it ran, the verification
+verdicts, and a per-tool aggregate at the foot. Tool calls flagged
+unsuccessful are surfaced in red; the outcome is colour-coded green
+(success), red (error/verification_failed/tool_failures),
+yellow (max_turns / max_tokens / budget_exceeded / stalled / timeout),
+grey (cancelled), or blue (anything unrecognised).
+
+ANSI colour is auto-detected: stdout to a TTY is coloured; stdout
+piped to a file or `less` is not. Override the detection with:
+
+```sh
+stirrup trace show example.jsonl --color=never   # plain text always
+stirrup trace show example.jsonl --color=always  # colour even when piping
+```
+
+## `trace tail`
+
+```sh
+stirrup trace tail live.jsonl       # one-shot equivalent of show
+stirrup trace tail -f live.jsonl    # follow the file as it grows
+```
+
+`tail` reads the file once and prints every record (one-shot). With
+`-f` (or `--follow`), it polls the file at `--interval` (default 100ms)
+and prints records as they are appended. The polling interval is
+configurable for very quiet files:
+
+```sh
+stirrup trace tail -f live.jsonl --interval=500ms
+```
+
+`tail` uses a polling loop rather than a kernel notification API.
+Trace files are append-only and a sub-second poll is sufficient to
+keep an operator's terminal in sync without inflating the dependency
+footprint.
+
+SIGINT (Ctrl-C) terminates the follow loop cleanly. `tail -f -` reads
+from stdin — the follow flag is redundant in that mode because stdin
+already blocks until more bytes are written.
+
+## `trace stats`
+
+```sh
+stirrup trace stats example.jsonl
+stirrup trace stats example.jsonl --output=json | jq .totalTurns
+```
+
+`stats` walks the file once and prints a compact summary. Metric
+names mirror the OTel counters in
+[`harness/internal/observability/metrics.go`](../harness/internal/observability/metrics.go)
+so a single vocabulary covers online dashboards and offline
+inspection.
+
+### Text output
+
+```
+trace stats
+  runId:            run-1735900000
+  harness version:  v1.7.0
+  records:          1
+  total turns:      12
+  tokens in / out:  18432 / 4116
+  tool calls:       45 (errors: 3)
+  verifications:    1 run (passed: 1, failed: 0)
+  longest call ms:  2811
+  wall clock:       42.317s
+  tool counts:
+    edit_file                        18
+    grep                             14
+    read_file                        10
+    run_command                       3  (errors: 3)
+  outcomes:
+    success                           1
+  slowest tool calls:
+     1. run_command                     2811ms  fail
+     2. grep                            1204ms  ok
+     ...
+```
+
+The `harnessVersion` line carries the version of the binary that
+computed the stats, NOT the binary that wrote the trace. Use this to
+correlate aggregate counters across deployments — a stats output
+produced by a newer `stirrup` binary against an older trace records
+the new binary's version.
+
+### JSON output
+
+```sh
+stirrup trace stats example.jsonl --output=json
+```
+
+Produces a single JSON line whose shape is `TraceStats` in
+[`harness/cmd/stirrup/cmd/trace_stats.go`](../harness/cmd/stirrup/cmd/trace_stats.go).
+The JSON form is stable across the same minor version of the binary
+and is intended as a dashboard / report ingestion shape:
+
+```json
+{
+  "runId": "run-1735900000",
+  "harnessVersion": "v1.7.0",
+  "records": 1,
+  "totalTurns": 12,
+  "tokensInput": 18432,
+  "tokensOutput": 4116,
+  "toolCalls": 45,
+  "toolErrors": 3,
+  "toolCallsByName": {"edit_file": 18, "grep": 14, ...},
+  "toolErrorsByName": {"run_command": 3},
+  "outcomes": {"success": 1},
+  "longestToolCallMs": 2811,
+  "totalWallClockMs": 42317,
+  "slowestToolCalls": [...]
+}
+```
+
+`--top N` controls how many entries appear in the text-mode
+`slowest tool calls` table. JSON output always carries the full list.
+
+## `trace grep`
+
+`grep` filters records and prints the matching JSON lines verbatim,
+one record per line — equivalent to `jq -c 'select(<predicate>)'` but
+without the `jq` binary dependency.
+
+### Substring matching
+
+```sh
+stirrup trace grep edit_file example.jsonl
+```
+
+Prints every record whose raw JSON contains the literal substring
+`edit_file`.
+
+### JSON-path predicate
+
+```sh
+stirrup trace grep --jq '.outcome == "success"' example.jsonl
+stirrup trace grep --jq '.turns != 0' example.jsonl
+stirrup trace grep --jq '.toolCalls.0.name == "edit_file"' example.jsonl
+stirrup trace grep --jq '.outcome contains "fail"' example.jsonl
+```
+
+The `--jq` predicate is a deliberately tiny three-operator grammar:
+
+```
+<path> ( == | != | contains ) <value>
+```
+
+The path is a dot-separated walk of object keys and numeric array
+indices. The value is a double-quoted string, a bare number, or one
+of the literals `true`, `false`, `null`. The grammar is enough to
+cover the common "give me the records where X is Y" workflow without
+embedding a full jq interpreter. For richer filtering, the substring
+and predicate combine, and the matching JSON is emitted verbatim so
+downstream `jq` can run on the filtered stream if installed.
+
+### Combining
+
+The positional pattern and `--jq` predicate are AND-combined — both
+must match. Use `--invert-match` to negate the result.
+
+```sh
+# Records whose outcome failed AND whose JSON mentions a specific tool.
+stirrup trace grep run_command --jq '.outcome != "success"' example.jsonl
+```
+
+## Reading from stdin
+
+Every subcommand accepts `-` as the file argument. This is the canonical
+shape for non-file sources: `gunzip`, `kubectl logs`, `gcloud storage cat`.
+
+```sh
+gcloud storage cat gs://stirrup-traces/run-42.jsonl | stirrup trace stats -
+```
+
+The `traceEmitter.type=jsonl` path also accepts `/dev/stdout` as a
+filename, so a run can stream its trace through a shell pipe:
+
+```sh
+stirrup harness --trace=/dev/stdout --trace-emitter=jsonl ... | stirrup trace tail -
+```
+
+## Edge cases the family handles
+
+- **Truncated or in-progress JSONL.** Malformed lines are skipped with
+  a `slog.Debug` log; the surrounding command continues. A tail-watch
+  of a live run therefore surfaces partial output without failing.
+- **Oversized records.** Records larger than the 4 MiB per-line cap
+  (matching the trace emitter's own write cap) are skipped with a
+  debug log.
+- **Empty files.** `show` and `stats` fail with a clear "no
+  well-formed records" message; `tail` (one-shot) and `grep` exit
+  cleanly with no output, matching `cat` / `grep` POSIX semantics.
+
+## Out of scope
+
+- **Compressed traces (`.gz`).** Pipe through `zcat`. Embedding a
+  gzip dependency would inflate the binary for a workflow shell
+  already covers.
+- **A full `jq` interpreter.** The three-op predicate covers the
+  motivating cases; the subcommands deliberately do not vendor a jq
+  library.
+- **File-watcher notification APIs (fsnotify et al.)** Polling at
+  100 ms is responsive enough for append-only files and avoids
+  pulling in a per-platform dependency.
+
+## Related docs
+
+- [`observability-cloud.md`](observability-cloud.md) — managed APM
+  routing for the OTel emitter.
+- [`safety-rings.md`](safety-rings.md) — what the harness records and
+  why.
+- [`architecture.md`](architecture.md) — the 13-component model the
+  trace records describe.

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -3,7 +3,6 @@
 package runner
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -18,6 +17,7 @@ import (
 	"github.com/rxbynerd/stirrup/eval"
 	"github.com/rxbynerd/stirrup/eval/judge"
 	"github.com/rxbynerd/stirrup/types"
+	tracereader "github.com/rxbynerd/stirrup/types/trace"
 )
 
 // defaultTaskTimeoutSeconds is the per-task timeout the runner falls back
@@ -456,43 +456,18 @@ func cloneRepo(ctx context.Context, repo, ref, targetDir string) error {
 	return nil
 }
 
-// parseTraceFile reads a JSONL trace file and returns the RunTrace from the
-// last line.
+// parseTraceFile reads a JSONL trace file and returns the RunTrace from
+// the last well-formed line. The streaming parser, malformed-line
+// skipping, and 4 MiB per-record cap all live in types/trace so the new
+// `stirrup trace …` subcommands and the eval runner share one
+// implementation.
 func parseTraceFile(path string) (*types.RunTrace, error) {
-	f, err := os.Open(path)
+	r, err := tracereader.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("opening trace file: %w", err)
+		return nil, err
 	}
-	defer func() { _ = f.Close() }()
-
-	var lastLine string
-	scanner := bufio.NewScanner(f)
-	// bufio.Scanner's default 64 KiB line limit is too small for traces
-	// that carry a large tool output in a single JSONL record. A
-	// correct harness run with a multi-hundred-KiB grep result would
-	// otherwise surface as "bufio.Scanner: token too long" and the
-	// task would land as an "error" outcome rather than a real fail.
-	// 4 MiB matches the trace-emitter's own per-record cap.
-	scanner.Buffer(make([]byte, 0, 256*1024), 4*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line != "" {
-			lastLine = line
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("reading trace file: %w", err)
-	}
-	if lastLine == "" {
-		return nil, fmt.Errorf("trace file is empty")
-	}
-
-	var trace types.RunTrace
-	if err := json.Unmarshal([]byte(lastLine), &trace); err != nil {
-		return nil, fmt.Errorf("parsing trace JSON: %w", err)
-	}
-
-	return &trace, nil
+	defer func() { _ = r.Close() }()
+	return r.Last()
 }
 
 // errorResult builds a TaskResult with outcome "error".

--- a/harness/cmd/stirrup/cmd/trace.go
+++ b/harness/cmd/stirrup/cmd/trace.go
@@ -61,12 +61,19 @@ func parseColorMode(s string) (colorMode, error) {
 
 // shouldColor reports whether the writer should receive ANSI escapes
 // under the given mode. The auto mode disables colour when the writer
-// is not a TTY (the standard behaviour ls/grep/git diff follow).
+// is not a TTY (the standard behaviour ls/grep/git diff follow) AND
+// honours the NO_COLOR convention (https://no-color.org/) — any
+// non-empty NO_COLOR environment variable suppresses ANSI output.
+// --color=always wins over NO_COLOR by design: an operator who
+// explicitly opts in is not overridden by ambient env.
 func shouldColor(mode colorMode, w io.Writer) bool {
 	switch mode {
 	case colorAlways:
 		return true
 	case colorNever:
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
 		return false
 	}
 	f, ok := w.(*os.File)
@@ -101,9 +108,15 @@ func colorize(enabled bool, c, s string) string {
 }
 
 // addColorFlag registers --color on cmd with the canonical
-// auto|always|never enum the family shares.
+// auto|always|never enum the family shares. The shell completion
+// function surfaces the three values to bash/zsh tab completion,
+// matching the convention every other closed-set flag in this
+// package (e.g. --mode, --provider) already follows.
 func addColorFlag(cmd *cobra.Command) {
 	cmd.Flags().String("color", "auto", "Colourise output: auto|always|never. 'auto' enables colour only when stdout is a TTY.")
+	_ = cmd.RegisterFlagCompletionFunc("color", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"auto", "always", "never"}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 // resolveColorMode parses the --color flag value into a colorMode.

--- a/harness/cmd/stirrup/cmd/trace.go
+++ b/harness/cmd/stirrup/cmd/trace.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// traceCmd is the root of the `stirrup trace …` subcommand family.
+// The subcommands inspect JSONL trace files produced by
+// traceEmitter.type=jsonl so operators do not have to reinvent
+// chronological pretty-printing, follow-tailing, aggregate stats, and
+// JSON-path filtering with ad-hoc jq pipelines.
+var traceCmd = &cobra.Command{
+	Use:   "trace",
+	Short: "Inspect JSONL trace files written by stirrup runs",
+	Long: `Inspect JSONL trace files produced by traceEmitter.type=jsonl.
+
+Subcommands:
+  show    Pretty-print a trace file in chronological order.
+  tail    Stream new records as they are appended (tail -f semantics).
+  stats   Aggregate token counts, tool calls, durations, security events.
+  grep    Filter records by substring or a small JSON-path predicate.
+
+Every subcommand accepts ` + "`-`" + ` as the file argument to read from
+stdin, so the family composes with shell pipelines:
+
+  tail -F live.jsonl | stirrup trace show -
+  stirrup trace stats run.jsonl --output=json | jq .totalTurns`,
+}
+
+func init() {
+	rootCmd.AddCommand(traceCmd)
+}
+
+// colorMode selects whether ANSI escapes are emitted on a writer.
+type colorMode int
+
+const (
+	colorAuto colorMode = iota
+	colorAlways
+	colorNever
+)
+
+func parseColorMode(s string) (colorMode, error) {
+	switch strings.ToLower(s) {
+	case "", "auto":
+		return colorAuto, nil
+	case "always", "force", "yes":
+		return colorAlways, nil
+	case "never", "no", "off":
+		return colorNever, nil
+	default:
+		return colorAuto, fmt.Errorf("invalid --color value %q (want auto|always|never)", s)
+	}
+}
+
+// shouldColor reports whether the writer should receive ANSI escapes
+// under the given mode. The auto mode disables colour when the writer
+// is not a TTY (the standard behaviour ls/grep/git diff follow).
+func shouldColor(mode colorMode, w io.Writer) bool {
+	switch mode {
+	case colorAlways:
+		return true
+	case colorNever:
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}
+
+// ANSI escape codes used by `trace show`. Kept small and dependency-free
+// — pulling in a colour library for four foreground colours and a reset
+// would dwarf the actual code.
+const (
+	ansiReset  = "\x1b[0m"
+	ansiBold   = "\x1b[1m"
+	ansiRed    = "\x1b[31m"
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+	ansiBlue   = "\x1b[34m"
+	ansiCyan   = "\x1b[36m"
+	ansiGrey   = "\x1b[90m"
+)
+
+// colorize wraps s in the ANSI escape c when enabled is true. Returns
+// s unchanged otherwise so call sites can write colour-or-not without
+// branching at every print.
+func colorize(enabled bool, c, s string) string {
+	if !enabled {
+		return s
+	}
+	return c + s + ansiReset
+}
+
+// addColorFlag registers --color on cmd with the canonical
+// auto|always|never enum the family shares.
+func addColorFlag(cmd *cobra.Command) {
+	cmd.Flags().String("color", "auto", "Colourise output: auto|always|never. 'auto' enables colour only when stdout is a TTY.")
+}
+
+// resolveColorMode parses the --color flag value into a colorMode.
+// Cobra returns "" for an unset flag; parseColorMode treats that as
+// auto, matching the registered default.
+func resolveColorMode(cmd *cobra.Command) (colorMode, error) {
+	v, _ := cmd.Flags().GetString("color")
+	return parseColorMode(v)
+}

--- a/harness/cmd/stirrup/cmd/trace_grep.go
+++ b/harness/cmd/stirrup/cmd/trace_grep.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+
+	tracereader "github.com/rxbynerd/stirrup/types/trace"
 )
 
 var traceGrepCmd = &cobra.Command{
@@ -83,11 +85,30 @@ func runTraceGrepWith(ctx context.Context, path string, out io.Writer, pattern s
 		src = f
 	}
 
+	// Scanner caps match types/trace.Reader so a record that fit on
+	// write also fits on read. Sharing the constant prevents grep from
+	// silently diverging from the reader if its cap is ever changed.
 	scanner := bufio.NewScanner(src)
-	scanner.Buffer(make([]byte, 0, 256*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 0, tracereader.MaxLineBytes/16), tracereader.MaxLineBytes)
 
-	for scanner.Scan() {
+	for {
 		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				// bufio.ErrTooLong is the cap-exceeded signal. Without
+				// resetting the scanner, every subsequent record on
+				// the same source is dropped silently with exit 0.
+				// Reset and continue past the oversized line, matching
+				// the recovery in tracereader.Reader.Next().
+				if errors.Is(err, bufio.ErrTooLong) {
+					scanner = bufio.NewScanner(src)
+					scanner.Buffer(make([]byte, 0, tracereader.MaxLineBytes/16), tracereader.MaxLineBytes)
+					continue
+				}
+				return fmt.Errorf("reading trace file: %w", err)
+			}
 			return nil
 		}
 		line := scanner.Bytes()
@@ -116,10 +137,6 @@ func runTraceGrepWith(ctx context.Context, path string, out io.Writer, pattern s
 			return err
 		}
 	}
-	if err := scanner.Err(); err != nil && !errors.Is(err, bufio.ErrTooLong) {
-		return fmt.Errorf("reading trace file: %w", err)
-	}
-	return nil
 }
 
 func lineMatches(line []byte, pattern string, pred jqPredicate) (bool, error) {

--- a/harness/cmd/stirrup/cmd/trace_grep.go
+++ b/harness/cmd/stirrup/cmd/trace_grep.go
@@ -1,0 +1,378 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+var traceGrepCmd = &cobra.Command{
+	Use:   "grep [pattern] <file>",
+	Short: "Filter JSONL trace records by substring or JSON-path predicate",
+	Long: `Filter JSONL trace records, printing only the matching lines.
+
+Match modes:
+  pattern   Substring match against the raw JSON line. Empty pattern
+            matches every line (so --jq alone is enough on its own).
+  --jq      A small JSON-path predicate of the form '<path> <op> <value>'.
+            Supported ops: == != contains. The value may be a quoted
+            string or a bare number. Examples:
+              --jq '.id == "run-42"'
+              --jq '.turns != 0'
+              --jq '.outcome contains "fail"'
+              --jq '.toolCalls.0.name == "edit_file"'
+            This is deliberately a thin predicate, not a full jq
+            interpreter — the goal is to drop the operational
+            dependency on having jq installed.
+
+Pass ` + "`-`" + ` as the file argument to read from stdin. Matching
+records are emitted verbatim, one JSON document per line.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runTraceGrep,
+}
+
+func init() {
+	traceCmd.AddCommand(traceGrepCmd)
+	f := traceGrepCmd.Flags()
+	f.String("jq", "", "JSON-path predicate (e.g. '.outcome == \"success\"'). Combine with the pattern arg for AND semantics.")
+	f.Bool("invert-match", false, "Invert the match — print records that do NOT satisfy the predicate.")
+}
+
+func runTraceGrep(cmd *cobra.Command, args []string) error {
+	var pattern, path string
+	switch len(args) {
+	case 1:
+		path = args[0]
+	case 2:
+		pattern = args[0]
+		path = args[1]
+	}
+	jq, _ := cmd.Flags().GetString("jq")
+	invert, _ := cmd.Flags().GetBool("invert-match")
+
+	pred, err := compileJQ(jq)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	return runTraceGrepWith(ctx, path, cmd.OutOrStdout(), pattern, pred, invert)
+}
+
+func runTraceGrepWith(ctx context.Context, path string, out io.Writer, pattern string, pred jqPredicate, invert bool) error {
+	var src io.Reader
+	if path == "-" {
+		src = os.Stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("opening trace file %q: %w", path, err)
+		}
+		defer func() { _ = f.Close() }()
+		src = f
+	}
+
+	scanner := bufio.NewScanner(src)
+	scanner.Buffer(make([]byte, 0, 256*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		matched, err := lineMatches(line, pattern, pred)
+		if err != nil {
+			// A line that fails predicate evaluation is treated as a
+			// non-match (e.g. it isn't valid JSON, or the path
+			// doesn't exist). Predicate compile errors are surfaced
+			// up-front; runtime evaluation errors must not abort
+			// `grep` mid-stream.
+			matched = false
+		}
+		if invert {
+			matched = !matched
+		}
+		if !matched {
+			continue
+		}
+		if _, err := out.Write(append([]byte(nil), line...)); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, "\n"); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, bufio.ErrTooLong) {
+		return fmt.Errorf("reading trace file: %w", err)
+	}
+	return nil
+}
+
+func lineMatches(line []byte, pattern string, pred jqPredicate) (bool, error) {
+	if pattern != "" && !strings.Contains(string(line), pattern) {
+		return false, nil
+	}
+	if pred.empty() {
+		return true, nil
+	}
+	var doc any
+	if err := json.Unmarshal(line, &doc); err != nil {
+		return false, err
+	}
+	return pred.eval(doc)
+}
+
+// jqPredicate is a deliberately tiny predicate evaluator over a JSON
+// document. It supports three operators: ==, !=, and `contains`. The
+// path is a dot-separated walk of object keys and numeric array
+// indices (e.g. `.toolCalls.0.name`). This is enough to cover the
+// acceptance-criteria examples in issue #244 without taking on a full
+// jq vendor dependency.
+type jqPredicate struct {
+	path []pathSeg
+	op   string
+	want any // string, float64, or nil (for null)
+	raw  bool
+}
+
+type pathSeg struct {
+	key string
+	idx int
+	num bool
+}
+
+func (p jqPredicate) empty() bool { return !p.raw }
+
+func compileJQ(expr string) (jqPredicate, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return jqPredicate{}, nil
+	}
+
+	// Tokenise as: <path> <op> <value>. The op is one of ==, !=, contains.
+	// A value may be a "double-quoted string", a bare number, or the
+	// literal null/true/false. The path begins with `.` and may
+	// reference an empty path with just `.` (meaning the whole doc).
+	rest := expr
+	pathToken, rest, err := lexJQPath(rest)
+	if err != nil {
+		return jqPredicate{}, fmt.Errorf("--jq: %w", err)
+	}
+	rest = strings.TrimSpace(rest)
+
+	var op string
+	switch {
+	case strings.HasPrefix(rest, "=="):
+		op = "=="
+		rest = rest[2:]
+	case strings.HasPrefix(rest, "!="):
+		op = "!="
+		rest = rest[2:]
+	case strings.HasPrefix(rest, "contains"):
+		op = "contains"
+		rest = rest[len("contains"):]
+	default:
+		return jqPredicate{}, fmt.Errorf("--jq: expected one of ==, !=, contains after path, got %q", rest)
+	}
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return jqPredicate{}, fmt.Errorf("--jq: missing value after operator %q", op)
+	}
+
+	want, err := parseJQValue(rest)
+	if err != nil {
+		return jqPredicate{}, fmt.Errorf("--jq: %w", err)
+	}
+
+	segs, err := compileJQPath(pathToken)
+	if err != nil {
+		return jqPredicate{}, fmt.Errorf("--jq: %w", err)
+	}
+
+	return jqPredicate{path: segs, op: op, want: want, raw: true}, nil
+}
+
+// lexJQPath returns the leading path token (e.g. `.foo.bar.0`) and the
+// remainder of the expression. A path is a `.`-prefixed run of word
+// characters, digits, and underscores separated by `.`.
+func lexJQPath(s string) (string, string, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, ".") {
+		return "", s, fmt.Errorf("path must start with '.'")
+	}
+	i := 1
+	for i < len(s) {
+		c := s[i]
+		if c == ' ' || c == '\t' {
+			break
+		}
+		if c == '=' || c == '!' {
+			break
+		}
+		// "contains" begins with 'c', which is a valid identifier
+		// character. Stop only at the boundary signalled by
+		// whitespace; the caller separates `contains` from the path
+		// using whitespace, which the issue's example respects.
+		i++
+	}
+	return s[:i], s[i:], nil
+}
+
+func compileJQPath(token string) ([]pathSeg, error) {
+	token = strings.TrimPrefix(token, ".")
+	if token == "" {
+		return nil, nil
+	}
+	parts := strings.Split(token, ".")
+	out := make([]pathSeg, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			return nil, fmt.Errorf("empty segment in path")
+		}
+		seg := pathSeg{key: p}
+		if n, ok := parseIndex(p); ok {
+			seg.idx = n
+			seg.num = true
+		}
+		out = append(out, seg)
+	}
+	return out, nil
+}
+
+func parseIndex(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+// parseJQValue parses a quoted string, a bare number, or a true/false/null
+// literal. Returns string, float64, bool, or nil.
+func parseJQValue(s string) (any, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, fmt.Errorf("empty value")
+	}
+	if s[0] == '"' {
+		var out string
+		if err := json.Unmarshal([]byte(s), &out); err != nil {
+			return nil, fmt.Errorf("invalid quoted string: %w", err)
+		}
+		return out, nil
+	}
+	switch s {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	case "null":
+		return nil, nil
+	}
+	var n float64
+	if err := json.Unmarshal([]byte(s), &n); err != nil {
+		return nil, fmt.Errorf("expected quoted string or number, got %q", s)
+	}
+	return n, nil
+}
+
+func (p jqPredicate) eval(doc any) (bool, error) {
+	got, ok := walkPath(doc, p.path)
+	if !ok {
+		// Path didn't resolve. != against any literal value is true;
+		// == is false. contains is false.
+		switch p.op {
+		case "!=":
+			return true, nil
+		default:
+			return false, nil
+		}
+	}
+	switch p.op {
+	case "==":
+		return jsonEqual(got, p.want), nil
+	case "!=":
+		return !jsonEqual(got, p.want), nil
+	case "contains":
+		gs, gok := got.(string)
+		ws, wok := p.want.(string)
+		if !gok || !wok {
+			return false, nil
+		}
+		return strings.Contains(gs, ws), nil
+	default:
+		return false, fmt.Errorf("unknown op %q", p.op)
+	}
+}
+
+func walkPath(doc any, path []pathSeg) (any, bool) {
+	cur := doc
+	for _, seg := range path {
+		switch v := cur.(type) {
+		case map[string]any:
+			next, ok := v[seg.key]
+			if !ok {
+				return nil, false
+			}
+			cur = next
+		case []any:
+			if !seg.num {
+				return nil, false
+			}
+			if seg.idx < 0 || seg.idx >= len(v) {
+				return nil, false
+			}
+			cur = v[seg.idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// jsonEqual compares two JSON-decoded values for equality with the
+// number-coercion semantics jq operators expect: int constants in the
+// query end up as float64 after parseJQValue, and JSON numbers in the
+// document are float64 too, so direct == works on those. Strings and
+// bools compare verbatim; null is `nil`.
+func jsonEqual(a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	switch av := a.(type) {
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case float64:
+		bv, ok := b.(float64)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	default:
+		return false
+	}
+}

--- a/harness/cmd/stirrup/cmd/trace_show.go
+++ b/harness/cmd/stirrup/cmd/trace_show.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/types"
+	tracereader "github.com/rxbynerd/stirrup/types/trace"
+)
+
+var traceShowCmd = &cobra.Command{
+	Use:   "show <file>",
+	Short: "Pretty-print a JSONL trace file",
+	Long: `Pretty-print a JSONL trace file in chronological order, surfacing
+the run metadata, every recorded turn, every tool call, and the final
+outcome. Pass ` + "`-`" + ` to read the trace from stdin.
+
+Colours are emitted by default when stdout is a TTY; override with
+--color=always to force, --color=never to disable (also honours plain
+pipes via the auto detection).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTraceShow,
+}
+
+func init() {
+	traceCmd.AddCommand(traceShowCmd)
+	addColorFlag(traceShowCmd)
+}
+
+func runTraceShow(cmd *cobra.Command, args []string) error {
+	mode, err := resolveColorMode(cmd)
+	if err != nil {
+		return err
+	}
+	return runTraceShowWith(args[0], cmd.OutOrStdout(), mode)
+}
+
+func runTraceShowWith(path string, out io.Writer, mode colorMode) error {
+	r, err := tracereader.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	color := shouldColor(mode, out)
+
+	any := false
+	for {
+		trace, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		any = true
+		if err := renderRunTrace(out, trace, color); err != nil {
+			return err
+		}
+	}
+	if !any {
+		return fmt.Errorf("trace file %q contained no well-formed records", path)
+	}
+	return nil
+}
+
+// renderRunTrace pretty-prints a single RunTrace block.
+func renderRunTrace(out io.Writer, t *types.RunTrace, color bool) error {
+	header := colorize(color, ansiBold+ansiCyan, fmt.Sprintf("=== run %s ===", strOrDash(t.ID)))
+	if _, err := fmt.Fprintln(out, header); err != nil {
+		return err
+	}
+
+	meta := fmt.Sprintf("  started:  %s\n  finished: %s\n  duration: %s\n  outcome:  %s\n  turns:    %d\n  tokens:   in=%d out=%d",
+		formatTime(t.StartedAt),
+		formatTime(t.CompletedAt),
+		t.CompletedAt.Sub(t.StartedAt).Round(time.Millisecond),
+		colorize(color, outcomeColor(t.Outcome), strOrDash(t.Outcome)),
+		t.Turns,
+		t.TokenUsage.Input,
+		t.TokenUsage.Output,
+	)
+	if _, err := fmt.Fprintln(out, meta); err != nil {
+		return err
+	}
+
+	if t.Config.RunID != "" {
+		fmt.Fprintf(out, "  runId:    %s\n", t.Config.RunID)
+	}
+
+	// Tool calls in arrival order — the trace stores them in the
+	// order they were recorded, which is also chronological.
+	if len(t.ToolCalls) > 0 {
+		fmt.Fprintln(out, colorize(color, ansiBold, "  tool calls:"))
+		for i, tc := range t.ToolCalls {
+			line := fmt.Sprintf("    %3d. %s  %s  %dms  in=%dB out=%dB",
+				i+1,
+				colorize(color, toolCallColor(tc.Success), tc.Name),
+				toolStatus(tc, color),
+				tc.DurationMs,
+				tc.InputSize,
+				tc.OutputSize,
+			)
+			if tc.ErrorReason != "" {
+				line += "  " + colorize(color, ansiRed, "err="+tc.ErrorReason)
+			}
+			if tc.RunID != "" {
+				line += colorize(color, ansiGrey, fmt.Sprintf("  [subagent %s]", tc.RunID))
+			}
+			fmt.Fprintln(out, line)
+		}
+	}
+
+	if len(t.VerificationResults) > 0 {
+		fmt.Fprintln(out, colorize(color, ansiBold, "  verification:"))
+		for i, vr := range t.VerificationResults {
+			passed := colorize(color, ansiRed, "FAIL")
+			if vr.Passed {
+				passed = colorize(color, ansiGreen, "PASS")
+			}
+			fmt.Fprintf(out, "    %3d. %s  %s\n", i+1, passed, vr.Feedback)
+		}
+	}
+
+	// Aggregate tool-name counts so a long tool stream is summarised
+	// before the wall of per-call detail goes by — useful when piping
+	// to less.
+	if len(t.ToolCalls) > 1 {
+		counts := map[string]int{}
+		for _, tc := range t.ToolCalls {
+			counts[tc.Name]++
+		}
+		names := make([]string, 0, len(counts))
+		for n := range counts {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		fmt.Fprintln(out, colorize(color, ansiGrey, "  tool counts:"))
+		for _, n := range names {
+			fmt.Fprintf(out, "    %-32s %d\n", n, counts[n])
+		}
+	}
+
+	_, err := fmt.Fprintln(out)
+	return err
+}
+
+func outcomeColor(outcome string) string {
+	switch outcome {
+	case "success":
+		return ansiGreen
+	case "error", "verification_failed", "verification_error", "tool_failures":
+		return ansiRed
+	case "max_turns", "max_tokens", "budget_exceeded", "stalled", "timeout":
+		return ansiYellow
+	case "cancelled":
+		return ansiGrey
+	default:
+		return ansiBlue
+	}
+}
+
+func toolCallColor(success bool) string {
+	if success {
+		return ansiBlue
+	}
+	return ansiRed
+}
+
+func toolStatus(tc types.ToolCallSummary, color bool) string {
+	if tc.Success {
+		return colorize(color, ansiGreen, "ok")
+	}
+	return colorize(color, ansiRed, "fail")
+}
+
+// strOrDash renders an empty string as "—" so the output table never
+// has a hole the reader has to mentally fill in.
+func strOrDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// formatTime renders a time.Time as RFC3339, treating the zero value
+// as "—" so a partial trace does not surface "0001-01-01T00:00:00Z".
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.Format(time.RFC3339)
+}
+

--- a/harness/cmd/stirrup/cmd/trace_show.go
+++ b/harness/cmd/stirrup/cmd/trace_show.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -69,36 +70,32 @@ func runTraceShowWith(path string, out io.Writer, mode colorMode) error {
 	return nil
 }
 
-// renderRunTrace pretty-prints a single RunTrace block.
+// renderRunTrace pretty-prints a single RunTrace block. The output is
+// assembled into a single strings.Builder and flushed at the end so a
+// short write on the underlying writer surfaces as one error rather
+// than leaving a half-rendered record in the user's terminal.
 func renderRunTrace(out io.Writer, t *types.RunTrace, color bool) error {
-	header := colorize(color, ansiBold+ansiCyan, fmt.Sprintf("=== run %s ===", strOrDash(t.ID)))
-	if _, err := fmt.Fprintln(out, header); err != nil {
-		return err
-	}
+	var b strings.Builder
 
-	meta := fmt.Sprintf("  started:  %s\n  finished: %s\n  duration: %s\n  outcome:  %s\n  turns:    %d\n  tokens:   in=%d out=%d",
-		formatTime(t.StartedAt),
-		formatTime(t.CompletedAt),
-		t.CompletedAt.Sub(t.StartedAt).Round(time.Millisecond),
-		colorize(color, outcomeColor(t.Outcome), strOrDash(t.Outcome)),
-		t.Turns,
-		t.TokenUsage.Input,
-		t.TokenUsage.Output,
-	)
-	if _, err := fmt.Fprintln(out, meta); err != nil {
-		return err
-	}
+	b.WriteString(colorize(color, ansiBold+ansiCyan, fmt.Sprintf("=== run %s ===", strOrDash(t.ID))))
+	b.WriteByte('\n')
+
+	fmt.Fprintf(&b, "  started:  %s\n", formatTime(t.StartedAt))
+	fmt.Fprintf(&b, "  finished: %s\n", formatTime(t.CompletedAt))
+	fmt.Fprintf(&b, "  duration: %s\n", t.CompletedAt.Sub(t.StartedAt).Round(time.Millisecond))
+	fmt.Fprintf(&b, "  outcome:  %s\n", colorize(color, outcomeColor(t.Outcome), strOrDash(t.Outcome)))
+	fmt.Fprintf(&b, "  turns:    %d\n", t.Turns)
+	fmt.Fprintf(&b, "  tokens:   in=%d out=%d\n", t.TokenUsage.Input, t.TokenUsage.Output)
 
 	if t.Config.RunID != "" {
-		fmt.Fprintf(out, "  runId:    %s\n", t.Config.RunID)
+		fmt.Fprintf(&b, "  runId:    %s\n", t.Config.RunID)
 	}
 
-	// Tool calls in arrival order — the trace stores them in the
-	// order they were recorded, which is also chronological.
 	if len(t.ToolCalls) > 0 {
-		fmt.Fprintln(out, colorize(color, ansiBold, "  tool calls:"))
+		b.WriteString(colorize(color, ansiBold, "  tool calls:"))
+		b.WriteByte('\n')
 		for i, tc := range t.ToolCalls {
-			line := fmt.Sprintf("    %3d. %s  %s  %dms  in=%dB out=%dB",
+			fmt.Fprintf(&b, "    %3d. %s  %s  %dms  in=%dB out=%dB",
 				i+1,
 				colorize(color, toolCallColor(tc.Success), tc.Name),
 				toolStatus(tc, color),
@@ -107,29 +104,27 @@ func renderRunTrace(out io.Writer, t *types.RunTrace, color bool) error {
 				tc.OutputSize,
 			)
 			if tc.ErrorReason != "" {
-				line += "  " + colorize(color, ansiRed, "err="+tc.ErrorReason)
+				b.WriteString("  " + colorize(color, ansiRed, "err="+tc.ErrorReason))
 			}
 			if tc.RunID != "" {
-				line += colorize(color, ansiGrey, fmt.Sprintf("  [subagent %s]", tc.RunID))
+				b.WriteString(colorize(color, ansiGrey, fmt.Sprintf("  [subagent %s]", tc.RunID)))
 			}
-			fmt.Fprintln(out, line)
+			b.WriteByte('\n')
 		}
 	}
 
 	if len(t.VerificationResults) > 0 {
-		fmt.Fprintln(out, colorize(color, ansiBold, "  verification:"))
+		b.WriteString(colorize(color, ansiBold, "  verification:"))
+		b.WriteByte('\n')
 		for i, vr := range t.VerificationResults {
 			passed := colorize(color, ansiRed, "FAIL")
 			if vr.Passed {
 				passed = colorize(color, ansiGreen, "PASS")
 			}
-			fmt.Fprintf(out, "    %3d. %s  %s\n", i+1, passed, vr.Feedback)
+			fmt.Fprintf(&b, "    %3d. %s  %s\n", i+1, passed, vr.Feedback)
 		}
 	}
 
-	// Aggregate tool-name counts so a long tool stream is summarised
-	// before the wall of per-call detail goes by — useful when piping
-	// to less.
 	if len(t.ToolCalls) > 1 {
 		counts := map[string]int{}
 		for _, tc := range t.ToolCalls {
@@ -140,13 +135,15 @@ func renderRunTrace(out io.Writer, t *types.RunTrace, color bool) error {
 			names = append(names, n)
 		}
 		sort.Strings(names)
-		fmt.Fprintln(out, colorize(color, ansiGrey, "  tool counts:"))
+		b.WriteString(colorize(color, ansiGrey, "  tool counts:"))
+		b.WriteByte('\n')
 		for _, n := range names {
-			fmt.Fprintf(out, "    %-32s %d\n", n, counts[n])
+			fmt.Fprintf(&b, "    %-32s %d\n", n, counts[n])
 		}
 	}
 
-	_, err := fmt.Fprintln(out)
+	b.WriteByte('\n')
+	_, err := io.WriteString(out, b.String())
 	return err
 }
 
@@ -196,4 +193,3 @@ func formatTime(t time.Time) string {
 	}
 	return t.Format(time.RFC3339)
 }
-

--- a/harness/cmd/stirrup/cmd/trace_stats.go
+++ b/harness/cmd/stirrup/cmd/trace_stats.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/types"
+	tracereader "github.com/rxbynerd/stirrup/types/trace"
+	"github.com/rxbynerd/stirrup/types/version"
+)
+
+var traceStatsCmd = &cobra.Command{
+	Use:   "stats <file>",
+	Short: "Aggregate token, tool-call, and outcome counters from a trace",
+	Long: `Aggregate the records in a JSONL trace file into a compact summary:
+total turns, total token usage, tool-call counts by tool, the top-N
+slowest tool calls, the longest tool call duration, the overall
+wall-clock duration, and per-outcome counts.
+
+Pass ` + "`-`" + ` to read from stdin. Use --output=json for a
+machine-readable line that downstream tooling can pipe through jq.
+
+Stats output includes the trace's runId and the version of the
+stirrup binary computing the stats, so an operator collecting
+aggregates across multiple traces can correlate the schema across
+harness versions.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTraceStats,
+}
+
+func init() {
+	traceCmd.AddCommand(traceStatsCmd)
+	f := traceStatsCmd.Flags()
+	f.String("output", "text", "Output format: text|json. JSON emits a single line; text is human-readable.")
+	f.Int("top", 10, "Number of slowest tool calls to list in the text output. Has no effect on JSON output, which carries the full list.")
+}
+
+func runTraceStats(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	format, _ := cmd.Flags().GetString("output")
+	top, _ := cmd.Flags().GetInt("top")
+	return runTraceStatsWith(args[0], out, format, top)
+}
+
+func runTraceStatsWith(path string, out io.Writer, format string, top int) error {
+	r, err := tracereader.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	stats := newTraceStats()
+	stats.HarnessVersion = version.Version()
+
+	for {
+		t, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		stats.absorb(t)
+	}
+	if stats.Records == 0 {
+		return fmt.Errorf("trace file %q contained no well-formed records", path)
+	}
+	stats.finalize()
+
+	switch strings.ToLower(format) {
+	case "", "text":
+		return writeStatsText(out, stats, top)
+	case "json":
+		enc := json.NewEncoder(out)
+		return enc.Encode(stats)
+	default:
+		return fmt.Errorf("invalid --output value %q (want text|json)", format)
+	}
+}
+
+// TraceStats is the aggregate produced by `stirrup trace stats`. The
+// metric names mirror the OTel counters in
+// harness/internal/observability/metrics.go so an operator switching
+// between online dashboards and offline trace inspection uses one
+// vocabulary.
+type TraceStats struct {
+	RunID                string             `json:"runId,omitempty"`
+	HarnessVersion       string             `json:"harnessVersion,omitempty"`
+	Records              int                `json:"records"`
+	TotalTurns           int                `json:"totalTurns"`
+	TokensInput          int                `json:"tokensInput"`
+	TokensOutput         int                `json:"tokensOutput"`
+	ToolCalls            int                `json:"toolCalls"`
+	ToolErrors           int                `json:"toolErrors"`
+	ToolCallsByName      map[string]int     `json:"toolCallsByName,omitempty"`
+	ToolErrorsByName     map[string]int     `json:"toolErrorsByName,omitempty"`
+	SubAgentToolCalls    int                `json:"subAgentToolCalls,omitempty"`
+	VerificationsRun     int                `json:"verificationsRun,omitempty"`
+	VerificationsPassed  int                `json:"verificationsPassed,omitempty"`
+	VerificationsFailed  int                `json:"verificationsFailed,omitempty"`
+	Outcomes             map[string]int     `json:"outcomes,omitempty"`
+	LongestToolCallMs    int64              `json:"longestToolCallMs"`
+	TotalWallClockMs     int64              `json:"totalWallClockMs"`
+	SlowestToolCalls     []SlowToolCallStat `json:"slowestToolCalls,omitempty"`
+	EarliestStart        time.Time          `json:"earliestStart,omitempty"`
+	LatestCompletion     time.Time          `json:"latestCompletion,omitempty"`
+
+	// slowest is an unsorted scratch slice used during aggregation;
+	// finalize() promotes it onto SlowestToolCalls.
+	slowest []SlowToolCallStat
+}
+
+// SlowToolCallStat captures one tool-call entry in the
+// SlowestToolCalls list.
+type SlowToolCallStat struct {
+	Name       string `json:"name"`
+	DurationMs int64  `json:"durationMs"`
+	Success    bool   `json:"success"`
+}
+
+func newTraceStats() *TraceStats {
+	return &TraceStats{
+		ToolCallsByName:  map[string]int{},
+		ToolErrorsByName: map[string]int{},
+		Outcomes:         map[string]int{},
+	}
+}
+
+func (s *TraceStats) absorb(t *types.RunTrace) {
+	s.Records++
+	if s.RunID == "" {
+		s.RunID = t.ID
+	}
+
+	s.TotalTurns += t.Turns
+	s.TokensInput += t.TokenUsage.Input
+	s.TokensOutput += t.TokenUsage.Output
+
+	for _, tc := range t.ToolCalls {
+		s.ToolCalls++
+		s.ToolCallsByName[tc.Name]++
+		if !tc.Success {
+			s.ToolErrors++
+			s.ToolErrorsByName[tc.Name]++
+		}
+		if tc.RunID != "" {
+			s.SubAgentToolCalls++
+		}
+		if tc.DurationMs > s.LongestToolCallMs {
+			s.LongestToolCallMs = tc.DurationMs
+		}
+		s.slowest = append(s.slowest, SlowToolCallStat{
+			Name:       tc.Name,
+			DurationMs: tc.DurationMs,
+			Success:    tc.Success,
+		})
+	}
+
+	for _, v := range t.VerificationResults {
+		s.VerificationsRun++
+		if v.Passed {
+			s.VerificationsPassed++
+		} else {
+			s.VerificationsFailed++
+		}
+	}
+
+	if t.Outcome != "" {
+		s.Outcomes[t.Outcome]++
+	}
+
+	if !t.StartedAt.IsZero() && (s.EarliestStart.IsZero() || t.StartedAt.Before(s.EarliestStart)) {
+		s.EarliestStart = t.StartedAt
+	}
+	if !t.CompletedAt.IsZero() && (s.LatestCompletion.IsZero() || t.CompletedAt.After(s.LatestCompletion)) {
+		s.LatestCompletion = t.CompletedAt
+	}
+}
+
+// finalize promotes scratch state to its final form: sorted slowest list,
+// wall-clock duration, and pruning of empty maps so JSON output is tidy.
+func (s *TraceStats) finalize() {
+	sort.SliceStable(s.slowest, func(i, j int) bool {
+		return s.slowest[i].DurationMs > s.slowest[j].DurationMs
+	})
+	s.SlowestToolCalls = s.slowest
+	s.slowest = nil
+
+	if !s.EarliestStart.IsZero() && !s.LatestCompletion.IsZero() {
+		s.TotalWallClockMs = s.LatestCompletion.Sub(s.EarliestStart).Milliseconds()
+	}
+
+	if len(s.ToolCallsByName) == 0 {
+		s.ToolCallsByName = nil
+	}
+	if len(s.ToolErrorsByName) == 0 {
+		s.ToolErrorsByName = nil
+	}
+	if len(s.Outcomes) == 0 {
+		s.Outcomes = nil
+	}
+}
+
+func writeStatsText(out io.Writer, s *TraceStats, top int) error {
+	if top <= 0 {
+		top = 10
+	}
+	fmt.Fprintf(out, "trace stats\n")
+	if s.RunID != "" {
+		fmt.Fprintf(out, "  runId:            %s\n", s.RunID)
+	}
+	if s.HarnessVersion != "" {
+		fmt.Fprintf(out, "  harness version:  %s\n", s.HarnessVersion)
+	}
+	fmt.Fprintf(out, "  records:          %d\n", s.Records)
+	fmt.Fprintf(out, "  total turns:      %d\n", s.TotalTurns)
+	fmt.Fprintf(out, "  tokens in / out:  %d / %d\n", s.TokensInput, s.TokensOutput)
+	fmt.Fprintf(out, "  tool calls:       %d (errors: %d)\n", s.ToolCalls, s.ToolErrors)
+	if s.SubAgentToolCalls > 0 {
+		fmt.Fprintf(out, "  sub-agent calls:  %d (of total tool calls)\n", s.SubAgentToolCalls)
+	}
+	if s.VerificationsRun > 0 {
+		fmt.Fprintf(out, "  verifications:    %d run (passed: %d, failed: %d)\n",
+			s.VerificationsRun, s.VerificationsPassed, s.VerificationsFailed)
+	}
+	fmt.Fprintf(out, "  longest call ms:  %d\n", s.LongestToolCallMs)
+	if s.TotalWallClockMs > 0 {
+		fmt.Fprintf(out, "  wall clock:       %s\n", time.Duration(s.TotalWallClockMs)*time.Millisecond)
+	}
+
+	if len(s.ToolCallsByName) > 0 {
+		names := sortedMapKeys(s.ToolCallsByName)
+		fmt.Fprintln(out, "  tool counts:")
+		for _, n := range names {
+			fmt.Fprintf(out, "    %-32s %d", n, s.ToolCallsByName[n])
+			if e := s.ToolErrorsByName[n]; e > 0 {
+				fmt.Fprintf(out, "  (errors: %d)", e)
+			}
+			fmt.Fprintln(out)
+		}
+	}
+
+	if len(s.Outcomes) > 0 {
+		names := sortedMapKeys(s.Outcomes)
+		fmt.Fprintln(out, "  outcomes:")
+		for _, n := range names {
+			fmt.Fprintf(out, "    %-32s %d\n", n, s.Outcomes[n])
+		}
+	}
+
+	if len(s.SlowestToolCalls) > 0 {
+		fmt.Fprintln(out, "  slowest tool calls:")
+		limit := top
+		if limit > len(s.SlowestToolCalls) {
+			limit = len(s.SlowestToolCalls)
+		}
+		for i := 0; i < limit; i++ {
+			tc := s.SlowestToolCalls[i]
+			status := "ok"
+			if !tc.Success {
+				status = "fail"
+			}
+			fmt.Fprintf(out, "    %2d. %-32s %6dms  %s\n", i+1, tc.Name, tc.DurationMs, status)
+		}
+	}
+
+	return nil
+}
+
+func sortedMapKeys(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/harness/cmd/stirrup/cmd/trace_stats.go
+++ b/harness/cmd/stirrup/cmd/trace_stats.go
@@ -91,26 +91,26 @@ func runTraceStatsWith(path string, out io.Writer, format string, top int) error
 // between online dashboards and offline trace inspection uses one
 // vocabulary.
 type TraceStats struct {
-	RunID                string             `json:"runId,omitempty"`
-	HarnessVersion       string             `json:"harnessVersion,omitempty"`
-	Records              int                `json:"records"`
-	TotalTurns           int                `json:"totalTurns"`
-	TokensInput          int                `json:"tokensInput"`
-	TokensOutput         int                `json:"tokensOutput"`
-	ToolCalls            int                `json:"toolCalls"`
-	ToolErrors           int                `json:"toolErrors"`
-	ToolCallsByName      map[string]int     `json:"toolCallsByName,omitempty"`
-	ToolErrorsByName     map[string]int     `json:"toolErrorsByName,omitempty"`
-	SubAgentToolCalls    int                `json:"subAgentToolCalls,omitempty"`
-	VerificationsRun     int                `json:"verificationsRun,omitempty"`
-	VerificationsPassed  int                `json:"verificationsPassed,omitempty"`
-	VerificationsFailed  int                `json:"verificationsFailed,omitempty"`
-	Outcomes             map[string]int     `json:"outcomes,omitempty"`
-	LongestToolCallMs    int64              `json:"longestToolCallMs"`
-	TotalWallClockMs     int64              `json:"totalWallClockMs"`
-	SlowestToolCalls     []SlowToolCallStat `json:"slowestToolCalls,omitempty"`
-	EarliestStart        time.Time          `json:"earliestStart,omitempty"`
-	LatestCompletion     time.Time          `json:"latestCompletion,omitempty"`
+	RunID               string             `json:"runId,omitempty"`
+	HarnessVersion      string             `json:"harnessVersion,omitempty"`
+	Records             int                `json:"records"`
+	TotalTurns          int                `json:"totalTurns"`
+	TokensInput         int                `json:"tokensInput"`
+	TokensOutput        int                `json:"tokensOutput"`
+	ToolCalls           int                `json:"toolCalls"`
+	ToolErrors          int                `json:"toolErrors"`
+	ToolCallsByName     map[string]int     `json:"toolCallsByName,omitempty"`
+	ToolErrorsByName    map[string]int     `json:"toolErrorsByName,omitempty"`
+	SubAgentToolCalls   int                `json:"subAgentToolCalls,omitempty"`
+	VerificationsRun    int                `json:"verificationsRun,omitempty"`
+	VerificationsPassed int                `json:"verificationsPassed,omitempty"`
+	VerificationsFailed int                `json:"verificationsFailed,omitempty"`
+	Outcomes            map[string]int     `json:"outcomes,omitempty"`
+	LongestToolCallMs   int64              `json:"longestToolCallMs"`
+	TotalWallClockMs    int64              `json:"totalWallClockMs"`
+	SlowestToolCalls    []SlowToolCallStat `json:"slowestToolCalls,omitempty"`
+	EarliestStart       time.Time          `json:"earliestStart,omitempty"`
+	LatestCompletion    time.Time          `json:"latestCompletion,omitempty"`
 
 	// slowest is an unsorted scratch slice used during aggregation;
 	// finalize() promotes it onto SlowestToolCalls.
@@ -212,51 +212,53 @@ func writeStatsText(out io.Writer, s *TraceStats, top int) error {
 	if top <= 0 {
 		top = 10
 	}
-	fmt.Fprintf(out, "trace stats\n")
+
+	var b strings.Builder
+	b.WriteString("trace stats\n")
 	if s.RunID != "" {
-		fmt.Fprintf(out, "  runId:            %s\n", s.RunID)
+		fmt.Fprintf(&b, "  runId:            %s\n", s.RunID)
 	}
 	if s.HarnessVersion != "" {
-		fmt.Fprintf(out, "  harness version:  %s\n", s.HarnessVersion)
+		fmt.Fprintf(&b, "  harness version:  %s\n", s.HarnessVersion)
 	}
-	fmt.Fprintf(out, "  records:          %d\n", s.Records)
-	fmt.Fprintf(out, "  total turns:      %d\n", s.TotalTurns)
-	fmt.Fprintf(out, "  tokens in / out:  %d / %d\n", s.TokensInput, s.TokensOutput)
-	fmt.Fprintf(out, "  tool calls:       %d (errors: %d)\n", s.ToolCalls, s.ToolErrors)
+	fmt.Fprintf(&b, "  records:          %d\n", s.Records)
+	fmt.Fprintf(&b, "  total turns:      %d\n", s.TotalTurns)
+	fmt.Fprintf(&b, "  tokens in / out:  %d / %d\n", s.TokensInput, s.TokensOutput)
+	fmt.Fprintf(&b, "  tool calls:       %d (errors: %d)\n", s.ToolCalls, s.ToolErrors)
 	if s.SubAgentToolCalls > 0 {
-		fmt.Fprintf(out, "  sub-agent calls:  %d (of total tool calls)\n", s.SubAgentToolCalls)
+		fmt.Fprintf(&b, "  sub-agent calls:  %d (of total tool calls)\n", s.SubAgentToolCalls)
 	}
 	if s.VerificationsRun > 0 {
-		fmt.Fprintf(out, "  verifications:    %d run (passed: %d, failed: %d)\n",
+		fmt.Fprintf(&b, "  verifications:    %d run (passed: %d, failed: %d)\n",
 			s.VerificationsRun, s.VerificationsPassed, s.VerificationsFailed)
 	}
-	fmt.Fprintf(out, "  longest call ms:  %d\n", s.LongestToolCallMs)
+	fmt.Fprintf(&b, "  longest call ms:  %d\n", s.LongestToolCallMs)
 	if s.TotalWallClockMs > 0 {
-		fmt.Fprintf(out, "  wall clock:       %s\n", time.Duration(s.TotalWallClockMs)*time.Millisecond)
+		fmt.Fprintf(&b, "  wall clock:       %s\n", time.Duration(s.TotalWallClockMs)*time.Millisecond)
 	}
 
 	if len(s.ToolCallsByName) > 0 {
 		names := sortedMapKeys(s.ToolCallsByName)
-		fmt.Fprintln(out, "  tool counts:")
+		b.WriteString("  tool counts:\n")
 		for _, n := range names {
-			fmt.Fprintf(out, "    %-32s %d", n, s.ToolCallsByName[n])
+			fmt.Fprintf(&b, "    %-32s %d", n, s.ToolCallsByName[n])
 			if e := s.ToolErrorsByName[n]; e > 0 {
-				fmt.Fprintf(out, "  (errors: %d)", e)
+				fmt.Fprintf(&b, "  (errors: %d)", e)
 			}
-			fmt.Fprintln(out)
+			b.WriteByte('\n')
 		}
 	}
 
 	if len(s.Outcomes) > 0 {
 		names := sortedMapKeys(s.Outcomes)
-		fmt.Fprintln(out, "  outcomes:")
+		b.WriteString("  outcomes:\n")
 		for _, n := range names {
-			fmt.Fprintf(out, "    %-32s %d\n", n, s.Outcomes[n])
+			fmt.Fprintf(&b, "    %-32s %d\n", n, s.Outcomes[n])
 		}
 	}
 
 	if len(s.SlowestToolCalls) > 0 {
-		fmt.Fprintln(out, "  slowest tool calls:")
+		b.WriteString("  slowest tool calls:\n")
 		limit := top
 		if limit > len(s.SlowestToolCalls) {
 			limit = len(s.SlowestToolCalls)
@@ -267,11 +269,12 @@ func writeStatsText(out io.Writer, s *TraceStats, top int) error {
 			if !tc.Success {
 				status = "fail"
 			}
-			fmt.Fprintf(out, "    %2d. %-32s %6dms  %s\n", i+1, tc.Name, tc.DurationMs, status)
+			fmt.Fprintf(&b, "    %2d. %-32s %6dms  %s\n", i+1, tc.Name, tc.DurationMs, status)
 		}
 	}
 
-	return nil
+	_, err := io.WriteString(out, b.String())
+	return err
 }
 
 func sortedMapKeys(m map[string]int) []string {

--- a/harness/cmd/stirrup/cmd/trace_stats.go
+++ b/harness/cmd/stirrup/cmd/trace_stats.go
@@ -135,7 +135,14 @@ func newTraceStats() *TraceStats {
 
 func (s *TraceStats) absorb(t *types.RunTrace) {
 	s.Records++
-	if s.RunID == "" {
+	// Prefer RunConfig.RunID (the operator-supplied identifier the spec
+	// calls out) and fall back to RunTrace.ID (the wire-level event id)
+	// when the config did not carry one. The two are identical for most
+	// runs, but a run with an explicit RunConfig.RunID must surface
+	// that value in stats.
+	if t.Config.RunID != "" {
+		s.RunID = t.Config.RunID
+	} else if s.RunID == "" {
 		s.RunID = t.ID
 	}
 

--- a/harness/cmd/stirrup/cmd/trace_tail.go
+++ b/harness/cmd/stirrup/cmd/trace_tail.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/types"
+	tracereader "github.com/rxbynerd/stirrup/types/trace"
+)
+
+var traceTailCmd = &cobra.Command{
+	Use:   "tail <file>",
+	Short: "Stream JSONL trace records as they are written",
+	Long: `Stream JSONL trace records from a file in chronological order.
+
+Without -f, tail prints every record currently in the file and exits
+(equivalent to ` + "`stirrup trace show`" + ` minus the per-run framing).
+With -f, tail keeps polling the file at --interval, printing records
+as they are appended. SIGINT terminates the follow loop cleanly.
+
+Pass ` + "`-`" + ` to read from stdin; the -f flag is ignored on stdin
+because stdin already blocks until more bytes are written.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTraceTail,
+}
+
+func init() {
+	traceCmd.AddCommand(traceTailCmd)
+	addColorFlag(traceTailCmd)
+	f := traceTailCmd.Flags()
+	f.BoolP("follow", "f", false, "Keep tailing the file, printing records as they are appended (tail -f semantics).")
+	f.Duration("interval", 100*time.Millisecond, "Polling interval when --follow is set. Defaults to 100ms; raise it to reduce CPU on a very quiet file.")
+}
+
+func runTraceTail(cmd *cobra.Command, args []string) error {
+	mode, err := resolveColorMode(cmd)
+	if err != nil {
+		return err
+	}
+	follow, _ := cmd.Flags().GetBool("follow")
+	interval, _ := cmd.Flags().GetDuration("interval")
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	return runTraceTailWith(ctx, args[0], cmd.OutOrStdout(), mode, follow, interval)
+}
+
+func runTraceTailWith(ctx context.Context, path string, out io.Writer, mode colorMode, follow bool, interval time.Duration) error {
+	color := shouldColor(mode, out)
+	return tracereader.Tail(ctx, path, tracereader.TailOptions{
+		Follow:       follow,
+		PollInterval: interval,
+	}, func(t *types.RunTrace) error {
+		return renderTailRecord(out, t, color)
+	})
+}
+
+// renderTailRecord emits a single record per RunTrace using the same
+// shape as `trace show`. Unlike show, tail does not error on an empty
+// stream — an empty follow-tail is normal while the run is still
+// warming up.
+func renderTailRecord(out io.Writer, t *types.RunTrace, color bool) error {
+	return renderRunTrace(out, t, color)
+}

--- a/harness/cmd/stirrup/cmd/trace_test.go
+++ b/harness/cmd/stirrup/cmd/trace_test.go
@@ -299,6 +299,66 @@ func TestTraceGrep_StdinPath(t *testing.T) {
 	}
 }
 
+func TestParseColorMode(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantMode  colorMode
+		wantError bool
+	}{
+		{"", colorAuto, false},
+		{"auto", colorAuto, false},
+		{"AUTO", colorAuto, false},
+		{"always", colorAlways, false},
+		{"force", colorAlways, false},
+		{"yes", colorAlways, false},
+		{"never", colorNever, false},
+		{"no", colorNever, false},
+		{"off", colorNever, false},
+		{"rainbow", colorAuto, true},
+		{"  ", colorAuto, true},
+	}
+	for _, c := range cases {
+		got, err := parseColorMode(c.in)
+		if c.wantError {
+			if err == nil {
+				t.Errorf("parseColorMode(%q): expected error, got nil", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseColorMode(%q): unexpected error %v", c.in, err)
+		}
+		if got != c.wantMode {
+			t.Errorf("parseColorMode(%q) = %v, want %v", c.in, got, c.wantMode)
+		}
+	}
+}
+
+func TestShouldColor_NoColorEnvVar(t *testing.T) {
+	// Per https://no-color.org/, any non-empty NO_COLOR must suppress
+	// ANSI output under auto-mode. Use a pipe (one end is an *os.File
+	// that IsTerminal returns true for is impossible to fabricate in
+	// a test without a real TTY) — but the NO_COLOR check sits before
+	// the TTY check, so even an actual TTY-looking file goes false.
+	t.Setenv("NO_COLOR", "1")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+	if shouldColor(colorAuto, w) {
+		t.Error("shouldColor(colorAuto) with NO_COLOR=1 must be false")
+	}
+	// colorAlways must still win over NO_COLOR — an explicit opt-in
+	// from the operator is not overridden by ambient env.
+	if !shouldColor(colorAlways, w) {
+		t.Error("shouldColor(colorAlways) must remain true even with NO_COLOR set")
+	}
+}
+
 func TestRunTraceGrepWith_OversizedLineSkipped(t *testing.T) {
 	// Write a valid record, then a line larger than MaxLineBytes, then
 	// a second valid record. The oversized line must be silently

--- a/harness/cmd/stirrup/cmd/trace_test.go
+++ b/harness/cmd/stirrup/cmd/trace_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rxbynerd/stirrup/types"
+	tracereader "github.com/rxbynerd/stirrup/types/trace"
 )
 
 func writeTraceFile(t *testing.T, traces []types.RunTrace) string {
@@ -295,6 +296,44 @@ func TestTraceGrep_StdinPath(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"id":"run-1"`) {
 		t.Errorf("stdin grep missing match: %q", out.String())
+	}
+}
+
+func TestRunTraceGrepWith_OversizedLineSkipped(t *testing.T) {
+	// Write a valid record, then a line larger than MaxLineBytes, then
+	// a second valid record. The oversized line must be silently
+	// skipped and BOTH valid records must appear in the output.
+	traces := sampleTraces()
+	first, _ := json.Marshal(traces[0])
+	second := types.RunTrace{ID: "run-2", Outcome: "success"}
+	secondBytes, _ := json.Marshal(second)
+
+	oversized := bytes.Repeat([]byte("x"), tracereader.MaxLineBytes+128)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversized.jsonl")
+	var buf bytes.Buffer
+	buf.Write(first)
+	buf.WriteByte('\n')
+	buf.Write(oversized)
+	buf.WriteByte('\n')
+	buf.Write(secondBytes)
+	buf.WriteByte('\n')
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pred, _ := compileJQ("")
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred, false); err != nil {
+		t.Fatalf("grep oversized: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `"id":"run-1"`) {
+		t.Errorf("first record missing from output: %q", got)
+	}
+	if !strings.Contains(got, `"id":"run-2"`) {
+		t.Errorf("second record (after oversized line) missing — grep dropped records after the cap: %q", got)
 	}
 }
 

--- a/harness/cmd/stirrup/cmd/trace_test.go
+++ b/harness/cmd/stirrup/cmd/trace_test.go
@@ -511,6 +511,199 @@ func (b *safeBuf) String() string {
 	return b.buf.String()
 }
 
+func TestOutcomeColor(t *testing.T) {
+	cases := []struct {
+		outcome string
+		want    string
+	}{
+		{"success", ansiGreen},
+		{"error", ansiRed},
+		{"verification_failed", ansiRed},
+		{"verification_error", ansiRed},
+		{"tool_failures", ansiRed},
+		{"max_turns", ansiYellow},
+		{"max_tokens", ansiYellow},
+		{"budget_exceeded", ansiYellow},
+		{"stalled", ansiYellow},
+		{"timeout", ansiYellow},
+		{"cancelled", ansiGrey},
+		{"", ansiBlue},
+		{"some_unknown_outcome", ansiBlue},
+	}
+	for _, c := range cases {
+		got := outcomeColor(c.outcome)
+		if got != c.want {
+			t.Errorf("outcomeColor(%q) = %q, want %q", c.outcome, got, c.want)
+		}
+	}
+}
+
+func TestParseJQValue(t *testing.T) {
+	cases := []struct {
+		in        string
+		want      any
+		wantError bool
+	}{
+		{`"hello"`, "hello", false},
+		{`"with \"quotes\""`, `with "quotes"`, false},
+		{"true", true, false},
+		{"false", false, false},
+		{"null", nil, false},
+		{"42", float64(42), false},
+		{"3.14", float64(3.14), false},
+		{"-7", float64(-7), false},
+		{"", nil, true},
+		{`"unclosed`, nil, true},
+		{"not_a_value", nil, true},
+	}
+	for _, c := range cases {
+		got, err := parseJQValue(c.in)
+		if c.wantError {
+			if err == nil {
+				t.Errorf("parseJQValue(%q): expected error, got %v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseJQValue(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseJQValue(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestWalkPath(t *testing.T) {
+	doc := map[string]any{
+		"name": "stirrup",
+		"toolCalls": []any{
+			map[string]any{"name": "edit_file"},
+			map[string]any{"name": "run_command"},
+		},
+		"count": float64(3),
+	}
+
+	cases := []struct {
+		name string
+		path []pathSeg
+		want any
+		ok   bool
+	}{
+		{
+			name: "object key",
+			path: []pathSeg{{key: "name"}},
+			want: "stirrup", ok: true,
+		},
+		{
+			name: "array indexed element",
+			path: []pathSeg{{key: "toolCalls"}, {key: "0", idx: 0, num: true}, {key: "name"}},
+			want: "edit_file", ok: true,
+		},
+		{
+			name: "non-numeric segment on array",
+			path: []pathSeg{{key: "toolCalls"}, {key: "first"}},
+			ok:   false,
+		},
+		{
+			name: "out-of-bounds index",
+			path: []pathSeg{{key: "toolCalls"}, {key: "9", idx: 9, num: true}},
+			ok:   false,
+		},
+		{
+			name: "scalar default arm",
+			path: []pathSeg{{key: "name"}, {key: "any"}},
+			ok:   false,
+		},
+		{
+			name: "missing object key",
+			path: []pathSeg{{key: "missing"}},
+			ok:   false,
+		},
+	}
+	for _, c := range cases {
+		got, ok := walkPath(doc, c.path)
+		if ok != c.ok {
+			t.Errorf("%s: ok = %v, want %v", c.name, ok, c.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestRunTraceGrepWith_JQNumericAndBool(t *testing.T) {
+	// Exercise jsonEqual's float64 and bool arms via the predicate
+	// path, plus jq paths that resolve to those JSON types.
+	traces := []types.RunTrace{
+		{ID: "run-1", Turns: 3, Outcome: "success", ToolCalls: []types.ToolCallSummary{{Name: "edit_file", Success: true}}},
+		{ID: "run-2", Turns: 0, Outcome: "max_turns", ToolCalls: []types.ToolCallSummary{{Name: "run_command", Success: false}}},
+	}
+	path := writeTraceFile(t, traces)
+
+	// .turns == 3 reaches the float64 equality arm.
+	pred, err := compileJQ(".turns == 3")
+	if err != nil {
+		t.Fatalf("compileJQ: %v", err)
+	}
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `"id":"run-1"`) {
+		t.Errorf(".turns == 3 should match run-1: %q", got)
+	}
+	if strings.Contains(got, `"id":"run-2"`) {
+		t.Errorf(".turns == 3 must not match run-2 (turns=0): %q", got)
+	}
+
+	// .toolCalls.0.success == true reaches the bool equality arm.
+	pred2, err := compileJQ(".toolCalls.0.success == true")
+	if err != nil {
+		t.Fatalf("compileJQ bool: %v", err)
+	}
+	out.Reset()
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred2, false); err != nil {
+		t.Fatalf("grep bool: %v", err)
+	}
+	got = out.String()
+	if !strings.Contains(got, `"id":"run-1"`) {
+		t.Errorf("bool predicate should match run-1: %q", got)
+	}
+	if strings.Contains(got, `"id":"run-2"`) {
+		t.Errorf("bool predicate must not match run-2 (success=false): %q", got)
+	}
+}
+
+func TestRunTraceStatsWith_PrefersConfigRunID(t *testing.T) {
+	// When RunConfig.RunID is set, stats must surface it rather than
+	// RunTrace.ID. Two records with the same event ID but distinct
+	// config IDs would otherwise lose the operator-supplied label.
+	traces := []types.RunTrace{{
+		ID:        "event-1",
+		Config:    types.RunConfig{RunID: "operator-supplied-id"},
+		Outcome:   "success",
+		StartedAt: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	}}
+	path := writeTraceFile(t, traces)
+	var out bytes.Buffer
+	if err := runTraceStatsWith(path, &out, "json", 5); err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	var stats TraceStats
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &stats); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if stats.RunID != "operator-supplied-id" {
+		t.Errorf("RunID = %q, want operator-supplied-id (RunConfig.RunID takes precedence over RunTrace.ID)", stats.RunID)
+	}
+}
+
 func TestTraceTail_FollowReadsAppended(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "live.jsonl")

--- a/harness/cmd/stirrup/cmd/trace_test.go
+++ b/harness/cmd/stirrup/cmd/trace_test.go
@@ -1,0 +1,392 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func writeTraceFile(t *testing.T, traces []types.RunTrace) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trace.jsonl")
+	var buf bytes.Buffer
+	for _, tr := range traces {
+		data, err := json.Marshal(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func sampleTraces() []types.RunTrace {
+	start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Second)
+	return []types.RunTrace{{
+		ID:          "run-1",
+		StartedAt:   start,
+		CompletedAt: end,
+		Turns:       3,
+		TokenUsage:  types.TokenUsage{Input: 100, Output: 200},
+		ToolCalls: []types.ToolCallSummary{
+			{Name: "edit_file", DurationMs: 50, Success: true, InputSize: 64, OutputSize: 12},
+			{Name: "run_command", DurationMs: 500, Success: false, ErrorReason: "exit 1"},
+			{Name: "edit_file", DurationMs: 25, Success: true},
+		},
+		VerificationResults: []types.VerificationResult{{Passed: true, Feedback: "all green"}},
+		Outcome:             "success",
+	}}
+}
+
+func TestTraceShow_PrintsRecords(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+
+	var out bytes.Buffer
+	if err := runTraceShowWith(path, &out, colorNever); err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	s := out.String()
+	wants := []string{"run-1", "edit_file", "run_command", "success", "tokens", "3", "ok", "fail"}
+	for _, w := range wants {
+		if !strings.Contains(s, w) {
+			t.Errorf("show output missing %q\n--- output ---\n%s", w, s)
+		}
+	}
+	if strings.Contains(s, "\x1b[") {
+		t.Error("colorNever output must not contain ANSI escapes")
+	}
+}
+
+func TestTraceShow_AlwaysEmitsAnsi(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	var out bytes.Buffer
+	if err := runTraceShowWith(path, &out, colorAlways); err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if !strings.Contains(out.String(), "\x1b[") {
+		t.Error("colorAlways output must contain ANSI escapes")
+	}
+}
+
+func TestTraceShow_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	err := runTraceShowWith(path, &out, colorNever)
+	if err == nil {
+		t.Fatal("show on empty file: expected error")
+	}
+}
+
+func TestTraceStats_JSONOutput(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	var out bytes.Buffer
+	if err := runTraceStatsWith(path, &out, "json", 5); err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+
+	var stats TraceStats
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+
+	if stats.TotalTurns != 3 {
+		t.Errorf("TotalTurns = %d, want 3", stats.TotalTurns)
+	}
+	if stats.TokensInput != 100 || stats.TokensOutput != 200 {
+		t.Errorf("tokens = %d/%d, want 100/200", stats.TokensInput, stats.TokensOutput)
+	}
+	if stats.ToolCalls != 3 || stats.ToolErrors != 1 {
+		t.Errorf("ToolCalls/Errors = %d/%d, want 3/1", stats.ToolCalls, stats.ToolErrors)
+	}
+	if stats.LongestToolCallMs != 500 {
+		t.Errorf("LongestToolCallMs = %d, want 500", stats.LongestToolCallMs)
+	}
+	if stats.TotalWallClockMs != 5000 {
+		t.Errorf("TotalWallClockMs = %d, want 5000", stats.TotalWallClockMs)
+	}
+	if stats.ToolCallsByName["edit_file"] != 2 {
+		t.Errorf("edit_file count = %d, want 2", stats.ToolCallsByName["edit_file"])
+	}
+	if stats.Outcomes["success"] != 1 {
+		t.Errorf("success count = %d, want 1", stats.Outcomes["success"])
+	}
+	if stats.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", stats.RunID)
+	}
+	if len(stats.SlowestToolCalls) != 3 {
+		t.Fatalf("SlowestToolCalls len = %d, want 3", len(stats.SlowestToolCalls))
+	}
+	if stats.SlowestToolCalls[0].DurationMs != 500 {
+		t.Errorf("slowest top = %dms, want 500ms", stats.SlowestToolCalls[0].DurationMs)
+	}
+}
+
+func TestTraceStats_TextOutput(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	var out bytes.Buffer
+	if err := runTraceStatsWith(path, &out, "text", 5); err != nil {
+		t.Fatalf("stats text: %v", err)
+	}
+	s := out.String()
+	for _, want := range []string{"trace stats", "run-1", "total turns:", "tokens in / out:", "edit_file", "outcomes:", "success"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("text stats missing %q\n%s", want, s)
+		}
+	}
+}
+
+func TestTraceStats_InvalidFormat(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	var out bytes.Buffer
+	err := runTraceStatsWith(path, &out, "yaml", 5)
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+}
+
+func TestTraceGrep_SubstringMatch(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	var out bytes.Buffer
+	pred, _ := compileJQ("")
+	if err := runTraceGrepWith(context.Background(), path, &out, "edit_file", pred, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(out.String(), "edit_file") {
+		t.Errorf("grep output missing match: %q", out.String())
+	}
+
+	out.Reset()
+	if err := runTraceGrepWith(context.Background(), path, &out, "no_such_string", pred, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("grep miss should be empty, got %q", out.String())
+	}
+}
+
+func TestTraceGrep_JQEqual(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	pred, err := compileJQ(`.outcome == "success"`)
+	if err != nil {
+		t.Fatalf("compileJQ: %v", err)
+	}
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(out.String(), `"id":"run-1"`) {
+		t.Errorf("grep output missing record: %q", out.String())
+	}
+
+	pred2, err := compileJQ(`.outcome == "max_turns"`)
+	if err != nil {
+		t.Fatalf("compileJQ: %v", err)
+	}
+	out.Reset()
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred2, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("non-matching predicate should produce no output, got %q", out.String())
+	}
+}
+
+func TestTraceGrep_JQContains(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	pred, err := compileJQ(`.outcome contains "uc"`)
+	if err != nil {
+		t.Fatalf("compileJQ: %v", err)
+	}
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(out.String(), `"outcome":"success"`) {
+		t.Errorf("contains should match: %q", out.String())
+	}
+}
+
+func TestTraceGrep_JQPathIntoArray(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	pred, err := compileJQ(`.toolCalls.0.name == "edit_file"`)
+	if err != nil {
+		t.Fatalf("compileJQ: %v", err)
+	}
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(out.String(), `"id":"run-1"`) {
+		t.Errorf("array path should match: %q", out.String())
+	}
+}
+
+func TestTraceGrep_Invert(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	pred, err := compileJQ(`.outcome == "success"`)
+	if err != nil {
+		t.Fatalf("compileJQ: %v", err)
+	}
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred, true); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("inverted match of the only record should be empty, got %q", out.String())
+	}
+}
+
+func TestCompileJQ_Errors(t *testing.T) {
+	cases := []string{
+		"no_dot == 1",
+		`. notanop "x"`,
+		`. == `,
+		`. == unclosed"`,
+	}
+	for _, c := range cases {
+		if _, err := compileJQ(c); err == nil {
+			t.Errorf("expected error for %q", c)
+		}
+	}
+}
+
+func TestTraceGrep_StdinPath(t *testing.T) {
+	traces := sampleTraces()
+	data, _ := json.Marshal(traces[0])
+
+	// Redirect os.Stdin to a temp file containing one record.
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "stdin.jsonl")
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	origStdin := os.Stdin
+	os.Stdin = f
+	defer func() { os.Stdin = origStdin }()
+
+	pred, _ := compileJQ(`.id == "run-1"`)
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), "-", &out, "", pred, false); err != nil {
+		t.Fatalf("grep -: %v", err)
+	}
+	if !strings.Contains(out.String(), `"id":"run-1"`) {
+		t.Errorf("stdin grep missing match: %q", out.String())
+	}
+}
+
+func TestTraceTail_OneShot(t *testing.T) {
+	path := writeTraceFile(t, sampleTraces())
+	var out bytes.Buffer
+	if err := runTraceTailWith(context.Background(), path, &out, colorNever, false, 10*time.Millisecond); err != nil {
+		t.Fatalf("tail: %v", err)
+	}
+	if !strings.Contains(out.String(), "run-1") {
+		t.Errorf("tail output missing record: %q", out.String())
+	}
+}
+
+// safeBuf is a tiny synchronised buffer so the tail goroutine can write
+// to a sink the test goroutine reads from without racing on bytes.Buffer.
+type safeBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuf) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuf) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestTraceTail_FollowReadsAppended(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "live.jsonl")
+	initial := sampleTraces()
+	data, _ := json.Marshal(initial[0])
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out := &safeBuf{}
+	doneCh := make(chan error, 1)
+	go func() {
+		doneCh <- runTraceTailWith(ctx, path, out, colorNever, true, 10*time.Millisecond)
+	}()
+
+	waitFor := func(needle string, deadline time.Duration) bool {
+		t.Helper()
+		end := time.Now().Add(deadline)
+		for time.Now().Before(end) {
+			if strings.Contains(out.String(), needle) {
+				return true
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return false
+	}
+
+	if !waitFor("run-1", 2*time.Second) {
+		cancel()
+		t.Fatalf("tail did not surface initial record; got %q", out.String())
+	}
+
+	// Append a second record while tail is following.
+	second := types.RunTrace{ID: "run-2", Turns: 1}
+	data2, _ := json.Marshal(second)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(data2, '\n')); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	if !waitFor("run-2", 2*time.Second) {
+		cancel()
+		t.Fatalf("tail did not surface appended record; got %q", out.String())
+	}
+
+	cancel()
+	select {
+	case err := <-doneCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("tail returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("tail did not exit after cancel")
+	}
+}

--- a/harness/cmd/stirrup/cmd/trace_test.go
+++ b/harness/cmd/stirrup/cmd/trace_test.go
@@ -241,6 +241,31 @@ func TestTraceGrep_JQPathIntoArray(t *testing.T) {
 	}
 }
 
+func TestRunTraceGrepWith_JQNotEqual(t *testing.T) {
+	traces := []types.RunTrace{
+		{ID: "run-1", Outcome: "success"},
+		{ID: "run-2", Outcome: "error"},
+		{ID: "run-3", Outcome: "max_turns"},
+	}
+	path := writeTraceFile(t, traces)
+
+	pred, err := compileJQ(`.outcome != "success"`)
+	if err != nil {
+		t.Fatalf("compileJQ: %v", err)
+	}
+	var out bytes.Buffer
+	if err := runTraceGrepWith(context.Background(), path, &out, "", pred, false); err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, `"id":"run-1"`) {
+		t.Errorf("!= predicate must drop success record: %q", got)
+	}
+	if !strings.Contains(got, `"id":"run-2"`) || !strings.Contains(got, `"id":"run-3"`) {
+		t.Errorf("!= predicate must keep non-success records: %q", got)
+	}
+}
+
 func TestTraceGrep_Invert(t *testing.T) {
 	path := writeTraceFile(t, sampleTraces())
 	pred, err := compileJQ(`.outcome == "success"`)
@@ -270,24 +295,40 @@ func TestCompileJQ_Errors(t *testing.T) {
 	}
 }
 
-func TestTraceGrep_StdinPath(t *testing.T) {
-	traces := sampleTraces()
-	data, _ := json.Marshal(traces[0])
-
-	// Redirect os.Stdin to a temp file containing one record.
+// withStdinFromTraces swaps os.Stdin for a temp file containing the
+// JSONL-encoded traces and restores the original on test cleanup.
+// The subcommand stdin paths all go through tracereader.Open("-"),
+// which reads from os.Stdin directly.
+func withStdinFromTraces(t *testing.T, traces []types.RunTrace) {
+	t.Helper()
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "stdin.jsonl")
-	if err := os.WriteFile(tmp, append(data, '\n'), 0o644); err != nil {
+	var buf bytes.Buffer
+	for _, tr := range traces {
+		data, err := json.Marshal(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	f, err := os.Open(tmp)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = f.Close() }()
 	origStdin := os.Stdin
 	os.Stdin = f
-	defer func() { os.Stdin = origStdin }()
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		_ = f.Close()
+	})
+}
+
+func TestTraceGrep_StdinPath(t *testing.T) {
+	withStdinFromTraces(t, sampleTraces())
 
 	pred, _ := compileJQ(`.id == "run-1"`)
 	var out bytes.Buffer
@@ -296,6 +337,49 @@ func TestTraceGrep_StdinPath(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"id":"run-1"`) {
 		t.Errorf("stdin grep missing match: %q", out.String())
+	}
+}
+
+func TestRunTraceShowWith_StdinPath(t *testing.T) {
+	withStdinFromTraces(t, sampleTraces())
+
+	var out bytes.Buffer
+	if err := runTraceShowWith("-", &out, colorNever); err != nil {
+		t.Fatalf("show -: %v", err)
+	}
+	if !strings.Contains(out.String(), "run-1") {
+		t.Errorf("stdin show missing record: %q", out.String())
+	}
+}
+
+func TestRunTraceStatsWith_StdinPath(t *testing.T) {
+	withStdinFromTraces(t, sampleTraces())
+
+	var out bytes.Buffer
+	if err := runTraceStatsWith("-", &out, "json", 5); err != nil {
+		t.Fatalf("stats -: %v", err)
+	}
+	var stats TraceStats
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if stats.RunID != "run-1" {
+		t.Errorf("stdin stats RunID = %q, want run-1", stats.RunID)
+	}
+	if stats.TotalTurns != 3 {
+		t.Errorf("stdin stats TotalTurns = %d, want 3", stats.TotalTurns)
+	}
+}
+
+func TestRunTraceTailWith_StdinPath(t *testing.T) {
+	withStdinFromTraces(t, sampleTraces())
+
+	var out bytes.Buffer
+	if err := runTraceTailWith(context.Background(), "-", &out, colorNever, false, 10*time.Millisecond); err != nil {
+		t.Fatalf("tail -: %v", err)
+	}
+	if !strings.Contains(out.String(), "run-1") {
+		t.Errorf("stdin tail missing record: %q", out.String())
 	}
 }
 

--- a/types/trace/reader.go
+++ b/types/trace/reader.go
@@ -1,0 +1,296 @@
+// Package trace provides offline parsers for the JSONL trace files
+// stirrup writes via traceEmitter.type=jsonl.
+//
+// The on-wire shape is one types.RunTrace per line. A run can produce
+// multiple lines (e.g. when a partial trace is appended ahead of the
+// final summary by future emitters); consumers are expected to walk
+// every record and either project them into typed sub-events or
+// collapse onto the last record (the historical contract of the eval
+// runner's parseTraceFile).
+//
+// Reader is the single-pass streaming entry point. Tail consumes the
+// same scanner shape but polls the underlying file for appended data
+// so operators can watch an in-progress run. Both helpers skip
+// malformed lines with a slog.Debug log — a truncated tail of an
+// in-flight JSONL file must not fail the surrounding command.
+package trace
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// MaxLineBytes is the per-record line cap the reader honours. Matches
+// the trace emitter's own cap so a record that fit on write also fits
+// on read. A line larger than the cap is skipped with a slog.Debug log
+// (consistent with the malformed-line policy) rather than aborting the
+// scan.
+const MaxLineBytes = 4 * 1024 * 1024
+
+// initialScanBuf is the bufio.Scanner starting buffer. It grows up to
+// MaxLineBytes when a single record is larger than 256 KiB. The choice
+// matches eval/runner/runner.go's prior local copy so the
+// extracted reader preserves the same memory footprint for the common
+// "small line" case.
+const initialScanBuf = 256 * 1024
+
+// defaultTailPollInterval is the poll cadence Tail uses when the
+// caller does not override it. 100 ms keeps a live `tail -f` view
+// responsive without burning CPU on a quiet file.
+const defaultTailPollInterval = 100 * time.Millisecond
+
+// Reader streams RunTrace records from a JSONL source.
+//
+// Reader is single-threaded; concurrent calls to Next on the same
+// Reader are not supported. The reader owns the bufio.Scanner and the
+// optional io.Closer it was constructed with.
+type Reader struct {
+	src     io.Reader
+	closer  io.Closer
+	scanner *bufio.Scanner
+	logger  *slog.Logger
+}
+
+// ReaderOption customises a Reader.
+type ReaderOption func(*Reader)
+
+// WithLogger installs a slog.Logger that receives debug-level messages
+// for every malformed or oversized line the reader skips. The default
+// is slog.Default(); pass slog.New(slog.DiscardHandler) to silence the
+// reader entirely.
+func WithLogger(l *slog.Logger) ReaderOption {
+	return func(r *Reader) {
+		if l != nil {
+			r.logger = l
+		}
+	}
+}
+
+// NewReader wraps r in a Reader. The caller retains ownership of r;
+// Close on the returned Reader does NOT close r.
+func NewReader(r io.Reader, opts ...ReaderOption) *Reader {
+	reader := &Reader{
+		src:     r,
+		logger:  slog.Default(),
+		scanner: bufio.NewScanner(r),
+	}
+	reader.scanner.Buffer(make([]byte, 0, initialScanBuf), MaxLineBytes)
+	for _, opt := range opts {
+		opt(reader)
+	}
+	return reader
+}
+
+// Open opens path for reading and returns a Reader that owns the file.
+// The special path "-" reads from os.Stdin; the resulting Reader does
+// not close stdin on Close.
+func Open(path string, opts ...ReaderOption) (*Reader, error) {
+	if path == "-" {
+		return NewReader(os.Stdin, opts...), nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening trace file %q: %w", path, err)
+	}
+	r := NewReader(f, opts...)
+	r.closer = f
+	return r, nil
+}
+
+// Close releases the underlying file when Reader was constructed via
+// Open on a real path. NewReader-constructed Readers and stdin-backed
+// Readers report nil.
+func (r *Reader) Close() error {
+	if r.closer == nil {
+		return nil
+	}
+	return r.closer.Close()
+}
+
+// resetScanner discards any cached EOF on the underlying scanner so a
+// follower can resume past the previous end of file once new bytes
+// have been appended. The file offset is preserved by the underlying
+// io.Reader, so a fresh scanner picks up exactly at the previous
+// stopping point.
+func (r *Reader) resetScanner() {
+	r.scanner = bufio.NewScanner(r.src)
+	r.scanner.Buffer(make([]byte, 0, initialScanBuf), MaxLineBytes)
+}
+
+// Next returns the next RunTrace record in the stream.
+//
+// Malformed JSON lines and lines exceeding MaxLineBytes are skipped
+// with a slog.Debug log; Next continues past them to the next
+// well-formed record. An io.EOF is returned when the stream is
+// exhausted with no further well-formed records to yield. Any other
+// I/O error from the underlying scanner is surfaced verbatim.
+func (r *Reader) Next() (*types.RunTrace, error) {
+	for r.scanner.Scan() {
+		line := r.scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var trace types.RunTrace
+		if err := json.Unmarshal(line, &trace); err != nil {
+			r.logger.Debug("trace.Reader: skip malformed line",
+				"err", err.Error(),
+				"bytes", len(line),
+			)
+			continue
+		}
+		return &trace, nil
+	}
+	if err := r.scanner.Err(); err != nil {
+		// bufio.ErrTooLong is the cap-exceeded signal; surface it as a
+		// debug-skipped record and reset the scanner so the next Next
+		// can resume past the offending line. The reader's contract
+		// promises a single oversized record never aborts the scan.
+		if errors.Is(err, bufio.ErrTooLong) {
+			r.logger.Debug("trace.Reader: skip oversized line",
+				"cap", MaxLineBytes,
+			)
+			r.scanner = bufio.NewScanner(r.src)
+			r.scanner.Buffer(make([]byte, 0, initialScanBuf), MaxLineBytes)
+			return r.Next()
+		}
+		return nil, fmt.Errorf("reading trace file: %w", err)
+	}
+	return nil, io.EOF
+}
+
+// All drains the reader into a slice. The slice is empty when the
+// stream contained no well-formed records (e.g. the file is empty or
+// every line was malformed); io.EOF is consumed and not surfaced.
+func (r *Reader) All() ([]types.RunTrace, error) {
+	var out []types.RunTrace
+	for {
+		t, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			return out, nil
+		}
+		if err != nil {
+			return out, err
+		}
+		out = append(out, *t)
+	}
+}
+
+// Last reads the stream to completion and returns the last well-formed
+// RunTrace, or an error if no records were present. Matches the
+// historical semantics the eval runner's parseTraceFile exposed: the
+// trailing line is the authoritative summary of a completed run.
+func (r *Reader) Last() (*types.RunTrace, error) {
+	var last *types.RunTrace
+	for {
+		t, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			if last == nil {
+				return nil, fmt.Errorf("trace file is empty")
+			}
+			return last, nil
+		}
+		if err != nil {
+			return last, err
+		}
+		last = t
+	}
+}
+
+// TailOptions configures Tail.
+type TailOptions struct {
+	// Follow keeps Tail running past EOF, polling the underlying file
+	// for appended records. When false, Tail terminates the moment the
+	// stream is exhausted (one-shot semantics, identical to All).
+	Follow bool
+
+	// PollInterval is the cadence Tail polls the file for appended
+	// data when Follow is true. Defaults to 100 ms when zero.
+	PollInterval time.Duration
+
+	// Logger receives debug messages for malformed/oversized lines.
+	// nil falls back to slog.Default().
+	Logger *slog.Logger
+}
+
+// Tail reads path and invokes handle for every well-formed RunTrace
+// record, returning when ctx is cancelled, the stream is exhausted
+// (Follow=false), or handle returns a non-nil error. The special path
+// "-" reads from os.Stdin and ignores Follow (stdin already has the
+// "block until appended" semantics built in).
+//
+// Tail uses a polling loop — no fsnotify or platform-specific file
+// notification — because the JSONL trace files are append-only and a
+// 100 ms poll is sufficient to keep an operator's `tail -f` view
+// responsive without inflating the dependency tree.
+func Tail(ctx context.Context, path string, opts TailOptions, handle func(*types.RunTrace) error) error {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	poll := opts.PollInterval
+	if poll <= 0 {
+		poll = defaultTailPollInterval
+	}
+
+	if path == "-" {
+		r := NewReader(os.Stdin, WithLogger(logger))
+		return streamReader(ctx, r, handle)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening trace file %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	r := NewReader(f, WithLogger(logger))
+
+	for {
+		if err := streamReader(ctx, r, handle); err != nil {
+			return err
+		}
+		if !opts.Follow {
+			return nil
+		}
+		// bufio.Scanner caches the EOF it returned, so a second pass
+		// over the same scanner would short-circuit even after new
+		// bytes land on disk. Re-attach a fresh scanner to the same
+		// open file: the file's offset is preserved, so we resume
+		// exactly where the previous pass stopped.
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(poll):
+		}
+		r.resetScanner()
+	}
+}
+
+// streamReader pumps every available record from r through handle until
+// handle errors, ctx is cancelled, or the stream EOFs.
+func streamReader(ctx context.Context, r *Reader, handle func(*types.RunTrace) error) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		t, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := handle(t); err != nil {
+			return err
+		}
+	}
+}

--- a/types/trace/reader.go
+++ b/types/trace/reader.go
@@ -231,6 +231,14 @@ type TailOptions struct {
 // notification — because the JSONL trace files are append-only and a
 // 100 ms poll is sufficient to keep an operator's `tail -f` view
 // responsive without inflating the dependency tree.
+//
+// Truncation and rotation are NOT followed: Tail keeps the same file
+// handle open across polls, so if the file is truncated or rotated
+// out from under it, the kernel offset stays past the new EOF and
+// the follow loop appears to stall with no further output and no
+// error. Restart the command to pick up the rotated file. Full
+// inode-tracking semantics (`tail --follow=name`) are intentionally
+// out of scope; trace files are written append-only by stirrup.
 func Tail(ctx context.Context, path string, opts TailOptions, handle func(*types.RunTrace) error) error {
 	logger := opts.Logger
 	if logger == nil {

--- a/types/trace/reader_test.go
+++ b/types/trace/reader_test.go
@@ -1,0 +1,243 @@
+package trace
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return data
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func TestReader_AllAndLast(t *testing.T) {
+	traces := []types.RunTrace{
+		{ID: "first", Turns: 1},
+		{ID: "second", Turns: 5},
+	}
+
+	var buf bytes.Buffer
+	for _, tr := range traces {
+		buf.Write(mustMarshal(t, tr))
+		buf.WriteByte('\n')
+	}
+	body := buf.Bytes()
+
+	r := NewReader(bytes.NewReader(body), WithLogger(discardLogger()))
+	got, err := r.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(All) = %d, want 2", len(got))
+	}
+	if got[0].ID != "first" || got[1].ID != "second" {
+		t.Errorf("All IDs = %q,%q want first,second", got[0].ID, got[1].ID)
+	}
+
+	r2 := NewReader(bytes.NewReader(body), WithLogger(discardLogger()))
+	last, err := r2.Last()
+	if err != nil {
+		t.Fatalf("Last: %v", err)
+	}
+	if last.ID != "second" {
+		t.Errorf("Last.ID = %q, want second", last.ID)
+	}
+}
+
+func TestReader_SkipMalformed(t *testing.T) {
+	good := mustMarshal(t, types.RunTrace{ID: "ok", Turns: 2})
+
+	var buf bytes.Buffer
+	buf.WriteString("not json at all\n")
+	buf.WriteString("\n") // blank line tolerated, not malformed
+	buf.Write(good)
+	buf.WriteByte('\n')
+	buf.WriteString("{still bad\n")
+
+	r := NewReader(&buf, WithLogger(discardLogger()))
+	got, err := r.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("All = %+v, want one record with ID=ok", got)
+	}
+}
+
+func TestReader_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Open(path, WithLogger(discardLogger()))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if _, err := r.Last(); err == nil {
+		t.Fatal("Last on empty file: expected error")
+	}
+}
+
+func TestReader_OversizedLineSkipped(t *testing.T) {
+	good := mustMarshal(t, types.RunTrace{ID: "ok"})
+	oversized := bytes.Repeat([]byte("x"), MaxLineBytes+8)
+
+	var buf bytes.Buffer
+	buf.Write(oversized)
+	buf.WriteByte('\n')
+	buf.Write(good)
+	buf.WriteByte('\n')
+
+	r := NewReader(&buf, WithLogger(discardLogger()))
+	got, err := r.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("got %+v, want one record with ID=ok", got)
+	}
+}
+
+func TestReader_NextReturnsEOF(t *testing.T) {
+	r := NewReader(strings.NewReader(""), WithLogger(discardLogger()))
+	if _, err := r.Next(); !errors.Is(err, io.EOF) {
+		t.Fatalf("Next on empty: err = %v, want io.EOF", err)
+	}
+}
+
+func TestOpen_StdinSentinel(t *testing.T) {
+	r, err := Open("-", WithLogger(discardLogger()))
+	if err != nil {
+		t.Fatalf("Open '-': %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	if r.closer != nil {
+		t.Error("Open('-') must not own stdin")
+	}
+}
+
+func TestTail_OneShotConsumesAll(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trace.jsonl")
+	var buf bytes.Buffer
+	for i, id := range []string{"a", "b", "c"} {
+		buf.Write(mustMarshal(t, types.RunTrace{ID: id, Turns: i + 1}))
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen []string
+	err := Tail(context.Background(), path, TailOptions{Logger: discardLogger()}, func(tr *types.RunTrace) error {
+		seen = append(seen, tr.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Tail: %v", err)
+	}
+	if got, want := strings.Join(seen, ","), "a,b,c"; got != want {
+		t.Errorf("Tail order = %q, want %q", got, want)
+	}
+}
+
+func TestTail_FollowStreamsAppends(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "live.jsonl")
+	initial := mustMarshal(t, types.RunTrace{ID: "first"})
+	if err := os.WriteFile(path, append(initial, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	seenCh := make(chan string, 8)
+	doneCh := make(chan error, 1)
+	go func() {
+		doneCh <- Tail(ctx, path, TailOptions{
+			Follow:       true,
+			PollInterval: 10 * time.Millisecond,
+			Logger:       discardLogger(),
+		}, func(tr *types.RunTrace) error {
+			seenCh <- tr.ID
+			return nil
+		})
+	}()
+
+	expectID := func(want string) {
+		t.Helper()
+		select {
+		case got := <-seenCh:
+			if got != want {
+				t.Fatalf("Tail saw %q, want %q", got, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for record %q", want)
+		}
+	}
+
+	expectID("first")
+
+	// Append a second record while Tail is following.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(mustMarshal(t, types.RunTrace{ID: "second"}), '\n')); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	expectID("second")
+
+	cancel()
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Fatalf("Tail returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Tail did not exit after cancel")
+	}
+}
+
+func TestTail_HandlerErrorAborts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trace.jsonl")
+	if err := os.WriteFile(path, append(mustMarshal(t, types.RunTrace{ID: "x"}), '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := errors.New("stop")
+	err := Tail(context.Background(), path, TailOptions{Logger: discardLogger()}, func(*types.RunTrace) error {
+		return stop
+	})
+	if !errors.Is(err, stop) {
+		t.Fatalf("Tail err = %v, want %v", err, stop)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #244.

Operators inspecting `traceEmitter.type=jsonl` output have been reaching for `cat`, `jq`, and ad-hoc shell. This PR exposes four first-party `stirrup trace` subcommands so the same workflow runs without installing the eval binary or shelling `jq`:

- `trace show` — chronological pretty-print with TTY colour autodetection (`--color=auto|always|never`).
- `trace tail` — polling follow-tail (`-f`, configurable `--interval`); no fsnotify or other notification dep.
- `trace stats` — aggregate token/tool-call/outcome counters in text or `--output=json`, metric names mirror the OTel vocabulary in `harness/internal/observability/metrics.go`.
- `trace grep` — substring + a tiny `--jq` predicate (`<path> ( == | != | contains ) <value>`) so the workflow does not require a `jq` binary.

Every subcommand accepts `-` as the file argument to read from stdin (pipes with `tail -F`, `gunzip -c`, `gcloud storage cat`, etc.). Malformed and oversized lines are skipped with `slog.Debug` so a tail-watch of an in-flight run keeps streaming partial output.

The JSONL parser is lifted into a new zero-dep `types/trace` package and shared with the existing eval runner (`eval/runner/runner.go::parseTraceFile`), so the new subcommands and the eval framework speak one implementation.

## Test plan

- [x] `just` (build + full test suite) passes
- [x] `just lint` passes
- [x] Existing `eval/runner` tests still pass (`TestReplayRecording_*`, `TestParseTraceFile`)
- [x] New tests cover the reader (malformed/oversized lines, follow-tail, stdin) and every subcommand path (show colour modes, stats JSON+text, grep substring/jq/array-path/invert, tail one-shot + follow)
- [x] Smoke-tested the binary end-to-end against a sample JSONL trace (show/stats/grep/tail one-shot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)