### PR TITLE
lakehouse: narrow TraceLakehouse to read surface

### DIFF
--- a/eval/lakehouse/filestore.go
+++ b/eval/lakehouse/filestore.go
@@ -1,4 +1,10 @@
-// Package lakehouse provides file-based implementations of the TraceLakehouse interface.
+// Package lakehouse provides a file-based implementation of the read
+// surface of types.TraceLakehouse plus the concrete write methods
+// (StoreTrace, StoreRecording) that stirrup-eval ingest calls
+// directly. The write methods are intentionally NOT part of the
+// TraceLakehouse interface — see #109 for the architectural rationale
+// (production writes flow through the control plane; cloud-backed
+// adapters never implement write).
 package lakehouse
 
 import (
@@ -18,12 +24,24 @@ const (
 	recordingsDir = "recordings"
 )
 
-// FileStore implements types.TraceLakehouse backed by JSON files on disk.
-// Traces are stored in <root>/traces/<id>.json and recordings in
-// <root>/recordings/<runId>.json.
+// FileStore implements the read surface of types.TraceLakehouse
+// (QueryTraces, QueryRecordings, Metrics, Close) backed by JSON
+// files on disk, and additionally exposes the concrete StoreTrace
+// and StoreRecording methods that `stirrup-eval ingest` constructs
+// a *FileStore for. Traces are stored in <root>/traces/<id>.json
+// and recordings in <root>/recordings/<runId>.json.
+//
+// A compile-time assertion below pins that *FileStore satisfies the
+// narrowed types.TraceLakehouse contract; if a method is ever
+// removed from the read surface accidentally, the build fails.
 type FileStore struct {
 	rootDir string
 }
+
+// _ var pins the interface conformance contract. Any change to
+// types.TraceLakehouse that removes a method from *FileStore will
+// break the build here before it can ship.
+var _ types.TraceLakehouse = (*FileStore)(nil)
 
 // NewFileStore creates a FileStore rooted at rootDir, creating the necessary
 // subdirectories if they don't already exist.

--- a/types/lakehouse.go
+++ b/types/lakehouse.go
@@ -2,17 +2,19 @@ package types
 
 import "context"
 
-// TraceLakehouse abstracts storage and querying of production run data.
-// Implementations may back this with files, Postgres JSONB, BigQuery, or
-// any other store — the eval framework consumes it without caring about
-// the backing store.
+// TraceLakehouse is the read surface eval consumers (baseline,
+// mine-failures, drift, compare-to-production, replay) depend on.
+// Implementations may back this with files, BigQuery, ClickHouse, or
+// any other store — the eval framework consumes it without caring
+// about the backing store.
+//
+// As of #109 the write surface (StoreTrace, StoreRecording) is NOT
+// part of this interface. Production writes flow through the control
+// plane; the local OSS path writes via the concrete `*FileStore` type
+// that `stirrup-eval ingest` constructs directly. Cloud-backed
+// adapters never implement the write methods — see the issue body
+// for the architectural rationale.
 type TraceLakehouse interface {
-	// StoreTrace persists a completed RunTrace.
-	StoreTrace(ctx context.Context, trace RunTrace) error
-
-	// StoreRecording persists a full RunRecording.
-	StoreRecording(ctx context.Context, recording RunRecording) error
-
 	// QueryTraces returns traces matching the filter, ordered by StartedAt desc.
 	QueryTraces(ctx context.Context, filter TraceFilter) ([]RunTrace, error)
 


### PR DESCRIPTION
## Summary

`StoreTrace` and `StoreRecording` move off the `TraceLakehouse` interface and live as concrete methods on `*FileStore`. The interface now contains only the read surface that eval consumers depend on (`QueryTraces`, `QueryRecordings`, `Metrics`, `Close`). A compile-time interface-conformance assertion in `filestore.go` pins the contract.

Architectural effect: future cloud-backed adapters are not required to implement write methods; production writes flow through the control plane; the OSS / dev path keeps writing via the concrete `*FileStore`.

Closes #109 (the interface-narrowing half — `HarnessEvent.trace` populate-or-drop is deferred per the issue body).
Part of #277.
Stacked on #282.

## Test plan

- [x] `just` passes
- [x] `just lint` passes
- [x] Compile-time `var _ types.TraceLakehouse = (*FileStore)(nil)` pins the contract
- [x] Existing FileStore tests cover both surfaces (read methods via the interface, write methods on the concrete type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)