### PR TITLE
trace: stream full transcript as JSONL events

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -284,6 +284,23 @@ traces, and let the `replay` runner re-evaluate old recordings under
 new judge criteria without re-running the harness
 (`eval/runner/replay.go`).
 
+#### Where recordings come from
+
+`TurnRecord` payloads are produced live by the
+`traceEmitter.type=jsonl` emitter in
+`harness/internal/trace/jsonl.go`. The emitter streams one
+`turn_record` event per agentic-loop turn into the configured trace
+file, carrying the full `ModelInput.Messages`, the model's
+`ModelOutput` content blocks, and every tool call's raw
+`Input`/`Output`. `types/trace.Reader.ReadRecording` reassembles a
+`types.RunRecording` from the event stream, including from
+partially-written files left behind by an interrupted run.
+
+Pre-streaming traces (single-blob `RunTrace` lines) parse through the
+same reader as recordings with no transcript turns; replay against
+those files is a degenerate case that succeeds only if the eval suite
+asks for zero turns.
+
 ### Trace lakehouse
 
 The `TraceLakehouse` interface (`types/lakehouse.go`) abstracts

--- a/docs/trace-inspection.md
+++ b/docs/trace-inspection.md
@@ -7,8 +7,39 @@ subcommand family inspects those files first-party so operators do
 not have to reinvent the wheel with `cat`, `jq`, and ad-hoc shell.
 
 This page is the operator walkthrough. For the wire schema, see the
-`types.RunTrace`, `types.TurnTrace`, and `types.ToolCallSummary`
-definitions in [`types/runtrace.go`](../types/runtrace.go).
+`types.RunTrace`, `types.TurnTrace`, `types.TurnRecord`, and
+`types.ToolCallSummary` definitions in
+[`types/runtrace.go`](../types/runtrace.go).
+
+## On-disk shape
+
+A JSONL trace file is a stream of one-line JSON events, each carrying
+a `kind` discriminator. A complete run produces:
+
+```jsonl
+{"kind":"run_started","schemaVersion":"1","runId":"...","config":{...redacted...},"startedAt":"..."}
+{"kind":"turn_record","turn":1,"modelInput":{...},"modelOutput":[...],"toolCalls":[...]}
+{"kind":"tool_call_record","turn":1,"name":"read_file","input":{...},"output":"..."}
+{"kind":"turn_record","turn":2,"modelInput":{...},"modelOutput":[...]}
+{"kind":"run_finished","trace":{...RunTrace summary...},"completedAt":"..."}
+```
+
+`turn_record` carries the full transcript the model saw and produced
+that turn, including raw tool inputs and outputs. `tool_call_record`
+is emitted in addition so a live consumer sees each call as soon as
+it lands. `run_finished` carries the same `RunTrace` summary the
+legacy single-blob format used; `stirrup trace show / stats / grep`
+read it transparently regardless of which on-disk shape produced it.
+
+Lines are flushed after each write, so a `SIGKILL`'d run leaves a
+JSONL file that parses up to the last completed event. A trace that
+predates the streaming format (one single-line `RunTrace` per file)
+is read as if it were a streaming file containing only the
+`run_finished` event.
+
+`stirrup trace show` and the rest of the `stirrup trace` family
+operate on the same `run_finished`-equivalent shape so operator
+workflows are unchanged across the format transition.
 
 ## Quick choice
 

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -40,6 +40,9 @@ type pendingCall struct {
 //
 // Returned values:
 //   - toolResults: results indexed by original call order (always len(toolCalls))
+//   - toolRecords: full per-call records (raw Input + Output) for the turn
+//     transcript. Indexed by original call order. Truncated to the same
+//     length as toolResults when the stall detector trips.
 //   - stallOutcome: non-empty when the stall detector tripped; the caller
 //     must append toolResults to the message history and return immediately
 //
@@ -56,7 +59,7 @@ func (l *AgenticLoop) planAndDispatch(
 	config *types.RunConfig,
 	toolCalls []types.ToolCall,
 	stall *stallDetector,
-) ([]types.ToolResult, string) {
+) ([]types.ToolResult, []types.ToolCallRecord, string) {
 	plan := make([]pendingCall, len(toolCalls))
 
 	// Phase 1: open the tool span, run PhasePreTool guard, and resolve the
@@ -195,6 +198,7 @@ func (l *AgenticLoop) planAndDispatch(
 	// (its identical-call heuristic depends on this) and that the
 	// transport observes a deterministic tool_result sequence.
 	toolResults := make([]types.ToolResult, len(toolCalls))
+	toolRecords := make([]types.ToolCallRecord, len(toolCalls))
 	for i := range plan {
 		p := &plan[i]
 		callDuration := time.Since(p.startedAt)
@@ -245,6 +249,21 @@ func (l *AgenticLoop) planAndDispatch(
 			Content:   p.output,
 			IsError:   !p.success,
 		}
+		// Full record carries raw input/output for the turn transcript.
+		// The dispatch site is the only place with both fields in scope:
+		// p.call.Input is the model-supplied raw JSON; p.output is the
+		// post-dispatch result string (either tool output or scrubbed
+		// error reason). Recording is done here so the loop's
+		// RecordTurnRecord call after planAndDispatch returns is a pure
+		// data hand-off.
+		toolRecords[i] = types.ToolCallRecord{
+			ID:         p.call.ID,
+			Name:       p.call.Name,
+			Input:      p.call.Input,
+			Output:     p.output,
+			DurationMs: callDuration.Milliseconds(),
+			Success:    p.success,
+		}
 
 		if err := l.Transport.Emit(types.HarnessEvent{
 			Type:      "tool_result",
@@ -274,9 +293,9 @@ func (l *AgenticLoop) planAndDispatch(
 			// from the loop; preserving that ensures appendToolResults
 			// produces a turn message identical to the sequential
 			// version when a stall trips on the first call.
-			return toolResults[:i+1], outcome
+			return toolResults[:i+1], toolRecords[:i+1], outcome
 		}
 	}
 
-	return toolResults, ""
+	return toolResults, toolRecords, ""
 }

--- a/harness/internal/core/dispatch_parallel_test.go
+++ b/harness/internal/core/dispatch_parallel_test.go
@@ -156,7 +156,7 @@ func TestParallelDispatch_FiveConcurrent_CompleteInMaxNotSum(t *testing.T) {
 	}
 
 	start := time.Now()
-	results, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
 	elapsed := time.Since(start)
 
 	if outcome != "" {
@@ -200,7 +200,7 @@ func TestParallelDispatch_OutOfOrderResolution_PreservesCallOrder(t *testing.T) 
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 0, "payload-for-second")
 	go fireResponseWhenEmitted(t, tr, calls[0].ID, 50*time.Millisecond, "payload-for-first")
 
-	results, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -284,7 +284,7 @@ func TestParallelDispatch_MaxParallelOne_Serialises(t *testing.T) {
 		}()
 	}
 
-	results, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -355,7 +355,7 @@ func TestParallelDispatch_CtxCancellation_DrainsInFlight(t *testing.T) {
 	}()
 
 	start := time.Now()
-	results, outcome := loop.planAndDispatch(ctx, config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(ctx, config, calls, &stallDetector{})
 	elapsed := time.Since(start)
 
 	if outcome != "" {
@@ -443,7 +443,7 @@ func TestParallelDispatch_MixedSyncAndAsync_DispatchesSyncInline(t *testing.T) {
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 0, "async-result-0")
 	go fireResponseWhenEmitted(t, tr, calls[3].ID, 0, "async-result-1")
 
-	results, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -521,7 +521,7 @@ func TestParallelDispatch_PanicInOneHandler_DoesNotStopOthers(t *testing.T) {
 
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 20*time.Millisecond, "good-result")
 
-	results, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -592,7 +592,7 @@ func TestParallelDispatch_StallDetector_ObservesCallOrder(t *testing.T) {
 	go fireResponseWhenEmitted(t, tr, calls[0].ID, 60*time.Millisecond, "r0")
 
 	stall := &stallDetector{}
-	results, outcome := loop.planAndDispatch(context.Background(), config, calls, stall)
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, stall)
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome %q: two identical calls + one different should not trip threshold=3", outcome)
 	}
@@ -645,7 +645,7 @@ func TestParallelDispatch_OTelSpans_AreSiblingsUnderTurn(t *testing.T) {
 	go fireResponseWhenEmitted(t, tr, calls[0].ID, 50*time.Millisecond, "r0")
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 50*time.Millisecond, "r1")
 
-	results, outcome := loop.planAndDispatch(turnCtx, config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(turnCtx, config, calls, &stallDetector{})
 	turnSpan.End()
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
@@ -737,7 +737,7 @@ func TestParallelDispatch_StallTrips_ClosesRemainingSpans(t *testing.T) {
 			fmt.Sprintf("result-%d", i))
 	}
 
-	results, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
 	if outcome != "stalled" {
 		t.Fatalf("expected outcome 'stalled', got %q", outcome)
 	}
@@ -793,7 +793,7 @@ func TestParallelDispatch_GuardDenyReason_ScrubbedBeforeTrace(t *testing.T) {
 		{ID: "tc_deny", Name: "async_echo", Input: json.RawMessage(`{}`)},
 	}
 
-	results, outcome := loop.planAndDispatch(context.Background(),
+	results, _, outcome := loop.planAndDispatch(context.Background(),
 		configWithMaxParallel(1), calls, &stallDetector{})
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -743,6 +743,27 @@ func (l *AgenticLoop) runInnerLoop(
 			BatchID:    turnBatchID,
 		})
 
+		// Snapshot the model input the provider just saw and the
+		// content blocks it produced. The full transcript is captured
+		// as a TurnRecord via RecordTurnRecord; recording emitters
+		// (streaming JSONLTraceEmitter) persist it for downstream
+		// replay / mine-failures, while summary-only emitters
+		// (OTel, GCS) ignore it.
+		//
+		// modelInput.Messages is the exact prepared-message slice the
+		// provider received this turn (pre-tool-result append).
+		// ModelOutput carries the assistant's content blocks. Tool
+		// calls are filled in after planAndDispatch runs below.
+		turnRecord := types.TurnRecord{
+			Turn: turn,
+			ModelInput: types.ModelInput{
+				Messages: preparedMessages,
+				Tools:    toolDefs,
+				Model:    selection.Model,
+			},
+			ModelOutput: sr.Blocks,
+		}
+
 		modeAttr := l.metricAttrs(attribute.String("run.mode", config.Mode))
 		l.Metrics.Turns.Add(ctx, 1, modeAttr)
 		l.Metrics.TokensInput.Add(ctx, int64(inputTokenEstimate), l.metricAttrs())
@@ -761,6 +782,12 @@ func (l *AgenticLoop) runInnerLoop(
 		toolCalls := collectToolCalls(sr.Blocks)
 
 		if sr.StopReason == "end_turn" {
+			// Record the turn transcript with no tool calls before the
+			// success return. Even an end_turn carries a transcript
+			// worth preserving: replay needs the model's final answer,
+			// and mine-failures distinguishes "model declared end_turn
+			// at turn N" from "loop ran out of turns at N".
+			l.Trace.RecordTurnRecord(turnRecord)
 			// PhasePostTurn guard: classify the assistant's final text
 			// before forwarding it. A deny terminates the run with the
 			// "guardrail_blocked" outcome. Spotlight is opt-in for
@@ -798,9 +825,15 @@ func (l *AgenticLoop) runInnerLoop(
 				l.Logger.Warn("provider returned empty stop reason", "turn", turn)
 				return messages, "error"
 			}
+			// Non-tool-use, non-end-turn stop reasons still represent
+			// a completed exchange that replay/mining cares about.
+			l.Trace.RecordTurnRecord(turnRecord)
 			return messages, sr.StopReason
 		}
 		if len(toolCalls) == 0 {
+			// Provider declared tool_use but produced no tool blocks —
+			// degenerate but observable.
+			l.Trace.RecordTurnRecord(turnRecord)
 			return messages, "error"
 		}
 
@@ -810,7 +843,9 @@ func (l *AgenticLoop) runInnerLoop(
 		// config.EffectiveToolDispatchMaxParallel(). planAndDispatch preserves
 		// result order, stall-detector ordering, per-call timeouts, and ctx
 		// cancellation propagation; see harness/internal/core/dispatch.go.
-		toolResults, stallOutcome := l.planAndDispatch(ctx, config, toolCalls, stall)
+		toolResults, toolRecords, stallOutcome := l.planAndDispatch(ctx, config, toolCalls, stall)
+		turnRecord.ToolCalls = toolRecords
+		l.Trace.RecordTurnRecord(turnRecord)
 		messages = appendToolResults(messages, toolResults)
 		if stallOutcome != "" {
 			return messages, stallOutcome

--- a/harness/internal/core/subagent_test.go
+++ b/harness/internal/core/subagent_test.go
@@ -33,9 +33,10 @@ import (
 // RecordTurn / RecordToolCall call so tests can assert on forwarding
 // behaviour from the NestedJSONLEmitter into the parent's emitter.
 type recordingTraceEmitter struct {
-	mu        sync.Mutex
-	turns     []types.TurnTrace
-	toolCalls []types.ToolCallTrace
+	mu          sync.Mutex
+	turns       []types.TurnTrace
+	turnRecords []types.TurnRecord
+	toolCalls   []types.ToolCallTrace
 }
 
 func (r *recordingTraceEmitter) Start(_ string, _ *types.RunConfig) {}
@@ -44,6 +45,12 @@ func (r *recordingTraceEmitter) RecordTurn(turn types.TurnTrace) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.turns = append(r.turns, turn)
+}
+
+func (r *recordingTraceEmitter) RecordTurnRecord(turn types.TurnRecord) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.turnRecords = append(r.turnRecords, turn)
 }
 
 func (r *recordingTraceEmitter) RecordToolCall(call types.ToolCallTrace) {

--- a/harness/internal/trace/events.go
+++ b/harness/internal/trace/events.go
@@ -65,20 +65,20 @@ const CurrentSchemaVersion = "1"
 // pointers so a future kind addition does not break older readers: an
 // unrecognised Kind round-trips as opaque bytes.
 type Event struct {
-	Kind          EventKind       `json:"kind"`
-	SchemaVersion string          `json:"schemaVersion,omitempty"`
-	RunID         string          `json:"runId,omitempty"`
-	StartedAt     *time.Time      `json:"startedAt,omitempty"`
-	CompletedAt   *time.Time      `json:"completedAt,omitempty"`
+	Kind          EventKind        `json:"kind"`
+	SchemaVersion string           `json:"schemaVersion,omitempty"`
+	RunID         string           `json:"runId,omitempty"`
+	StartedAt     *time.Time       `json:"startedAt,omitempty"`
+	CompletedAt   *time.Time       `json:"completedAt,omitempty"`
 	Config        *types.RunConfig `json:"config,omitempty"`
 
 	// Turn / ToolCall payload — populated for turn_record and
 	// tool_call_record respectively.
-	Turn          int                  `json:"turn,omitempty"`
-	ModelInput    *types.ModelInput    `json:"modelInput,omitempty"`
-	ModelOutput   []types.ContentBlock `json:"modelOutput,omitempty"`
-	ToolCalls     []types.ToolCallRecord `json:"toolCalls,omitempty"`
-	ToolCall      *types.ToolCallRecord `json:"toolCall,omitempty"`
+	Turn        int                    `json:"turn,omitempty"`
+	ModelInput  *types.ModelInput      `json:"modelInput,omitempty"`
+	ModelOutput []types.ContentBlock   `json:"modelOutput,omitempty"`
+	ToolCalls   []types.ToolCallRecord `json:"toolCalls,omitempty"`
+	ToolCall    *types.ToolCallRecord  `json:"toolCall,omitempty"`
 
 	// Trace summary — populated for run_finished events. Embedding the
 	// full RunTrace here keeps the backward-compat reader's job trivial:

--- a/harness/internal/trace/events.go
+++ b/harness/internal/trace/events.go
@@ -1,0 +1,99 @@
+// Package trace — events.go defines the on-disk JSONL event shape the
+// streaming JSONLTraceEmitter writes and the reader in
+// types/trace/reader.go consumes.
+//
+// Each line in a streaming trace file is one JSON object with a "kind"
+// discriminator. A complete run produces:
+//
+//	{"kind":"run_started",      "schemaVersion":"1","runId":"...","config":{...redacted...},"startedAt":"..."}
+//	{"kind":"turn_record",      "turn":1,"modelInput":{...},"modelOutput":[...],"toolCalls":[...]}
+//	{"kind":"tool_call_record", "turn":1,"name":"read_file","input":{...},"output":"..."}
+//	...
+//	{"kind":"run_finished",     "trace":{...RunTrace summary...},"completedAt":"..."}
+//
+// turn_record carries the full transcript a sub-agent / replay path needs.
+// tool_call_record is emitted in addition to the inline toolCalls inside
+// turn_record so a strict event-by-event consumer (e.g. future gRPC fan-out)
+// sees each call as soon as it lands rather than waiting for the enclosing
+// turn to flush. Both views are scrubbed for known secret patterns by the
+// emitter before the line is written.
+//
+// An interrupted run (SIGKILL, crash, OOM) may end without run_finished;
+// the on-disk file is still parseable up to the last completed event.
+//
+// Backward compatibility: pre-streaming traces emitted a single
+// json.Marshal(types.RunTrace) line with no "kind" field. The reader
+// (types/trace/reader.go) treats a kindless line as an implicit
+// run_finished event with the trace payload embedded.
+package trace
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// EventKind is the discriminator that prefixes every streaming event.
+type EventKind string
+
+const (
+	// EventKindRunStarted is the first line of a streaming trace file.
+	EventKindRunStarted EventKind = "run_started"
+	// EventKindTurnRecord captures one agentic-loop turn's full I/O.
+	EventKindTurnRecord EventKind = "turn_record"
+	// EventKindToolCallRecord captures one tool invocation's raw input
+	// and output. Emitted in addition to the inline ToolCalls inside the
+	// enclosing turn_record so per-call consumers (e.g. live UIs, future
+	// gRPC fan-out) see each call as soon as it lands.
+	EventKindToolCallRecord EventKind = "tool_call_record"
+	// EventKindRunFinished is the last line of a streaming trace file.
+	// Carries the canonical RunTrace summary; backward-compatible with
+	// pre-streaming single-blob traces.
+	EventKindRunFinished EventKind = "run_finished"
+)
+
+// CurrentSchemaVersion is the streaming-trace schema version emitted in
+// run_started events. Bump on backward-incompatible event-shape changes.
+const CurrentSchemaVersion = "1"
+
+// Event is the wire-shape of one line in a streaming JSONL trace file.
+// Fields are populated according to Kind; reading code must dispatch
+// on Kind before consulting the payload.
+//
+// Marshal/Unmarshal use json.RawMessage rather than concrete payload
+// pointers so a future kind addition does not break older readers: an
+// unrecognised Kind round-trips as opaque bytes.
+type Event struct {
+	Kind          EventKind       `json:"kind"`
+	SchemaVersion string          `json:"schemaVersion,omitempty"`
+	RunID         string          `json:"runId,omitempty"`
+	StartedAt     *time.Time      `json:"startedAt,omitempty"`
+	CompletedAt   *time.Time      `json:"completedAt,omitempty"`
+	Config        *types.RunConfig `json:"config,omitempty"`
+
+	// Turn / ToolCall payload — populated for turn_record and
+	// tool_call_record respectively.
+	Turn          int                  `json:"turn,omitempty"`
+	ModelInput    *types.ModelInput    `json:"modelInput,omitempty"`
+	ModelOutput   []types.ContentBlock `json:"modelOutput,omitempty"`
+	ToolCalls     []types.ToolCallRecord `json:"toolCalls,omitempty"`
+	ToolCall      *types.ToolCallRecord `json:"toolCall,omitempty"`
+
+	// Trace summary — populated for run_finished events. Embedding the
+	// full RunTrace here keeps the backward-compat reader's job trivial:
+	// a kindless legacy line and a run_finished event both decode the
+	// RunTrace payload from the same position.
+	Trace *types.RunTrace `json:"trace,omitempty"`
+}
+
+// MarshalLine renders the event as a single line of JSON terminated by
+// '\n'. Returns an error only if json.Marshal does (no event field is
+// itself non-marshalable in practice).
+func MarshalLine(e Event) ([]byte, error) {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}

--- a/harness/internal/trace/gcs.go
+++ b/harness/internal/trace/gcs.go
@@ -152,6 +152,13 @@ func (e *GCSTraceEmitter) RecordTurn(turn types.TurnTrace) {
 	e.turns = append(e.turns, turn)
 }
 
+// RecordTurnRecord is a no-op for GCS. The single-blob upload path
+// is summary-only by design — full transcript recording lives on the
+// JSONLTraceEmitter which streams events to a local file. A future
+// follow-up could ship the streamed events to GCS as a separate object;
+// for v0.1 the summary upload is unchanged.
+func (e *GCSTraceEmitter) RecordTurnRecord(_ types.TurnRecord) {}
+
 // RecordToolCall appends a tool call trace.
 func (e *GCSTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	e.mu.Lock()

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -8,23 +8,45 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
 )
 
-// JSONLTraceEmitter writes run traces as newline-delimited JSON to an
-// io.Writer (typically a file).
+// JSONLTraceEmitter writes a streaming, line-delimited JSON event log
+// for a single harness run. Each call to Start, RecordTurnRecord,
+// RecordToolCall (via the inline tool_call_record path), and Finish
+// emits one line. Lines are flushed immediately so a SIGKILL leaves a
+// parseable partial recording on disk up to the last completed event.
+//
+// The on-wire shape is documented in events.go. Defence-in-depth
+// scrubbing runs over modelOutput, tool call input, and tool call
+// output before each line is written; the line never contains raw
+// secret material even if the upstream LogScrubber in the agentic loop
+// missed a substring.
+//
+// Concurrency: every public method takes a write lock around the
+// underlying io.Writer. The lock is held only for the duration of a
+// single Marshal+Write to keep the loop's hot path responsive.
 type JSONLTraceEmitter struct {
-	writer    io.Writer
-	closer    io.Closer
+	writer io.Writer
+	closer io.Closer
+
 	mu        sync.Mutex
 	runID     string
 	config    *types.RunConfig
 	startedAt time.Time
+
+	// Accumulators retained for the run_finished summary. The streaming
+	// event log carries the full transcript, but Finish still produces a
+	// canonical RunTrace (token totals, tool call summaries, outcome)
+	// for the in-process caller (harness factory, eval runner) that
+	// reads it directly without re-parsing the file.
 	turns     []types.TurnTrace
 	toolCalls []types.ToolCallTrace
 }
 
-// NewJSONLTraceEmitter creates a trace emitter that writes to w.
+// NewJSONLTraceEmitter creates a streaming trace emitter that writes to w.
+// If w implements io.Closer, Close on the emitter closes it.
 func NewJSONLTraceEmitter(w io.Writer) *JSONLTraceEmitter {
 	emitter := &JSONLTraceEmitter{writer: w}
 	if closer, ok := w.(io.Closer); ok {
@@ -33,7 +55,30 @@ func NewJSONLTraceEmitter(w io.Writer) *JSONLTraceEmitter {
 	return emitter
 }
 
-// Start initialises the trace with run metadata.
+// writeLineLocked marshals e as a single newline-terminated JSON line
+// and writes it to the backing writer. Must be called with e.mu held.
+//
+// Errors from the writer are surfaced to the caller. The emitter has no
+// retry / buffering policy: when the file handle is a regular file (the
+// production case via factory.go), os.File.Write is effectively atomic
+// for the line-sized writes used here and a write failure is unusual.
+// When a write does fail the emitter does NOT mutate its in-memory
+// accumulators (the line was never observable on disk; the next event
+// can still land), and the run's outer error path surfaces the failure.
+func (e *JSONLTraceEmitter) writeLineLocked(ev Event) error {
+	line, err := MarshalLine(ev)
+	if err != nil {
+		return fmt.Errorf("marshal trace event: %w", err)
+	}
+	if _, err := e.writer.Write(line); err != nil {
+		return fmt.Errorf("write trace event: %w", err)
+	}
+	return nil
+}
+
+// Start initialises the trace and writes the run_started event. The
+// config is redacted via RunConfig.Redact() so secret references never
+// appear on disk even if a future config field exposes a raw value.
 func (e *JSONLTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -43,44 +88,112 @@ func (e *JSONLTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.startedAt = time.Now()
 	e.turns = nil
 	e.toolCalls = nil
+
+	startedAt := e.startedAt
+	var redacted types.RunConfig
+	if config != nil {
+		redacted = config.Redact()
+	}
+	ev := Event{
+		Kind:          EventKindRunStarted,
+		SchemaVersion: CurrentSchemaVersion,
+		RunID:         runID,
+		StartedAt:     &startedAt,
+		Config:        &redacted,
+	}
+	// A failure to write the run_started line is non-fatal: the trace
+	// will be missing its preamble but the rest of the run still
+	// produces records, and Finish surfaces a synthetic run_finished if
+	// the writer recovers. The agentic loop has no error channel from
+	// Start (the interface returns no error to preserve the existing
+	// contract); failure here is rare in practice and the run-level
+	// outcome is decided independently of trace durability.
+	_ = e.writeLineLocked(ev)
 }
 
-// RecordTurn appends a turn trace.
+// RecordTurn appends a turn summary to the in-memory accumulator. The
+// summary is written to disk as part of the run_finished event's
+// embedded RunTrace; per-turn detail belongs in RecordTurnRecord.
 func (e *JSONLTraceEmitter) RecordTurn(turn types.TurnTrace) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.turns = append(e.turns, turn)
 }
 
-// RecordToolCall appends a tool call trace.
+// RecordTurnRecord scrubs the transcript and writes one turn_record
+// line. The scrubber runs over message content, model output blocks,
+// and each tool call's raw input/output. The line is flushed before
+// RecordTurnRecord returns so an immediately-following SIGKILL still
+// leaves a parseable record on disk.
+func (e *JSONLTraceEmitter) RecordTurnRecord(turn types.TurnRecord) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	scrubbed := scrubTurnRecord(turn)
+	ev := Event{
+		Kind:        EventKindTurnRecord,
+		Turn:        scrubbed.Turn,
+		ModelInput:  &scrubbed.ModelInput,
+		ModelOutput: scrubbed.ModelOutput,
+		ToolCalls:   scrubbed.ToolCalls,
+	}
+	_ = e.writeLineLocked(ev)
+}
+
+// RecordToolCall appends a tool call summary to the in-memory
+// accumulator AND streams an inline tool_call_record event. The
+// summary feeds the run_finished aggregate; the streamed event lets a
+// live consumer (or a SIGKILL-resilient post-hoc reader) see calls as
+// they land. The summary carries counters only — raw I/O is captured
+// at RecordTurnRecord time on the enclosing turn.
 func (e *JSONLTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.toolCalls = append(e.toolCalls, call)
+	// Streaming event carries only the summary fields; the full raw
+	// input/output is attached at RecordTurnRecord time when the
+	// turn's complete tool-call sequence is known. We emit a lean
+	// tool_call_record here so live consumers see per-call events
+	// before the turn finishes.
+	tc := types.ToolCallRecord{
+		Name:    call.Name,
+		Success: call.Success,
+		// DurationMs and other counters live on call; for the
+		// inline event we keep the schema aligned with the turn-
+		// embedded ToolCallRecord shape and surface only fields
+		// that are meaningful at this point. Output carries
+		// ErrorReason (already scrubbed by the dispatch site) for
+		// failed calls so a live consumer sees the failure detail.
+		Output:     call.ErrorReason,
+		DurationMs: call.DurationMs,
+	}
+	ev := Event{
+		Kind:     EventKindToolCallRecord,
+		ToolCall: &tc,
+	}
+	_ = e.writeLineLocked(ev)
 }
 
-// Finish builds the final RunTrace, redacts the config, writes it as a
-// JSON line to the backing writer, and returns the trace.
+// Finish builds the canonical RunTrace summary, writes the
+// run_finished event, and returns the summary. A run with zero turns
+// still produces a valid run_finished line.
 func (e *JSONLTraceEmitter) Finish(_ context.Context, outcome string) (*types.RunTrace, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	now := time.Now()
 
-	// Aggregate token usage across turns.
 	var totalTokens types.TokenUsage
 	for _, turn := range e.turns {
 		totalTokens.Input += turn.Tokens.Input
 		totalTokens.Output += turn.Tokens.Output
 	}
 
-	// Convert tool call traces to summaries.
 	summaries := make([]types.ToolCallSummary, len(e.toolCalls))
 	for i, tc := range e.toolCalls {
 		summaries[i] = types.ToolCallSummary(tc)
 	}
 
-	// Redact sensitive config fields.
 	var redactedConfig types.RunConfig
 	if e.config != nil {
 		redactedConfig = e.config.Redact()
@@ -97,23 +210,128 @@ func (e *JSONLTraceEmitter) Finish(_ context.Context, outcome string) (*types.Ru
 		Outcome:     outcome,
 	}
 
-	data, err := json.Marshal(trace)
-	if err != nil {
-		return nil, fmt.Errorf("marshal trace: %w", err)
+	ev := Event{
+		Kind:        EventKindRunFinished,
+		CompletedAt: &now,
+		Trace:       trace,
 	}
-
-	data = append(data, '\n')
-	if _, err := e.writer.Write(data); err != nil {
-		return nil, fmt.Errorf("write trace: %w", err)
+	if err := e.writeLineLocked(ev); err != nil {
+		return nil, err
 	}
-
 	return trace, nil
 }
 
-// Close releases the backing writer when it owns a closable resource such as a file.
+// Close releases the backing writer when it owns a closable resource
+// (e.g. an os.File opened by the factory). NewReader-backed and
+// in-memory writers report nil.
 func (e *JSONLTraceEmitter) Close() error {
 	if e.closer == nil {
 		return nil
 	}
 	return e.closer.Close()
+}
+
+// scrubTurnRecord returns a deep-copied TurnRecord with secret-shaped
+// substrings replaced by [REDACTED] in every string-valued field that
+// can carry untrusted content. The defence-in-depth contract: a future
+// regression that bypasses the upstream LogScrubber must not leak raw
+// secret material into a persisted trace.
+//
+// Scrubbing surfaces:
+//   - turn.ModelInput.Messages[*].Content (text blocks; tool_use Input
+//     and tool_result Content are scrubbed through their respective
+//     paths below).
+//   - turn.ModelOutput[*].Text and ToolUseId/Name carriers' inputs.
+//   - turn.ToolCalls[*].Input (raw JSON; scrubbed as a string then
+//     re-parsed; if the scrubbed string is not valid JSON it is
+//     wrapped as a JSON string literal so the on-disk shape stays a
+//     valid json.RawMessage).
+//   - turn.ToolCalls[*].Output (string).
+func scrubTurnRecord(t types.TurnRecord) types.TurnRecord {
+	out := types.TurnRecord{
+		Turn:        t.Turn,
+		ModelInput:  scrubModelInput(t.ModelInput),
+		ModelOutput: scrubContentBlocks(t.ModelOutput),
+		ToolCalls:   make([]types.ToolCallRecord, len(t.ToolCalls)),
+	}
+	for i, tc := range t.ToolCalls {
+		out.ToolCalls[i] = types.ToolCallRecord{
+			ID:         tc.ID,
+			Name:       tc.Name,
+			Input:      scrubRawJSON(tc.Input),
+			Output:     security.Scrub(tc.Output),
+			DurationMs: tc.DurationMs,
+			Success:    tc.Success,
+		}
+	}
+	return out
+}
+
+// scrubModelInput deep-copies a ModelInput with text content scrubbed.
+// Tool definitions and the model string are not scrubbed: tool schemas
+// are constants compiled into the harness, and the model identifier
+// (e.g. "claude-3-5-sonnet-latest") is not a secret.
+func scrubModelInput(in types.ModelInput) types.ModelInput {
+	out := types.ModelInput{
+		Model:    in.Model,
+		Tools:    in.Tools,
+		Messages: make([]types.Message, len(in.Messages)),
+	}
+	for i, m := range in.Messages {
+		out.Messages[i] = types.Message{
+			Role:    m.Role,
+			Content: scrubContentBlocks(m.Content),
+		}
+	}
+	return out
+}
+
+// scrubContentBlocks scrubs text and tool-result content. Tool-use
+// blocks carry an Input json.RawMessage that may itself encode arbitrary
+// content; we re-use scrubRawJSON to preserve a valid JSON shape.
+func scrubContentBlocks(blocks []types.ContentBlock) []types.ContentBlock {
+	if blocks == nil {
+		return nil
+	}
+	out := make([]types.ContentBlock, len(blocks))
+	for i, b := range blocks {
+		nb := b
+		if nb.Text != "" {
+			nb.Text = security.Scrub(nb.Text)
+		}
+		if len(nb.Input) > 0 {
+			nb.Input = scrubRawJSON(nb.Input)
+		}
+		out[i] = nb
+	}
+	return out
+}
+
+// scrubRawJSON scrubs secret-shaped substrings out of a json.RawMessage
+// while preserving JSON validity. The scrubber operates on the string
+// form of the message and re-validates the result. If the scrubbed
+// payload is no longer valid JSON (an extreme corner case: a regex
+// boundary breaks a JSON literal), the entire payload is replaced by a
+// JSON string literal carrying the scrubbed text so the on-disk shape
+// stays parseable.
+func scrubRawJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	scrubbed := security.Scrub(string(raw))
+	if scrubbed == string(raw) {
+		return raw
+	}
+	if json.Valid([]byte(scrubbed)) {
+		return json.RawMessage(scrubbed)
+	}
+	// Wrap the scrubbed text as a JSON string. json.Marshal escapes
+	// any embedded quotes/backslashes so the result is always valid.
+	wrapped, err := json.Marshal(scrubbed)
+	if err != nil {
+		// json.Marshal on a string cannot fail in practice; fall back
+		// to a defensive empty-object literal so the line stays valid.
+		return json.RawMessage(`{}`)
+	}
+	return json.RawMessage(wrapped)
 }

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -1,13 +1,55 @@
 package trace
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/types"
 )
+
+// readEvents walks a streaming JSONL trace buffer and returns the events
+// in order. Used by the JSONL emitter tests to assert on the on-wire
+// shape without coupling to the reader package (which lives under
+// types/trace and would form a test-only dependency cycle).
+func readEvents(t *testing.T, src []byte) []Event {
+	t.Helper()
+	scanner := bufio.NewScanner(bytes.NewReader(src))
+	scanner.Buffer(make([]byte, 0, 256*1024), 4*1024*1024)
+	var events []Event
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal event: %v\n%s", err, line)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan events: %v", err)
+	}
+	return events
+}
+
+// pickEvent returns the first event of the given kind, or fails the
+// test. The streaming emitter writes at most one run_started and one
+// run_finished per run, so "first" is unambiguous for those kinds.
+func pickEvent(t *testing.T, events []Event, kind EventKind) Event {
+	t.Helper()
+	for _, ev := range events {
+		if ev.Kind == kind {
+			return ev
+		}
+	}
+	t.Fatalf("no event of kind %q in stream", kind)
+	return Event{}
+}
 
 func TestJSONLTraceEmitter_FullLifecycle(t *testing.T) {
 	var buf bytes.Buffer
@@ -57,7 +99,7 @@ func TestJSONLTraceEmitter_FullLifecycle(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify trace fields.
+	// Verify the in-memory trace summary.
 	if trace.ID != "run-123" {
 		t.Errorf("ID: got %q, want %q", trace.ID, "run-123")
 	}
@@ -73,29 +115,59 @@ func TestJSONLTraceEmitter_FullLifecycle(t *testing.T) {
 	if trace.Outcome != "success" {
 		t.Errorf("Outcome: got %q, want %q", trace.Outcome, "success")
 	}
-
-	// Verify config was redacted.
 	if trace.Config.Provider.APIKeyRef != "secret://[REDACTED]" {
 		t.Errorf("APIKeyRef should be redacted, got %q", trace.Config.Provider.APIKeyRef)
 	}
 
-	// Verify JSONL output is valid.
-	var written types.RunTrace
-	if err := json.Unmarshal(buf.Bytes(), &written); err != nil {
-		t.Fatalf("unmarshal written trace: %v", err)
+	// Verify the on-disk stream is well-formed and carries the events
+	// the streaming-trace contract promises.
+	events := readEvents(t, buf.Bytes())
+	if len(events) < 4 {
+		t.Fatalf("expected at least 4 events (started, 2 tool_call_record, finished), got %d", len(events))
 	}
-	if written.ID != "run-123" {
-		t.Errorf("written ID: got %q, want %q", written.ID, "run-123")
+
+	started := pickEvent(t, events, EventKindRunStarted)
+	if started.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("run_started schemaVersion: got %q, want %q", started.SchemaVersion, CurrentSchemaVersion)
+	}
+	if started.RunID != "run-123" {
+		t.Errorf("run_started runId: got %q, want run-123", started.RunID)
+	}
+	if started.Config == nil {
+		t.Fatal("run_started missing config")
+	}
+	if started.Config.Provider.APIKeyRef != "secret://[REDACTED]" {
+		t.Errorf("run_started Config.Provider.APIKeyRef not redacted: %q", started.Config.Provider.APIKeyRef)
+	}
+
+	var toolCallEvents int
+	for _, ev := range events {
+		if ev.Kind == EventKindToolCallRecord {
+			toolCallEvents++
+		}
+	}
+	if toolCallEvents != 2 {
+		t.Errorf("tool_call_record events: got %d, want 2", toolCallEvents)
+	}
+
+	finished := pickEvent(t, events, EventKindRunFinished)
+	if finished.Trace == nil {
+		t.Fatal("run_finished missing embedded trace summary")
+	}
+	if finished.Trace.ID != "run-123" {
+		t.Errorf("run_finished trace ID: got %q, want run-123", finished.Trace.ID)
+	}
+	if finished.Trace.Outcome != "success" {
+		t.Errorf("run_finished outcome: got %q, want success", finished.Trace.Outcome)
 	}
 }
 
 // TestJSONLTraceEmitter_SessionNameRoundTrip pins that a SessionName set
-// on the RunConfig flows into the JSONL trace and survives a JSON round
-// trip. The eval lakehouse and replay tooling rely on this — without it,
-// a run labelled --name "nightly-eval" would not be filterable by label
-// in downstream analysis. (Construction-style test rather than booting
-// the full agentic loop, which would require a provider, executor, etc.;
-// the round-trip is the load-bearing property.)
+// on the RunConfig flows into both the run_started event's redacted
+// config and the run_finished event's embedded trace summary. The eval
+// lakehouse and replay tooling rely on this — without it, a run
+// labelled --name "nightly-eval" would not be filterable by label in
+// downstream analysis.
 func TestJSONLTraceEmitter_SessionNameRoundTrip(t *testing.T) {
 	var buf bytes.Buffer
 	emitter := NewJSONLTraceEmitter(&buf)
@@ -115,18 +187,18 @@ func TestJSONLTraceEmitter_SessionNameRoundTrip(t *testing.T) {
 		t.Fatalf("Finish: %v", err)
 	}
 
-	// Trace returned in memory should carry SessionName.
 	if tr.Config.SessionName != "nightly-eval" {
 		t.Errorf("returned trace SessionName: got %q, want nightly-eval", tr.Config.SessionName)
 	}
 
-	// And the persisted JSONL line must round-trip the field.
-	var written types.RunTrace
-	if err := json.Unmarshal(buf.Bytes(), &written); err != nil {
-		t.Fatalf("unmarshal JSONL: %v\n%s", err, buf.String())
+	events := readEvents(t, buf.Bytes())
+	started := pickEvent(t, events, EventKindRunStarted)
+	if started.Config == nil || started.Config.SessionName != "nightly-eval" {
+		t.Errorf("run_started SessionName: got %+v, want nightly-eval", started.Config)
 	}
-	if written.Config.SessionName != "nightly-eval" {
-		t.Errorf("written SessionName: got %q, want nightly-eval", written.Config.SessionName)
+	finished := pickEvent(t, events, EventKindRunFinished)
+	if finished.Trace == nil || finished.Trace.Config.SessionName != "nightly-eval" {
+		t.Errorf("run_finished trace SessionName: got %+v, want nightly-eval", finished.Trace)
 	}
 }
 
@@ -148,5 +220,111 @@ func TestJSONLTraceEmitter_EmptyRun(t *testing.T) {
 	}
 	if buf.Len() == 0 {
 		t.Error("expected output to be written")
+	}
+
+	// An empty run still produces a valid two-line stream: run_started
+	// (with a nil config — the trace_emitter accepts a nil config so
+	// callers that fail validation before constructing a full RunConfig
+	// can still record telemetry) followed by run_finished.
+	events := readEvents(t, buf.Bytes())
+	if len(events) != 2 {
+		t.Fatalf("empty run events: got %d, want 2 (started + finished)", len(events))
+	}
+	if events[0].Kind != EventKindRunStarted {
+		t.Errorf("first event: got %q, want run_started", events[0].Kind)
+	}
+	if events[len(events)-1].Kind != EventKindRunFinished {
+		t.Errorf("last event: got %q, want run_finished", events[len(events)-1].Kind)
+	}
+}
+
+// TestJSONLTraceEmitter_RecordTurnRecord_Scrubs pins the defence-in-
+// depth scrubbing contract: a recorded TurnRecord with secret-shaped
+// substrings in the model output, tool input, or tool output never
+// reaches disk in raw form. The scrubber runs before the line is
+// written, so a SIGKILL between RecordTurnRecord and Finish still
+// leaves a scrubbed event on disk.
+func TestJSONLTraceEmitter_RecordTurnRecord_Scrubs(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+
+	emitter.Start("run-scrub", nil)
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 1,
+		ModelInput: types.ModelInput{
+			Model: "claude-3-5-sonnet-latest",
+			Messages: []types.Message{
+				{
+					Role: "user",
+					Content: []types.ContentBlock{
+						{Type: "text", Text: "here is my key sk-ant-api03-redactme please"},
+					},
+				},
+			},
+		},
+		ModelOutput: []types.ContentBlock{
+			{Type: "text", Text: "ack, your bearer Bearer ABCDEFG is unsafe"},
+		},
+		ToolCalls: []types.ToolCallRecord{
+			{
+				Name:   "run_command",
+				Input:  json.RawMessage(`{"cmd":"echo sk-ant-api03-leak-leak"}`),
+				Output: "stdout: sk-ant-api03-leak\nstderr: ok",
+			},
+		},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	on_disk := buf.String()
+	// Anchor on a known-distinctive secret prefix: if any substring of
+	// the form sk-ant-api03-... lands on disk verbatim the scrubber is
+	// broken.
+	if strings.Contains(on_disk, "sk-ant-api03-redactme") {
+		t.Errorf("scrubber missed model input secret in on-disk trace:\n%s", on_disk)
+	}
+	if strings.Contains(on_disk, "sk-ant-api03-leak-leak") {
+		t.Errorf("scrubber missed tool input secret in on-disk trace:\n%s", on_disk)
+	}
+	if strings.Contains(on_disk, "Bearer ABCDEFG") {
+		t.Errorf("scrubber missed bearer token in on-disk trace:\n%s", on_disk)
+	}
+	// At least one [REDACTED] marker proves the scrubber ran.
+	if !strings.Contains(on_disk, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] placeholder in scrubbed trace, got:\n%s", on_disk)
+	}
+}
+
+// TestJSONLTraceEmitter_PartialStream pins the SIGKILL-safety property:
+// when a run is interrupted between RecordTurnRecord and Finish, the
+// on-disk file is still parseable up to the last completed event.
+// A bytes.Buffer is used to simulate the file; in production the
+// emitter writes to an os.File whose os.Write calls are line-flushed
+// by the kernel for sub-PIPE_BUF writes.
+func TestJSONLTraceEmitter_PartialStream(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+
+	emitter.Start("run-partial", nil)
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 1,
+		ModelOutput: []types.ContentBlock{
+			{Type: "text", Text: "first turn"},
+		},
+	})
+	// Simulate a SIGKILL: no Finish call.
+	events := readEvents(t, buf.Bytes())
+	if len(events) != 2 {
+		t.Fatalf("partial stream events: got %d, want 2 (started + turn_record)", len(events))
+	}
+	if events[0].Kind != EventKindRunStarted {
+		t.Errorf("first event: got %q, want run_started", events[0].Kind)
+	}
+	if events[1].Kind != EventKindTurnRecord {
+		t.Errorf("second event: got %q, want turn_record", events[1].Kind)
+	}
+	if events[1].Turn != 1 {
+		t.Errorf("turn_record Turn: got %d, want 1", events[1].Turn)
 	}
 }

--- a/harness/internal/trace/nested_jsonl.go
+++ b/harness/internal/trace/nested_jsonl.go
@@ -90,6 +90,20 @@ func (e *NestedJSONLEmitter) RecordTurn(turn types.TurnTrace) {
 	e.parent.RecordTurn(tagged)
 }
 
+// RecordTurnRecord forwards the child's full transcript turn to the
+// parent emitter. The child's RunRecording is reassembled on the
+// reader side from the streamed events on the parent's file, so a
+// nested run's transcripts land in the same JSONL stream as the
+// parent's. The child does not retain a local copy: TurnRecord is
+// the streaming-only surface, distinct from the summary RunTrace the
+// child's Finish returns.
+func (e *NestedJSONLEmitter) RecordTurnRecord(turn types.TurnRecord) {
+	if e.parent == nil {
+		return
+	}
+	e.parent.RecordTurnRecord(turn)
+}
+
 // RecordToolCall appends to the child's local trace and forwards a
 // tagged copy to the parent emitter.
 func (e *NestedJSONLEmitter) RecordToolCall(call types.ToolCallTrace) {

--- a/harness/internal/trace/nested_jsonl_test.go
+++ b/harness/internal/trace/nested_jsonl_test.go
@@ -12,14 +12,15 @@ import (
 // without writing anywhere. Used to assert forwarding behaviour on the
 // NestedJSONLEmitter without coupling tests to a particular wire format.
 type recordingEmitter struct {
-	mu         sync.Mutex
-	starts     []startCall
-	turns      []types.TurnTrace
-	toolCalls  []types.ToolCallTrace
-	finishes   []string
-	finishErr  error
-	finishRet  *types.RunTrace
-	finishCtxs []context.Context
+	mu          sync.Mutex
+	starts      []startCall
+	turns       []types.TurnTrace
+	turnRecords []types.TurnRecord
+	toolCalls   []types.ToolCallTrace
+	finishes    []string
+	finishErr   error
+	finishRet   *types.RunTrace
+	finishCtxs  []context.Context
 }
 
 type startCall struct {
@@ -37,6 +38,12 @@ func (r *recordingEmitter) RecordTurn(turn types.TurnTrace) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.turns = append(r.turns, turn)
+}
+
+func (r *recordingEmitter) RecordTurnRecord(turn types.TurnRecord) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.turnRecords = append(r.turnRecords, turn)
 }
 
 func (r *recordingEmitter) RecordToolCall(call types.ToolCallTrace) {

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -346,6 +346,15 @@ func (e *OTelTraceEmitter) RecordTurn(turn types.TurnTrace) {
 	span.End(oteltrace.WithTimestamp(spanEnd))
 }
 
+// RecordTurnRecord is a no-op for OTel. OTel spans capture turn-level
+// counters (tokens, duration, stop reason) and tool spans capture per-
+// call metadata, but full transcript content is not modelled as span
+// attributes — span exporters typically truncate large strings and the
+// GenAI semantic conventions intentionally do not push raw prompt /
+// completion text through trace exporters. Transcript recording lives
+// on the streamed JSONLTraceEmitter.
+func (e *OTelTraceEmitter) RecordTurnRecord(_ types.TurnRecord) {}
+
 // RecordToolCall creates a child span for a tool invocation.
 func (e *OTelTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	e.mu.Lock()

--- a/harness/internal/trace/trace.go
+++ b/harness/internal/trace/trace.go
@@ -13,8 +13,19 @@ type TraceEmitter interface {
 	// Start initialises a new trace with the given run ID and configuration.
 	Start(runID string, config *types.RunConfig)
 
-	// RecordTurn appends a turn trace to the current run.
+	// RecordTurn appends a turn summary to the current run. The summary
+	// carries counters (tokens, duration, stop reason) but no transcript
+	// content; the full ModelInput/ModelOutput/tool I/O lives in
+	// RecordTurnRecord.
 	RecordTurn(turn types.TurnTrace)
+
+	// RecordTurnRecord appends a full transcript record for one turn,
+	// including the messages the model saw, the model's output content
+	// blocks, and the raw inputs/outputs of every tool call dispatched
+	// in that turn. Recording emitters write this as a streamed
+	// `turn_record` event; summary-only emitters (OTel, GCS, the
+	// nested-forwarder) may ignore it.
+	RecordTurnRecord(turn types.TurnRecord)
 
 	// RecordToolCall appends a tool call trace to the current run.
 	RecordToolCall(call types.ToolCallTrace)

--- a/types/trace/reader.go
+++ b/types/trace/reader.go
@@ -205,18 +205,18 @@ const (
 // at the fields the reader cares about. Re-defining the shape locally
 // avoids an internal-package import while keeping the decoder lean.
 type streamedEvent struct {
-	Kind          string             `json:"kind"`
-	SchemaVersion string             `json:"schemaVersion,omitempty"`
-	RunID         string             `json:"runId,omitempty"`
-	StartedAt     *time.Time         `json:"startedAt,omitempty"`
-	CompletedAt   *time.Time         `json:"completedAt,omitempty"`
-	Config        *types.RunConfig   `json:"config,omitempty"`
-	Turn          int                `json:"turn,omitempty"`
-	ModelInput    *types.ModelInput  `json:"modelInput,omitempty"`
-	ModelOutput   []types.ContentBlock `json:"modelOutput,omitempty"`
+	Kind          string                 `json:"kind"`
+	SchemaVersion string                 `json:"schemaVersion,omitempty"`
+	RunID         string                 `json:"runId,omitempty"`
+	StartedAt     *time.Time             `json:"startedAt,omitempty"`
+	CompletedAt   *time.Time             `json:"completedAt,omitempty"`
+	Config        *types.RunConfig       `json:"config,omitempty"`
+	Turn          int                    `json:"turn,omitempty"`
+	ModelInput    *types.ModelInput      `json:"modelInput,omitempty"`
+	ModelOutput   []types.ContentBlock   `json:"modelOutput,omitempty"`
 	ToolCalls     []types.ToolCallRecord `json:"toolCalls,omitempty"`
-	ToolCall      *types.ToolCallRecord `json:"toolCall,omitempty"`
-	Trace         *types.RunTrace    `json:"trace,omitempty"`
+	ToolCall      *types.ToolCallRecord  `json:"toolCall,omitempty"`
+	Trace         *types.RunTrace        `json:"trace,omitempty"`
 }
 
 // kindOnly is used to peek at the discriminator without decoding the

--- a/types/trace/reader.go
+++ b/types/trace/reader.go
@@ -1,12 +1,22 @@
 // Package trace provides offline parsers for the JSONL trace files
 // stirrup writes via traceEmitter.type=jsonl.
 //
-// The on-wire shape is one types.RunTrace per line. A run can produce
-// multiple lines (e.g. when a partial trace is appended ahead of the
-// final summary by future emitters); consumers are expected to walk
-// every record and either project them into typed sub-events or
-// collapse onto the last record (the historical contract of the eval
-// runner's parseTraceFile).
+// Two on-wire shapes are supported, and Reader transparently handles
+// both:
+//
+//   - The legacy single-blob shape: one types.RunTrace per line, with
+//     a complete run emitting one line at Finish.
+//   - The streaming event shape (since #270): line-delimited events
+//     with a "kind" discriminator — run_started, turn_record,
+//     tool_call_record, run_finished. The legacy shape is treated as
+//     an implicit run_finished event with no preceding events.
+//
+// For backward compatibility, Reader.Next continues to yield
+// types.RunTrace values; on a streaming-format file it surfaces the
+// trace embedded in the run_finished event and skips the other event
+// kinds. Consumers that want full transcript reassembly use
+// ReadRecording, which walks the stream and returns a
+// *types.RunRecording.
 //
 // Reader is the single-pass streaming entry point. Tail consumes the
 // same scanner shape but polls the underlying file for appended data
@@ -128,6 +138,13 @@ func (r *Reader) resetScanner() {
 
 // Next returns the next RunTrace record in the stream.
 //
+// Both wire shapes are accepted: a legacy single-blob line is decoded
+// as a types.RunTrace directly; a streaming-event line is decoded as
+// an event and yields a *RunTrace only when its kind is run_finished
+// (other event kinds — run_started, turn_record, tool_call_record —
+// are silently skipped so legacy consumers see one RunTrace per
+// completed run regardless of the on-disk format).
+//
 // Malformed JSON lines and lines exceeding MaxLineBytes are skipped
 // with a slog.Debug log; Next continues past them to the next
 // well-formed record. An io.EOF is returned when the stream is
@@ -139,15 +156,21 @@ func (r *Reader) Next() (*types.RunTrace, error) {
 		if len(line) == 0 {
 			continue
 		}
-		var trace types.RunTrace
-		if err := json.Unmarshal(line, &trace); err != nil {
+		trace, ok, err := decodeRunTraceLine(line)
+		if err != nil {
 			r.logger.Debug("trace.Reader: skip malformed line",
 				"err", err.Error(),
 				"bytes", len(line),
 			)
 			continue
 		}
-		return &trace, nil
+		if !ok {
+			// Streaming event with no embedded RunTrace (run_started,
+			// turn_record, tool_call_record). Legacy consumers see
+			// only run_finished records; skip the rest.
+			continue
+		}
+		return trace, nil
 	}
 	if err := r.scanner.Err(); err != nil {
 		// bufio.ErrTooLong is the cap-exceeded signal; surface it as a
@@ -165,6 +188,184 @@ func (r *Reader) Next() (*types.RunTrace, error) {
 		return nil, fmt.Errorf("reading trace file: %w", err)
 	}
 	return nil, io.EOF
+}
+
+// EventKind names a streaming-trace event kind. The values match the
+// discriminator emitted by harness/internal/trace; they are defined
+// here as untyped string constants so this package does not import the
+// harness internal trace package (which depends on types).
+const (
+	eventKindRunStarted     = "run_started"
+	eventKindTurnRecord     = "turn_record"
+	eventKindToolCallRecord = "tool_call_record"
+	eventKindRunFinished    = "run_finished"
+)
+
+// streamedEvent mirrors the on-wire shape of harness/internal/trace.Event
+// at the fields the reader cares about. Re-defining the shape locally
+// avoids an internal-package import while keeping the decoder lean.
+type streamedEvent struct {
+	Kind          string             `json:"kind"`
+	SchemaVersion string             `json:"schemaVersion,omitempty"`
+	RunID         string             `json:"runId,omitempty"`
+	StartedAt     *time.Time         `json:"startedAt,omitempty"`
+	CompletedAt   *time.Time         `json:"completedAt,omitempty"`
+	Config        *types.RunConfig   `json:"config,omitempty"`
+	Turn          int                `json:"turn,omitempty"`
+	ModelInput    *types.ModelInput  `json:"modelInput,omitempty"`
+	ModelOutput   []types.ContentBlock `json:"modelOutput,omitempty"`
+	ToolCalls     []types.ToolCallRecord `json:"toolCalls,omitempty"`
+	ToolCall      *types.ToolCallRecord `json:"toolCall,omitempty"`
+	Trace         *types.RunTrace    `json:"trace,omitempty"`
+}
+
+// kindOnly is used to peek at the discriminator without decoding the
+// rest of the line. A line missing "kind" is the legacy single-blob
+// shape and decodes directly as types.RunTrace.
+type kindOnly struct {
+	Kind string `json:"kind"`
+}
+
+// decodeRunTraceLine decodes a single JSONL line and returns either a
+// RunTrace (legacy shape, or the trace embedded in a run_finished
+// event), nothing (ok=false: a streaming event with no embedded
+// trace), or an error (malformed JSON).
+func decodeRunTraceLine(line []byte) (*types.RunTrace, bool, error) {
+	var probe kindOnly
+	if err := json.Unmarshal(line, &probe); err != nil {
+		return nil, false, err
+	}
+	if probe.Kind == "" {
+		// Legacy single-blob shape.
+		var trace types.RunTrace
+		if err := json.Unmarshal(line, &trace); err != nil {
+			return nil, false, err
+		}
+		return &trace, true, nil
+	}
+	if probe.Kind != eventKindRunFinished {
+		return nil, false, nil
+	}
+	var ev streamedEvent
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return nil, false, err
+	}
+	if ev.Trace == nil {
+		// A run_finished without an embedded trace is malformed but
+		// not fatal — the reader skips it like any other unusable
+		// line.
+		return nil, false, nil
+	}
+	return ev.Trace, true, nil
+}
+
+// ReadRecording walks the stream and reassembles a *types.RunRecording
+// from a streaming-event trace file. A complete recording requires a
+// run_started event (for RunID and Config) plus zero or more
+// turn_record events (for the transcript) plus a run_finished event
+// (for FinalOutcome). An interrupted run with no run_finished event
+// is returned with FinalOutcome zero-valued; the caller can detect
+// this via FinalOutcome.ID == "".
+//
+// A legacy single-blob trace (no kind discriminator) is treated as a
+// recording with no transcript turns: RunID and Config come from the
+// embedded RunTrace, FinalOutcome is the trace itself, and Turns is
+// nil. This lets a single consumer accept both wire shapes without
+// branching on the format.
+//
+// Malformed and oversized lines are skipped with a slog.Debug log per
+// the policy that governs Next. The reader is consumed end-to-end;
+// the caller does not call Next afterwards.
+func (r *Reader) ReadRecording() (*types.RunRecording, error) {
+	recording := &types.RunRecording{}
+	seenStarted := false
+	for r.scanner.Scan() {
+		line := r.scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var probe kindOnly
+		if err := json.Unmarshal(line, &probe); err != nil {
+			r.logger.Debug("trace.Reader: skip malformed line",
+				"err", err.Error(),
+				"bytes", len(line),
+			)
+			continue
+		}
+		if probe.Kind == "" {
+			// Legacy: one RunTrace blob is the entire recording.
+			var trace types.RunTrace
+			if err := json.Unmarshal(line, &trace); err != nil {
+				r.logger.Debug("trace.Reader: skip malformed legacy line",
+					"err", err.Error(),
+					"bytes", len(line),
+				)
+				continue
+			}
+			recording.RunID = trace.ID
+			recording.Config = trace.Config
+			recording.FinalOutcome = trace
+			continue
+		}
+		var ev streamedEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			r.logger.Debug("trace.Reader: skip malformed event",
+				"err", err.Error(),
+				"bytes", len(line),
+			)
+			continue
+		}
+		switch ev.Kind {
+		case eventKindRunStarted:
+			seenStarted = true
+			recording.RunID = ev.RunID
+			if ev.Config != nil {
+				recording.Config = *ev.Config
+			}
+		case eventKindTurnRecord:
+			tr := types.TurnRecord{
+				Turn:        ev.Turn,
+				ModelOutput: ev.ModelOutput,
+				ToolCalls:   ev.ToolCalls,
+			}
+			if ev.ModelInput != nil {
+				tr.ModelInput = *ev.ModelInput
+			}
+			recording.Turns = append(recording.Turns, tr)
+		case eventKindRunFinished:
+			if ev.Trace != nil {
+				recording.FinalOutcome = *ev.Trace
+				if !seenStarted {
+					// No run_started observed (e.g. a legacy stream
+					// that prefixed a single blob with the new wire
+					// shape, or a recording that lost its preamble).
+					// Fall back to fields on the embedded trace.
+					recording.RunID = ev.Trace.ID
+					recording.Config = ev.Trace.Config
+				}
+			}
+		default:
+			// Unknown kind: skip. Forward compatibility — a future
+			// event kind added to the wire must not abort old
+			// readers.
+		}
+	}
+	if err := r.scanner.Err(); err != nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			r.logger.Debug("trace.Reader: skip oversized line",
+				"cap", MaxLineBytes,
+			)
+			r.scanner = bufio.NewScanner(r.src)
+			r.scanner.Buffer(make([]byte, 0, initialScanBuf), MaxLineBytes)
+			// Re-enter the loop to consume any remaining lines past
+			// the oversized one. ReadRecording returns whatever it
+			// accumulated; a single bad line should not lose the
+			// surrounding context.
+			return r.ReadRecording()
+		}
+		return recording, fmt.Errorf("reading trace file: %w", err)
+	}
+	return recording, nil
 }
 
 // All drains the reader into a slice. The slice is empty when the

--- a/types/trace/reader_test.go
+++ b/types/trace/reader_test.go
@@ -241,3 +241,212 @@ func TestTail_HandlerErrorAborts(t *testing.T) {
 		t.Fatalf("Tail err = %v, want %v", err, stop)
 	}
 }
+
+// streamingTrace renders a synthetic streaming-event JSONL file: one
+// run_started, len(turns) turn_records, and one run_finished (when
+// finalOutcome.ID != ""). Used to drive the reader's streaming-format
+// tests without coupling them to harness/internal/trace.
+func streamingTrace(t *testing.T, runID string, config types.RunConfig, turns []types.TurnRecord, finalOutcome types.RunTrace) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	started := map[string]any{
+		"kind":          "run_started",
+		"schemaVersion": "1",
+		"runId":         runID,
+		"startedAt":     time.Now().UTC(),
+		"config":        config,
+	}
+	buf.Write(mustMarshal(t, started))
+	buf.WriteByte('\n')
+	for _, tr := range turns {
+		ev := map[string]any{
+			"kind":        "turn_record",
+			"turn":        tr.Turn,
+			"modelInput":  tr.ModelInput,
+			"modelOutput": tr.ModelOutput,
+			"toolCalls":   tr.ToolCalls,
+		}
+		buf.Write(mustMarshal(t, ev))
+		buf.WriteByte('\n')
+	}
+	if finalOutcome.ID != "" {
+		ev := map[string]any{
+			"kind":        "run_finished",
+			"completedAt": time.Now().UTC(),
+			"trace":       finalOutcome,
+		}
+		buf.Write(mustMarshal(t, ev))
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+// TestReader_StreamingFormat_NextYieldsRunFinishedTrace pins that on
+// the new streaming wire shape, Reader.Next surfaces the trace
+// embedded in the run_finished event and silently skips the
+// run_started / turn_record / tool_call_record events. Legacy
+// consumers (eval runner's parseTraceFile) keep working unchanged.
+func TestReader_StreamingFormat_NextYieldsRunFinishedTrace(t *testing.T) {
+	body := streamingTrace(t,
+		"run-stream",
+		types.RunConfig{RunID: "run-stream", Mode: "execution"},
+		[]types.TurnRecord{
+			{Turn: 1, ModelOutput: []types.ContentBlock{{Type: "text", Text: "hello"}}},
+		},
+		types.RunTrace{ID: "run-stream", Turns: 1, Outcome: "success"},
+	)
+	r := NewReader(bytes.NewReader(body), WithLogger(discardLogger()))
+	got, err := r.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d traces, want 1", len(got))
+	}
+	if got[0].ID != "run-stream" || got[0].Outcome != "success" {
+		t.Errorf("trace = %+v, want ID=run-stream Outcome=success", got[0])
+	}
+}
+
+// TestReader_LegacyAndStreamingParseEquivalent pins that a legacy
+// single-blob trace and a streaming trace describing the same run
+// surface identical *types.RunTrace values via Reader.Next. This is
+// the backward-compatibility AC of #270.
+func TestReader_LegacyAndStreamingParseEquivalent(t *testing.T) {
+	finalOutcome := types.RunTrace{
+		ID:       "run-shared",
+		Turns:    2,
+		Outcome:  "success",
+		Config:   types.RunConfig{RunID: "run-shared"},
+	}
+
+	legacy := append(mustMarshal(t, finalOutcome), '\n')
+	streaming := streamingTrace(t,
+		"run-shared",
+		types.RunConfig{RunID: "run-shared"},
+		[]types.TurnRecord{
+			{Turn: 1, ModelOutput: []types.ContentBlock{{Type: "text", Text: "first"}}},
+			{Turn: 2, ModelOutput: []types.ContentBlock{{Type: "text", Text: "second"}}},
+		},
+		finalOutcome,
+	)
+
+	rLegacy := NewReader(bytes.NewReader(legacy), WithLogger(discardLogger()))
+	gotLegacy, err := rLegacy.All()
+	if err != nil {
+		t.Fatalf("legacy All: %v", err)
+	}
+	rStreaming := NewReader(bytes.NewReader(streaming), WithLogger(discardLogger()))
+	gotStreaming, err := rStreaming.All()
+	if err != nil {
+		t.Fatalf("streaming All: %v", err)
+	}
+	if len(gotLegacy) != 1 || len(gotStreaming) != 1 {
+		t.Fatalf("len: legacy=%d streaming=%d, want 1/1", len(gotLegacy), len(gotStreaming))
+	}
+	if gotLegacy[0].ID != gotStreaming[0].ID {
+		t.Errorf("ID differs: legacy=%q streaming=%q", gotLegacy[0].ID, gotStreaming[0].ID)
+	}
+	if gotLegacy[0].Outcome != gotStreaming[0].Outcome {
+		t.Errorf("Outcome differs: legacy=%q streaming=%q", gotLegacy[0].Outcome, gotStreaming[0].Outcome)
+	}
+	if gotLegacy[0].Turns != gotStreaming[0].Turns {
+		t.Errorf("Turns differs: legacy=%d streaming=%d", gotLegacy[0].Turns, gotStreaming[0].Turns)
+	}
+}
+
+// TestReadRecording_StreamingFormat pins that ReadRecording walks
+// run_started + turn_record* + run_finished and returns a complete
+// *types.RunRecording with transcripts in order.
+func TestReadRecording_StreamingFormat(t *testing.T) {
+	turns := []types.TurnRecord{
+		{
+			Turn: 1,
+			ModelInput: types.ModelInput{Model: "claude-3-5"},
+			ModelOutput: []types.ContentBlock{{Type: "text", Text: "first"}},
+		},
+		{
+			Turn: 2,
+			ModelOutput: []types.ContentBlock{{Type: "text", Text: "second"}},
+		},
+	}
+	body := streamingTrace(t,
+		"run-rec",
+		types.RunConfig{RunID: "run-rec", Mode: "execution"},
+		turns,
+		types.RunTrace{ID: "run-rec", Turns: 2, Outcome: "success"},
+	)
+
+	r := NewReader(bytes.NewReader(body), WithLogger(discardLogger()))
+	rec, err := r.ReadRecording()
+	if err != nil {
+		t.Fatalf("ReadRecording: %v", err)
+	}
+	if rec.RunID != "run-rec" {
+		t.Errorf("RunID: got %q, want run-rec", rec.RunID)
+	}
+	if rec.Config.Mode != "execution" {
+		t.Errorf("Config.Mode: got %q, want execution", rec.Config.Mode)
+	}
+	if len(rec.Turns) != 2 {
+		t.Fatalf("Turns: got %d, want 2", len(rec.Turns))
+	}
+	if rec.Turns[0].Turn != 1 || rec.Turns[1].Turn != 2 {
+		t.Errorf("turn order: got %d, %d, want 1, 2", rec.Turns[0].Turn, rec.Turns[1].Turn)
+	}
+	if rec.FinalOutcome.Outcome != "success" {
+		t.Errorf("FinalOutcome.Outcome: got %q, want success", rec.FinalOutcome.Outcome)
+	}
+}
+
+// TestReadRecording_PartialStream pins that a stream interrupted
+// before run_finished still reassembles a recording with whatever
+// turns it observed; FinalOutcome.ID stays empty so callers can
+// detect the truncation.
+func TestReadRecording_PartialStream(t *testing.T) {
+	body := streamingTrace(t,
+		"run-partial",
+		types.RunConfig{RunID: "run-partial"},
+		[]types.TurnRecord{
+			{Turn: 1, ModelOutput: []types.ContentBlock{{Type: "text", Text: "only"}}},
+		},
+		types.RunTrace{}, // no final outcome — streamingTrace skips emit
+	)
+	r := NewReader(bytes.NewReader(body), WithLogger(discardLogger()))
+	rec, err := r.ReadRecording()
+	if err != nil {
+		t.Fatalf("ReadRecording: %v", err)
+	}
+	if rec.RunID != "run-partial" {
+		t.Errorf("RunID: got %q, want run-partial", rec.RunID)
+	}
+	if len(rec.Turns) != 1 {
+		t.Errorf("Turns: got %d, want 1", len(rec.Turns))
+	}
+	if rec.FinalOutcome.ID != "" {
+		t.Errorf("FinalOutcome.ID: got %q, want \"\" (truncated stream)", rec.FinalOutcome.ID)
+	}
+}
+
+// TestReadRecording_LegacyFormat pins that a legacy single-blob trace
+// is surfaced through ReadRecording with the embedded RunTrace as
+// FinalOutcome and Turns nil. This lets a single consumer accept
+// both wire shapes.
+func TestReadRecording_LegacyFormat(t *testing.T) {
+	finalOutcome := types.RunTrace{ID: "run-legacy", Turns: 3, Outcome: "success"}
+	body := append(mustMarshal(t, finalOutcome), '\n')
+	r := NewReader(bytes.NewReader(body), WithLogger(discardLogger()))
+	rec, err := r.ReadRecording()
+	if err != nil {
+		t.Fatalf("ReadRecording: %v", err)
+	}
+	if rec.RunID != "run-legacy" {
+		t.Errorf("RunID: got %q, want run-legacy", rec.RunID)
+	}
+	if len(rec.Turns) != 0 {
+		t.Errorf("Turns: got %d, want 0 (legacy has no transcript)", len(rec.Turns))
+	}
+	if rec.FinalOutcome.ID != "run-legacy" {
+		t.Errorf("FinalOutcome.ID: got %q, want run-legacy", rec.FinalOutcome.ID)
+	}
+}

--- a/types/trace/reader_test.go
+++ b/types/trace/reader_test.go
@@ -314,10 +314,10 @@ func TestReader_StreamingFormat_NextYieldsRunFinishedTrace(t *testing.T) {
 // the backward-compatibility AC of #270.
 func TestReader_LegacyAndStreamingParseEquivalent(t *testing.T) {
 	finalOutcome := types.RunTrace{
-		ID:       "run-shared",
-		Turns:    2,
-		Outcome:  "success",
-		Config:   types.RunConfig{RunID: "run-shared"},
+		ID:      "run-shared",
+		Turns:   2,
+		Outcome: "success",
+		Config:  types.RunConfig{RunID: "run-shared"},
 	}
 
 	legacy := append(mustMarshal(t, finalOutcome), '\n')
@@ -361,12 +361,12 @@ func TestReader_LegacyAndStreamingParseEquivalent(t *testing.T) {
 func TestReadRecording_StreamingFormat(t *testing.T) {
 	turns := []types.TurnRecord{
 		{
-			Turn: 1,
-			ModelInput: types.ModelInput{Model: "claude-3-5"},
+			Turn:        1,
+			ModelInput:  types.ModelInput{Model: "claude-3-5"},
 			ModelOutput: []types.ContentBlock{{Type: "text", Text: "first"}},
 		},
 		{
-			Turn: 2,
+			Turn:        2,
 			ModelOutput: []types.ContentBlock{{Type: "text", Text: "second"}},
 		},
 	}


### PR DESCRIPTION
## Summary

Replaces the buffered single-blob JSONL trace emitter with a streaming, event-typed line-delimited JSON writer. Each agentic-loop turn now lands a `turn_record` on disk the moment it completes, carrying the full `ModelInput.Messages`, the model's `ModelOutput`, and every tool call's raw input/output. A `SIGKILL`'d run leaves a parseable JSONL file up to the last completed event.

Defence-in-depth scrubbing (`harness/internal/security.Scrub`) runs over all transcript text and raw tool I/O before any line is written, giving recordings a second independent redaction layer on top of the existing `RunConfig.Redact()` posture.

`types/trace.Reader` transparently accepts both the legacy single-blob shape (one `RunTrace` per line) and the new streaming shape; `Reader.Next` still yields one `*RunTrace` per completed run so the eval runner's `parseTraceFile` keeps working unchanged. A new `Reader.ReadRecording` walks the stream and reassembles a `*types.RunRecording` for replay / mine-failures.

Closes #270.
Part of #277.

## Commits

- `trace: stream typed events from JSONLTraceEmitter` — interface + emitter
- `trace: reader handles streaming events and reassembles RunRecording` — read path
- `core: wire full-turn transcripts through TraceEmitter` — loop / dispatch wiring
- `docs: describe streamed-events JSONL trace shape` — `eval.md` + `trace-inspection.md`

## Test plan

- [x] `just` passes (build + tests, 36 packages)
- [x] `just lint` passes (golangci-lint v2 clean)
- [x] New tests pin: full lifecycle, session-name round trip, scrubbing, partial-stream (SIGKILL), legacy/streaming equivalence, recording reassembly (streaming + partial + legacy), forward compatibility for unknown event kinds
- [ ] Operator smoke: run a real harness session with `--trace tmp/x.jsonl`, confirm a) at least one `turn_record` event per turn, b) the file is parseable by `stirrup trace show` mid-run, c) `Reader.ReadRecording` reassembles the run
- [ ] Performance: no measurable wall-time regression on existing eval suites (~50 extra one-line writes per 10-turn run; well under measurement noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)