### PR TITLE
eval/lakehouse: manifest index for O(matches) queries

### DIFF
--- a/eval/lakehouse/filestore.go
+++ b/eval/lakehouse/filestore.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -54,25 +55,61 @@ func NewFileStore(rootDir string) (*FileStore, error) {
 	return &FileStore{rootDir: rootDir}, nil
 }
 
-// StoreTrace writes a RunTrace as JSON to traces/<id>.json.
+// StoreTrace writes a RunTrace as JSON to traces/<id>.json and
+// appends a manifest entry so QueryTraces can answer filter queries
+// without loading every trace file from disk (#275). A manifest
+// append failure is logged but does not propagate — the JSON file
+// is already on disk and the next query path will fall back to a
+// directory rebuild.
 func (fs *FileStore) StoreTrace(_ context.Context, trace types.RunTrace) error {
 	if trace.ID == "" {
 		return fmt.Errorf("trace ID is empty")
 	}
-	return fs.writeJSON(filepath.Join(fs.rootDir, tracesDir, trace.ID+".json"), trace)
+	if err := fs.writeJSON(filepath.Join(fs.rootDir, tracesDir, trace.ID+".json"), trace); err != nil {
+		return err
+	}
+	fs.appendManifest(manifestEntryForTrace(trace))
+	return nil
 }
 
-// StoreRecording writes a RunRecording as JSON to recordings/<runId>.json.
+// StoreRecording writes a RunRecording as JSON to
+// recordings/<runId>.json and appends a manifest entry. See the
+// StoreTrace godoc for the manifest's role.
 func (fs *FileStore) StoreRecording(_ context.Context, recording types.RunRecording) error {
 	if recording.RunID == "" {
 		return fmt.Errorf("recording RunID is empty")
 	}
-	return fs.writeJSON(filepath.Join(fs.rootDir, recordingsDir, recording.RunID+".json"), recording)
+	if err := fs.writeJSON(filepath.Join(fs.rootDir, recordingsDir, recording.RunID+".json"), recording); err != nil {
+		return err
+	}
+	fs.appendManifest(manifestEntryForRecording(recording))
+	return nil
 }
 
-// QueryTraces reads all stored traces, applies the filter, sorts by StartedAt
-// descending, and applies the limit.
+// QueryTraces reads stored traces matching filter and sorts by
+// StartedAt descending.
+//
+// When a manifest is present and parseable, the read path consults
+// it to skip JSON-file loads for entries the filter rejects on
+// pre-decoded fields (Outcome / Mode / Model / Provider). This is
+// the day-to-day-usable performance win promised by #275: a
+// 10,000-trace lakehouse with a narrow filter loads only the
+// matching subset rather than every JSON file. Time-range filters
+// (After / Before) still require the underlying trace's
+// StartedAt to be parsed post-load.
+//
+// A missing or unparseable manifest falls through to a scan of
+// the on-disk trace directory and rebuilds the manifest as a
+// side effect (logged at info level).
 func (fs *FileStore) QueryTraces(_ context.Context, filter types.TraceFilter) ([]types.RunTrace, error) {
+	manifestTraces, _, ok := fs.loadManifestIndex()
+	if !ok {
+		// Rebuild on miss; ignore rebuild errors (a transient FS
+		// failure should not break the query — we fall through to
+		// a full scan below and try again next time).
+		_ = fs.rebuildManifest()
+	}
+
 	entries, err := os.ReadDir(filepath.Join(fs.rootDir, tracesDir))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -85,6 +122,21 @@ func (fs *FileStore) QueryTraces(_ context.Context, filter types.TraceFilter) ([
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
+		}
+		// Skip atomic-write tmp files left behind by a crashed
+		// writer; the rename pattern guarantees these are never
+		// the canonical content.
+		if strings.HasPrefix(entry.Name(), ".tmp") {
+			continue
+		}
+		// Strip ".json" to get the trace ID; the manifest is keyed
+		// by ID and lets us skip pure-field-mismatch entries before
+		// the file system has to read the file.
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		if ok && manifestTraces != nil {
+			if me, found := manifestTraces[id]; found && !matchesManifestEntry(me, filter) {
+				continue
+			}
 		}
 		var trace types.RunTrace
 		if err := fs.readJSON(filepath.Join(fs.rootDir, tracesDir, entry.Name()), &trace); err != nil {
@@ -105,10 +157,22 @@ func (fs *FileStore) QueryTraces(_ context.Context, filter types.TraceFilter) ([
 	return traces, nil
 }
 
-// QueryRecordings reads all stored recordings, applies the filter (using the
-// recording's FinalOutcome fields), sorts by FinalOutcome.StartedAt descending,
-// and applies the limit.
+// QueryRecordings reads stored recordings matching filter and sorts
+// by FinalOutcome.StartedAt descending. Recordings are 10-100x
+// larger than traces (full conversation history + tool I/O) so the
+// manifest-driven short-circuit pays its biggest dividend here:
+// rejecting a recording from a pre-decoded field saves loading the
+// whole transcript.
+//
+// Behaviour mirrors QueryTraces: manifest-driven skip on field
+// mismatch, full-scan fallback when the manifest is missing or
+// corrupt.
 func (fs *FileStore) QueryRecordings(_ context.Context, filter types.TraceFilter) ([]types.RunRecording, error) {
+	_, manifestRecordings, ok := fs.loadManifestIndex()
+	if !ok {
+		_ = fs.rebuildManifest()
+	}
+
 	entries, err := os.ReadDir(filepath.Join(fs.rootDir, recordingsDir))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -121,6 +185,18 @@ func (fs *FileStore) QueryRecordings(_ context.Context, filter types.TraceFilter
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
+		}
+		// Skip atomic-write tmp files left behind by a crashed
+		// writer; the rename pattern guarantees these are never
+		// the canonical content.
+		if strings.HasPrefix(entry.Name(), ".tmp") {
+			continue
+		}
+		runID := strings.TrimSuffix(entry.Name(), ".json")
+		if ok && manifestRecordings != nil {
+			if me, found := manifestRecordings[runID]; found && !matchesManifestEntry(me, filter) {
+				continue
+			}
 		}
 		var rec types.RunRecording
 		if err := fs.readJSON(filepath.Join(fs.rootDir, recordingsDir, entry.Name()), &rec); err != nil {

--- a/eval/lakehouse/manifest.go
+++ b/eval/lakehouse/manifest.go
@@ -1,0 +1,313 @@
+package lakehouse
+
+// manifest.go implements the append-only JSONL manifest the FileStore
+// uses to answer QueryTraces / QueryRecordings without loading every
+// JSON file on disk (#275).
+//
+// Wire shape: <lakehouse>/manifest.jsonl, one event per line:
+//
+//	{"kind":"trace","id":"...","startedAt":"...","outcome":"...","mode":"...","model":"...","provider":"..."}
+//	{"kind":"recording","runId":"...","startedAt":"...","outcome":"...","mode":"...","model":"...","provider":"..."}
+//
+// StoreTrace / StoreRecording append one entry per call. Re-ingest of
+// the same id appends a duplicate; the read path uses the LAST entry
+// per id so last-write-wins matches the JSON-file write semantics.
+//
+// Concurrency: a single os.OpenFile with O_APPEND ensures every write
+// is atomic on POSIX for sub-PIPE_BUF payloads (4 KiB on Linux, larger
+// on macOS — a manifest line is well under that). A second writer
+// appending concurrently sees a consistent on-disk shape; the
+// only ordering guarantee is "if A's append returned before B's
+// started, A's bytes precede B's." The read path tolerates any order
+// because last-write-wins is symmetric.
+//
+// Missing or corrupt manifest is recoverable: the read path detects
+// the failure, falls back to scanning every JSON file, and rebuilds
+// the manifest as a side effect with a single info-level log line.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+const manifestFile = "manifest.jsonl"
+
+// manifestKind discriminates the two record types the FileStore
+// indexes. They share the same filterable fields but live in
+// different on-disk subdirectories.
+type manifestKind string
+
+const (
+	manifestKindTrace     manifestKind = "trace"
+	manifestKindRecording manifestKind = "recording"
+)
+
+// manifestEntry is one line in the manifest. Fields cover the
+// filterable surface of TraceFilter (Outcome, Mode, Model, Provider,
+// time-range via StartedAt); a future filter addition that needs a
+// new field bumps the manifest's effective version implicitly because
+// the read path skips entries lacking the field and falls through to
+// a JSON-file read.
+type manifestEntry struct {
+	Kind      manifestKind `json:"kind"`
+	ID        string       `json:"id,omitempty"`    // trace ID
+	RunID     string       `json:"runId,omitempty"` // recording RunID
+	StartedAt string       `json:"startedAt"`       // ISO-8601 / RFC3339
+	Outcome   string       `json:"outcome,omitempty"`
+	Mode      string       `json:"mode,omitempty"`
+	Model     string       `json:"model,omitempty"`
+	Provider  string       `json:"provider,omitempty"`
+}
+
+// manifestPath returns the absolute path of the manifest file rooted
+// at the FileStore's directory.
+func (fs *FileStore) manifestPath() string {
+	return filepath.Join(fs.rootDir, manifestFile)
+}
+
+// appendManifest appends a single entry to manifest.jsonl.
+// O_APPEND makes the write atomic at the kernel layer for sub-
+// PIPE_BUF payloads; manifest lines are well under that. A failure
+// is logged but does not propagate — the JSON file write already
+// succeeded by the time appendManifest is called, so a transient
+// FS error must not cause the operator to see a "store failed"
+// when the data is on disk. The next query falls back to a
+// rebuild from the directory listing.
+func (fs *FileStore) appendManifest(e manifestEntry) {
+	data, err := json.Marshal(e)
+	if err != nil {
+		slog.Default().Info("lakehouse manifest: marshal failed",
+			"err", err.Error())
+		return
+	}
+	data = append(data, '\n')
+	f, err := os.OpenFile(fs.manifestPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		slog.Default().Info("lakehouse manifest: open failed",
+			"err", err.Error())
+		return
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(data); err != nil {
+		slog.Default().Info("lakehouse manifest: write failed",
+			"err", err.Error())
+	}
+}
+
+// loadManifestIndex reads manifest.jsonl and returns one map per
+// kind, keyed by id. Later entries with the same id replace earlier
+// ones (last-write-wins, matching the JSON-file write semantics).
+// A missing or unparseable manifest yields ok=false; the caller
+// should fall back to a directory rebuild.
+func (fs *FileStore) loadManifestIndex() (traces, recordings map[string]manifestEntry, ok bool) {
+	f, err := os.Open(fs.manifestPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Common case on a fresh lakehouse: not an error.
+			return nil, nil, false
+		}
+		slog.Default().Info("lakehouse manifest: open failed; rebuilding",
+			"err", err.Error())
+		return nil, nil, false
+	}
+	defer func() { _ = f.Close() }()
+
+	traces = make(map[string]manifestEntry)
+	recordings = make(map[string]manifestEntry)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var e manifestEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			// A single malformed line invalidates the whole
+			// manifest's "I know what's on disk" claim. Rebuild
+			// is cheaper than guessing which entries to trust.
+			slog.Default().Info("lakehouse manifest: corrupt line; rebuilding",
+				"err", err.Error())
+			return nil, nil, false
+		}
+		switch e.Kind {
+		case manifestKindTrace:
+			if e.ID != "" {
+				traces[e.ID] = e
+			}
+		case manifestKindRecording:
+			if e.RunID != "" {
+				recordings[e.RunID] = e
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		slog.Default().Info("lakehouse manifest: scan failed; rebuilding",
+			"err", err.Error())
+		return nil, nil, false
+	}
+	return traces, recordings, true
+}
+
+// rebuildManifest scans the on-disk trace and recording directories
+// and writes a fresh manifest.jsonl. Used by the query path when
+// the manifest is missing or corrupt. Atomicity is delivered via the
+// writeJSON-style write-then-rename pattern (#267) so a concurrent
+// reader never sees a half-written manifest.
+func (fs *FileStore) rebuildManifest() error {
+	tmp, err := os.CreateTemp(fs.rootDir, ".tmp-manifest-*.jsonl")
+	if err != nil {
+		return fmt.Errorf("create temp manifest: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := fs.scanAndWriteTraces(tmp); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := fs.scanAndWriteRecordings(tmp); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp manifest: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		return fmt.Errorf("chmod temp manifest: %w", err)
+	}
+	if err := os.Rename(tmpPath, fs.manifestPath()); err != nil {
+		return fmt.Errorf("rename temp manifest: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+func (fs *FileStore) scanAndWriteTraces(out *os.File) error {
+	entries, err := os.ReadDir(filepath.Join(fs.rootDir, tracesDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read traces directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ".tmp") {
+			continue
+		}
+		var t types.RunTrace
+		if err := fs.readJSON(filepath.Join(fs.rootDir, tracesDir, entry.Name()), &t); err != nil {
+			return fmt.Errorf("read trace %s during manifest rebuild: %w", entry.Name(), err)
+		}
+		if err := writeManifestEntry(out, manifestEntryForTrace(t)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fs *FileStore) scanAndWriteRecordings(out *os.File) error {
+	entries, err := os.ReadDir(filepath.Join(fs.rootDir, recordingsDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read recordings directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ".tmp") {
+			continue
+		}
+		var rec types.RunRecording
+		if err := fs.readJSON(filepath.Join(fs.rootDir, recordingsDir, entry.Name()), &rec); err != nil {
+			return fmt.Errorf("read recording %s during manifest rebuild: %w", entry.Name(), err)
+		}
+		if err := writeManifestEntry(out, manifestEntryForRecording(rec)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeManifestEntry(out *os.File, e manifestEntry) error {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshal manifest entry: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := out.Write(data); err != nil {
+		return fmt.Errorf("write manifest entry: %w", err)
+	}
+	return nil
+}
+
+func manifestEntryForTrace(t types.RunTrace) manifestEntry {
+	return manifestEntry{
+		Kind:      manifestKindTrace,
+		ID:        t.ID,
+		StartedAt: t.StartedAt.Format("2006-01-02T15:04:05.999999999Z07:00"),
+		Outcome:   t.Outcome,
+		Mode:      t.Config.Mode,
+		Model:     t.Config.ModelRouter.Model,
+		Provider:  t.Config.Provider.Type,
+	}
+}
+
+func manifestEntryForRecording(rec types.RunRecording) manifestEntry {
+	return manifestEntry{
+		Kind:      manifestKindRecording,
+		RunID:     rec.RunID,
+		StartedAt: rec.FinalOutcome.StartedAt.Format("2006-01-02T15:04:05.999999999Z07:00"),
+		Outcome:   rec.FinalOutcome.Outcome,
+		Mode:      rec.Config.Mode,
+		Model:     rec.Config.ModelRouter.Model,
+		Provider:  rec.Config.Provider.Type,
+	}
+}
+
+// matchesManifestEntry reports whether an entry passes a
+// TraceFilter. Mirrors matchesTraceFilter but reads from the
+// pre-decoded manifest fields. The function exists separately so
+// the manifest path can short-circuit a JSON-file load: if the
+// manifest entry doesn't match the filter, we skip loading the
+// underlying file.
+func matchesManifestEntry(e manifestEntry, f types.TraceFilter) bool {
+	if f.Outcome != "" && e.Outcome != f.Outcome {
+		return false
+	}
+	if f.Mode != "" && e.Mode != f.Mode {
+		return false
+	}
+	if f.Model != "" && e.Model != f.Model {
+		return false
+	}
+	if f.Provider != "" && e.Provider != f.Provider {
+		return false
+	}
+	// After/Before are checked against the trace's actual StartedAt
+	// after the file is loaded — the manifest entry only carries a
+	// formatted string and parsing here twice (manifest read + post-
+	// load) doubles the parse cost without value. The full
+	// matchesTraceFilter re-evaluates the time bounds on the loaded
+	// trace, so the manifest's role is to skip files that can't
+	// match Outcome/Mode/Model/Provider regardless of time.
+	return true
+}

--- a/eval/lakehouse/manifest_test.go
+++ b/eval/lakehouse/manifest_test.go
@@ -1,0 +1,255 @@
+package lakehouse
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestManifest_PopulatedOnStore pins #275's core write-path
+// behaviour: every StoreTrace and StoreRecording call appends a
+// matching manifest.jsonl line. A regression that wrote the JSON
+// but skipped the manifest would silently degrade query
+// performance back to O(files).
+func TestManifest_PopulatedOnStore(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fs.Close() }()
+
+	ctx := context.Background()
+	if err := fs.StoreTrace(ctx, types.RunTrace{ID: "t1", Outcome: "success"}); err != nil {
+		t.Fatalf("StoreTrace: %v", err)
+	}
+	if err := fs.StoreRecording(ctx, types.RunRecording{
+		RunID:        "r1",
+		FinalOutcome: types.RunTrace{ID: "r1", Outcome: "error"},
+	}); err != nil {
+		t.Fatalf("StoreRecording: %v", err)
+	}
+
+	traces, recordings, ok := fs.loadManifestIndex()
+	if !ok {
+		t.Fatal("loadManifestIndex returned ok=false")
+	}
+	if _, has := traces["t1"]; !has {
+		t.Errorf("manifest missing trace t1; got %v", traces)
+	}
+	if _, has := recordings["r1"]; !has {
+		t.Errorf("manifest missing recording r1; got %v", recordings)
+	}
+	if traces["t1"].Outcome != "success" {
+		t.Errorf("manifest entry for t1: outcome = %q, want success", traces["t1"].Outcome)
+	}
+}
+
+// TestManifest_FilterShortCircuitsLoad pins the read-path
+// performance contract: a filter that rejects entries on a
+// pre-decoded field (Outcome here) must skip the JSON load for
+// those entries. The smoke test stores a passing trace whose JSON
+// file is then truncated to invalid JSON; a query filtering for
+// Outcome=="failed" must succeed because the manifest entry tells
+// the read path it can skip loading the broken file.
+func TestManifest_FilterShortCircuitsLoad(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fs.Close() }()
+
+	ctx := context.Background()
+	if err := fs.StoreTrace(ctx, types.RunTrace{ID: "good-passing", Outcome: "success"}); err != nil {
+		t.Fatalf("StoreTrace good: %v", err)
+	}
+	if err := fs.StoreTrace(ctx, types.RunTrace{ID: "good-failing", Outcome: "error"}); err != nil {
+		t.Fatalf("StoreTrace failing: %v", err)
+	}
+
+	// Corrupt the passing trace's JSON file. The manifest still
+	// claims it's outcome=success, so a filter for outcome=error
+	// must short-circuit and never try to load it.
+	if err := os.WriteFile(filepath.Join(dir, "traces", "good-passing.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("corrupt: %v", err)
+	}
+
+	got, err := fs.QueryTraces(ctx, types.TraceFilter{Outcome: "error"})
+	if err != nil {
+		t.Fatalf("QueryTraces with manifest short-circuit: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "good-failing" {
+		t.Errorf("got %v, want one trace ID=good-failing", got)
+	}
+}
+
+// TestManifest_RebuildOnMissing pins the missing-manifest recovery
+// path: when manifest.jsonl is absent (or removed by an operator),
+// the next query falls back to a directory scan AND rebuilds the
+// manifest as a side effect.
+func TestManifest_RebuildOnMissing(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fs.Close() }()
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if err := fs.StoreTrace(ctx, types.RunTrace{
+			ID:      "t" + string(rune('1'+i)),
+			Outcome: "success",
+		}); err != nil {
+			t.Fatalf("StoreTrace t%d: %v", i, err)
+		}
+	}
+
+	// Operator forces a rebuild by removing the manifest.
+	if err := os.Remove(fs.manifestPath()); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+
+	got, err := fs.QueryTraces(ctx, types.TraceFilter{})
+	if err != nil {
+		t.Fatalf("QueryTraces after manifest removal: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("got %d traces, want 3 (rebuild must surface all)", len(got))
+	}
+
+	// And the manifest is back.
+	if _, err := os.Stat(fs.manifestPath()); err != nil {
+		t.Errorf("manifest not rebuilt: %v", err)
+	}
+}
+
+// TestManifest_RebuildOnCorrupt pins recovery from a malformed
+// manifest. A single garbled line in manifest.jsonl invalidates
+// the index; the read path falls back to scanning everything and
+// rewrites a fresh manifest.
+func TestManifest_RebuildOnCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fs.Close() }()
+
+	ctx := context.Background()
+	if err := fs.StoreTrace(ctx, types.RunTrace{ID: "ok-1", Outcome: "success"}); err != nil {
+		t.Fatalf("StoreTrace: %v", err)
+	}
+
+	// Append garbage to the manifest.
+	if err := os.WriteFile(fs.manifestPath(), []byte("not-json-at-all\n"), 0o644); err != nil {
+		t.Fatalf("corrupt manifest: %v", err)
+	}
+
+	got, err := fs.QueryTraces(ctx, types.TraceFilter{})
+	if err != nil {
+		t.Fatalf("QueryTraces after corruption: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ok-1" {
+		t.Errorf("got %v, want one trace ID=ok-1", got)
+	}
+
+	// Manifest should now parse again.
+	traces, _, ok := fs.loadManifestIndex()
+	if !ok {
+		t.Fatal("manifest still corrupt after rebuild")
+	}
+	if _, has := traces["ok-1"]; !has {
+		t.Errorf("rebuilt manifest missing ok-1: %v", traces)
+	}
+}
+
+// TestManifest_LastWriteWins pins that re-storing a trace with the
+// same ID overwrites the manifest entry (last entry per id wins).
+// Critical for idempotent re-ingest: the index should reflect the
+// final stored state, not a stale earlier version.
+func TestManifest_LastWriteWins(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fs.Close() }()
+
+	ctx := context.Background()
+	if err := fs.StoreTrace(ctx, types.RunTrace{ID: "same", Outcome: "success"}); err != nil {
+		t.Fatalf("StoreTrace v1: %v", err)
+	}
+	if err := fs.StoreTrace(ctx, types.RunTrace{ID: "same", Outcome: "error"}); err != nil {
+		t.Fatalf("StoreTrace v2: %v", err)
+	}
+
+	traces, _, ok := fs.loadManifestIndex()
+	if !ok {
+		t.Fatal("loadManifestIndex returned ok=false")
+	}
+	if traces["same"].Outcome != "error" {
+		t.Errorf("manifest entry outcome = %q, want error (last-write-wins)", traces["same"].Outcome)
+	}
+}
+
+// TestManifest_ConcurrentAppendSafe smoke-tests the O_APPEND
+// atomicity assumption: multiple goroutines appending to the
+// manifest concurrently must produce a parseable file where every
+// store call is represented.
+func TestManifest_ConcurrentAppendSafe(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fs.Close() }()
+
+	const goroutines = 8
+	const each = 20
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			ctx := context.Background()
+			for i := 0; i < each; i++ {
+				id := "g" + string(rune('0'+g)) + "-" + string(rune('0'+i%10))
+				_ = fs.StoreTrace(ctx, types.RunTrace{
+					ID:        id,
+					Outcome:   "success",
+					StartedAt: time.Now(),
+				})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Manifest should parse cleanly.
+	data, err := os.ReadFile(fs.manifestPath())
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) == 0 {
+		t.Fatal("manifest empty after concurrent writes")
+	}
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		var e manifestEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %d corrupt under concurrency: %v\n%s", i, err, line)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds an append-only `<lakehouse>/manifest.jsonl` index. `StoreTrace`/`StoreRecording` append a manifest line on success; `QueryTraces`/`QueryRecordings` consult the manifest first and skip JSON loads for entries the filter rejects on pre-decoded fields (Outcome / Mode / Model / Provider). Recordings — 10-100x larger than traces — get the biggest read-amplification win.

A missing or corrupt manifest falls back to a directory scan and rebuilds as a side effect. Concurrency relies on POSIX `O_APPEND` atomicity for sub-PIPE_BUF writes (manifest lines are ~200 bytes).

Closes #275.
Part of #277.
Stacked on #287.

## Test plan

- [x] `just` passes
- [x] `just lint` passes
- [x] `TestManifest_PopulatedOnStore` — store appends manifest line
- [x] `TestManifest_FilterShortCircuitsLoad` — corrupt JSON file is never loaded when manifest filter rejects
- [x] `TestManifest_RebuildOnMissing` / `_RebuildOnCorrupt` — recovery paths
- [x] `TestManifest_LastWriteWins` — re-store overrides earlier manifest entries
- [x] `TestManifest_ConcurrentAppendSafe` — 8 goroutines × 20 stores produces a parseable manifest
- [x] All existing FileStore tests still pass — manifest is transparent to read correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)