### PR TITLE
eval: expose stirrup-eval replay subcommand

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -559,11 +559,39 @@ now). Schedule:
 
 ### Iterating on a judge
 
-`eval/runner/replay.go` re-evaluates recorded runs through judges
-without re-running the harness. This is the fast loop for iterating
-on judge criteria — change the regex or composite logic, replay the
-recording set, see whether outcomes match expectations. Pair with
-`compare` to diff judge changes against a baseline.
+```bash
+./stirrup-eval replay \
+  --lakehouse var/lakehouse \
+  --suite eval/suites/some-suite.hcl \
+  --workspace path/to/preserved-workspace \
+  --outcome failed \
+  --output results/replay.json
+```
+
+`stirrup-eval replay` re-evaluates recorded runs through suite
+judges without re-running the harness or hitting any provider.
+This is the fast loop for iterating on judge criteria — change the
+regex or composite logic, replay the recording set, see whether
+outcomes match expectations. Pair with `compare` to diff judge
+changes against a baseline.
+
+Selection of recordings is either explicit (`--recording <runId>`,
+repeatable) or by outcome filter (`--outcome failed`). Each
+recording is paired with a suite task by position (task `i %
+len(tasks)`) — a sole-task suite applies one judge across every
+selected recording, which is the common authoring pattern.
+
+`--workspace` is the directory the judges evaluate against. A
+recording carries the conversation and tool I/O but not the
+post-run file state, so judges that need file state
+(`file-exists`, `file-contains`, `test-command`) require the
+workspace to be preserved separately — `eval run --output ...`
+retains per-task artifacts that suit this. For content-only
+judges, `--workspace` can be empty.
+
+The harness-replay flavour (replaying through a stirrup binary
+configured with ReplayProvider+ReplayExecutor) is a future
+follow-up; v0.1 is judge-only.
 
 ---
 

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -47,7 +47,9 @@ var evalCompletionSubcommands = []string{
 	"completion",
 	"convert",
 	"drift",
+	"ingest",
 	"mine-failures",
+	"replay",
 	"run",
 }
 
@@ -61,10 +63,12 @@ var evalCompletionSubcommands = []string{
 var evalCompletionFlags = map[string][]string{
 	"run":                   {"suite", "harness", "output", "concurrency", "dry-run", "junit"},
 	"compare":               {"current", "baseline"},
-	"baseline":              {"lakehouse", "after", "before", "mode", "model", "output"},
-	"mine-failures":         {"lakehouse", "after", "limit", "output"},
-	"drift":                 {"lakehouse", "window", "compare-window", "mode", "model"},
-	"compare-to-production": {"lakehouse", "results", "experiment-id", "after", "before", "mode", "model", "output"},
+	"baseline":              {"lakehouse", "after", "before", "mode", "model", "provider", "output"},
+	"mine-failures":         {"lakehouse", "after", "limit", "output", "include-batch", "include-inconclusive"},
+	"drift":                 {"lakehouse", "window", "compare-window", "mode", "model", "provider"},
+	"compare-to-production": {"lakehouse", "results", "experiment-id", "after", "before", "mode", "model", "provider", "output"},
+	"ingest":                {"lakehouse", "trace", "skip-partial"},
+	"replay":                {"lakehouse", "suite", "workspace", "output", "recording", "outcome"},
 	"convert":               {"from", "to-junit"},
 	"completion":            {"bash", "zsh", "fish", "powershell"},
 }

--- a/eval/cmd/eval/completion_test.go
+++ b/eval/cmd/eval/completion_test.go
@@ -154,7 +154,7 @@ func TestEvalCompletionFishScript_QuotesValues(t *testing.T) {
 func TestEvalCompletionFlagMap_TracksDispatcher(t *testing.T) {
 	dispatcherSubs := []string{
 		"run", "compare", "compare-to-production",
-		"baseline", "mine-failures", "drift", "convert",
+		"baseline", "mine-failures", "drift", "ingest", "replay", "convert",
 		"completion",
 	}
 	if len(evalCompletionSubcommands) != len(dispatcherSubs) {

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -41,6 +41,7 @@ Commands:
   mine-failures          Turn production failures into eval tasks
   drift                  Detect metric changes over time windows
   ingest                 Ingest harness JSONL traces into a lakehouse
+  replay                 Re-evaluate recorded runs against suite judges
   convert                Convert a result.json into another format (e.g. JUnit XML)
   completion             Emit a shell completion script (bash|zsh|fish|powershell)
 
@@ -83,6 +84,8 @@ func run(args []string, stdout io.Writer) int {
 		cmdCompareToProduction(args[1:])
 	case "ingest":
 		cmdIngest(args[1:])
+	case "replay":
+		cmdReplay(args[1:])
 	case "convert":
 		cmdConvert(args[1:])
 	case "completion":

--- a/eval/cmd/eval/replay.go
+++ b/eval/cmd/eval/replay.go
@@ -1,0 +1,179 @@
+package main
+
+// stirrup-eval replay re-evaluates one or more recorded runs against a
+// fresh judge specification, without invoking the harness or any
+// provider. This is the fast loop for iterating on judge criteria —
+// change the regex or composite logic, replay the recording set, see
+// whether outcomes match expectations — without re-burning provider
+// tokens.
+//
+// The v0.1 scope is the judge-only flavour: load recordings from the
+// lakehouse, apply each suite task's judge to a workspace dir, write
+// a SuiteResult. The harness-replay flavour (spawning a harness
+// configured with ReplayProvider+ReplayExecutor) is a follow-up; the
+// building blocks already exist in harness/internal/provider/replay.go
+// and harness/internal/executor/replay.go but the orchestration is
+// non-trivial. See #272 for the scope decision.
+//
+// Workspace caveat: judge-only replay against a recording with no
+// preserved workspace dir works for content-only judges (composite
+// over text predicates, future LLM-as-judge) but fails for judges
+// that require file state (file-exists, file-contains, test-command).
+// Operators must preserve the workspace alongside the recording —
+// the `eval run --output` path retains per-task artifacts that suit
+// this. For arbitrary production recordings the workspace is opt-in
+// per #272.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/rxbynerd/stirrup/eval"
+	"github.com/rxbynerd/stirrup/eval/lakehouse"
+	"github.com/rxbynerd/stirrup/eval/runner"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// cmdReplay is the `stirrup-eval replay` entry point.
+func cmdReplay(args []string) {
+	fs := flag.NewFlagSet("replay", flag.ExitOnError)
+	lakehousePath := fs.String("lakehouse", "", "Path to lakehouse directory (required)")
+	suitePath := fs.String("suite", "", "Path to eval suite HCL file (required)")
+	workspaceDir := fs.String("workspace", "", "Workspace directory to evaluate judges against. May be empty for judges that do not need file state (some composite judges).")
+	output := fs.String("output", "", "Write SuiteResult JSON to this path (default: print summary only)")
+	recordingIDs := newStringSliceFlag(fs, "recording", "RunID of a recording to replay (repeatable). If omitted, all recordings in the lakehouse are replayed.")
+	outcomeFilter := fs.String("outcome", "", "Filter recordings to replay by outcome (e.g. failed, error). Ignored if --recording is set.")
+	if err := fs.Parse(args); err != nil {
+		log.Fatalf("parsing flags: %v", err)
+	}
+	if *lakehousePath == "" {
+		log.Fatal("-lakehouse is required")
+	}
+	if *suitePath == "" {
+		log.Fatal("-suite is required")
+	}
+
+	suite, err := loadSuite(*suitePath)
+	if err != nil {
+		log.Fatalf("loading suite: %v", err)
+	}
+	if len(suite.Tasks) == 0 {
+		log.Fatal("suite has no tasks; nothing to replay against")
+	}
+
+	store, err := lakehouse.NewFileStore(*lakehousePath)
+	if err != nil {
+		log.Fatalf("opening lakehouse: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	recordings, err := selectRecordings(ctx, store, *recordingIDs, *outcomeFilter)
+	if err != nil {
+		log.Fatalf("selecting recordings: %v", err)
+	}
+	if len(recordings) == 0 {
+		log.Fatal("no matching recordings found")
+	}
+
+	runID := fmt.Sprintf("replay-%d", time.Now().UnixMilli())
+	startedAt := time.Now()
+
+	tasks := make([]eval.TaskResult, 0, len(recordings))
+	pass := 0
+	for i, rec := range recordings {
+		// Pair recording with suite task by position; if the suite
+		// has fewer tasks than recordings, the i-th recording uses
+		// task i%len(tasks). Sole-task suites are a common authoring
+		// pattern (one judge applied across all mined failures).
+		task := suite.Tasks[i%len(suite.Tasks)]
+		result, err := runner.ReplayRecording(ctx, rec, task, *workspaceDir)
+		if err != nil {
+			result = eval.TaskResult{
+				TaskID:  task.ID,
+				Outcome: "error",
+				Error:   err.Error(),
+				JudgeVerdict: eval.JudgeVerdict{
+					Passed: false,
+					Reason: err.Error(),
+				},
+			}
+		}
+		// Tag the result with the source recording's runId so a
+		// downstream `compare` knows which production run each
+		// verdict came from. result.TaskID is otherwise the suite
+		// task ID, which collapses when one task replays N
+		// recordings.
+		result.TaskID = fmt.Sprintf("%s/%s", task.ID, rec.RunID)
+		if result.Outcome == "pass" {
+			pass++
+		}
+		tasks = append(tasks, result)
+	}
+
+	passRate := float64(0)
+	if len(tasks) > 0 {
+		passRate = float64(pass) / float64(len(tasks))
+	}
+	result := eval.SuiteResult{
+		SuiteID:     suite.ID,
+		RunID:       runID,
+		StartedAt:   startedAt,
+		CompletedAt: time.Now(),
+		Tasks:       tasks,
+		PassRate:    passRate,
+	}
+
+	if *output != "" {
+		// Ensure parent dir exists for callers that pass a fresh path.
+		if dir := filepath.Dir(*output); dir != "." && dir != "/" {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				log.Fatalf("creating output dir: %v", err)
+			}
+		}
+		if err := writeJSON(*output, result); err != nil {
+			log.Fatalf("writing replay result: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "Replay result written to %s\n", *output)
+	}
+
+	fmt.Printf("Replay: %d recordings, %d passed, %d failed/errored (pass rate %.1f%%)\n",
+		len(tasks), pass, len(tasks)-pass, passRate*100)
+}
+
+// selectRecordings resolves the --recording / --outcome flags into a
+// concrete slice. Explicit IDs short-circuit the lakehouse filter:
+// each ID is fetched individually and a missing ID is fatal so the
+// operator notices the typo before the replay runs.
+func selectRecordings(ctx context.Context, store *lakehouse.FileStore, ids []string, outcome string) ([]types.RunRecording, error) {
+	if len(ids) > 0 {
+		all, err := store.QueryRecordings(ctx, types.TraceFilter{})
+		if err != nil {
+			return nil, fmt.Errorf("query recordings: %w", err)
+		}
+		byID := make(map[string]types.RunRecording, len(all))
+		for _, rec := range all {
+			byID[rec.RunID] = rec
+		}
+		out := make([]types.RunRecording, 0, len(ids))
+		for _, id := range ids {
+			rec, ok := byID[id]
+			if !ok {
+				return nil, fmt.Errorf("recording %q not found in lakehouse", id)
+			}
+			out = append(out, rec)
+		}
+		return out, nil
+	}
+	filter := types.TraceFilter{Outcome: outcome}
+	return store.QueryRecordings(ctx, filter)
+}

--- a/eval/cmd/eval/replay_test.go
+++ b/eval/cmd/eval/replay_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/eval/lakehouse"
+	"github.com/rxbynerd/stirrup/eval/runner"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// seedRecordings populates a FileStore with N recordings, returning
+// the lakehouse path and the recording IDs in order. The shape is
+// minimal: each recording carries an Outcome that the outcome filter
+// can target plus a workspace-independent file-exists judge target.
+func seedRecordings(t *testing.T, runIDs []string, outcomes []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := lakehouse.NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	for i, id := range runIDs {
+		rec := types.RunRecording{
+			RunID:  id,
+			Config: types.RunConfig{RunID: id},
+			FinalOutcome: types.RunTrace{
+				ID:      id,
+				Outcome: outcomes[i],
+			},
+		}
+		if err := store.StoreRecording(context.Background(), rec); err != nil {
+			t.Fatalf("StoreRecording %s: %v", id, err)
+		}
+		if err := store.StoreTrace(context.Background(), rec.FinalOutcome); err != nil {
+			t.Fatalf("StoreTrace %s: %v", id, err)
+		}
+	}
+	return dir
+}
+
+// TestSelectRecordings_ByID pins explicit --recording selection: the
+// returned slice preserves the input order and a missing ID is a
+// fatal error so an operator's typo doesn't silently swallow the
+// targeted recording.
+func TestSelectRecordings_ByID(t *testing.T) {
+	dir := seedRecordings(t,
+		[]string{"r1", "r2", "r3"},
+		[]string{"success", "error", "max_turns"},
+	)
+	store, err := lakehouse.NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	got, err := selectRecordings(context.Background(), store, []string{"r2", "r1"}, "")
+	if err != nil {
+		t.Fatalf("selectRecordings: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d recordings, want 2", len(got))
+	}
+	if got[0].RunID != "r2" || got[1].RunID != "r1" {
+		t.Errorf("order: got [%s, %s], want [r2, r1]", got[0].RunID, got[1].RunID)
+	}
+}
+
+// TestSelectRecordings_MissingIDIsError pins the informative-failure
+// AC of #272: a missing ID is fatal, not silently skipped.
+func TestSelectRecordings_MissingIDIsError(t *testing.T) {
+	dir := seedRecordings(t,
+		[]string{"r1"},
+		[]string{"success"},
+	)
+	store, err := lakehouse.NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, err = selectRecordings(context.Background(), store, []string{"nonexistent"}, "")
+	if err == nil {
+		t.Fatal("expected error for missing recording ID; got nil")
+	}
+}
+
+// TestSelectRecordings_OutcomeFilter pins the --outcome bulk-replay
+// path: with no explicit IDs and a non-empty outcome filter, the
+// returned set matches every recording whose Outcome equals the
+// filter.
+func TestSelectRecordings_OutcomeFilter(t *testing.T) {
+	dir := seedRecordings(t,
+		[]string{"r1", "r2", "r3"},
+		[]string{"success", "error", "error"},
+	)
+	store, err := lakehouse.NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	got, err := selectRecordings(context.Background(), store, nil, "error")
+	if err != nil {
+		t.Fatalf("selectRecordings: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d recordings, want 2", len(got))
+	}
+	for _, rec := range got {
+		if rec.FinalOutcome.Outcome != "error" {
+			t.Errorf("rec %q outcome = %q, want error", rec.RunID, rec.FinalOutcome.Outcome)
+		}
+	}
+}
+
+// TestCompletion_ReplayAndIngestFlagsRegistered pins that the new
+// subcommands are wired into the completion table so tab-completion
+// surfaces their flags. The lookup is keyed by subcommand name and
+// returns the flag set the subcommand accepts.
+func TestCompletion_ReplayAndIngestFlagsRegistered(t *testing.T) {
+	for _, sub := range []string{"replay", "ingest"} {
+		flags, ok := evalCompletionFlags[sub]
+		if !ok {
+			t.Errorf("%s missing from evalCompletionFlags", sub)
+			continue
+		}
+		if len(flags) == 0 {
+			t.Errorf("%s has no completion flags", sub)
+		}
+	}
+	for _, sub := range []string{"replay", "ingest"} {
+		found := false
+		for _, s := range evalCompletionSubcommands {
+			if s == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s missing from evalCompletionSubcommands", sub)
+		}
+	}
+}
+
+// TestReplay_WorkspaceCaveat documents the workspace-dependency
+// behaviour expected by judges that need file state. With an empty
+// --workspace flag and a file-exists judge that references a
+// concrete path, the judge fails informatively rather than
+// crashing — which is the v0.1 contract per #272's "informative
+// error" AC.
+func TestReplay_WorkspaceCaveat(t *testing.T) {
+	dir := seedRecordings(t, []string{"r1"}, []string{"success"})
+	store, err := lakehouse.NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	recordings, err := selectRecordings(context.Background(), store, []string{"r1"}, "")
+	if err != nil {
+		t.Fatalf("selectRecordings: %v", err)
+	}
+
+	// A workspace dir that does not exist on disk → file-exists
+	// judge yields Passed=false, not a process-level error.
+	task := types.EvalTask{
+		ID: "task-1",
+		Judge: types.EvalJudge{
+			Type:  "file-exists",
+			Paths: []string{"output.txt"},
+		},
+	}
+	// Sanity: with an empty workspace dir, the file-exists judge
+	// returns a verdict-only fail rather than crashing.
+	emptyDir := t.TempDir()
+	_, err = os.Stat(filepath.Join(emptyDir, "output.txt"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("test setup: empty workspace unexpectedly has output.txt")
+	}
+	res, err := runner.ReplayRecording(context.Background(), recordings[0], task, emptyDir)
+	if err != nil {
+		t.Fatalf("ReplayRecording: %v", err)
+	}
+	if res.Outcome == "pass" {
+		t.Errorf("file-exists with absent file: outcome = pass, want fail")
+	}
+}


### PR DESCRIPTION
## Summary

`stirrup-eval replay` re-evaluates one or more recorded runs against a suite's judges, without invoking the harness or any provider. The judge-iteration loop the docs have advertised is now real on the CLI.

Selection by explicit ID (`--recording`, repeatable) or by outcome filter (`--outcome failed`). Workspace dir is opt-in via `--workspace` — judges that don't need file state work without it.

Harness-replay (running through `ReplayProvider`+`ReplayExecutor`) is deferred per the issue's v0.1 scope decision.

Closes #272.
Part of #277.
Stacked on #284.

## Test plan

- [x] `just` passes
- [x] `just lint` passes
- [x] `TestSelectRecordings_ByID`, `TestSelectRecordings_MissingIDIsError`, `TestSelectRecordings_OutcomeFilter`
- [x] `TestCompletion_ReplayAndIngestFlagsRegistered` — tab-completion surfaces the new flags
- [x] `TestReplay_WorkspaceCaveat` — file-exists judge with absent file yields verdict-only fail, not crash
- [x] Existing `TestEvalCompletionFlagMap_TracksDispatcher` updated for the two new subcommands (replay + ingest from the stacked PR #284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)