### PR TITLE
eval: quarantine envelope for mine-failures

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -474,6 +474,23 @@ as canonical HCL (parseable by `eval run` directly) and is a starting
 point — judges and prompts typically need editing before the suite is
 committed.
 
+#### Quarantine envelope
+
+Mined suites carry raw conversation content from production runs. If
+the source recordings trip a quarantine classifier — `large_payload`
+today, `unscrubbed_secret_event` and `pii_classification` reserved
+for future control-plane scoring — `mine-failures` refuses to write
+the suite unless `--accept-quarantine` is passed. `eval run` mirrors
+the refusal: a suite whose HCL declares `quarantine_flags = [...]`
+will not execute without the same flag. This puts the operator in
+charge of declaring "this content is safe to exfiltrate" rather than
+silently shipping classified material to contributors.
+
+Committing a flagged suite to a public repo is a code-review smell;
+the `quarantine_flags = [...]` attribute on the suite block makes
+the situation visible in PR review. See #115 for the design
+rationale.
+
 ### `drift` — compare adjacent time windows
 
 ```bash

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -61,10 +61,10 @@ var evalCompletionSubcommands = []string{
 // scripts have no positional-argument completion path, so the shells
 // are surfaced through the flag-name lookup so they remain reachable.
 var evalCompletionFlags = map[string][]string{
-	"run":                   {"suite", "harness", "output", "concurrency", "dry-run", "junit"},
+	"run":                   {"suite", "harness", "output", "concurrency", "dry-run", "junit", "accept-quarantine"},
 	"compare":               {"current", "baseline"},
 	"baseline":              {"lakehouse", "after", "before", "mode", "model", "provider", "output"},
-	"mine-failures":         {"lakehouse", "after", "limit", "output", "include-batch", "include-inconclusive"},
+	"mine-failures":         {"lakehouse", "after", "limit", "output", "include-batch", "include-inconclusive", "accept-quarantine"},
 	"drift":                 {"lakehouse", "window", "compare-window", "mode", "model", "provider"},
 	"compare-to-production": {"lakehouse", "results", "experiment-id", "after", "before", "mode", "model", "provider", "output"},
 	"ingest":                {"lakehouse", "trace", "skip-partial"},

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -126,6 +126,7 @@ func cmdRun(args []string) {
 	concurrency := fs.Int("concurrency", 1, "Maximum number of tasks to run in parallel (values <= 0 are treated as 1)")
 	dryRun := fs.Bool("dry-run", false, "Validate suite without executing tasks")
 	junitPath := fs.String("junit", "", "Write JUnit XML to this path after result.json (default: disabled)")
+	acceptQuarantine := fs.Bool("accept-quarantine", false, "Permit execution of suites whose QuarantineFlags is non-empty. Without this flag, mined-from-production suites that carry classified content are refused. See #115.")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
@@ -137,6 +138,15 @@ func cmdRun(args []string) {
 	suite, err := loadSuite(*suitePath)
 	if err != nil {
 		log.Fatalf("loading suite: %v", err)
+	}
+
+	if len(suite.QuarantineFlags) > 0 {
+		if !*acceptQuarantine {
+			log.Fatalf("refusing to execute quarantined suite %q (flags: %v). Re-run with --accept-quarantine to acknowledge the privacy implications.", suite.ID, suite.QuarantineFlags)
+		}
+		fmt.Fprintf(os.Stderr,
+			"eval run: executing quarantined suite %q with flags %v (operator opted in via --accept-quarantine)\n",
+			suite.ID, suite.QuarantineFlags)
 	}
 
 	if *outputDir == "" {
@@ -400,6 +410,7 @@ func cmdMineFailures(args []string) {
 	output := fs.String("output", "", "Write EvalSuite HCL to this file (.hcl recommended)")
 	includeBatch := fs.Bool("include-batch", false, "By default, batch runs (provider.batch.enabled=true) are excluded from mined failures because their wall-clock duration inflates apparent stall metrics. Pass --include-batch to include them.")
 	includeInconclusive := fs.Bool("include-inconclusive", false, "By default, only EvalOutcome==failed traces are mined. Inconclusive runs (max_turns / budget_exceeded / timeout / max_tokens / stalled / cancelled / verification_error) are typically investigated manually rather than codified as regressions; pass --include-inconclusive to include them anyway.")
+	acceptQuarantine := fs.Bool("accept-quarantine", false, "Mined suites carry raw conversation content from production runs. If the source recordings trip a quarantine classifier (large payloads, future PII / unscrubbed-secret signals), the suite write is refused unless --accept-quarantine is set. See #115 for the design rationale.")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
@@ -433,10 +444,27 @@ func cmdMineFailures(args []string) {
 
 	tasks := mineFailureTasksFiltered(recordings, *limit, *includeBatch, *includeInconclusive)
 
+	// Classify the source recordings the miner is about to bake into
+	// the suite. The flags ride on EvalSuite.QuarantineFlags so the
+	// runner can refuse to execute a flagged suite without an
+	// explicit --accept-quarantine, and CI lint can treat a checked-
+	// in flagged suite as a code-review smell.
+	flags := types.ClassifyForQuarantine(recordings)
+	if len(flags) > 0 && !*acceptQuarantine {
+		fmt.Fprintf(os.Stderr,
+			"mine-failures: refusing to write quarantined suite to %s (flags: %v). Re-run with --accept-quarantine to acknowledge the privacy implications.\n",
+			*output, flags)
+		os.Exit(1)
+	}
+	if len(flags) > 0 {
+		fmt.Fprintf(os.Stderr, "mine-failures: quarantine flags present: %v\n", flags)
+	}
+
 	suite := types.EvalSuite{
-		ID:          fmt.Sprintf("mined-failures-%d", time.Now().Unix()),
-		Description: fmt.Sprintf("Failures mined from production (%d of %d recordings)", len(tasks), len(recordings)),
-		Tasks:       tasks,
+		ID:              fmt.Sprintf("mined-failures-%d", time.Now().Unix()),
+		Description:     fmt.Sprintf("Failures mined from production (%d of %d recordings)", len(tasks), len(recordings)),
+		Tasks:           tasks,
+		QuarantineFlags: flags,
 	}
 
 	if *output != "" {
@@ -459,6 +487,13 @@ func writeSuiteHCL(path string, s types.EvalSuite) error {
 	suiteBody := f.Body().AppendNewBlock("suite", []string{s.ID}).Body()
 	if s.Description != "" {
 		suiteBody.SetAttributeValue("description", cty.StringVal(s.Description))
+	}
+	if len(s.QuarantineFlags) > 0 {
+		vals := make([]cty.Value, len(s.QuarantineFlags))
+		for i, f := range s.QuarantineFlags {
+			vals[i] = cty.StringVal(string(f))
+		}
+		suiteBody.SetAttributeValue("quarantine_flags", cty.ListVal(vals))
 	}
 	for _, t := range s.Tasks {
 		taskBody := suiteBody.AppendNewBlock("task", []string{t.ID}).Body()

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -823,6 +823,43 @@ func TestWriteSuiteHCL_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestWriteSuiteHCL_QuarantineFlagsRoundTrip pins #115's wire-format
+// contract: a suite with QuarantineFlags survives HCL serialise +
+// parse with the same flags in the same order. The runner refuses
+// to execute a quarantined suite without --accept-quarantine, so
+// the load path must surface the flags verbatim.
+func TestWriteSuiteHCL_QuarantineFlagsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "quarantined.hcl")
+
+	original := types.EvalSuite{
+		ID:          "quarantined-suite",
+		Description: "mined with QuarantineLargePayload flag",
+		QuarantineFlags: []types.QuarantineFlag{
+			types.QuarantineLargePayload,
+		},
+		Tasks: []types.EvalTask{
+			{
+				ID:     "t1",
+				Mode:   "execution",
+				Prompt: "fix",
+				Judge:  types.EvalJudge{Type: "file-exists", Paths: []string{"x"}},
+			},
+		},
+	}
+
+	if err := writeSuiteHCL(path, original); err != nil {
+		t.Fatalf("writeSuiteHCL: %v", err)
+	}
+	got, err := loadSuite(path)
+	if err != nil {
+		t.Fatalf("loadSuite: %v", err)
+	}
+	if len(got.QuarantineFlags) != 1 || got.QuarantineFlags[0] != types.QuarantineLargePayload {
+		t.Errorf("QuarantineFlags = %v, want [%s]", got.QuarantineFlags, types.QuarantineLargePayload)
+	}
+}
+
 // TestWriteSuiteHCL_EscapesInterpolation ensures hclwrite is escaping
 // HCL-significant sequences (in particular `${...}` interpolation
 // markers) so that user prompts mined out of production traces are

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -133,11 +133,12 @@ type rootSpec struct {
 }
 
 type suiteSpec struct {
-	ID            string         `hcl:"id,label"`
-	Description   string         `hcl:"description,optional"`
-	RunConfigFile string         `hcl:"run_config_file,optional"`
-	RunConfig     *runConfigSpec `hcl:"run_config,block"`
-	Tasks         []taskSpec     `hcl:"task,block"`
+	ID              string         `hcl:"id,label"`
+	Description     string         `hcl:"description,optional"`
+	RunConfigFile   string         `hcl:"run_config_file,optional"`
+	RunConfig       *runConfigSpec `hcl:"run_config,block"`
+	QuarantineFlags []string       `hcl:"quarantine_flags,optional"`
+	Tasks           []taskSpec     `hcl:"task,block"`
 }
 
 type taskSpec struct {
@@ -308,12 +309,21 @@ func convertSuite(s suiteSpec) (types.EvalSuite, error) {
 		})
 	}
 
+	var quarantineFlags []types.QuarantineFlag
+	if len(s.QuarantineFlags) > 0 {
+		quarantineFlags = make([]types.QuarantineFlag, len(s.QuarantineFlags))
+		for i, f := range s.QuarantineFlags {
+			quarantineFlags[i] = types.QuarantineFlag(f)
+		}
+	}
+
 	return types.EvalSuite{
-		ID:            s.ID,
-		Description:   s.Description,
-		Tasks:         tasks,
-		RunConfigFile: s.RunConfigFile,
-		RunConfig:     suiteRunConfig,
+		ID:              s.ID,
+		Description:     s.Description,
+		Tasks:           tasks,
+		RunConfigFile:   s.RunConfigFile,
+		RunConfig:       suiteRunConfig,
+		QuarantineFlags: quarantineFlags,
 	}, nil
 }
 

--- a/types/eval.go
+++ b/types/eval.go
@@ -19,7 +19,55 @@ type EvalSuite struct {
 	// overrides. Nil means "not set". Mutually exclusive with
 	// RunConfigFile; the HCL parser rejects suites that set both.
 	RunConfig *RunConfig `json:"runConfig,omitempty"`
+
+	// QuarantineFlags marks suites mined from production data that
+	// carry raw conversation content and may have privacy / safety
+	// implications. A non-empty list means the suite was mined from
+	// classified or oversized recordings (see QuarantineFlag for the
+	// enumeration). The runner refuses to execute a quarantined
+	// suite without --accept-quarantine and CI should treat the
+	// presence of this field as a code-review smell. See #115 for
+	// the design rationale.
+	QuarantineFlags []QuarantineFlag `json:"quarantineFlags,omitempty"`
 }
+
+// QuarantineFlag classifies why a mined suite carries
+// privacy / safety implications. Values are open enums — operators
+// may add policy-specific flags upstream — but the canonical
+// set below is what the FileStore-side miner emits.
+type QuarantineFlag string
+
+const (
+	// QuarantineUnscrubbedSecretEvent indicates a source recording
+	// triggered SecretRedactedInOutput during the harness run. The
+	// upstream scrubber redacted the matched substring, but the
+	// surrounding context that *almost* leaked may still be in the
+	// recording — a precautionary flag rather than a "secret is on
+	// disk" claim.
+	QuarantineUnscrubbedSecretEvent QuarantineFlag = "unscrubbed_secret_event"
+
+	// QuarantineLargePayload indicates a source recording carries a
+	// turn or tool-call payload above the configurable byte limit
+	// (see DefaultLargePayloadBytes). Large payloads are a privacy
+	// risk by sheer surface area: an attacker who exfiltrates a
+	// quarantined suite gets megabytes of model-context per task.
+	QuarantineLargePayload QuarantineFlag = "large_payload"
+
+	// QuarantinePIIClassification indicates a source recording was
+	// classified `restricted` by the upstream PII pipeline. v0.1
+	// does not implement a classifier — the flag is reserved so
+	// future control-plane scoring can populate it without a
+	// schema change.
+	QuarantinePIIClassification QuarantineFlag = "pii_classification"
+)
+
+// DefaultLargePayloadBytes is the per-recording-payload byte
+// threshold above which QuarantineLargePayload fires. 256 KiB is a
+// conservative pick: a turn carrying that much content is large
+// enough to imply file-shaped data (config dumps, log captures) was
+// pulled into the conversation. Operators can override per-policy
+// in a future iteration.
+const DefaultLargePayloadBytes = 256 * 1024
 
 // EvalTask describes a single evaluation task.
 type EvalTask struct {

--- a/types/quarantine.go
+++ b/types/quarantine.go
@@ -1,0 +1,69 @@
+package types
+
+// ClassifyForQuarantine inspects a slice of recordings the eval miner
+// is about to bake into a suite and returns the QuarantineFlags that
+// the resulting QuarantinedSuite should carry. The function is pure:
+// the input recordings are not mutated.
+//
+// Flag semantics (see EvalSuite.QuarantineFlags godoc for the
+// per-flag contract):
+//
+//   - QuarantineUnscrubbedSecretEvent: V0.1 has no upstream signal
+//     for "a SecretRedactedInOutput fired during this run" — the
+//     recording itself does not carry that bit. The flag is reserved
+//     for future control-plane scoring; today it never fires from
+//     the local-OSS path. The local path's defence-in-depth lives
+//     in security.Scrub at trace write time (#270), so a
+//     post-scrub recording does not contain raw secret-shaped
+//     substrings; the QuarantineUnscrubbedSecretEvent flag will
+//     light up once the control plane attaches its own scrub-event
+//     metadata to recordings.
+//
+//   - QuarantineLargePayload: fires if any recording carries a
+//     turn whose total content (model output + tool I/O) exceeds
+//     DefaultLargePayloadBytes, or a tool call whose output exceeds
+//     the same limit individually. The threshold is conservative —
+//     enough room for ordinary conversation turns, tight enough to
+//     catch attached config dumps and log captures.
+//
+//   - QuarantinePIIClassification: V0.1 reserves the flag without a
+//     local heuristic. The harness has no PII classifier today, and
+//     a regex-based stand-in would either over-block (every
+//     conversation mentions names) or under-block (semantic PII is
+//     not regex-shaped). Future control-plane scoring populates
+//     this from upstream metadata.
+//
+// The returned slice is freshly allocated; the order matches the
+// constant declaration order in eval.go so a textual diff between
+// two miner runs over comparable data is stable.
+func ClassifyForQuarantine(recordings []RunRecording) []QuarantineFlag {
+	var flags []QuarantineFlag
+	if hasLargePayload(recordings, DefaultLargePayloadBytes) {
+		flags = append(flags, QuarantineLargePayload)
+	}
+	return flags
+}
+
+// hasLargePayload reports whether any recording carries a turn
+// (sum of modelOutput + tool I/O sizes) or a tool call (output size
+// alone) exceeding limit bytes.
+func hasLargePayload(recordings []RunRecording, limit int) bool {
+	for _, rec := range recordings {
+		for _, turn := range rec.Turns {
+			turnSize := 0
+			for _, blk := range turn.ModelOutput {
+				turnSize += len(blk.Text) + len(blk.Input)
+			}
+			for _, tc := range turn.ToolCalls {
+				turnSize += len(tc.Input) + len(tc.Output)
+				if len(tc.Output) > limit {
+					return true
+				}
+			}
+			if turnSize > limit {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/types/quarantine_test.go
+++ b/types/quarantine_test.go
@@ -1,0 +1,95 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassifyForQuarantine_Empty pins that an empty recording set
+// produces no flags. A no-data miner output is allowed through
+// without a quarantine challenge.
+func TestClassifyForQuarantine_Empty(t *testing.T) {
+	flags := ClassifyForQuarantine(nil)
+	if len(flags) != 0 {
+		t.Errorf("nil recordings flags = %v, want empty", flags)
+	}
+	flags = ClassifyForQuarantine([]RunRecording{})
+	if len(flags) != 0 {
+		t.Errorf("empty recordings flags = %v, want empty", flags)
+	}
+}
+
+// TestClassifyForQuarantine_SmallPayload pins that recordings well
+// under the default 256 KiB threshold do not trigger
+// QuarantineLargePayload. A modest conversation should ingest
+// without lighting up the flag.
+func TestClassifyForQuarantine_SmallPayload(t *testing.T) {
+	recordings := []RunRecording{
+		{
+			RunID: "r1",
+			Turns: []TurnRecord{
+				{
+					Turn:        1,
+					ModelOutput: []ContentBlock{{Type: "text", Text: "hello world"}},
+				},
+			},
+		},
+	}
+	flags := ClassifyForQuarantine(recordings)
+	if len(flags) != 0 {
+		t.Errorf("small-payload recording flags = %v, want empty", flags)
+	}
+}
+
+// TestClassifyForQuarantine_LargeToolOutput pins that a tool call
+// whose output exceeds the threshold individually trips
+// QuarantineLargePayload. The threshold is conservative enough that
+// ordinary conversation turns stay under it; a single multi-hundred-
+// kilobyte tool output is the signal we want to flag.
+func TestClassifyForQuarantine_LargeToolOutput(t *testing.T) {
+	big := strings.Repeat("x", DefaultLargePayloadBytes+1)
+	recordings := []RunRecording{
+		{
+			RunID: "r1",
+			Turns: []TurnRecord{
+				{
+					Turn: 1,
+					ToolCalls: []ToolCallRecord{
+						{Name: "read_file", Output: big},
+					},
+				},
+			},
+		},
+	}
+	flags := ClassifyForQuarantine(recordings)
+	if len(flags) != 1 || flags[0] != QuarantineLargePayload {
+		t.Errorf("large-payload flags = %v, want [%s]", flags, QuarantineLargePayload)
+	}
+}
+
+// TestClassifyForQuarantine_LargeTurnAggregate pins that a turn
+// whose aggregate content (model output + tool I/O) exceeds the
+// threshold trips the flag even when no single payload is big on
+// its own. Catches the "many medium-sized tool outputs" case.
+func TestClassifyForQuarantine_LargeTurnAggregate(t *testing.T) {
+	half := strings.Repeat("y", DefaultLargePayloadBytes/2)
+	recordings := []RunRecording{
+		{
+			RunID: "r1",
+			Turns: []TurnRecord{
+				{
+					Turn:        1,
+					ModelOutput: []ContentBlock{{Type: "text", Text: half}},
+					ToolCalls: []ToolCallRecord{
+						{Name: "a", Output: half},
+						{Name: "b", Output: half},
+					},
+				},
+			},
+		},
+	}
+	flags := ClassifyForQuarantine(recordings)
+	if len(flags) != 1 || flags[0] != QuarantineLargePayload {
+		t.Errorf("aggregate-large flags = %v, want [%s]", flags, QuarantineLargePayload)
+	}
+}


### PR DESCRIPTION
## Summary

Mined suites carry raw conversation content from production runs. This adds the `QuarantinedSuite` envelope from #115: `EvalSuite.QuarantineFlags`, three canonical flag values (`large_payload`, `unscrubbed_secret_event`, `pii_classification`), and a `ClassifyForQuarantine` classifier.

`mine-failures` refuses to write a flagged suite without `--accept-quarantine`; `eval run` mirrors the refusal at execute time. The HCL writer + parser round-trip the suite-level `quarantine_flags` attribute. V0.1 emits only `QuarantineLargePayload`; the other two flags are reserved for future control-plane scoring.

The open question from the issue (redact-vs-refuse default) is settled as refuse-by-default: the operator opts in explicitly, and the software never silently strips potentially-load-bearing content.

Closes #115.
Part of #277.
Stacked on #285.

## Test plan

- [x] `just` passes
- [x] `just lint` passes
- [x] `TestClassifyForQuarantine_Empty/SmallPayload/LargeToolOutput/LargeTurnAggregate` cover the classifier
- [x] `TestWriteSuiteHCL_QuarantineFlagsRoundTrip` pins the HCL serialise/parse round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)