### PR TITLE
trace: outcome taxonomy v2

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -314,6 +314,40 @@ The lakehouse is what `baseline`, `mine-failures`, `drift`, and
 range, outcome, mode, and model, and computes aggregate metrics
 including p50/p95 duration percentiles.
 
+### Outcome taxonomy
+
+`RunTrace.Outcome` records *why the loop stopped*: `success`,
+`error`, `max_turns`, `verification_failed`, `verification_error`,
+`budget_exceeded`, `stalled`, `tool_failures`, `cancelled`,
+`timeout`, `max_tokens`. By itself it conflates two very different
+states in execution mode: "the harness made the correct change"
+vs. "the loop exited cleanly with zero useful changes." Metrics
+derived from `Outcome == "success"` therefore lie about quality.
+
+`types.EvalOutcome` (`types/evaloutcome.go`) collapses
+`(Outcome, VerificationResults)` onto three buckets:
+
+| Termination outcome                                                                       | Verifier ran? | Verdict   | `EvalOutcome` |
+|-------------------------------------------------------------------------------------------|---------------|-----------|---------------|
+| `success`                                                                                 | yes           | all pass  | `passed`      |
+| `success`                                                                                 | yes           | any fail  | `failed`      |
+| `success`                                                                                 | no            | n/a       | `passed` *    |
+| `verification_failed`, `error`, `tool_failures`                                           | any           | any       | `failed`      |
+| `max_turns`, `budget_exceeded`, `timeout`, `max_tokens`, `stalled`, `cancelled`, `verification_error` | any | any | `inconclusive` |
+| anything else (unknown / empty)                                                           | any           | any       | `inconclusive` |
+
+\* The success-without-verifier branch is trusted as `passed` for
+v0.1 to keep existing baselines stable. Operators who want stricter
+fidelity should wire a verifier (even a cheap smoke-test command);
+a future opt-in `evalOutcomeQuality: verified | unverified` label
+is tracked in #273.
+
+`baseline` and `drift` report `passRate`, `failRate`, and
+`inconclusiveRate` — the three rates sum to 1.0 by construction.
+`mine-failures` defaults to mining only `EvalOutcome == failed`;
+pass `--include-inconclusive` to also mine limit-hit and interrupted
+runs.
+
 ---
 
 ## Subcommands

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -393,6 +393,7 @@ func cmdMineFailures(args []string) {
 	limit := fs.Int("limit", 0, "Maximum number of failures to mine")
 	output := fs.String("output", "", "Write EvalSuite HCL to this file (.hcl recommended)")
 	includeBatch := fs.Bool("include-batch", false, "By default, batch runs (provider.batch.enabled=true) are excluded from mined failures because their wall-clock duration inflates apparent stall metrics. Pass --include-batch to include them.")
+	includeInconclusive := fs.Bool("include-inconclusive", false, "By default, only EvalOutcome==failed traces are mined. Inconclusive runs (max_turns / budget_exceeded / timeout / max_tokens / stalled / cancelled / verification_error) are typically investigated manually rather than codified as regressions; pass --include-inconclusive to include them anyway.")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
@@ -424,7 +425,7 @@ func cmdMineFailures(args []string) {
 		log.Fatalf("querying recordings: %v", err)
 	}
 
-	tasks := mineFailureTasksFiltered(recordings, *limit, *includeBatch)
+	tasks := mineFailureTasksFiltered(recordings, *limit, *includeBatch, *includeInconclusive)
 
 	suite := types.EvalSuite{
 		ID:          fmt.Sprintf("mined-failures-%d", time.Now().Unix()),
@@ -588,19 +589,36 @@ func cmdDrift(args []string) {
 	}
 }
 
-// mineFailureTasksFiltered filters recordings for non-success outcomes
+// mineFailureTasksFiltered filters recordings for non-passing outcomes
 // and converts them into EvalTasks with a default test-command judge.
+//
+// As of #273 the filter is `EvalOutcomeFor(rec.FinalOutcome) ==
+// EvalFailed` by default, replacing the previous `Outcome !=
+// "success"` predicate. Failed and inconclusive are distinct
+// categories: failed means the harness produced a wrong-direction
+// result; inconclusive means the harness ran out of room or was
+// interrupted. The latter is typically investigated manually rather
+// than codified as a regression, so it is excluded by default.
+// Pass includeInconclusive=true to mine both.
+//
 // When includeBatch is false (the documented default), recordings
 // whose RunConfig opted into batch provider submission are skipped:
 // their wall-clock duration is dominated by provider-side queue time,
 // not the harness's stall pattern, so including them inflates apparent
 // stall metrics and obscures the prompt patterns mine-failures is here
 // to surface (#138).
-func mineFailureTasksFiltered(recordings []types.RunRecording, limit int, includeBatch bool) []types.EvalTask {
+func mineFailureTasksFiltered(recordings []types.RunRecording, limit int, includeBatch bool, includeInconclusive bool) []types.EvalTask {
 	var tasks []types.EvalTask
 	for _, rec := range recordings {
-		if rec.FinalOutcome.Outcome == "success" {
+		switch types.EvalOutcomeFor(rec.FinalOutcome) {
+		case types.EvalPassed:
 			continue
+		case types.EvalInconclusive:
+			if !includeInconclusive {
+				continue
+			}
+		case types.EvalFailed:
+			// keep
 		}
 		if !includeBatch && isBatchRecording(rec) {
 			continue

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -417,7 +417,13 @@ func TestParseDuration_BadDays(t *testing.T) {
 
 // --- mineFailureTasks tests ---
 
-func TestMineFailureTasks_FiltersNonSuccess(t *testing.T) {
+// TestMineFailureTasks_FiltersByEvalOutcome pins #273's mining filter:
+// by default only EvalOutcome==failed traces are mined; success traces
+// are excluded as before, and inconclusive traces (max_turns,
+// budget_exceeded, timeout, max_tokens, stalled, cancelled,
+// verification_error) are excluded too unless includeInconclusive is
+// set. The old "anything not success" semantics is gone.
+func TestMineFailureTasks_FiltersByEvalOutcome(t *testing.T) {
 	recordings := []types.RunRecording{
 		{
 			RunID:  "r1",
@@ -453,16 +459,13 @@ func TestMineFailureTasks_FiltersNonSuccess(t *testing.T) {
 		},
 	}
 
-	tasks := mineFailureTasksFiltered(recordings, 0, false)
-	if len(tasks) != 2 {
-		t.Fatalf("got %d tasks, want 2", len(tasks))
+	// Default: only the EvalFailed trace is mined.
+	tasks := mineFailureTasksFiltered(recordings, 0, false, false)
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1 (default mines only failed)", len(tasks))
 	}
-
 	if tasks[0].Prompt != "fix bug B" {
 		t.Errorf("task[0].Prompt = %q, want %q", tasks[0].Prompt, "fix bug B")
-	}
-	if tasks[0].Mode != "execution" {
-		t.Errorf("task[0].Mode = %q, want %q", tasks[0].Mode, "execution")
 	}
 	if tasks[0].Judge.Type != "test-command" {
 		t.Errorf("task[0].Judge.Type = %q, want %q", tasks[0].Judge.Type, "test-command")
@@ -471,11 +474,41 @@ func TestMineFailureTasks_FiltersNonSuccess(t *testing.T) {
 		t.Errorf("task[0].Judge.Command = %q, want %q", tasks[0].Judge.Command, "go test ./...")
 	}
 
-	if tasks[1].Prompt != "fix bug C" {
-		t.Errorf("task[1].Prompt = %q, want %q", tasks[1].Prompt, "fix bug C")
+	// With --include-inconclusive: max_turns is also mined.
+	tasksWithInconclusive := mineFailureTasksFiltered(recordings, 0, false, true)
+	if len(tasksWithInconclusive) != 2 {
+		t.Fatalf("got %d tasks, want 2 (failed + inconclusive)", len(tasksWithInconclusive))
 	}
-	if tasks[1].Mode != "planning" {
-		t.Errorf("task[1].Mode = %q, want %q", tasks[1].Mode, "planning")
+	if tasksWithInconclusive[1].Prompt != "fix bug C" {
+		t.Errorf("task[1].Prompt = %q, want %q", tasksWithInconclusive[1].Prompt, "fix bug C")
+	}
+}
+
+// TestMineFailureTasks_SuccessWithFailingVerifierMined pins that a
+// run that terminated with Outcome=="success" but where the verifier
+// disagreed is classified EvalFailed and therefore mined by default.
+// The old `Outcome != "success"` filter would have excluded these,
+// silently dropping a genuine quality failure.
+func TestMineFailureTasks_SuccessWithFailingVerifierMined(t *testing.T) {
+	recordings := []types.RunRecording{
+		{
+			RunID:  "r1",
+			Config: types.RunConfig{Prompt: "fix bug A", Mode: "execution"},
+			FinalOutcome: types.RunTrace{
+				ID:      "r1",
+				Outcome: "success",
+				VerificationResults: []types.VerificationResult{
+					{Passed: false, Feedback: "build failed"},
+				},
+			},
+		},
+	}
+	tasks := mineFailureTasksFiltered(recordings, 0, false, false)
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1 (success+failed-verifier is EvalFailed)", len(tasks))
+	}
+	if tasks[0].Prompt != "fix bug A" {
+		t.Errorf("task[0].Prompt = %q, want %q", tasks[0].Prompt, "fix bug A")
 	}
 }
 
@@ -486,7 +519,7 @@ func TestMineFailureTasks_RespectsLimit(t *testing.T) {
 		{RunID: "r3", Config: types.RunConfig{Prompt: "c"}, FinalOutcome: types.RunTrace{Outcome: "error"}},
 	}
 
-	tasks := mineFailureTasksFiltered(recordings, 2, false)
+	tasks := mineFailureTasksFiltered(recordings, 2, false, false)
 	if len(tasks) != 2 {
 		t.Fatalf("got %d tasks, want 2", len(tasks))
 	}
@@ -497,7 +530,7 @@ func TestMineFailureTasks_NoFailures(t *testing.T) {
 		{RunID: "r1", Config: types.RunConfig{Prompt: "a"}, FinalOutcome: types.RunTrace{Outcome: "success"}},
 	}
 
-	tasks := mineFailureTasksFiltered(recordings, 0, false)
+	tasks := mineFailureTasksFiltered(recordings, 0, false, false)
 	if len(tasks) != 0 {
 		t.Fatalf("got %d tasks, want 0", len(tasks))
 	}
@@ -537,7 +570,7 @@ func TestMineFailureTasksFiltered_ExcludesBatchByDefault(t *testing.T) {
 		makeBatchRecording("batch-fail", "error", "batch failure"),
 	}
 
-	tasks := mineFailureTasksFiltered(recordings, 0, false)
+	tasks := mineFailureTasksFiltered(recordings, 0, false, false)
 	if len(tasks) != 1 {
 		t.Fatalf("got %d tasks, want 1 (batch failure must be excluded)", len(tasks))
 	}
@@ -560,7 +593,7 @@ func TestMineFailureTasksFiltered_IncludesBatchWhenRequested(t *testing.T) {
 		makeBatchRecording("batch-fail", "error", "batch failure"),
 	}
 
-	tasks := mineFailureTasksFiltered(recordings, 0, true)
+	tasks := mineFailureTasksFiltered(recordings, 0, true, false)
 	if len(tasks) != 2 {
 		t.Fatalf("got %d tasks, want 2 (both failures included)", len(tasks))
 	}

--- a/eval/lakehouse/filestore.go
+++ b/eval/lakehouse/filestore.go
@@ -252,16 +252,28 @@ func computeMetrics(traces []types.RunTrace) types.TraceMetrics {
 	}
 
 	var (
-		passCount    int
-		totalTurns   int
-		totalTokens  int
-		streamingDur []float64
-		batchDur     []float64
+		passCount         int
+		failCount         int
+		inconclusiveCount int
+		totalTurns        int
+		totalTokens       int
+		streamingDur      []float64
+		batchDur          []float64
 	)
 
 	for _, t := range traces {
-		if t.Outcome == "success" {
+		// Pass / fail / inconclusive is derived consumer-side per
+		// types.EvalOutcomeFor (#273). PassRate is now a quality
+		// signal: a success that the verifier disagreed with does NOT
+		// count as a pass, and limit-hit terminations are bucketed
+		// inconclusive rather than silently boosting the failure rate.
+		switch types.EvalOutcomeFor(t) {
+		case types.EvalPassed:
 			passCount++
+		case types.EvalFailed:
+			failCount++
+		case types.EvalInconclusive:
+			inconclusiveCount++
 		}
 		totalTurns += t.Turns
 		totalTokens += t.TokenUsage.Input + t.TokenUsage.Output
@@ -285,6 +297,8 @@ func computeMetrics(traces []types.RunTrace) types.TraceMetrics {
 	return types.TraceMetrics{
 		Count:            n,
 		PassRate:         float64(passCount) / float64(n),
+		FailRate:         float64(failCount) / float64(n),
+		InconclusiveRate: float64(inconclusiveCount) / float64(n),
 		MeanTurns:        float64(totalTurns) / float64(n),
 		MeanTokens:       float64(totalTokens) / float64(n),
 		P50Duration:      percentile(streamingDur, 0.50),

--- a/types/evaloutcome.go
+++ b/types/evaloutcome.go
@@ -1,0 +1,109 @@
+package types
+
+// EvalOutcome describes the *quality* of a harness run, derived
+// consumer-side from RunTrace.Outcome (the loop's stop reason) and
+// RunTrace.VerificationResults (the verifier's verdict).
+//
+// RunTrace.Outcome tells you *why the loop stopped* — `success`,
+// `error`, `max_turns`, `verification_failed`, and so on. By itself it
+// conflates two very different states in execution mode: "the harness
+// made the correct change" vs. "the loop exited cleanly with zero
+// useful changes." Every metric derived from `Outcome == "success"`
+// therefore lies about quality.
+//
+// EvalOutcome collapses the (Outcome, VerificationResults) pair onto
+// passed / failed / inconclusive so eval aggregates and mining
+// decisions can rest on a falsifiable signal. The derivation rules
+// live in EvalOutcomeFor.
+//
+// The type is consumer-side: traces continue to store the loop's
+// Outcome verbatim; EvalOutcome is computed on read at aggregation
+// time. No proto change, no wire shape mutation, no historical
+// trace re-write. Backward compatibility for existing baselines is
+// preserved by trusting Outcome=="success" without a verifier as
+// passed; the trade-off and a future `evalOutcomeQuality` label
+// are tracked in #273.
+type EvalOutcome string
+
+const (
+	// EvalPassed indicates the run completed successfully and any
+	// verifier that ran agreed. Without a verifier, EvalPassed is
+	// inherited from RunTrace.Outcome=="success" verbatim per the
+	// v0.1 backward-compatibility decision (#273).
+	EvalPassed EvalOutcome = "passed"
+
+	// EvalFailed indicates the run produced a wrong-direction result.
+	// Either the loop terminated in an error class (`error`,
+	// `tool_failures`, `verification_failed`) or it ran to `success`
+	// but a verifier disagreed.
+	EvalFailed EvalOutcome = "failed"
+
+	// EvalInconclusive indicates the run terminated without enough
+	// signal to call it. Limit-hit terminations (`max_turns`,
+	// `budget_exceeded`, `timeout`, `max_tokens`, `stalled`) and
+	// non-result terminations (`cancelled`, `verification_error`) all
+	// produce inconclusive: the harness ran out of room or was
+	// interrupted, so the run is neither a quality win nor a quality
+	// loss.
+	EvalInconclusive EvalOutcome = "inconclusive"
+)
+
+// EvalOutcomeFor maps a RunTrace's termination outcome and verifier
+// verdict onto an EvalOutcome. The full table:
+//
+//	Outcome              | Verifier ran? | Verdict   | EvalOutcome
+//	---------------------|---------------|-----------|---------------
+//	success              | yes           | all pass  | passed
+//	success              | yes           | any fail  | failed
+//	success              | no            | n/a       | passed (compat)
+//	verification_failed  | yes (impl.)   | failed    | failed
+//	error                | any           | any       | failed
+//	tool_failures        | any           | any       | failed
+//	max_turns            | any           | any       | inconclusive
+//	budget_exceeded      | any           | any       | inconclusive
+//	timeout              | any           | any       | inconclusive
+//	max_tokens           | any           | any       | inconclusive
+//	stalled              | any           | any       | inconclusive
+//	cancelled            | any           | any       | inconclusive
+//	verification_error   | any           | any       | inconclusive
+//	(empty / unknown)    | any           | any       | inconclusive
+//
+// The success-without-verifier branch is the load-bearing call here.
+// V0.1 trusts it as passed to preserve existing baselines; the
+// stricter "demote to inconclusive when no verifier ran" alternative
+// is tracked in #273 as a follow-up behind an opt-in
+// `evalOutcomeQuality` label.
+func EvalOutcomeFor(t RunTrace) EvalOutcome {
+	switch t.Outcome {
+	case "success":
+		if verifierFailed(t.VerificationResults) {
+			return EvalFailed
+		}
+		return EvalPassed
+	case "verification_failed", "error", "tool_failures":
+		return EvalFailed
+	case "max_turns", "budget_exceeded", "timeout", "max_tokens", "stalled",
+		"cancelled", "verification_error":
+		return EvalInconclusive
+	default:
+		// Unknown / empty outcomes default to inconclusive so a future
+		// outcome added upstream cannot silently land in the wrong
+		// bucket. The default is conservative: an unknown outcome must
+		// not be treated as a quality pass.
+		return EvalInconclusive
+	}
+}
+
+// verifierFailed reports whether any verifier in the result set
+// returned Passed=false. A nil or empty slice means "no verifier
+// ran" and returns false — i.e. EvalOutcomeFor falls back to the
+// success-without-verifier branch. The compact name keeps the
+// switch arm above readable.
+func verifierFailed(results []VerificationResult) bool {
+	for _, r := range results {
+		if !r.Passed {
+			return true
+		}
+	}
+	return false
+}

--- a/types/evaloutcome_test.go
+++ b/types/evaloutcome_test.go
@@ -1,0 +1,87 @@
+package types
+
+import "testing"
+
+// TestEvalOutcomeFor walks every row of the derivation table in the
+// EvalOutcomeFor docstring. A failing row indicates a regression in
+// the (Outcome, VerificationResults) → EvalOutcome mapping.
+func TestEvalOutcomeFor(t *testing.T) {
+	cases := []struct {
+		name  string
+		trace RunTrace
+		want  EvalOutcome
+	}{
+		{
+			name:  "success without verifier",
+			trace: RunTrace{Outcome: "success"},
+			want:  EvalPassed,
+		},
+		{
+			name: "success with passing verifier",
+			trace: RunTrace{
+				Outcome: "success",
+				VerificationResults: []VerificationResult{
+					{Passed: true},
+				},
+			},
+			want: EvalPassed,
+		},
+		{
+			name: "success with multiple passing verifiers",
+			trace: RunTrace{
+				Outcome: "success",
+				VerificationResults: []VerificationResult{
+					{Passed: true},
+					{Passed: true},
+				},
+			},
+			want: EvalPassed,
+		},
+		{
+			name: "success with failing verifier",
+			trace: RunTrace{
+				Outcome: "success",
+				VerificationResults: []VerificationResult{
+					{Passed: false},
+				},
+			},
+			want: EvalFailed,
+		},
+		{
+			name: "success with mixed verifier verdicts",
+			trace: RunTrace{
+				Outcome: "success",
+				VerificationResults: []VerificationResult{
+					{Passed: true},
+					{Passed: false},
+				},
+			},
+			want: EvalFailed,
+		},
+		{name: "verification_failed", trace: RunTrace{Outcome: "verification_failed"}, want: EvalFailed},
+		{name: "error", trace: RunTrace{Outcome: "error"}, want: EvalFailed},
+		{name: "tool_failures", trace: RunTrace{Outcome: "tool_failures"}, want: EvalFailed},
+
+		{name: "max_turns", trace: RunTrace{Outcome: "max_turns"}, want: EvalInconclusive},
+		{name: "budget_exceeded", trace: RunTrace{Outcome: "budget_exceeded"}, want: EvalInconclusive},
+		{name: "timeout", trace: RunTrace{Outcome: "timeout"}, want: EvalInconclusive},
+		{name: "max_tokens", trace: RunTrace{Outcome: "max_tokens"}, want: EvalInconclusive},
+		{name: "stalled", trace: RunTrace{Outcome: "stalled"}, want: EvalInconclusive},
+		{name: "cancelled", trace: RunTrace{Outcome: "cancelled"}, want: EvalInconclusive},
+		{name: "verification_error", trace: RunTrace{Outcome: "verification_error"}, want: EvalInconclusive},
+
+		// Unknown / empty outcomes fall through to inconclusive so a
+		// future outcome class added upstream cannot silently land in
+		// the wrong bucket.
+		{name: "empty outcome", trace: RunTrace{Outcome: ""}, want: EvalInconclusive},
+		{name: "unknown outcome", trace: RunTrace{Outcome: "guardrail_blocked"}, want: EvalInconclusive},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EvalOutcomeFor(tc.trace)
+			if got != tc.want {
+				t.Errorf("EvalOutcomeFor(%+v) = %q, want %q", tc.trace.Outcome, got, tc.want)
+			}
+		})
+	}
+}

--- a/types/metrics.go
+++ b/types/metrics.go
@@ -88,8 +88,24 @@ type DriftDeltas struct {
 // cover batch runs separately for operators tracking batch throughput.
 // Both pairs are zero (not nil) when their bucket has no entries.
 type TraceMetrics struct {
-	Count            int     `json:"count"`
-	PassRate         float64 `json:"passRate"`
+	Count int `json:"count"`
+	// PassRate is the fraction of traces whose derived EvalOutcome is
+	// EvalPassed. As of #273 this is a quality signal, not a
+	// termination signal: a run that terminated with Outcome=="success"
+	// but a verifier disagreed is excluded from the numerator.
+	PassRate float64 `json:"passRate"`
+	// FailRate is the fraction of traces whose derived EvalOutcome is
+	// EvalFailed — termination outcomes `error`, `tool_failures`,
+	// `verification_failed`, plus successes where the verifier
+	// disagreed.
+	FailRate float64 `json:"failRate"`
+	// InconclusiveRate is the fraction of traces whose derived
+	// EvalOutcome is EvalInconclusive — limit-hit terminations
+	// (`max_turns`, `budget_exceeded`, `timeout`, `max_tokens`,
+	// `stalled`) and interrupted terminations (`cancelled`,
+	// `verification_error`). The three rates sum to 1.0 by
+	// construction.
+	InconclusiveRate float64 `json:"inconclusiveRate"`
 	MeanTurns        float64 `json:"meanTurns"`
 	MeanTokens       float64 `json:"meanTokens"`
 	P50Duration      float64 `json:"p50DurationMs"`


### PR DESCRIPTION
## Summary

Introduces `types.EvalOutcome` (`passed` / `failed` / `inconclusive`) derived consumer-side from `(RunTrace.Outcome, RunTrace.VerificationResults)` via `EvalOutcomeFor`. The eval lakehouse and `mine-failures` now bucket on the derived signal rather than the raw termination outcome. `TraceMetrics` gains `FailRate` and `InconclusiveRate`; `mine-failures` defaults to mining only `failed` traces and accepts `--include-inconclusive` to widen.

A success that the verifier disagreed with is now correctly classified `failed` (the previous filter silently dropped it).

Closes #273.
Part of #277.
Stacked on #280.

## Test plan

- [x] `just` passes (build + tests)
- [x] `just lint` passes (golangci-lint clean)
- [x] `TestEvalOutcomeFor` walks every row of the derivation table (15 cases)
- [x] `TestMineFailureTasks_FiltersByEvalOutcome` pins the failed-only-by-default contract and the `--include-inconclusive` opt-in
- [x] `TestMineFailureTasks_SuccessWithFailingVerifierMined` pins the success-with-failing-verifier case the old filter dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)