### PR TITLE
lakehouse: wire TraceFilter.Provider

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -381,10 +381,12 @@ the `eval-gate` CI job uses.
 ```
 
 Reads aggregate metrics (`types.TraceMetrics`) from a lakehouse,
-optionally filtered by time range, mode, and model. Writes JSON to
-`--output` if set and prints a summary (count, pass rate, mean
-turns, p50/p95 duration) to stdout. Use this to seed an experiment
-baseline from real production data instead of static fixtures.
+optionally filtered by time range, `--mode`, `--model`, and
+`--provider` (e.g. `anthropic`, `openai-responses`, `gemini`).
+Writes JSON to `--output` if set and prints a summary (count, pass
+rate, mean turns, p50/p95 duration) to stdout. Use this to seed an
+experiment baseline from real production data instead of static
+fixtures.
 
 ### `mine-failures` — turn production failures into tasks
 

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -331,6 +331,7 @@ func cmdBaseline(args []string) {
 	beforeStr := fs.String("before", "", "Filter traces before this date (RFC3339 or YYYY-MM-DD)")
 	mode := fs.String("mode", "", "Filter by run mode")
 	model := fs.String("model", "", "Filter by model name")
+	provider := fs.String("provider", "", "Filter by provider name (e.g. anthropic, openai-responses, gemini)")
 	output := fs.String("output", "", "Write TraceMetrics JSON to this file")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
@@ -347,8 +348,9 @@ func cmdBaseline(args []string) {
 	defer func() { _ = store.Close() }()
 
 	filter := types.TraceFilter{
-		Mode:  *mode,
-		Model: *model,
+		Mode:     *mode,
+		Model:    *model,
+		Provider: *provider,
 	}
 	if *afterStr != "" {
 		t, err := parseDate(*afterStr)
@@ -516,6 +518,7 @@ func cmdDrift(args []string) {
 	compareWindowStr := fs.String("compare-window", "", "Baseline window duration (defaults to -window)")
 	mode := fs.String("mode", "", "Filter by run mode")
 	model := fs.String("model", "", "Filter by model name")
+	provider := fs.String("provider", "", "Filter by provider name (e.g. anthropic, openai-responses, gemini)")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
@@ -551,17 +554,19 @@ func cmdDrift(args []string) {
 	baselineStart := currentStart.Add(-compareWindow)
 
 	currentFilter := types.TraceFilter{
-		After:  &currentStart,
-		Before: &now,
-		Mode:   *mode,
-		Model:  *model,
+		After:    &currentStart,
+		Before:   &now,
+		Mode:     *mode,
+		Model:    *model,
+		Provider: *provider,
 	}
 	baselineEnd := currentStart
 	baselineFilter := types.TraceFilter{
-		After:  &baselineStart,
-		Before: &baselineEnd,
-		Mode:   *mode,
-		Model:  *model,
+		After:    &baselineStart,
+		Before:   &baselineEnd,
+		Mode:     *mode,
+		Model:    *model,
+		Provider: *provider,
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -710,6 +715,7 @@ func cmdCompareToProduction(args []string) {
 	beforeStr := fs.String("before", "", "Filter production traces before this date (RFC3339 or YYYY-MM-DD)")
 	mode := fs.String("mode", "", "Filter by run mode")
 	model := fs.String("model", "", "Filter by model name")
+	provider := fs.String("provider", "", "Filter by provider name (e.g. anthropic, openai-responses, gemini)")
 	outputPath := fs.String("output", "", "Output path for report JSON")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
@@ -734,8 +740,9 @@ func cmdCompareToProduction(args []string) {
 	defer func() { _ = store.Close() }()
 
 	filter := types.TraceFilter{
-		Mode:  *mode,
-		Model: *model,
+		Mode:     *mode,
+		Model:    *model,
+		Provider: *provider,
 	}
 	if *afterStr != "" {
 		t, err := parseDate(*afterStr)

--- a/eval/lakehouse/filestore.go
+++ b/eval/lakehouse/filestore.go
@@ -206,6 +206,14 @@ func (fs *FileStore) readJSON(path string, v any) error {
 }
 
 // matchesTraceFilter returns true if the trace satisfies all non-zero filter fields.
+//
+// TraceFilter.Provider is matched against RunTrace.Config.Provider.Type
+// — the provider implementation selector (e.g. "anthropic", "openai-
+// responses", "gemini") set when the run was launched. Sub-agent runs
+// and model-router runs that switch providers mid-execution carry
+// their parent's Provider.Type at the top level; provider routing
+// changes per-turn live on individual TurnTraces, which this filter
+// does not consult.
 func matchesTraceFilter(trace types.RunTrace, f types.TraceFilter) bool {
 	if f.After != nil && !trace.StartedAt.After(*f.After) {
 		return false
@@ -220,6 +228,9 @@ func matchesTraceFilter(trace types.RunTrace, f types.TraceFilter) bool {
 		return false
 	}
 	if f.Model != "" && trace.Config.ModelRouter.Model != f.Model {
+		return false
+	}
+	if f.Provider != "" && trace.Config.Provider.Type != f.Provider {
 		return false
 	}
 	return true

--- a/eval/lakehouse/filestore_test.go
+++ b/eval/lakehouse/filestore_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -257,6 +258,71 @@ func TestQueryTraces_FilterModel(t *testing.T) {
 	}
 	if results[0].ID != "t4" {
 		t.Fatalf("expected t4, got %s", results[0].ID)
+	}
+}
+
+// TestQueryTraces_FilterProvider pins that TraceFilter.Provider is
+// honoured by the FileStore. The field was inert before #142 (the
+// filter type had a Provider slot but matchesTraceFilter never
+// consulted it); a regression would silently let through traces from
+// the wrong provider and quietly skew --sample-by provider in #274.
+func TestQueryTraces_FilterProvider(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	ctx := context.Background()
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		id       string
+		provider string
+		model    string
+	}{
+		{"p1", "anthropic", "claude-sonnet-4-6"},
+		{"p2", "anthropic", "claude-haiku-3"},
+		{"p3", "openai-responses", "gpt-4o"},
+		{"p4", "gemini", "gemini-2.5-pro"},
+	} {
+		tr := makeTrace(tc.id, "success", "execution", tc.model, base, 1000, 1, types.TokenUsage{Input: 10, Output: 20})
+		tr.Config.Provider.Type = tc.provider
+		if err := fs.StoreTrace(ctx, tr); err != nil {
+			t.Fatalf("StoreTrace %s: %v", tc.id, err)
+		}
+	}
+
+	cases := []struct {
+		provider string
+		wantIDs  []string
+	}{
+		{"anthropic", []string{"p1", "p2"}},
+		{"openai-responses", []string{"p3"}},
+		{"gemini", []string{"p4"}},
+		{"bedrock", nil},
+	}
+	for _, tc := range cases {
+		got, err := fs.QueryTraces(ctx, types.TraceFilter{Provider: tc.provider})
+		if err != nil {
+			t.Fatalf("QueryTraces %q: %v", tc.provider, err)
+		}
+		gotIDs := make([]string, len(got))
+		for i, tr := range got {
+			gotIDs[i] = tr.ID
+		}
+		sort.Strings(gotIDs)
+		want := append([]string{}, tc.wantIDs...)
+		sort.Strings(want)
+		if len(gotIDs) != len(want) {
+			t.Errorf("provider=%q: got %v, want %v", tc.provider, gotIDs, want)
+			continue
+		}
+		for i := range gotIDs {
+			if gotIDs[i] != want[i] {
+				t.Errorf("provider=%q: got %v, want %v", tc.provider, gotIDs, want)
+				break
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Wires the previously-inert `TraceFilter.Provider` field end-to-end. `matchesTraceFilter` now checks `RunTrace.Config.Provider.Type` against the filter; `baseline`, `drift`, and `compare-to-production` accept a `--provider` flag. `mine-failures` is intentionally left for the broader rewrite in #274.

Closes #142.
Part of #277.
Stacked on #279.

## Test plan

- [x] `just` passes (build + tests)
- [x] `just lint` passes (golangci-lint clean)
- [x] New `TestQueryTraces_FilterProvider` covers anthropic / openai-responses / gemini / unmatched-bedrock
- [x] Existing FileStore tests still pass — the new filter check is gated on a non-empty field

🤖 Generated with [Claude Code](https://claude.com/claude-code)