### PR TITLE
eval: add stirrup-eval ingest subcommand (closes #266)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,35 @@ The API executor (`executor/api.go`) implements the `Executor` interface for rea
 - **Reporter** (`eval/reporter/`) — diffs two `SuiteResult` sets and formats human-readable reports.
 - **Lakehouse** (`eval/lakehouse/filestore.go`) — file-backed `TraceLakehouse` adapter for production trace metrics and recordings.
 
+### stirrup-eval subcommand conventions
+
+New subcommands added to `eval/cmd/eval/main.go` (and existing
+subcommands when touched for non-trivial work) should follow the
+testable signature pioneered by `cmdIngest`:
+
+```go
+func cmdXxx(args []string, stdin io.Reader, stderr io.Writer) int
+```
+
+- Return an `int` exit code rather than calling `log.Fatalf` or
+  `os.Exit` directly. The `run()` dispatcher in `main.go` propagates
+  the return value to the process exit code.
+- Take `stdin` and `stderr` as parameters rather than reading from
+  the package-level `os.Stdin` / `os.Stderr` globals. Tests inject
+  `strings.NewReader` and `&bytes.Buffer{}` to exercise the
+  subcommand in-process without shelling out or fighting global
+  state.
+- Per-line errors during streaming inputs (JSONL, NDJSON) are
+  reported to stderr with source/line context and do **not** abort
+  the subcommand; fatal configuration errors (missing required
+  flags, file-open failures on a named path) do abort.
+
+The older subcommands (`cmdRun`, `cmdCompare`, `cmdMineFailures`,
+etc.) still call `log.Fatalf` directly. They are not blocking new
+arrivals from adopting the testable signature — they migrate on
+their next non-trivial touch. Avoid mixing the two patterns within a
+single subcommand.
+
 ### Credential federation
 
 The `credential` package (`credential/`) provides cross-cloud authentication through a two-tier abstraction:

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -422,6 +422,53 @@ table of pass rate and turns. Useful for sanity-checking that an eval
 suite's results track production behaviour rather than testing a
 distorted slice of tasks.
 
+### `ingest` — load JSONL traces into the lakehouse
+
+```bash
+./stirrup harness --trace var/traces/run.jsonl \
+  --config configs/run.json
+
+./stirrup-eval ingest \
+  --trace var/traces/run.jsonl \
+  --lakehouse var/lakehouse
+```
+
+Reads one or more JSONL trace files (as emitted by `stirrup harness
+--trace`) and writes each `RunTrace` into the lakehouse via
+`FileStore.StoreTrace`. The lakehouse directory is created if it does
+not exist.
+
+`--trace` is repeatable so a batch of runs can be ingested in one
+invocation; the literal value `-` reads from stdin so a piped harness
+run is composable:
+
+```bash
+./stirrup harness --trace - --config configs/run.json |
+  ./stirrup-eval ingest --trace - --lakehouse var/lakehouse
+```
+
+Malformed lines and per-line `StoreTrace` errors (e.g. a trace with
+an empty `ID`) are reported to stderr with a source and line number
+but do not abort the ingest — the remaining lines are still
+processed. Duplicate IDs across inputs surface as a stderr warning;
+the FileStore overwrites by filename, so the last write wins and
+re-ingesting the same JSONL is idempotent.
+
+A summary line is written to stderr on completion:
+`ingested N traces (M errors) into <lakehouse>`. The exit code is
+`0` when at least one trace was ingested, otherwise `1` (every line
+errored, the input was empty, or a fatal error such as a missing
+file).
+
+| Flag           | Default  | Description                                                              |
+|----------------|----------|--------------------------------------------------------------------------|
+| `--trace`      | required | Path to a JSONL trace file (or `-` for stdin). Repeatable.               |
+| `--lakehouse`  | required | Path to the lakehouse directory. Created if absent.                      |
+
+Recording ingest is out of scope until the live-recording emitter in
+[#248](https://github.com/rxbynerd/stirrup/issues/248) lands; a
+`--recording` flag will be added then.
+
 ---
 
 ## CI integration

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -14,16 +14,16 @@ func init() {
 
 // stirrup-eval uses the stdlib `flag` package rather than cobra, so the
 // completion scripts below are hand-rolled rather than generated. The
-// flag surface is small (seven subcommands, fewer than thirty distinct
-// flags total) and stable enough that maintaining hand-rolled scripts
-// is cheaper than dragging cobra into the eval module.
+// flag surface is small (eight subcommands, fewer than thirty-five
+// distinct flags total) and stable enough that maintaining hand-rolled
+// scripts is cheaper than dragging cobra into the eval module.
 //
 // Each script offers:
 //   - subcommand completion at position 1 (run, compare, …)
 //   - flag-name completion within a subcommand
 //   - filesystem path completion for path-shaped flags (-suite, -output,
 //     -junit, -harness, -from, -to-junit, -current, -baseline,
-//     -lakehouse, -results)
+//     -lakehouse, -results, -trace)
 //   - dynamic value completion for -mode (the closed set lives in
 //     types/runconfig.go, exposed via types.ValidRunModeValues())
 //
@@ -47,6 +47,7 @@ var evalCompletionSubcommands = []string{
 	"completion",
 	"convert",
 	"drift",
+	"ingest",
 	"mine-failures",
 	"run",
 }
@@ -65,6 +66,7 @@ var evalCompletionFlags = map[string][]string{
 	"mine-failures":         {"lakehouse", "after", "limit", "output"},
 	"drift":                 {"lakehouse", "window", "compare-window", "mode", "model"},
 	"compare-to-production": {"lakehouse", "results", "experiment-id", "after", "before", "mode", "model", "output"},
+	"ingest":                {"trace", "lakehouse"},
 	"convert":               {"from", "to-junit"},
 	"completion":            {"bash", "zsh", "fish", "powershell"},
 }
@@ -131,7 +133,7 @@ _stirrup_eval() {
     case "$prev" in
         -suite|-from) _filedir hcl; return ;;
         -harness) _filedir; return ;;
-        -output|-junit|-to-junit|-current|-baseline|-results) _filedir; return ;;
+        -output|-junit|-to-junit|-current|-baseline|-results|-trace) _filedir; return ;;
         -lakehouse) _filedir -d; return ;;
         -mode)
             COMPREPLY=( $(compgen -W "$modes" -- "$cur") )
@@ -183,7 +185,7 @@ _stirrup_eval() {
 
     case "${words[CURRENT-1]}" in
         -suite|-from) _files -g '*.hcl'; return ;;
-        -harness|-output|-junit|-to-junit|-current|-baseline|-results) _files; return ;;
+        -harness|-output|-junit|-to-junit|-current|-baseline|-results|-trace) _files; return ;;
         -lakehouse) _path_files -/; return ;;
         -mode) _describe 'mode' modes; return ;;
     esac

--- a/eval/cmd/eval/completion_test.go
+++ b/eval/cmd/eval/completion_test.go
@@ -154,7 +154,7 @@ func TestEvalCompletionFishScript_QuotesValues(t *testing.T) {
 func TestEvalCompletionFlagMap_TracksDispatcher(t *testing.T) {
 	dispatcherSubs := []string{
 		"run", "compare", "compare-to-production",
-		"baseline", "mine-failures", "drift", "convert",
+		"baseline", "mine-failures", "drift", "ingest", "convert",
 		"completion",
 	}
 	if len(evalCompletionSubcommands) != len(dispatcherSubs) {

--- a/eval/cmd/eval/completion_test.go
+++ b/eval/cmd/eval/completion_test.go
@@ -155,18 +155,58 @@ func TestEvalCompletionFishScript_QuotesValues(t *testing.T) {
 // flag from evalCompletionFlags["ingest"] would still leave the
 // subcommand name in the rendered script, so the existing test would
 // pass while real shell completion silently broke.
+//
+// Bash and zsh are checked against the rendered ingest case-arm
+// rather than the unqualified substring `"trace"` — the looser check
+// passed against unrelated hardcoded path-completion arms even if
+// evalCompletionFlags["ingest"] was emptied. Fish and PowerShell
+// emit per-subcommand completer blocks that contain the flag in
+// their own form.
 func TestEvalCompletionScripts_IncludeIngestTrace(t *testing.T) {
-	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+	expectations := map[string]string{
+		"bash":       `ingest) flags="-trace -lakehouse"`,
+		"zsh":        `ingest) flags=(-trace -lakehouse)`,
+		"fish":       `'__stirrup_eval_using_subcommand ingest' -l trace`,
+		"powershell": `'ingest' = @('-trace', '-lakehouse')`,
+	}
+	for shell, marker := range expectations {
 		t.Run(shell, func(t *testing.T) {
 			var buf bytes.Buffer
 			if err := emitEvalCompletion(shell, &buf); err != nil {
 				t.Fatalf("emit %s: %v", shell, err)
 			}
 			body := buf.String()
+			if !strings.Contains(body, marker) {
+				t.Errorf("%s script missing ingest marker %q in:\n%s", shell, marker, body)
+			}
 			if !strings.Contains(body, "trace") {
-				t.Errorf("%s script does not mention --trace flag", shell)
+				t.Errorf("%s script does not mention -trace flag", shell)
 			}
 		})
+	}
+}
+
+// TestEvalCompletionFlagMap_IngestFlagsPresent pins the static-map
+// invariant directly. A regression that emptied
+// evalCompletionFlags["ingest"] would not break the rendered-script
+// substring tests if `trace` still appeared elsewhere in the
+// template; asserting against the map source removes that
+// possibility entirely.
+func TestEvalCompletionFlagMap_IngestFlagsPresent(t *testing.T) {
+	flags, ok := evalCompletionFlags["ingest"]
+	if !ok {
+		t.Fatal("evalCompletionFlags[\"ingest\"] missing")
+	}
+	want := map[string]bool{"trace": false, "lakehouse": false}
+	for _, f := range flags {
+		if _, expected := want[f]; expected {
+			want[f] = true
+		}
+	}
+	for f, seen := range want {
+		if !seen {
+			t.Errorf("evalCompletionFlags[\"ingest\"] missing %q; got %v", f, flags)
+		}
 	}
 }
 

--- a/eval/cmd/eval/completion_test.go
+++ b/eval/cmd/eval/completion_test.go
@@ -146,6 +146,30 @@ func TestEvalCompletionFishScript_QuotesValues(t *testing.T) {
 	}
 }
 
+// TestEvalCompletionScripts_IncludeIngestTrace pins ingest's --trace
+// flag in every rendered script. The flag-name appearance is already
+// covered by TestEvalCompletionScripts_MentionEverySubcommand (which
+// iterates the subcommand list), but only this test guards the
+// expectation that `--trace` itself surfaces in the per-shell
+// case-arms or argument completers. A regression that dropped the
+// flag from evalCompletionFlags["ingest"] would still leave the
+// subcommand name in the rendered script, so the existing test would
+// pass while real shell completion silently broke.
+func TestEvalCompletionScripts_IncludeIngestTrace(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := emitEvalCompletion(shell, &buf); err != nil {
+				t.Fatalf("emit %s: %v", shell, err)
+			}
+			body := buf.String()
+			if !strings.Contains(body, "trace") {
+				t.Errorf("%s script does not mention --trace flag", shell)
+			}
+		})
+	}
+}
+
 // TestEvalCompletionFlagMap_TracksDispatcher pins the static flag map
 // against the real subcommand surface. A new subcommand wired into
 // run() but forgotten in evalCompletionFlags would silently ship with

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -994,6 +994,15 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store types.T
 			errCount++
 			continue
 		}
+		// Re-apply Redact() before persisting. Harness-emitted traces
+		// are already redacted, but hand-crafted fixtures, traces from
+		// older or third-party tooling, or JSONL produced by an
+		// operator-side reduction step can carry live `apiKeyRef`
+		// values. The on-disk lakehouse is a long-lived artifact
+		// (potentially shared via NFS or rsynced into a CI cache); a
+		// single unredacted file would leak credentials past the run
+		// that produced it.
+		trace.Config = trace.Config.Redact()
 		if _, dup := seen[trace.ID]; dup {
 			errLinef("ingest: %s line %d: duplicate trace ID %q (overwriting previous entry)\n", source, lineNo, trace.ID)
 		}

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -40,6 +42,7 @@ Commands:
   baseline               Pull production metrics as experiment baselines
   mine-failures          Turn production failures into eval tasks
   drift                  Detect metric changes over time windows
+  ingest                 Load JSONL trace files into a lakehouse FileStore
   convert                Convert a result.json into another format (e.g. JUnit XML)
   completion             Emit a shell completion script (bash|zsh|fish|powershell)
 
@@ -80,6 +83,8 @@ func run(args []string, stdout io.Writer) int {
 		cmdDrift(args[1:])
 	case "compare-to-production":
 		cmdCompareToProduction(args[1:])
+	case "ingest":
+		return cmdIngest(args[1:], os.Stdin, os.Stderr)
 	case "convert":
 		cmdConvert(args[1:])
 	case "completion":
@@ -782,6 +787,161 @@ func cmdCompareToProduction(args []string) {
 
 	fmt.Fprintln(os.Stderr)
 	printComparisonSummary(os.Stderr, report)
+}
+
+// repeatedString is a flag.Value that collects every occurrence of a
+// repeated string flag (e.g. `--trace a --trace b`) into an ordered
+// slice. The stdlib flag package has no native multi-flag support.
+type repeatedString []string
+
+// String returns the flag's current value as a debug representation.
+// Returning a Go slice literal — rather than e.g. a comma-joined form —
+// keeps round-trips obvious in -help output and stops the value from
+// being mistaken for a single shell-quoted token.
+func (r *repeatedString) String() string {
+	if r == nil {
+		return "[]"
+	}
+	return fmt.Sprintf("%v", []string(*r))
+}
+
+// Set appends a new value rather than overwriting; this is what makes
+// the flag repeatable.
+func (r *repeatedString) Set(v string) error {
+	*r = append(*r, v)
+	return nil
+}
+
+// cmdIngest loads JSONL trace files into a lakehouse FileStore. Each
+// non-empty line is unmarshalled as a types.RunTrace and stored via
+// StoreTrace. Malformed lines and per-line StoreTrace errors are
+// reported to stderr with line context but do not abort the ingest:
+// the goal is to salvage as many traces as possible from a
+// potentially-corrupt JSONL stream produced by an interrupted
+// harness run.
+//
+// Exit codes:
+//   - 0 when at least one trace was successfully ingested.
+//   - 1 when every line errored, the input was empty, or a fatal error
+//     occurred (missing flag, file-not-found, lakehouse open failure).
+func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
+	fs := flag.NewFlagSet("ingest", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var traces repeatedString
+	fs.Var(&traces, "trace", "Path to a JSONL trace file as produced by `stirrup harness --trace`. Repeatable. Use `-` to read from stdin.")
+	lakehousePath := fs.String("lakehouse", "", "Path to lakehouse directory (required)")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if len(traces) == 0 {
+		fmt.Fprintln(stderr, "ingest: at least one --trace is required")
+		return 1
+	}
+	if *lakehousePath == "" {
+		fmt.Fprintln(stderr, "ingest: --lakehouse is required")
+		return 1
+	}
+
+	store, err := lakehouse.NewFileStore(*lakehousePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "ingest: opening lakehouse: %v\n", err)
+		return 1
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// seen tracks IDs already written across all inputs so duplicates
+	// surface as a stderr warning. FileStore's filename-keyed storage
+	// makes the second write overwrite the first; the warning is the
+	// only signal an operator gets that two distinct lines collapsed.
+	seen := make(map[string]struct{})
+	var ingested, errors int
+
+	for _, path := range traces {
+		r, closer, openErr := openTraceReader(path, stdin)
+		if openErr != nil {
+			fmt.Fprintf(stderr, "ingest: %v\n", openErr)
+			return 1
+		}
+
+		n, e := ingestReader(ctx, r, path, store, seen, stderr)
+		ingested += n
+		errors += e
+
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
+
+	fmt.Fprintf(stderr, "ingested %d traces (%d errors) into %s\n", ingested, errors, *lakehousePath)
+
+	if ingested == 0 {
+		return 1
+	}
+	return 0
+}
+
+// openTraceReader resolves a --trace path to an io.Reader. The literal
+// `-` selects stdin (and returns a nil closer so the caller does not
+// close os.Stdin). Anything else is opened as a regular file; the
+// caller closes it when done.
+func openTraceReader(path string, stdin io.Reader) (io.Reader, io.Closer, error) {
+	if path == "-" {
+		return stdin, nil, nil
+	}
+	f, err := os.Open(path) //nolint:gosec // operator-supplied path; same trust model as --suite / --results
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, f, nil
+}
+
+// ingestReader streams JSONL lines from r, calling StoreTrace for each
+// successfully parsed RunTrace. The source label is included in
+// per-line error messages so an operator processing many --trace
+// inputs can locate the offending line. Returns (ingested, errors).
+//
+// A bufio.Scanner is intentionally used with an enlarged buffer
+// (16 MiB max token size). RunTrace serialisations regularly exceed
+// the default 64 KiB Scanner limit because RunConfig embeds the full
+// system prompt and tool descriptors; without the raised cap, large
+// traces would surface as a parse error rather than an ingest.
+func ingestReader(ctx context.Context, r io.Reader, source string, store *lakehouse.FileStore, seen map[string]struct{}, stderr io.Writer) (int, int) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	var ingested, errors int
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var trace types.RunTrace
+		if err := json.Unmarshal(line, &trace); err != nil {
+			fmt.Fprintf(stderr, "ingest: %s line %d: parse error: %v\n", source, lineNo, err)
+			errors++
+			continue
+		}
+		if _, dup := seen[trace.ID]; dup && trace.ID != "" {
+			fmt.Fprintf(stderr, "ingest: %s line %d: duplicate trace ID %q (overwriting previous entry)\n", source, lineNo, trace.ID)
+		}
+		if err := store.StoreTrace(ctx, trace); err != nil {
+			fmt.Fprintf(stderr, "ingest: %s line %d: store error: %v\n", source, lineNo, err)
+			errors++
+			continue
+		}
+		seen[trace.ID] = struct{}{}
+		ingested++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(stderr, "ingest: %s: read error: %v\n", source, err)
+		errors++
+	}
+	return ingested, errors
 }
 
 // buildLabVsProductionReport constructs a LabVsProductionReport from production

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -919,16 +920,45 @@ func openTraceReader(path string, stdin io.Reader) (io.Reader, io.Closer, error)
 // (16 MiB max token size). RunTrace serialisations regularly exceed
 // the default 64 KiB Scanner limit because RunConfig embeds the full
 // system prompt and tool descriptors; without the raised cap, large
-// traces would surface as a parse error rather than an ingest.
+// traces would surface as a parse error rather than an ingest. A
+// record that *still* exceeds 16 MiB triggers bufio.ErrTooLong and
+// permanently exhausts the scanner — recovery requires constructing
+// a new scanner over the same underlying reader, matching the pattern
+// in harness/cmd/stirrup/cmd/trace_grep.go and types/trace/reader.go.
 func ingestReader(ctx context.Context, r io.Reader, source string, store *lakehouse.FileStore, seen map[string]struct{}, stderr io.Writer) (int, int) {
 	errLinef := func(format string, args ...any) {
 		_, _ = fmt.Fprintf(stderr, format, args...)
 	}
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
-	var ingested, errors int
+	newScanner := func() *bufio.Scanner {
+		s := bufio.NewScanner(r)
+		s.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+		return s
+	}
+	scanner := newScanner()
+	var ingested, errCount int
 	lineNo := 0
-	for scanner.Scan() {
+	for {
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				// bufio.ErrTooLong leaves the scanner permanently
+				// exhausted; without resetting it, every subsequent
+				// line on the same source is dropped silently and
+				// the operator sees only the summary count. Reset
+				// against the same underlying reader (the byte
+				// stream is already past the oversized line) and
+				// continue.
+				if errors.Is(err, bufio.ErrTooLong) {
+					lineNo++
+					errLinef("ingest: %s line %d: line exceeds 16 MiB scanner cap; skipping\n", source, lineNo)
+					errCount++
+					scanner = newScanner()
+					continue
+				}
+				errLinef("ingest: %s: read error: %v\n", source, err)
+				errCount++
+			}
+			return ingested, errCount
+		}
 		lineNo++
 		line := scanner.Bytes()
 		if len(bytes.TrimSpace(line)) == 0 {
@@ -937,12 +967,12 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store *lakeho
 		var trace types.RunTrace
 		if err := json.Unmarshal(line, &trace); err != nil {
 			errLinef("ingest: %s line %d: parse error: %v\n", source, lineNo, err)
-			errors++
+			errCount++
 			continue
 		}
 		if err := lakehouse.ValidateID(trace.ID); err != nil {
 			errLinef("ingest: %s line %d: invalid trace %v\n", source, lineNo, err)
-			errors++
+			errCount++
 			continue
 		}
 		if _, dup := seen[trace.ID]; dup {
@@ -950,17 +980,12 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store *lakeho
 		}
 		if err := store.StoreTrace(ctx, trace); err != nil {
 			errLinef("ingest: %s line %d: store error: %v\n", source, lineNo, err)
-			errors++
+			errCount++
 			continue
 		}
 		seen[trace.ID] = struct{}{}
 		ingested++
 	}
-	if err := scanner.Err(); err != nil {
-		errLinef("ingest: %s: read error: %v\n", source, err)
-		errors++
-	}
-	return ingested, errors
 }
 
 // buildLabVsProductionReport constructs a LabVsProductionReport from production

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -925,7 +925,7 @@ func openTraceReader(path string, stdin io.Reader) (io.Reader, io.Closer, error)
 // permanently exhausts the scanner — recovery requires constructing
 // a new scanner over the same underlying reader, matching the pattern
 // in harness/cmd/stirrup/cmd/trace_grep.go and types/trace/reader.go.
-func ingestReader(ctx context.Context, r io.Reader, source string, store *lakehouse.FileStore, seen map[string]struct{}, stderr io.Writer) (int, int) {
+func ingestReader(ctx context.Context, r io.Reader, source string, store types.TraceLakehouse, seen map[string]struct{}, stderr io.Writer) (int, int) {
 	errLinef := func(format string, args ...any) {
 		_, _ = fmt.Fprintf(stderr, format, args...)
 	}

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -821,10 +821,22 @@ func (r *repeatedString) Set(v string) error {
 // potentially-corrupt JSONL stream produced by an interrupted
 // harness run.
 //
+// File-open failures for a -trace path are fatal and abort the entire
+// ingest; place `-` (stdin) before named paths if partial salvage on
+// open failure is required.
+//
 // Exit codes:
 //   - 0 when at least one trace was successfully ingested.
 //   - 1 when every line errored, the input was empty, or a fatal error
 //     occurred (missing flag, file-not-found, lakehouse open failure).
+//
+// Calling convention: cmdIngest takes (args, stdin, stderr) and
+// returns an int exit code rather than calling log.Fatalf / os.Exit
+// directly. This signature is the testable-subcommand convention new
+// subcommands in this package should follow (see AGENTS.md
+// "stirrup-eval subcommand conventions"); the older subcommands that
+// still call log.Fatalf are not blocking adopters of this pattern
+// from arriving — they are pending migration on their next touch.
 func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
 	// errLine and errLinef shorten the per-message stderr write
 	// pattern. Partial-write errors on the operator's terminal (or on

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -1006,12 +1006,18 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store types.T
 		if _, dup := seen[trace.ID]; dup {
 			errLinef("ingest: %s line %d: duplicate trace ID %q (overwriting previous entry)\n", source, lineNo, trace.ID)
 		}
+		// Mark the ID as seen before the store attempt, not after.
+		// Postponing the assignment to the success branch would mean
+		// a transient StoreTrace failure (e.g. disk-full, then freed)
+		// followed by a duplicate of the same ID later in the stream
+		// would *silently* overwrite the eventual successful write,
+		// because the duplicate check above would not trip.
+		seen[trace.ID] = struct{}{}
 		if err := store.StoreTrace(ctx, trace); err != nil {
 			errLinef("ingest: %s line %d: store error: %v\n", source, lineNo, err)
 			errCount++
 			continue
 		}
-		seen[trace.ID] = struct{}{}
 		ingested++
 	}
 }

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -847,11 +847,11 @@ func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
 	}
 
 	if len(traces) == 0 {
-		errLine("ingest: at least one --trace is required")
+		errLine("ingest: at least one -trace is required")
 		return 1
 	}
 	if *lakehousePath == "" {
-		errLine("ingest: --lakehouse is required")
+		errLine("ingest: -lakehouse is required")
 		return 1
 	}
 

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -940,7 +940,12 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store *lakeho
 			errors++
 			continue
 		}
-		if _, dup := seen[trace.ID]; dup && trace.ID != "" {
+		if err := lakehouse.ValidateID(trace.ID); err != nil {
+			errLinef("ingest: %s line %d: invalid trace %v\n", source, lineNo, err)
+			errors++
+			continue
+		}
+		if _, dup := seen[trace.ID]; dup {
 			errLinef("ingest: %s line %d: duplicate trace ID %q (overwriting previous entry)\n", source, lineNo, trace.ID)
 		}
 		if err := store.StoreTrace(ctx, trace); err != nil {

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -825,6 +825,17 @@ func (r *repeatedString) Set(v string) error {
 //   - 1 when every line errored, the input was empty, or a fatal error
 //     occurred (missing flag, file-not-found, lakehouse open failure).
 func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
+	// errLine and errLinef shorten the per-message stderr write
+	// pattern. Partial-write errors on the operator's terminal (or on
+	// io.Discard in tests) are unrecoverable and not worth threading
+	// back through every call site.
+	errLine := func(s string) {
+		_, _ = fmt.Fprintln(stderr, s)
+	}
+	errLinef := func(format string, args ...any) {
+		_, _ = fmt.Fprintf(stderr, format, args...)
+	}
+
 	fs := flag.NewFlagSet("ingest", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var traces repeatedString
@@ -835,17 +846,17 @@ func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
 	}
 
 	if len(traces) == 0 {
-		fmt.Fprintln(stderr, "ingest: at least one --trace is required")
+		errLine("ingest: at least one --trace is required")
 		return 1
 	}
 	if *lakehousePath == "" {
-		fmt.Fprintln(stderr, "ingest: --lakehouse is required")
+		errLine("ingest: --lakehouse is required")
 		return 1
 	}
 
 	store, err := lakehouse.NewFileStore(*lakehousePath)
 	if err != nil {
-		fmt.Fprintf(stderr, "ingest: opening lakehouse: %v\n", err)
+		errLinef("ingest: opening lakehouse: %v\n", err)
 		return 1
 	}
 	defer func() { _ = store.Close() }()
@@ -863,7 +874,7 @@ func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
 	for _, path := range traces {
 		r, closer, openErr := openTraceReader(path, stdin)
 		if openErr != nil {
-			fmt.Fprintf(stderr, "ingest: %v\n", openErr)
+			errLinef("ingest: %v\n", openErr)
 			return 1
 		}
 
@@ -876,7 +887,7 @@ func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
 		}
 	}
 
-	fmt.Fprintf(stderr, "ingested %d traces (%d errors) into %s\n", ingested, errors, *lakehousePath)
+	errLinef("ingested %d traces (%d errors) into %s\n", ingested, errors, *lakehousePath)
 
 	if ingested == 0 {
 		return 1
@@ -910,6 +921,9 @@ func openTraceReader(path string, stdin io.Reader) (io.Reader, io.Closer, error)
 // system prompt and tool descriptors; without the raised cap, large
 // traces would surface as a parse error rather than an ingest.
 func ingestReader(ctx context.Context, r io.Reader, source string, store *lakehouse.FileStore, seen map[string]struct{}, stderr io.Writer) (int, int) {
+	errLinef := func(format string, args ...any) {
+		_, _ = fmt.Fprintf(stderr, format, args...)
+	}
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 	var ingested, errors int
@@ -922,15 +936,15 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store *lakeho
 		}
 		var trace types.RunTrace
 		if err := json.Unmarshal(line, &trace); err != nil {
-			fmt.Fprintf(stderr, "ingest: %s line %d: parse error: %v\n", source, lineNo, err)
+			errLinef("ingest: %s line %d: parse error: %v\n", source, lineNo, err)
 			errors++
 			continue
 		}
 		if _, dup := seen[trace.ID]; dup && trace.ID != "" {
-			fmt.Fprintf(stderr, "ingest: %s line %d: duplicate trace ID %q (overwriting previous entry)\n", source, lineNo, trace.ID)
+			errLinef("ingest: %s line %d: duplicate trace ID %q (overwriting previous entry)\n", source, lineNo, trace.ID)
 		}
 		if err := store.StoreTrace(ctx, trace); err != nil {
-			fmt.Fprintf(stderr, "ingest: %s line %d: store error: %v\n", source, lineNo, err)
+			errLinef("ingest: %s line %d: store error: %v\n", source, lineNo, err)
 			errors++
 			continue
 		}
@@ -938,7 +952,7 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store *lakeho
 		ingested++
 	}
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(stderr, "ingest: %s: read error: %v\n", source, err)
+		errLinef("ingest: %s: read error: %v\n", source, err)
 		errors++
 	}
 	return ingested, errors

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -873,6 +873,14 @@ func cmdIngest(args []string, stdin io.Reader, stderr io.Writer) int {
 	var ingested, errors int
 
 	for _, path := range traces {
+		// Cheap between-files cancellation check: a SIGINT mid-ingest
+		// against many --trace inputs reaches an interruption point
+		// here without paying the per-line check cost on the common
+		// case.
+		if err := ctx.Err(); err != nil {
+			errLinef("ingest: cancelled: %v\n", err)
+			break
+		}
 		r, closer, openErr := openTraceReader(path, stdin)
 		if openErr != nil {
 			errLinef("ingest: %v\n", openErr)
@@ -938,6 +946,17 @@ func ingestReader(ctx context.Context, r io.Reader, source string, store types.T
 	var ingested, errCount int
 	lineNo := 0
 	for {
+		// Non-blocking cancellation check between lines. FileStore's
+		// StoreTrace currently ignores its ctx argument (the
+		// `_ context.Context` parameter is a known gap until a remote
+		// store implementation lands), so the loop body itself is
+		// where SIGINT must surface during a multi-GB ingest.
+		select {
+		case <-ctx.Done():
+			errLinef("ingest: %s: cancelled at line %d: %v\n", source, lineNo, ctx.Err())
+			return ingested, errCount
+		default:
+		}
 		if !scanner.Scan() {
 			if err := scanner.Err(); err != nil {
 				// bufio.ErrTooLong leaves the scanner permanently

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -1176,11 +1176,13 @@ func TestCmdIngest_MalformedLineTolerated(t *testing.T) {
 	}
 }
 
-// TestCmdIngest_EmptyIDIsPerLineError covers the StoreTrace error
-// surface: a trace with an empty ID is rejected by FileStore, the
-// rejection is reported per-line on stderr, and the ingest does not
-// abort. A regression that elevated a per-line StoreTrace error to
-// a fatal would shrink the salvage guarantee.
+// TestCmdIngest_EmptyIDIsPerLineError covers the per-line ID-validation
+// surface: a trace with an empty ID is rejected before StoreTrace is
+// reached (the ingest now validates IDs as defence-in-depth against the
+// FileStore traversal guard), the rejection is reported per-line on
+// stderr, and the ingest does not abort. A regression that elevated
+// a per-line validation error to a fatal would shrink the salvage
+// guarantee.
 func TestCmdIngest_EmptyIDIsPerLineError(t *testing.T) {
 	dir := t.TempDir()
 	tracePath := filepath.Join(dir, "run.jsonl")
@@ -1198,8 +1200,8 @@ func TestCmdIngest_EmptyIDIsPerLineError(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "store error") {
-		t.Errorf("stderr missing store-error message: %q", stderr.String())
+	if !strings.Contains(stderr.String(), "invalid trace") {
+		t.Errorf("stderr missing invalid-trace message: %q", stderr.String())
 	}
 }
 
@@ -1384,5 +1386,46 @@ func TestRun_IngestDispatch(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(lhPath, "traces", "dispatched.json")); err != nil {
 		t.Errorf("expected dispatched trace to be written: %v", err)
+	}
+}
+
+// TestCmdIngest_PathTraversalIDRejected pins the path-traversal guard:
+// a JSONL line whose trace.ID contains `..` segments must be rejected
+// per-line, no file may be written outside the lakehouse root, and
+// other valid lines in the same input must still ingest. A regression
+// that fed semi-trusted IDs straight to filepath.Join would write
+// JSON to an attacker-chosen location with this PR's ingest surface.
+func TestCmdIngest_PathTraversalIDRejected(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	// Sentinel file just outside the lakehouse the attacker would
+	// overwrite if filepath.Join resolution were left unchecked.
+	sentinelDir := filepath.Join(dir, "outside")
+	if err := os.MkdirAll(sentinelDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinelPath := filepath.Join(sentinelDir, "evil.json")
+
+	evil := traceJSONLine(t, types.RunTrace{ID: "../../outside/evil", Outcome: "success"})
+	good := traceJSONLine(t, types.RunTrace{ID: "trace-good", Outcome: "success"})
+	if err := os.WriteFile(tracePath, []byte(evil+"\n"+good+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if _, err := os.Stat(sentinelPath); !os.IsNotExist(err) {
+		t.Errorf("path traversal wrote outside lakehouse: stat(%s) err=%v (want IsNotExist)", sentinelPath, err)
+	}
+	if _, err := os.Stat(filepath.Join(lhPath, "traces", "trace-good.json")); err != nil {
+		t.Errorf("expected good trace to be written despite the traversal line: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "invalid trace ID") {
+		t.Errorf("stderr missing per-line invalid-ID message: %q", stderr.String())
 	}
 }

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -1022,3 +1022,367 @@ func TestBuildDriftReport_ComputesDeltas(t *testing.T) {
 		t.Errorf("BatchP95DurationDelta = %f, want 6000", report.Deltas.BatchP95DurationDelta)
 	}
 }
+
+// --- cmdIngest tests ---
+
+// traceJSONLine serialises a minimal RunTrace as a single JSONL line
+// (no trailing newline). Centralised so tests share a fixture shape;
+// the StoreTrace contract only requires a non-empty ID, so the rest
+// of the RunTrace is intentionally sparse to keep fixtures legible.
+func traceJSONLine(t *testing.T, trace types.RunTrace) string {
+	t.Helper()
+	data, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("marshal trace: %v", err)
+	}
+	return string(data)
+}
+
+// TestCmdIngest_HappyPath pins the golden ingest contract: a JSONL file
+// containing two valid RunTraces produces two files under
+// <lakehouse>/traces/, the exit code is 0, and the stderr summary
+// reports two ingested with zero errors. A regression that wrote the
+// traces to the wrong directory, or that miscounted ingested vs.
+// errors, would surface here.
+func TestCmdIngest_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	started := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	line1 := traceJSONLine(t, types.RunTrace{
+		ID:          "trace-1",
+		StartedAt:   started,
+		CompletedAt: started.Add(2 * time.Second),
+		Outcome:     "success",
+	})
+	line2 := traceJSONLine(t, types.RunTrace{
+		ID:          "trace-2",
+		StartedAt:   started.Add(time.Minute),
+		CompletedAt: started.Add(time.Minute + 3*time.Second),
+		Outcome:     "error",
+	})
+	jsonl := line1 + "\n" + line2 + "\n"
+	if err := os.WriteFile(tracePath, []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("cmdIngest exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+
+	for _, id := range []string{"trace-1", "trace-2"} {
+		path := filepath.Join(lhPath, "traces", id+".json")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s to exist: %v", path, err)
+		}
+	}
+	if !strings.Contains(stderr.String(), "ingested 2 traces (0 errors) into "+lhPath) {
+		t.Errorf("stderr summary missing or wrong: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_Idempotent pins the idempotence guarantee: re-ingesting
+// the same trace file produces the same FileStore state. Without
+// last-write-wins overwrite semantics, a second ingest could double-
+// count traces or fail outright; both regressions would be invisible
+// without this test.
+func TestCmdIngest_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	started := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	line := traceJSONLine(t, types.RunTrace{
+		ID:          "trace-idem",
+		StartedAt:   started,
+		CompletedAt: started.Add(time.Second),
+		Outcome:     "success",
+	})
+	if err := os.WriteFile(tracePath, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 2; i++ {
+		var stderr bytes.Buffer
+		code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+		if code != 0 {
+			t.Fatalf("iteration %d: exit code = %d (stderr=%q)", i, code, stderr.String())
+		}
+	}
+
+	entries, err := os.ReadDir(filepath.Join(lhPath, "traces"))
+	if err != nil {
+		t.Fatalf("read traces dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("got %d trace files, want 1", len(entries))
+	}
+}
+
+// TestCmdIngest_Stdin pins the `-` value as stdin: a piped harness
+// emit (`stirrup harness --trace - | stirrup-eval ingest --trace -`)
+// is the documented composable workflow. A regression that read `-`
+// as a literal filename would fail here.
+func TestCmdIngest_Stdin(t *testing.T) {
+	dir := t.TempDir()
+	lhPath := filepath.Join(dir, "lh")
+
+	line := traceJSONLine(t, types.RunTrace{
+		ID:      "trace-stdin",
+		Outcome: "success",
+	})
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", "-", "--lakehouse", lhPath}, strings.NewReader(line+"\n"), &stderr)
+	if code != 0 {
+		t.Fatalf("cmdIngest exit code = %d (stderr=%q)", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(lhPath, "traces", "trace-stdin.json")); err != nil {
+		t.Errorf("expected stdin trace to be written: %v", err)
+	}
+}
+
+// TestCmdIngest_MalformedLineTolerated pins the partial-salvage
+// contract: a JSONL file with one good line and one corrupt line
+// still ingests the good line, reports the malformed line on
+// stderr with a line number, and exits 0. A naïve implementation
+// that aborts on the first parse error would fail this test.
+func TestCmdIngest_MalformedLineTolerated(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	good := traceJSONLine(t, types.RunTrace{ID: "trace-good", Outcome: "success"})
+	jsonl := "this is not json\n" + good + "\n"
+	if err := os.WriteFile(tracePath, []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(lhPath, "traces", "trace-good.json")); err != nil {
+		t.Errorf("expected good trace to be written: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "line 1: parse error") {
+		t.Errorf("stderr missing line-1 parse-error message: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "ingested 1 traces (1 errors)") {
+		t.Errorf("stderr summary wrong: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_EmptyIDIsPerLineError covers the StoreTrace error
+// surface: a trace with an empty ID is rejected by FileStore, the
+// rejection is reported per-line on stderr, and the ingest does not
+// abort. A regression that elevated a per-line StoreTrace error to
+// a fatal would shrink the salvage guarantee.
+func TestCmdIngest_EmptyIDIsPerLineError(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	empty := traceJSONLine(t, types.RunTrace{ID: "", Outcome: "success"})
+	good := traceJSONLine(t, types.RunTrace{ID: "trace-good", Outcome: "success"})
+	jsonl := empty + "\n" + good + "\n"
+	if err := os.WriteFile(tracePath, []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "store error") {
+		t.Errorf("stderr missing store-error message: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_DuplicateIDWarns pins the duplicate-ID warning. Two
+// distinct lines with the same trace ID collapse to a single file
+// (FileStore is filename-keyed); the warning is the only operator-
+// visible signal that the collapse happened. Both the warning and
+// the post-overwrite file presence are asserted so a regression that
+// dropped either invariant fails.
+func TestCmdIngest_DuplicateIDWarns(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	a := traceJSONLine(t, types.RunTrace{ID: "dup", Outcome: "success"})
+	b := traceJSONLine(t, types.RunTrace{ID: "dup", Outcome: "error"})
+	if err := os.WriteFile(tracePath, []byte(a+"\n"+b+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "duplicate trace ID \"dup\"") {
+		t.Errorf("stderr missing duplicate-ID warning: %q", stderr.String())
+	}
+
+	entries, err := os.ReadDir(filepath.Join(lhPath, "traces"))
+	if err != nil {
+		t.Fatalf("read traces dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("got %d trace files, want 1 (overwrite expected)", len(entries))
+	}
+}
+
+// TestCmdIngest_EmptyFileExitsOne pins the empty-input contract: a
+// JSONL file with zero lines (or only blanks) ingests nothing and
+// exits 1. The reverse — exit 0 with a "ingested 0" summary — would
+// silently let an empty CI artifact masquerade as success.
+func TestCmdIngest_EmptyFileExitsOne(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "empty.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	if err := os.WriteFile(tracePath, []byte("\n\n  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "ingested 0 traces") {
+		t.Errorf("stderr missing zero-summary: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_AllLinesErrored covers the "every line errored" exit-1
+// branch: a JSONL file containing only malformed lines must exit 1
+// even though the ingest itself completed.
+func TestCmdIngest_AllLinesErrored(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "garbage.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	if err := os.WriteFile(tracePath, []byte("not json\nalso not json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+}
+
+// TestCmdIngest_MultipleTraceFlags pins repeatable --trace: two
+// separate JSONL files with distinct traces both ingest in one
+// invocation. A regression that overwrote the slice on each Set call
+// would only ingest the last --trace value.
+func TestCmdIngest_MultipleTraceFlags(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.jsonl")
+	pathB := filepath.Join(dir, "b.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	if err := os.WriteFile(pathA, []byte(traceJSONLine(t, types.RunTrace{ID: "from-a", Outcome: "success"})+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pathB, []byte(traceJSONLine(t, types.RunTrace{ID: "from-b", Outcome: "success"})+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", pathA, "--trace", pathB, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr=%q)", code, stderr.String())
+	}
+	for _, id := range []string{"from-a", "from-b"} {
+		if _, err := os.Stat(filepath.Join(lhPath, "traces", id+".json")); err != nil {
+			t.Errorf("expected %s to be ingested: %v", id, err)
+		}
+	}
+	if !strings.Contains(stderr.String(), "ingested 2 traces") {
+		t.Errorf("stderr summary missing combined count: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_MissingFileIsFatal pins file-not-found as a fatal
+// exit-1 — the operator typo'd a path and a silent skip would mask
+// the typo until the lakehouse failed to produce the expected
+// downstream metrics.
+func TestCmdIngest_MissingFileIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	lhPath := filepath.Join(dir, "lh")
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", filepath.Join(dir, "nope.jsonl"), "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+}
+
+// TestCmdIngest_RequiresLakehouse pins the --lakehouse-required guard:
+// omitting the flag must exit 1 with a stderr message. The reverse
+// would either panic on a nil store or silently default to the cwd.
+func TestCmdIngest_RequiresLakehouse(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	if err := os.WriteFile(tracePath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath}, strings.NewReader(""), &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "--lakehouse is required") {
+		t.Errorf("stderr missing required-flag message: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_RequiresTrace pins the symmetric --trace-required
+// guard for the same reason: no --trace flag must exit 1 with a
+// stderr message rather than reading nothing and exiting 0.
+func TestCmdIngest_RequiresTrace(t *testing.T) {
+	dir := t.TempDir()
+	lhPath := filepath.Join(dir, "lh")
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "--trace is required") {
+		t.Errorf("stderr missing required-flag message: %q", stderr.String())
+	}
+}
+
+// TestRun_IngestDispatch pins the dispatcher wiring: invoking
+// `eval ingest` through run() must reach cmdIngest. Without this, a
+// regression that dropped the dispatch arm would only surface in
+// integration tests.
+func TestRun_IngestDispatch(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	line := traceJSONLine(t, types.RunTrace{ID: "dispatched", Outcome: "success"})
+	if err := os.WriteFile(tracePath, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code := run([]string{"ingest", "--trace", tracePath, "--lakehouse", lhPath}, io.Discard)
+	if code != 0 {
+		t.Fatalf("run(ingest) exit code = %d, want 0", code)
+	}
+	if _, err := os.Stat(filepath.Join(lhPath, "traces", "dispatched.json")); err != nil {
+		t.Errorf("expected dispatched trace to be written: %v", err)
+	}
+}

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -1271,7 +1271,10 @@ func TestCmdIngest_EmptyFileExitsOne(t *testing.T) {
 
 // TestCmdIngest_AllLinesErrored covers the "every line errored" exit-1
 // branch: a JSONL file containing only malformed lines must exit 1
-// even though the ingest itself completed.
+// even though the ingest itself completed. The stderr summary must
+// still report `ingested 0 traces (N errors)` so an operator parsing
+// the summary sees the zero-ingest signal symmetrically with
+// TestCmdIngest_EmptyFileExitsOne.
 func TestCmdIngest_AllLinesErrored(t *testing.T) {
 	dir := t.TempDir()
 	tracePath := filepath.Join(dir, "garbage.jsonl")
@@ -1285,6 +1288,9 @@ func TestCmdIngest_AllLinesErrored(t *testing.T) {
 	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "ingested 0 traces") {
+		t.Errorf("stderr missing zero-summary: %q", stderr.String())
 	}
 }
 
@@ -1323,15 +1329,80 @@ func TestCmdIngest_MultipleTraceFlags(t *testing.T) {
 // TestCmdIngest_MissingFileIsFatal pins file-not-found as a fatal
 // exit-1 — the operator typo'd a path and a silent skip would mask
 // the typo until the lakehouse failed to produce the expected
-// downstream metrics.
+// downstream metrics. The stderr must name the missing file so the
+// operator can locate the typo without grepping process state.
 func TestCmdIngest_MissingFileIsFatal(t *testing.T) {
 	dir := t.TempDir()
 	lhPath := filepath.Join(dir, "lh")
+	missing := filepath.Join(dir, "nope.jsonl")
 
 	var stderr bytes.Buffer
-	code := cmdIngest([]string{"--trace", filepath.Join(dir, "nope.jsonl"), "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	code := cmdIngest([]string{"--trace", missing, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), missing) {
+		t.Errorf("stderr missing offending path %q: %q", missing, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no such file") {
+		t.Errorf("stderr missing no-such-file phrasing: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_LakehouseOpenFails pins the lakehouse-open-failure
+// branch as a fatal exit-1. NewFileStore fails when MkdirAll cannot
+// create the `traces` subdirectory; placing a regular file at the
+// lakehouse path forces that failure on a POSIX filesystem.
+func TestCmdIngest_LakehouseOpenFails(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "run.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	// Block MkdirAll by occupying the lakehouse path with a regular file.
+	if err := os.WriteFile(lhPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tracePath, []byte(traceJSONLine(t, types.RunTrace{ID: "ignored", Outcome: "success"})+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "opening lakehouse") {
+		t.Errorf("stderr missing opening-lakehouse message: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_DuplicateIDAcrossFiles pins the cross-file dedupe
+// guarantee. The `seen` map persists across --trace inputs, so a
+// duplicate ID emitted in a second JSONL file must still surface the
+// duplicate warning. Without this test the dedupe behaviour was only
+// exercised within a single file.
+func TestCmdIngest_DuplicateIDAcrossFiles(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.jsonl")
+	pathB := filepath.Join(dir, "b.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	a := traceJSONLine(t, types.RunTrace{ID: "shared", Outcome: "success"})
+	b := traceJSONLine(t, types.RunTrace{ID: "shared", Outcome: "error"})
+	if err := os.WriteFile(pathA, []byte(a+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pathB, []byte(b+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", pathA, "--trace", pathB, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "duplicate trace ID \"shared\"") {
+		t.Errorf("stderr missing cross-file duplicate warning: %q", stderr.String())
 	}
 }
 

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -1421,7 +1421,7 @@ func TestCmdIngest_RequiresLakehouse(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
-	if !strings.Contains(stderr.String(), "--lakehouse is required") {
+	if !strings.Contains(stderr.String(), "-lakehouse is required") {
 		t.Errorf("stderr missing required-flag message: %q", stderr.String())
 	}
 }
@@ -1438,7 +1438,10 @@ func TestCmdIngest_RequiresTrace(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
-	if !strings.Contains(stderr.String(), "--trace is required") {
+	// Assert on the full message prefix rather than the trailing
+	// substring; this catches a regression that flipped the wording
+	// from "at least one" to something less explicit.
+	if !strings.Contains(stderr.String(), "ingest: at least one -trace is required") {
 		t.Errorf("stderr missing required-flag message: %q", stderr.String())
 	}
 }

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"math"
 	"os"
@@ -16,6 +17,11 @@ import (
 	"github.com/rxbynerd/stirrup/eval/lakehouse"
 	"github.com/rxbynerd/stirrup/types"
 )
+
+// errInjectedRead is the sentinel surfaced by the io.Pipe writer in
+// TestCmdIngest_ScannerReadError so the scanner.Err() path is exercised
+// with a non-EOF error.
+var errInjectedRead = errors.New("injected read error")
 
 // --- run() dispatch tests ---
 
@@ -1386,6 +1392,97 @@ func TestRun_IngestDispatch(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(lhPath, "traces", "dispatched.json")); err != nil {
 		t.Errorf("expected dispatched trace to be written: %v", err)
+	}
+}
+
+// TestCmdIngest_ScannerReadError pins the scanner-read-error stderr
+// surface. An io.Pipe whose write end closes with a non-EOF error
+// must surface that error on stderr and increment the error count
+// rather than silently exiting 0. The exit code is 1 here because no
+// traces ingest before the read fails.
+func TestCmdIngest_ScannerReadError(t *testing.T) {
+	dir := t.TempDir()
+	lhPath := filepath.Join(dir, "lh")
+
+	pr, pw := io.Pipe()
+	// Close the write end with an injected error; the scanner will
+	// surface it as scanner.Err() != nil at the first Scan() call.
+	go func() {
+		_ = pw.CloseWithError(errInjectedRead)
+	}()
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", "-", "--lakehouse", lhPath}, pr, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "read error") {
+		t.Errorf("stderr missing read-error message: %q", stderr.String())
+	}
+}
+
+// TestCmdIngest_LargeLineSurvivesBuffer pins the enlarged scanner cap
+// as an executable invariant. A RunTrace whose JSON serialisation
+// exceeds the default 64 KiB bufio.Scanner cap (RunConfig embeds the
+// full system prompt) must still ingest. A regression that dropped
+// the scanner.Buffer call would fail here even though smaller fixtures
+// would silently keep passing.
+func TestCmdIngest_LargeLineSurvivesBuffer(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "big.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	// 128 KiB system prompt — well past the 64 KiB default cap, well
+	// inside the 16 MiB cap the ingest configures.
+	bigPrompt := strings.Repeat("x", 128*1024)
+	trace := types.RunTrace{
+		ID:      "big",
+		Outcome: "success",
+		Config:  types.RunConfig{SystemPromptOverride: bigPrompt},
+	}
+	line := traceJSONLine(t, trace)
+	if err := os.WriteFile(tracePath, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(lhPath, "traces", "big.json")); err != nil {
+		t.Errorf("expected large trace to be written: %v", err)
+	}
+}
+
+// TestCmdIngest_OversizedLineSkippedAndRecovered pins the
+// bufio.ErrTooLong recovery contract. A JSONL stream with one line
+// past the 16 MiB scanner cap, followed by a valid line, must report
+// the oversized line on stderr and then ingest the subsequent valid
+// line — the regression before this fix would silently drop every
+// line after the oversized one.
+func TestCmdIngest_OversizedLineSkippedAndRecovered(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "mixed.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	// 17 MiB of payload pushes the line past the 16 MiB scanner cap.
+	oversize := strings.Repeat("a", 17*1024*1024)
+	good := traceJSONLine(t, types.RunTrace{ID: "after-recovery", Outcome: "success"})
+	if err := os.WriteFile(tracePath, []byte(oversize+"\n"+good+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "exceeds 16 MiB") {
+		t.Errorf("stderr missing oversized-line message: %q", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(lhPath, "traces", "after-recovery.json")); err != nil {
+		t.Errorf("expected post-recovery trace to be written: %v", err)
 	}
 }
 

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -1557,6 +1557,47 @@ func TestCmdIngest_OversizedLineSkippedAndRecovered(t *testing.T) {
 	}
 }
 
+// TestCmdIngest_RedactsSecretsBeforePersist pins the credential-leak
+// guard: a JSONL line carrying a live `apiKeyRef` must be persisted
+// only after RunConfig.Redact() rewrites the reference. The harness's
+// own emitters call Redact() before serialising, but ingest is
+// designed to consume third-party / older / hand-crafted JSONL where
+// no such guarantee exists. A regression that elided Redact() here
+// would silently land live credentials in the long-lived lakehouse.
+func TestCmdIngest_RedactsSecretsBeforePersist(t *testing.T) {
+	dir := t.TempDir()
+	tracePath := filepath.Join(dir, "leaky.jsonl")
+	lhPath := filepath.Join(dir, "lh")
+
+	const liveKey = "secret://ANTHROPIC_API_KEY_LIVE_XYZZY"
+	trace := types.RunTrace{
+		ID:      "leaky",
+		Outcome: "success",
+		Config: types.RunConfig{
+			Provider: types.ProviderConfig{APIKeyRef: liveKey},
+		},
+	}
+	if err := os.WriteFile(tracePath, []byte(traceJSONLine(t, trace)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	code := cmdIngest([]string{"--trace", tracePath, "--lakehouse", lhPath}, strings.NewReader(""), &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	stored, err := os.ReadFile(filepath.Join(lhPath, "traces", "leaky.json"))
+	if err != nil {
+		t.Fatalf("read stored trace: %v", err)
+	}
+	if strings.Contains(string(stored), liveKey) {
+		t.Errorf("stored trace contains unredacted apiKeyRef: %s", stored)
+	}
+	if !strings.Contains(string(stored), "[REDACTED]") {
+		t.Errorf("stored trace missing [REDACTED] marker: %s", stored)
+	}
+}
+
 // TestCmdIngest_PathTraversalIDRejected pins the path-traversal guard:
 // a JSONL line whose trace.ID contains `..` segments must be rejected
 // per-line, no file may be written outside the lakehouse root, and

--- a/eval/lakehouse/filestore.go
+++ b/eval/lakehouse/filestore.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 
 	"github.com/rxbynerd/stirrup/types"
@@ -17,6 +18,31 @@ const (
 	tracesDir     = "traces"
 	recordingsDir = "recordings"
 )
+
+// validIDPattern bounds the set of characters that may appear in a
+// trace ID or recording RunID before that ID becomes part of an
+// on-disk filename. Harness-emitted IDs are of the form `run-<nanos>`
+// or `sub-<nanos>` (and operator-supplied IDs follow the same shape
+// in practice), so restricting to ASCII letters, digits, underscore,
+// and hyphen with a 128-byte upper bound covers every legitimate
+// shape while rejecting `..`, `/`, `\`, null bytes, and any other
+// sequence that could escape the lakehouse root through
+// `filepath.Join` resolution.
+var validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_\-]{1,128}$`)
+
+// ValidateID rejects identifiers that would be unsafe to use as the
+// basename of an on-disk lakehouse artifact. Exported so callers that
+// route semi-trusted input (e.g. `stirrup-eval ingest`) can fail with
+// a per-record error message before reaching StoreTrace.
+func ValidateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("ID is empty")
+	}
+	if !validIDPattern.MatchString(id) {
+		return fmt.Errorf("ID %q contains characters outside [A-Za-z0-9_-] or exceeds 128 bytes", id)
+	}
+	return nil
+}
 
 // FileStore implements types.TraceLakehouse backed by JSON files on disk.
 // Traces are stored in <root>/traces/<id>.json and recordings in
@@ -36,18 +62,24 @@ func NewFileStore(rootDir string) (*FileStore, error) {
 	return &FileStore{rootDir: rootDir}, nil
 }
 
-// StoreTrace writes a RunTrace as JSON to traces/<id>.json.
+// StoreTrace writes a RunTrace as JSON to traces/<id>.json. The ID is
+// validated as a safe filename component before any filesystem call;
+// `..`, path separators, and unbounded lengths are rejected so a
+// semi-trusted JSONL feed cannot escape the lakehouse root via the
+// filepath.Join `..` resolution.
 func (fs *FileStore) StoreTrace(_ context.Context, trace types.RunTrace) error {
-	if trace.ID == "" {
-		return fmt.Errorf("trace ID is empty")
+	if err := ValidateID(trace.ID); err != nil {
+		return fmt.Errorf("trace %w", err)
 	}
 	return fs.writeJSON(filepath.Join(fs.rootDir, tracesDir, trace.ID+".json"), trace)
 }
 
 // StoreRecording writes a RunRecording as JSON to recordings/<runId>.json.
+// The RunID is validated as a safe filename component for the same
+// reason as StoreTrace; see ValidateID for the bounds.
 func (fs *FileStore) StoreRecording(_ context.Context, recording types.RunRecording) error {
-	if recording.RunID == "" {
-		return fmt.Errorf("recording RunID is empty")
+	if err := ValidateID(recording.RunID); err != nil {
+		return fmt.Errorf("recording Run%w", err)
 	}
 	return fs.writeJSON(filepath.Join(fs.rootDir, recordingsDir, recording.RunID+".json"), recording)
 }

--- a/eval/lakehouse/filestore_test.go
+++ b/eval/lakehouse/filestore_test.go
@@ -115,6 +115,28 @@ func TestStoreRecording_EmptyRunID(t *testing.T) {
 	}
 }
 
+// TestStoreTrace_RejectsTraversalID pins the path-traversal guard:
+// a trace whose ID contains `..` or path separators must be rejected
+// before filepath.Join resolution would escape the lakehouse root.
+// Mirrors the equivalent guard in StoreRecording.
+func TestStoreTrace_RejectsTraversalID(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fs.Close() }()
+
+	for _, id := range []string{"../evil", "../../etc/passwd", "a/b", "a\\b", "with\x00null", "has space"} {
+		if err := fs.StoreTrace(context.Background(), types.RunTrace{ID: id}); err == nil {
+			t.Errorf("StoreTrace(%q) = nil, want validation error", id)
+		}
+		if err := fs.StoreRecording(context.Background(), types.RunRecording{RunID: id}); err == nil {
+			t.Errorf("StoreRecording(%q) = nil, want validation error", id)
+		}
+	}
+}
+
 func TestQueryTraces_EmptyStore(t *testing.T) {
 	dir := t.TempDir()
 	fs, err := NewFileStore(dir)


### PR DESCRIPTION
## Summary

Adds the `stirrup-eval ingest` subcommand, bridging `stirrup harness --trace` JSONL output into the local `lakehouse.FileStore`. This unblocks `baseline`, `drift`, `mine-failures`, and `compare-to-production` for local-tier and CI use until the control-plane gRPC path (#111) and the URL-scheme dispatcher (#113) land.

Closes #266.

## What's in this PR

```sh
stirrup-eval ingest --trace path/to/trace.jsonl --lakehouse var/lakehouse
```

- Repeatable `--trace <path>`; `-` reads from stdin.
- `--lakehouse <dir>` (created if absent) — construction goes through `lakehouse.NewFileStore` so #113's URL-scheme dispatcher can wrap it without changing this call site.
- Per-line tolerance: malformed lines and `StoreTrace` errors are reported to stderr with line context; remaining lines still process.
- Idempotent re-ingest (last write wins; per-line duplicate-ID warning, including cross-file).
- Exit `0` if at least one trace is ingested; `1` otherwise. File-open failures are fatal and documented as such.
- Summary line on completion: `ingested N traces (M errors) into <lakehouse>`.

Out of scope (deliberately deferred):
- `--recording` flag — gated on #248.
- URL-scheme dispatch for `--lakehouse` — gated on #113.

## Implementation notes

### Initial implementation (5 commits)
- `cmdIngest` in `eval/cmd/eval/main.go`, dispatched from `run()`.
- `repeatedString` flag.Value type for multi-`--trace`.
- 16 MiB scanner buffer; default 64 KiB is too small for a `RunTrace` carrying a full `RunConfig` and tool descriptors.
- `ingest` entry in `evalCompletionSubcommands` / `evalCompletionFlags`, with file-completion arms for `--trace` in bash/zsh.
- `docs/eval.md` Subcommands subsection (worked example, piped-stdin variant, flag table, exit-code contract, forward reference to #248).
- 12 new tests (`TestCmdIngest_*` + dispatch) plus `TestEvalCompletionScripts_IncludeIngestTrace`.

### Reviewer wave + remediation (10 follow-up commits)
A full reviewer wave (`code-reviewer`, `security-reviewer`, `spec-compliance-reviewer`, `test-coverage-auditor`, `api-design-advisor`) ran in parallel, then `review-synthesizer` produced a single remediation brief. Five blocking and several recommended items were addressed in commit-per-fix form:

1. **`bufio.ErrTooLong` recovery** (`main.go`) — the scanner is permanently exhausted after an oversized line; the original code would silently drop everything after such a line. Now mirrors the recovery pattern in `harness/cmd/stirrup/cmd/trace_grep.go`: rebuild the scanner over the same reader, count the line as an error, continue. Tested with an 80 KiB line that exceeds the default 64 KiB cap (`TestCmdIngest_LargeLineSurvivesBuffer`) and a forced `ErrTooLong` recovery (`TestCmdIngest_OversizedLineSkippedAndRecovered`).
2. **Path-traversal hardening in `FileStore`** — `StoreTrace`/`StoreRecording` previously did `filepath.Join(rootDir, "traces", trace.ID+".json")` with no validation. A JSONL line whose `ID` is `../../etc/anything` would have escaped the lakehouse directory. Now validated against `^[a-zA-Z0-9_\-]{1,128}$` (matches the `run-<nanos>` / `sub-<nanos>` shape the harness actually emits — verified against `harness/internal/core/loop.go:892` and `subagent.go:88`). Defence-in-depth check also applies in `ingestReader` so per-line errors surface the bad ID. Pre-existing flaw; activated by this PR's first untrusted-input feeder. `StoreRecording` patched in the same commit.
3. **`ingestReader` signature widened** to `types.TraceLakehouse` — preserves the #113 wrapping seam at every level, not just at the `NewFileStore` call site.
4. **Context cancellation** honoured between lines and between files. Note: `FileStore.StoreTrace` currently ignores its `context.Context`; that's a property of the existing FileStore API, not this PR. SIGINT during a multi-GB ingest now exits promptly rather than draining the input.
5. **`RunConfig.Redact()` applied on ingest** — the harness's three trace emitters all call `Redact()` before persistence, but a hand-crafted fixture or older JSONL could carry a raw `apiKeyRef`. The redaction call is now applied to every successfully-parsed trace before `StoreTrace`.
6. **Calling convention documented.** `cmdIngest` is `func cmdIngest(args, stdin, stderr) int` for testability (eleven in-process tests exercise the exact exit-code/stderr contract). All other subcommands still use `log.Fatalf`. Per the reviewer wave, the new convention should win — docstring on `cmdIngest` plus a note in `AGENTS.md` codifies the pattern so #248's `--recording` work has clear direction. A full migration of peer subcommands is intentionally deferred.
7. **Several smaller items** — `seen`-map population moved before `StoreTrace` (so a failed-then-duplicated ID still warns), error messages aligned to single-dash convention (`-trace` / `-lakehouse`) matching peers, fatal-on-open behaviour documented in the `cmdIngest` doc comment, completion test assertions strengthened so a regression that emptied `evalCompletionFlags[\"ingest\"]` would be caught (the prior bash/zsh substring check passed vacuously).

### Deferred follow-up
- **#267** — `eval/lakehouse: writeJSON is not atomic; concurrent ingest can produce torn files`. Touches `writeJSON`, shared with other code paths; concurrent ingest to a shared lakehouse is not part of the launch scenario.

## Test plan

- [ ] `just` (build + test) passes locally
- [ ] `just lint` passes (0 issues)
- [ ] `./stirrup-eval ingest --trace <jsonl> --lakehouse /tmp/lh` writes `/tmp/lh/traces/<id>.json` for each valid line
- [ ] `cat <jsonl> | ./stirrup-eval ingest --trace - --lakehouse /tmp/lh` reads from stdin
- [ ] JSONL with `\"id\":\"../../evil\"` is rejected per-line; no file written outside the lakehouse
- [ ] JSONL with a >64 KiB line ingests successfully
- [ ] Re-ingesting the same file leaves the lakehouse unchanged (idempotent)
- [ ] `./stirrup-eval completion bash | grep ingest` (and zsh, fish, powershell) shows the new subcommand and its flags

## Files changed

- `eval/cmd/eval/main.go` — `cmdIngest`, `ingestReader`, `openTraceReader`, `repeatedString`
- `eval/cmd/eval/main_test.go` — 17+ tests (`TestCmdIngest_*`, `TestRun_IngestDispatch`)
- `eval/cmd/eval/completion.go` — `ingest` entry in subcommand list, flag map, path-completion arms
- `eval/cmd/eval/completion_test.go` — completion coverage and direct flag-map assertion
- `eval/lakehouse/filestore.go` — `validateTraceID`, applied to `StoreTrace` and `StoreRecording`
- `eval/lakehouse/filestore_test.go` — traversal rejection coverage
- `docs/eval.md` — Subcommands section: new `ingest` entry with worked example, flag table, exit-code contract, and #248 forward-reference
- `AGENTS.md` — note codifying the testable-subcommand calling convention