### PR TITLE
eval: rework mine-failures for representative task generation

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -463,16 +463,44 @@ rename via #267) so retries do not corrupt the lakehouse.
 ```bash
 ./stirrup-eval mine-failures \
   --lakehouse var/lakehouse \
+  --after 2026-04-01 --before 2026-05-01 \
+  --outcome failed \
   --limit 20 \
-  --output eval/suites/mined.hcl
+  --sample-by outcome \
+  --output eval/suites/mined.hcl \
+  --accept-quarantine
 ```
 
-Queries non-success recordings from the lakehouse and constructs an
-`EvalSuite` from them, defaulting each task to a `test-command` judge
-running `go test ./...`. The resulting suite is written to `--output`
-as canonical HCL (parseable by `eval run` directly) and is a starting
-point — judges and prompts typically need editing before the suite is
-committed.
+Queries production traces from the lakehouse, opportunistically
+hydrates each with its `RunRecording` (when one exists), and
+constructs an `EvalSuite` of regression tasks. Each task defaults
+to a `test-command` judge running `go test ./...`; the
+description carries the failing-turn context (last assistant
+message excerpt and any failing tool call) so a human reading the
+suite knows what went wrong without re-running the trace.
+
+Filters (all optional):
+
+- `--after <date>` / `--before <date>` — window the candidate traces.
+- `--outcome <passed|failed|inconclusive>` — target a specific
+  `EvalOutcome` bucket. Defaults to `failed`.
+- `--include-inconclusive` — broaden to also include
+  `inconclusive` traces (limit-hit or interrupted runs).
+- `--include-batch` — by default, batch runs are excluded because
+  their wall-clock is dominated by provider queue dynamics.
+- `--limit N` — cap the output at N tasks.
+- `--sample-by <outcome|model|mode|provider>` — when more
+  candidates exist than `--limit`, stratify proportionally across
+  the chosen dimension instead of taking the top N by recency.
+  Empty (the default) takes the top N by recency.
+
+When the lakehouse holds no recording for a candidate trace, the
+task is still emitted but its description flags "thin trace only;
+refine prompt manually" — operators decide whether to keep or
+drop it.
+
+Without `--output`, `mine-failures` runs in dry-run mode and
+prints a preview to stderr without writing a suite file.
 
 #### Quarantine envelope
 

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -64,7 +64,7 @@ var evalCompletionFlags = map[string][]string{
 	"run":                   {"suite", "harness", "output", "concurrency", "dry-run", "junit", "accept-quarantine"},
 	"compare":               {"current", "baseline"},
 	"baseline":              {"lakehouse", "after", "before", "mode", "model", "provider", "output"},
-	"mine-failures":         {"lakehouse", "after", "limit", "output", "include-batch", "include-inconclusive", "accept-quarantine"},
+	"mine-failures":         {"lakehouse", "after", "before", "outcome", "limit", "sample-by", "output", "include-batch", "include-inconclusive", "accept-quarantine"},
 	"drift":                 {"lakehouse", "window", "compare-window", "mode", "model", "provider"},
 	"compare-to-production": {"lakehouse", "results", "experiment-id", "after", "before", "mode", "model", "provider", "output"},
 	"ingest":                {"lakehouse", "trace", "skip-partial"},

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -401,16 +401,28 @@ func cmdBaseline(args []string) {
 	printMetricsSummary(metrics)
 }
 
-// cmdMineFailures queries production failures and constructs eval tasks from them.
+// cmdMineFailures queries production traces, hydrates recordings
+// opportunistically, and constructs an EvalSuite of regression tasks
+// that capture the failing-turn context an operator needs to write a
+// meaningful test (#274).
+//
+// The data path switches from QueryRecordings to QueryTraces because
+// traces always exist (every harness run emits one) while recordings
+// are opportunistic (only the streaming JSONL emitter writes them).
+// Mining stays useful when no recording is available — the task just
+// carries less context and the description says so.
 func cmdMineFailures(args []string) {
 	fs := flag.NewFlagSet("mine-failures", flag.ExitOnError)
 	lakehousePath := fs.String("lakehouse", "", "Path to lakehouse directory (required)")
 	afterStr := fs.String("after", "", "Filter traces after this date (RFC3339 or YYYY-MM-DD)")
-	limit := fs.Int("limit", 0, "Maximum number of failures to mine")
-	output := fs.String("output", "", "Write EvalSuite HCL to this file (.hcl recommended)")
+	beforeStr := fs.String("before", "", "Filter traces before this date (RFC3339 or YYYY-MM-DD)")
+	outcome := fs.String("outcome", "failed", "Filter by EvalOutcome (passed|failed|inconclusive). Defaults to failed; pass --include-inconclusive to broaden.")
+	limit := fs.Int("limit", 0, "Maximum number of tasks to mine")
+	sampleBy := fs.String("sample-by", "", "Stratify --limit across a dimension: outcome|model|mode|provider. Empty (the default) takes the top --limit by recency.")
+	output := fs.String("output", "", "Write EvalSuite HCL to this file (.hcl recommended). Empty: dry-run to stdout.")
 	includeBatch := fs.Bool("include-batch", false, "By default, batch runs (provider.batch.enabled=true) are excluded from mined failures because their wall-clock duration inflates apparent stall metrics. Pass --include-batch to include them.")
-	includeInconclusive := fs.Bool("include-inconclusive", false, "By default, only EvalOutcome==failed traces are mined. Inconclusive runs (max_turns / budget_exceeded / timeout / max_tokens / stalled / cancelled / verification_error) are typically investigated manually rather than codified as regressions; pass --include-inconclusive to include them anyway.")
-	acceptQuarantine := fs.Bool("accept-quarantine", false, "Mined suites carry raw conversation content from production runs. If the source recordings trip a quarantine classifier (large payloads, future PII / unscrubbed-secret signals), the suite write is refused unless --accept-quarantine is set. See #115 for the design rationale.")
+	includeInconclusive := fs.Bool("include-inconclusive", false, "Include EvalOutcome==inconclusive (max_turns / timeout / etc.) traces in addition to the --outcome target.")
+	acceptQuarantine := fs.Bool("accept-quarantine", false, "Mined suites carry raw conversation content. If the source recordings trip a quarantine classifier, the file write is refused unless --accept-quarantine is set. See #115.")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
@@ -433,24 +445,64 @@ func cmdMineFailures(args []string) {
 		}
 		filter.After = &t
 	}
+	if *beforeStr != "" {
+		t, err := parseDate(*beforeStr)
+		if err != nil {
+			log.Fatalf("parsing -before: %v", err)
+		}
+		filter.Before = &t
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	recordings, err := store.QueryRecordings(ctx, filter)
+	traces, err := store.QueryTraces(ctx, filter)
+	if err != nil {
+		log.Fatalf("querying traces: %v", err)
+	}
+
+	// Build a runId -> recording map opportunistically. Recordings are
+	// stored alongside traces in <root>/recordings/<runId>.json; a
+	// QueryRecordings call returns whatever is present. Missing
+	// recordings are absent from the map; the per-trace mining loop
+	// below detects that and emits a thin-trace task.
+	recordings, err := store.QueryRecordings(ctx, types.TraceFilter{})
 	if err != nil {
 		log.Fatalf("querying recordings: %v", err)
 	}
+	recByID := make(map[string]types.RunRecording, len(recordings))
+	for _, rec := range recordings {
+		recByID[rec.RunID] = rec
+	}
 
-	tasks := mineFailureTasksFiltered(recordings, *limit, *includeBatch, *includeInconclusive)
+	// Filter traces by EvalOutcome and the batch / inconclusive
+	// switches, then optionally stratify across --sample-by before
+	// taking the top --limit. Pre-filter so a 50-trace cap on a
+	// 5,000-trace lakehouse doesn't waste the sampler's time on
+	// passing runs.
+	target := types.EvalOutcome(*outcome)
+	filtered := filterTracesForMining(traces, target, *includeInconclusive, *includeBatch)
+	selected := sampleTraces(filtered, *sampleBy, *limit)
 
-	// Classify the source recordings the miner is about to bake into
-	// the suite. The flags ride on EvalSuite.QuarantineFlags so the
-	// runner can refuse to execute a flagged suite without an
-	// explicit --accept-quarantine, and CI lint can treat a checked-
-	// in flagged suite as a code-review smell.
-	flags := types.ClassifyForQuarantine(recordings)
-	if len(flags) > 0 && !*acceptQuarantine {
+	// Build tasks, hydrating from recordings when present.
+	var (
+		hydratedRecordings []types.RunRecording
+		tasks              []types.EvalTask
+	)
+	for _, t := range selected {
+		rec, hasRec := recByID[t.ID]
+		tasks = append(tasks, buildMinedTask(t, rec, hasRec))
+		if hasRec {
+			hydratedRecordings = append(hydratedRecordings, rec)
+		}
+	}
+
+	// Classify the recordings we actually used for hydration. Traces
+	// with no recording cannot trip the classifier (they carry no
+	// transcript content), so the flag set is a function of the
+	// hydrated subset.
+	flags := types.ClassifyForQuarantine(hydratedRecordings)
+	if len(flags) > 0 && *output != "" && !*acceptQuarantine {
 		fmt.Fprintf(os.Stderr,
 			"mine-failures: refusing to write quarantined suite to %s (flags: %v). Re-run with --accept-quarantine to acknowledge the privacy implications.\n",
 			*output, flags)
@@ -462,7 +514,7 @@ func cmdMineFailures(args []string) {
 
 	suite := types.EvalSuite{
 		ID:              fmt.Sprintf("mined-failures-%d", time.Now().Unix()),
-		Description:     fmt.Sprintf("Failures mined from production (%d of %d recordings)", len(tasks), len(recordings)),
+		Description:     fmt.Sprintf("Failures mined from production: %d task(s) from %d candidate trace(s) (%d with recordings)", len(tasks), len(filtered), len(hydratedRecordings)),
 		Tasks:           tasks,
 		QuarantineFlags: flags,
 	}
@@ -472,9 +524,237 @@ func cmdMineFailures(args []string) {
 			log.Fatalf("writing suite: %v", err)
 		}
 		fmt.Fprintf(os.Stderr, "Suite written to %s\n", *output)
+	} else {
+		// Dry-run: print a brief summary to stdout. Operators run
+		// without --output to preview before writing.
+		fmt.Fprintln(os.Stderr, "mine-failures: dry-run (no --output set); preview only:")
+		for _, t := range tasks {
+			fmt.Fprintf(os.Stderr, "  - %s: %s\n", t.ID, oneLine(t.Description))
+		}
 	}
 
-	fmt.Printf("%d failures mined from %d total recordings\n", len(tasks), len(recordings))
+	fmt.Printf("%d task(s) mined from %d candidate trace(s) (%d hydrated with recordings)\n",
+		len(tasks), len(filtered), len(hydratedRecordings))
+}
+
+// filterTracesForMining applies the (outcome, includeInconclusive,
+// includeBatch) predicates to a trace slice. Returns the subset that
+// should feed sampling + task generation.
+func filterTracesForMining(traces []types.RunTrace, target types.EvalOutcome, includeInconclusive, includeBatch bool) []types.RunTrace {
+	out := make([]types.RunTrace, 0, len(traces))
+	for _, t := range traces {
+		got := types.EvalOutcomeFor(t)
+		matches := got == target ||
+			(includeInconclusive && got == types.EvalInconclusive)
+		if !matches {
+			continue
+		}
+		if !includeBatch && t.Config.Provider.IsBatchEnabled() {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// sampleTraces stratifies a candidate slice across the dimension
+// named by sampleBy. Empty sampleBy => take the top limit by
+// recency (the existing behaviour). limit=0 => return all.
+//
+// The proportional allocation uses largest-remainder rounding so a
+// limit smaller than the stratum count still surfaces at least one
+// trace per non-empty stratum (down to the smallest strata, which
+// may yield zero when limit < strata count). The trade-off favours
+// representativeness over strict per-stratum proportionality at the
+// very small end.
+func sampleTraces(traces []types.RunTrace, sampleBy string, limit int) []types.RunTrace {
+	if limit <= 0 || len(traces) <= limit {
+		return traces
+	}
+	if sampleBy == "" {
+		return traces[:limit]
+	}
+
+	type stratum struct {
+		key     string
+		members []types.RunTrace
+	}
+	keys := []string{}
+	byKey := map[string]*stratum{}
+	keyFn := func(t types.RunTrace) string {
+		switch sampleBy {
+		case "outcome":
+			return string(types.EvalOutcomeFor(t))
+		case "model":
+			return t.Config.ModelRouter.Model
+		case "mode":
+			return t.Config.Mode
+		case "provider":
+			return t.Config.Provider.Type
+		default:
+			return ""
+		}
+	}
+	for _, t := range traces {
+		k := keyFn(t)
+		if _, ok := byKey[k]; !ok {
+			byKey[k] = &stratum{key: k}
+			keys = append(keys, k)
+		}
+		byKey[k].members = append(byKey[k].members, t)
+	}
+
+	// Largest-remainder allocation: floor(limit * len(stratum) / total)
+	// for each stratum, then distribute the remaining slots to the
+	// strata with the highest fractional remainders.
+	type alloc struct {
+		key       string
+		quota     int
+		remainder float64
+		members   []types.RunTrace
+	}
+	allocs := make([]alloc, 0, len(keys))
+	total := len(traces)
+	used := 0
+	for _, k := range keys {
+		s := byKey[k]
+		want := float64(limit*len(s.members)) / float64(total)
+		quota := int(want)
+		used += quota
+		allocs = append(allocs, alloc{
+			key:       k,
+			quota:     quota,
+			remainder: want - float64(quota),
+			members:   s.members,
+		})
+	}
+	for used < limit {
+		// Find the stratum with the largest remainder; on ties prefer
+		// the stratum with the lowest current quota (more
+		// representative across small strata), then alphabetically by
+		// key so the result is deterministic.
+		bestIdx := -1
+		for i := range allocs {
+			if allocs[i].quota >= len(allocs[i].members) {
+				continue
+			}
+			if bestIdx == -1 {
+				bestIdx = i
+				continue
+			}
+			cur := allocs[bestIdx]
+			cand := allocs[i]
+			switch {
+			case cand.remainder > cur.remainder:
+				bestIdx = i
+			case cand.remainder == cur.remainder && cand.quota < cur.quota:
+				bestIdx = i
+			case cand.remainder == cur.remainder && cand.quota == cur.quota && cand.key < cur.key:
+				bestIdx = i
+			}
+		}
+		if bestIdx == -1 {
+			break // every stratum capped
+		}
+		allocs[bestIdx].quota++
+		allocs[bestIdx].remainder = 0
+		used++
+	}
+
+	out := make([]types.RunTrace, 0, limit)
+	for _, a := range allocs {
+		n := a.quota
+		if n > len(a.members) {
+			n = len(a.members)
+		}
+		out = append(out, a.members[:n]...)
+	}
+	return out
+}
+
+// buildMinedTask produces an EvalTask from a trace plus an optional
+// recording. When the recording is present, the task Description
+// includes the failing-turn context (last assistant message excerpt
+// and any failing tool call) so the operator reading the suite knows
+// what went wrong without re-running the trace. When only the thin
+// trace is present, the description says so and the operator decides
+// whether to keep the task or refine the prompt manually.
+func buildMinedTask(trace types.RunTrace, rec types.RunRecording, hasRecording bool) types.EvalTask {
+	desc := fmt.Sprintf("Mined from run %s (outcome: %s)", trace.ID, trace.Outcome)
+	if !hasRecording {
+		desc += " — thin trace only, no recording available; refine prompt manually."
+	} else {
+		desc += "\n" + summariseFailingTurn(rec)
+	}
+	return types.EvalTask{
+		ID:          fmt.Sprintf("mined-%s", trace.ID),
+		Description: desc,
+		Prompt:      trace.Config.Prompt,
+		Mode:        trace.Config.Mode,
+		Judge: types.EvalJudge{
+			Type:    "test-command",
+			Command: "go test ./...",
+		},
+	}
+}
+
+// summariseFailingTurn extracts a short, human-readable excerpt of
+// the failing turn from a recording: the last assistant text block
+// (truncated to keep the suite file readable) and the name + status
+// of any failing tool call. Sub-agent activity surfaces as a
+// dedicated line so multi-agent failures don't read as single-turn
+// ones.
+func summariseFailingTurn(rec types.RunRecording) string {
+	if len(rec.Turns) == 0 {
+		return "  recording present but no turns captured."
+	}
+	last := rec.Turns[len(rec.Turns)-1]
+	parts := []string{
+		fmt.Sprintf("  last turn: %d", last.Turn),
+	}
+
+	var assistantText string
+	for _, blk := range last.ModelOutput {
+		if blk.Type == "text" && blk.Text != "" {
+			assistantText = blk.Text
+			break
+		}
+	}
+	if assistantText != "" {
+		parts = append(parts, fmt.Sprintf("  assistant: %s", truncate(oneLine(assistantText), 240)))
+	}
+
+	for _, tc := range last.ToolCalls {
+		if tc.Success {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("  failing tool: %s (output: %s)", tc.Name, truncate(oneLine(tc.Output), 200)))
+	}
+
+	for _, summary := range rec.FinalOutcome.ToolCalls {
+		if summary.ParentRunID != "" || (summary.RunID != "" && summary.RunID != rec.RunID) {
+			parts = append(parts, fmt.Sprintf("  sub-agent tool: %s (run %s, parent %s)", summary.Name, summary.RunID, summary.ParentRunID))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// oneLine collapses internal newlines to spaces so a multi-line
+// excerpt fits onto one line of the suite description without
+// breaking HCL.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// truncate caps s at n runes (NOT bytes) and appends an ellipsis
+// when truncation happens. Used to keep mined task descriptions
+// readable in the HCL output.
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
 }
 
 // writeSuiteHCL serialises a types.EvalSuite as canonical HCL and writes

--- a/eval/cmd/eval/main_test.go
+++ b/eval/cmd/eval/main_test.go
@@ -541,17 +541,22 @@ func TestMineFailureTasks_NoFailures(t *testing.T) {
 // Centralised so the BatchProviderConfig construction is not
 // scattered across multiple test cases.
 func makeBatchRecording(runID, outcome, prompt string) types.RunRecording {
-	return types.RunRecording{
-		RunID: runID,
-		Config: types.RunConfig{
-			Prompt: prompt,
-			Mode:   "execution",
-			Provider: types.ProviderConfig{
-				Type:  "anthropic",
-				Batch: &types.BatchProviderConfig{Enabled: true},
-			},
+	cfg := types.RunConfig{
+		Prompt: prompt,
+		Mode:   "execution",
+		Provider: types.ProviderConfig{
+			Type:  "anthropic",
+			Batch: &types.BatchProviderConfig{Enabled: true},
 		},
-		FinalOutcome: types.RunTrace{ID: runID, Outcome: outcome},
+	}
+	return types.RunRecording{
+		RunID:  runID,
+		Config: cfg,
+		FinalOutcome: types.RunTrace{
+			ID:      runID,
+			Outcome: outcome,
+			Config:  cfg,
+		},
 	}
 }
 
@@ -619,13 +624,27 @@ func writeMineFailuresFixture(t *testing.T, dir string) {
 				Prompt: "streaming failure prompt",
 				Mode:   "execution",
 			},
-			FinalOutcome: types.RunTrace{ID: "stream-fail", Outcome: "error"},
+			FinalOutcome: types.RunTrace{
+				ID:      "stream-fail",
+				Outcome: "error",
+				Config: types.RunConfig{
+					Prompt: "streaming failure prompt",
+					Mode:   "execution",
+				},
+			},
 		},
 		makeBatchRecording("batch-fail", "error", "batch failure prompt"),
 	}
 	for _, rec := range recordings {
 		if err := store.StoreRecording(context.Background(), rec); err != nil {
 			t.Fatalf("StoreRecording %s: %v", rec.RunID, err)
+		}
+		// As of #274 mine-failures reads QueryTraces first and
+		// hydrates recordings opportunistically — the fixture has
+		// to seed both stores so the new code path sees the
+		// candidates the old recording-only path saw.
+		if err := store.StoreTrace(context.Background(), rec.FinalOutcome); err != nil {
+			t.Fatalf("StoreTrace %s: %v", rec.RunID, err)
 		}
 	}
 }

--- a/eval/cmd/eval/mine_failures_v2_test.go
+++ b/eval/cmd/eval/mine_failures_v2_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// makeTraceWithOutcomeMode is a small helper to build a RunTrace
+// with the fields the new mining filters consult: outcome, mode,
+// provider type, model, and start time. Keeping the helper local
+// to the file avoids polluting main_test.go's shared fixtures.
+func makeTraceWithOutcomeMode(id, outcome, mode, provider, model string, started time.Time) types.RunTrace {
+	return types.RunTrace{
+		ID:        id,
+		Outcome:   outcome,
+		StartedAt: started,
+		Config: types.RunConfig{
+			Prompt: "p-" + id,
+			Mode:   mode,
+			Provider: types.ProviderConfig{
+				Type: provider,
+			},
+			ModelRouter: types.ModelRouterConfig{
+				Model: model,
+			},
+		},
+	}
+}
+
+// TestFilterTracesForMining_FailedOnlyDefault pins the new default:
+// only EvalFailed traces match unless --include-inconclusive is set.
+// EvalPassed (success) is always excluded; EvalInconclusive (max_turns
+// etc.) is excluded by default and included with the flag.
+func TestFilterTracesForMining_FailedOnlyDefault(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	traces := []types.RunTrace{
+		makeTraceWithOutcomeMode("t1", "success", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("t2", "error", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("t3", "max_turns", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("t4", "tool_failures", "execution", "anthropic", "claude", base),
+	}
+
+	// Default: only EvalFailed (error + tool_failures).
+	got := filterTracesForMining(traces, types.EvalFailed, false, false)
+	gotIDs := traceIDs(got)
+	want := []string{"t2", "t4"}
+	if !sameSet(gotIDs, want) {
+		t.Errorf("default: got %v, want %v", gotIDs, want)
+	}
+
+	// With --include-inconclusive: add t3.
+	got = filterTracesForMining(traces, types.EvalFailed, true, false)
+	gotIDs = traceIDs(got)
+	want = []string{"t2", "t3", "t4"}
+	if !sameSet(gotIDs, want) {
+		t.Errorf("include-inconclusive: got %v, want %v", gotIDs, want)
+	}
+}
+
+// TestFilterTracesForMining_ExcludesBatchByDefault pins #138's
+// batch-exclusion default through the new code path.
+func TestFilterTracesForMining_ExcludesBatchByDefault(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	stream := makeTraceWithOutcomeMode("s1", "error", "execution", "anthropic", "claude", base)
+	batch := makeTraceWithOutcomeMode("b1", "error", "execution", "anthropic", "claude", base)
+	batch.Config.Provider.Batch = &types.BatchProviderConfig{Enabled: true}
+
+	got := filterTracesForMining([]types.RunTrace{stream, batch}, types.EvalFailed, false, false)
+	if len(got) != 1 || got[0].ID != "s1" {
+		t.Errorf("default-excludes-batch: got %v, want [s1]", traceIDs(got))
+	}
+	got = filterTracesForMining([]types.RunTrace{stream, batch}, types.EvalFailed, false, true)
+	if len(got) != 2 {
+		t.Errorf("include-batch: got %d, want 2", len(got))
+	}
+}
+
+// TestSampleTraces_Limit pins the simplest sampling case: no
+// stratification, limit truncates to the first N (by input order,
+// which is StartedAt-desc from QueryTraces).
+func TestSampleTraces_Limit(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	traces := []types.RunTrace{
+		makeTraceWithOutcomeMode("a", "error", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("b", "error", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("c", "error", "execution", "anthropic", "claude", base),
+	}
+	got := sampleTraces(traces, "", 2)
+	if len(got) != 2 {
+		t.Fatalf("limit=2: got %d, want 2", len(got))
+	}
+	if got[0].ID != "a" || got[1].ID != "b" {
+		t.Errorf("limit=2 order: got %v, want [a, b]", traceIDs(got))
+	}
+
+	// limit=0 returns all.
+	got = sampleTraces(traces, "", 0)
+	if len(got) != 3 {
+		t.Errorf("limit=0: got %d, want 3", len(got))
+	}
+}
+
+// TestSampleTraces_StratifyByModel pins the proportional-sampling
+// behaviour. With three failed traces from model A and one from
+// model B, --sample-by model --limit 2 should pick one from each.
+func TestSampleTraces_StratifyByModel(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	traces := []types.RunTrace{
+		makeTraceWithOutcomeMode("a1", "error", "execution", "anthropic", "claude-3-5", base),
+		makeTraceWithOutcomeMode("a2", "error", "execution", "anthropic", "claude-3-5", base),
+		makeTraceWithOutcomeMode("a3", "error", "execution", "anthropic", "claude-3-5", base),
+		makeTraceWithOutcomeMode("b1", "error", "execution", "anthropic", "claude-opus-4", base),
+	}
+	got := sampleTraces(traces, "model", 2)
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2", len(got))
+	}
+	models := map[string]int{}
+	for _, tr := range got {
+		models[tr.Config.ModelRouter.Model]++
+	}
+	if models["claude-3-5"] != 1 || models["claude-opus-4"] != 1 {
+		t.Errorf("stratified counts = %v, want one per model", models)
+	}
+}
+
+// TestBuildMinedTask_HydratedDescriptionIncludesContext pins the
+// representativeness AC: when a recording is available, the mined
+// task's Description must include the failing-turn excerpt (last
+// assistant message + failing tool name) so the operator reading
+// the suite knows what went wrong.
+func TestBuildMinedTask_HydratedDescriptionIncludesContext(t *testing.T) {
+	trace := makeTraceWithOutcomeMode("h1", "tool_failures", "execution", "anthropic", "claude", time.Now())
+	rec := types.RunRecording{
+		RunID:  "h1",
+		Config: trace.Config,
+		Turns: []types.TurnRecord{
+			{
+				Turn: 1,
+				ModelOutput: []types.ContentBlock{
+					{Type: "text", Text: "I'll run the failing command now."},
+				},
+				ToolCalls: []types.ToolCallRecord{
+					{
+						Name:    "run_command",
+						Output:  "exit 1: permission denied",
+						Success: false,
+					},
+				},
+			},
+		},
+		FinalOutcome: trace,
+	}
+	task := buildMinedTask(trace, rec, true)
+	if !strings.Contains(task.Description, "I'll run the failing command now.") {
+		t.Errorf("description missing assistant excerpt: %q", task.Description)
+	}
+	if !strings.Contains(task.Description, "run_command") {
+		t.Errorf("description missing failing tool name: %q", task.Description)
+	}
+}
+
+// TestBuildMinedTask_ThinTraceFallback pins the "no recording
+// available" path: the task is still emitted, the description
+// flags the thin-trace status, and the prompt comes from the
+// trace's RunConfig as before.
+func TestBuildMinedTask_ThinTraceFallback(t *testing.T) {
+	trace := makeTraceWithOutcomeMode("t1", "error", "execution", "anthropic", "claude", time.Now())
+	task := buildMinedTask(trace, types.RunRecording{}, false)
+	if task.Prompt != "p-t1" {
+		t.Errorf("Prompt = %q, want p-t1", task.Prompt)
+	}
+	if !strings.Contains(task.Description, "thin trace") {
+		t.Errorf("description missing thin-trace marker: %q", task.Description)
+	}
+}
+
+// TestSampleTraces_StratifyByOutcome pins stratification across
+// EvalOutcome buckets. With failed + inconclusive traces, sampling
+// by outcome at a small limit pulls one from each non-empty
+// stratum before doubling up.
+func TestSampleTraces_StratifyByOutcome(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	traces := []types.RunTrace{
+		makeTraceWithOutcomeMode("e1", "error", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("e2", "error", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("e3", "error", "execution", "anthropic", "claude", base),
+		makeTraceWithOutcomeMode("i1", "max_turns", "execution", "anthropic", "claude", base),
+	}
+	got := sampleTraces(traces, "outcome", 2)
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2", len(got))
+	}
+	outcomes := map[types.EvalOutcome]int{}
+	for _, tr := range got {
+		outcomes[types.EvalOutcomeFor(tr)]++
+	}
+	if outcomes[types.EvalFailed] != 1 || outcomes[types.EvalInconclusive] != 1 {
+		t.Errorf("stratified outcomes = %v, want one each", outcomes)
+	}
+}
+
+// --- helpers ---
+
+func traceIDs(traces []types.RunTrace) []string {
+	ids := make([]string, len(traces))
+	for i, t := range traces {
+		ids[i] = t.ID
+	}
+	return ids
+}
+
+func sameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	a := map[string]struct{}{}
+	for _, s := range got {
+		a[s] = struct{}{}
+	}
+	for _, s := range want {
+		if _, ok := a[s]; !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

`mine-failures` now reads `QueryTraces` (every harness run emits one) and hydrates the matching `RunRecording` per `runId` opportunistically. A trace with no recording still yields a task — the description flags "thin trace only" so the operator can refine the prompt manually.

When a recording is available, the task description carries the failing-turn excerpt (last assistant message text + any failing tool call name and truncated output) so suite authors can discriminate "model hallucinated a path" from "tool returned permission denied" without re-running the trace.

Five new CLI flags: `--before`, `--outcome`, `--include-inconclusive`, `--sample-by <outcome|model|mode|provider>` (largest-remainder stratified sampling), `--output` (now optional — empty runs as a dry-run preview).

Closes #274.
Part of #277.
Stacked on #286.

## Test plan

- [x] `just` passes
- [x] `just lint` passes
- [x] `TestFilterTracesForMining_FailedOnlyDefault` / `_ExcludesBatchByDefault`
- [x] `TestSampleTraces_Limit` / `_StratifyByModel` / `_StratifyByOutcome`
- [x] `TestBuildMinedTask_HydratedDescriptionIncludesContext` / `_ThinTraceFallback`
- [x] Existing `TestRun_MineFailures_DefaultExcludesBatch` / `_IncludeBatchFlag` updated to seed traces alongside recordings (the new code reads from traces first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)