### PR TITLE
eval/judge: implement diff-review judge (LLM judge for eval)

### DIFF
--- a/eval/judge/diffreview.go
+++ b/eval/judge/diffreview.go
@@ -1,0 +1,231 @@
+package judge
+
+// diff-review judge: feed the workspace's working diff into an LLM
+// (cheap model — defaults to Claude Haiku) and ask the model whether
+// the diff meets the natural-language criteria. The output JSON
+// shape mirrors verifier/llmjudge.go so a control-plane gate can
+// route either at-run-time (verifier) or post-run (this judge)
+// verdicts through one parser.
+//
+// Implementation notes:
+//
+//   - eval/* cannot import harness/internal/* (CLAUDE.md
+//     boundary), so the API client is implemented here directly
+//     against api.anthropic.com using stdlib net/http. Per the
+//     project's "hand-rolled HTTP over SDKs" invariant, no vendor
+//     module is added.
+//   - The API key is sourced from ANTHROPIC_API_KEY at evaluation
+//     time. Mining suites that bundle a diff-review judge MUST NOT
+//     embed the key in the suite HCL — the secret stays in the
+//     operator's environment.
+//   - The judge invokes the model NON-streaming: we want the whole
+//     verdict before deciding, and the JSON envelope is small.
+//   - A network failure (timeout, 5xx) surfaces as a judge ERROR
+//     (returned error from Evaluate). A model that returns
+//     malformed JSON is a verdict FAILURE with diagnostics — same
+//     posture as the verifier-side parser.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/rxbynerd/stirrup/eval"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+const (
+	diffReviewDefaultModel = "claude-3-5-haiku-latest"
+	diffReviewMaxDiffBytes = 64 * 1024
+	diffReviewAPIURL       = "https://api.anthropic.com/v1/messages"
+	diffReviewAPIVersion   = "2023-06-01"
+	diffReviewMaxTokens    = 1024
+	diffReviewTimeout      = 30 * time.Second
+
+	diffReviewSystemPrompt = `You are a code-review judge. Evaluate the supplied git diff against the natural-language criteria.
+
+Respond with ONLY a JSON object in this exact format:
+{"passed": true, "feedback": "brief explanation"}
+
+- "passed" must be a boolean indicating whether the diff meets the criteria.
+- "feedback" must be a short explanation citing the most decisive evidence from the diff.
+
+Do not include any text outside the JSON object.`
+)
+
+// evaluateDiffReview is the judge.Evaluate handler for the
+// diff-review type. Runs `git diff` in the workspace, sends the
+// captured diff + criteria to the configured LLM, parses the JSON
+// verdict.
+func evaluateDiffReview(ctx context.Context, j types.EvalJudge, jctx JudgeContext) (eval.JudgeVerdict, error) {
+	if j.Criteria == "" {
+		return eval.JudgeVerdict{}, fmt.Errorf("diff-review judge requires a criteria string")
+	}
+	if jctx.WorkspaceDir == "" {
+		return eval.JudgeVerdict{}, fmt.Errorf("diff-review judge requires a workspace dir")
+	}
+
+	diff, err := captureDiff(ctx, jctx.WorkspaceDir)
+	if err != nil {
+		return eval.JudgeVerdict{}, fmt.Errorf("capturing git diff: %w", err)
+	}
+	if len(diff) > diffReviewMaxDiffBytes {
+		// Truncate but mark in the prompt; the model is told the
+		// trailing portion is missing so it does not silently
+		// review an incomplete diff.
+		diff = diff[:diffReviewMaxDiffBytes] + "\n\n[... diff truncated at " + fmt.Sprintf("%d", diffReviewMaxDiffBytes) + " bytes ...]\n"
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	if apiKey == "" {
+		return eval.JudgeVerdict{}, fmt.Errorf("diff-review judge: ANTHROPIC_API_KEY not set")
+	}
+
+	model := diffReviewDefaultModel
+	// EvalJudge has no dedicated model field; the criteria string
+	// is the user-facing surface. Future iterations may add a
+	// j.Model attribute (and an HCL `model = "..."` line); for now
+	// the default cheap model is hard-coded.
+
+	verdict, err := callDiffReviewModel(ctx, apiKey, model, j.Criteria, diff)
+	if err != nil {
+		return eval.JudgeVerdict{}, fmt.Errorf("diff-review: %w", err)
+	}
+	return verdict, nil
+}
+
+// captureDiff runs `git diff HEAD` inside dir and returns the
+// resulting text. An empty working tree (no diff) is the dominant
+// "I added nothing" case for an execution-mode harness run; the
+// judge handles it gracefully by passing the empty diff through —
+// the model can then decide whether "no change" is acceptable per
+// the criteria.
+func captureDiff(ctx context.Context, dir string) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "git", "diff", "HEAD")
+	cmd.Dir = dir
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git diff HEAD: %v: %s", err, errOut.String())
+	}
+	return out.String(), nil
+}
+
+// anthropicRequest mirrors the subset of the /v1/messages request
+// schema the diff-review judge needs. Kept local rather than
+// imported from the harness provider so the eval module stays
+// independent of harness/internal/.
+type anthropicRequest struct {
+	Model       string             `json:"model"`
+	System      string             `json:"system,omitempty"`
+	Messages    []anthropicMessage `json:"messages"`
+	MaxTokens   int                `json:"max_tokens"`
+	Temperature float64            `json:"temperature"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicResponse struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+// callDiffReviewModel posts the diff and criteria to
+// api.anthropic.com/v1/messages and returns the parsed verdict.
+// The HTTP client has an explicit 30-second timeout per the
+// project's "no http.DefaultClient" invariant.
+func callDiffReviewModel(ctx context.Context, apiKey, model, criteria, diff string) (eval.JudgeVerdict, error) {
+	body := anthropicRequest{
+		Model:       model,
+		System:      diffReviewSystemPrompt,
+		MaxTokens:   diffReviewMaxTokens,
+		Temperature: 0.0,
+		Messages: []anthropicMessage{
+			{
+				Role:    "user",
+				Content: "## Criteria\n\n" + criteria + "\n\n## Diff\n\n```diff\n" + diff + "\n```\n",
+			},
+		},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return eval.JudgeVerdict{}, fmt.Errorf("marshal request: %w", err)
+	}
+
+	client := &http.Client{
+		Timeout: diffReviewTimeout,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, diffReviewAPIURL, bytes.NewReader(payload))
+	if err != nil {
+		return eval.JudgeVerdict{}, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("anthropic-version", diffReviewAPIVersion)
+	req.Header.Set("x-api-key", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return eval.JudgeVerdict{}, fmt.Errorf("api call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		var sb bytes.Buffer
+		_, _ = sb.ReadFrom(resp.Body)
+		return eval.JudgeVerdict{}, fmt.Errorf("api returned %d: %s", resp.StatusCode, sb.String())
+	}
+
+	var ar anthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ar); err != nil {
+		return eval.JudgeVerdict{}, fmt.Errorf("decode response: %w", err)
+	}
+
+	var text strings.Builder
+	for _, blk := range ar.Content {
+		if blk.Type == "text" {
+			text.WriteString(blk.Text)
+		}
+	}
+	return parseDiffReviewVerdict(text.String()), nil
+}
+
+// diffReviewResponse is the expected JSON shape from the model.
+type diffReviewResponse struct {
+	Passed   bool   `json:"passed"`
+	Feedback string `json:"feedback"`
+}
+
+// parseDiffReviewVerdict translates the model's JSON response into a
+// JudgeVerdict. A malformed response is a verdict FAILURE with the
+// raw response as the reason — matching the verifier's posture so
+// the eval framework's caller sees a consistent failure surface
+// whether the misbehaviour was at-run-time (verifier) or post-run
+// (this judge).
+func parseDiffReviewVerdict(response string) eval.JudgeVerdict {
+	trimmed := strings.TrimSpace(response)
+	var dr diffReviewResponse
+	if err := json.Unmarshal([]byte(trimmed), &dr); err != nil {
+		return eval.JudgeVerdict{
+			Passed: false,
+			Reason: fmt.Sprintf("diff-review model returned malformed JSON: %s (raw: %s)", err, trimmed),
+		}
+	}
+	return eval.JudgeVerdict{
+		Passed: dr.Passed,
+		Reason: dr.Feedback,
+	}
+}

--- a/eval/judge/diffreview.go
+++ b/eval/judge/diffreview.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	diffReviewDefaultModel = "claude-3-5-haiku-latest"
+	diffReviewDefaultModel = "claude-haiku-4-5-20251001"
 	diffReviewMaxDiffBytes = 64 * 1024
 	diffReviewAPIURL       = "https://api.anthropic.com/v1/messages"
 	diffReviewAPIVersion   = "2023-06-01"

--- a/eval/judge/diffreview.go
+++ b/eval/judge/diffreview.go
@@ -71,6 +71,11 @@ func evaluateDiffReview(ctx context.Context, j types.EvalJudge, jctx JudgeContex
 		return eval.JudgeVerdict{}, fmt.Errorf("diff-review judge requires a workspace dir")
 	}
 
+	apiKey := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	if apiKey == "" {
+		return eval.JudgeVerdict{}, fmt.Errorf("diff-review judge: ANTHROPIC_API_KEY not set")
+	}
+
 	diff, err := captureDiff(ctx, jctx.WorkspaceDir)
 	if err != nil {
 		return eval.JudgeVerdict{}, fmt.Errorf("capturing git diff: %w", err)
@@ -80,11 +85,6 @@ func evaluateDiffReview(ctx context.Context, j types.EvalJudge, jctx JudgeContex
 		// trailing portion is missing so it does not silently
 		// review an incomplete diff.
 		diff = diff[:diffReviewMaxDiffBytes] + "\n\n[... diff truncated at " + fmt.Sprintf("%d", diffReviewMaxDiffBytes) + " bytes ...]\n"
-	}
-
-	apiKey := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
-	if apiKey == "" {
-		return eval.JudgeVerdict{}, fmt.Errorf("diff-review judge: ANTHROPIC_API_KEY not set")
 	}
 
 	model := diffReviewDefaultModel

--- a/eval/judge/diffreview_test.go
+++ b/eval/judge/diffreview_test.go
@@ -82,7 +82,7 @@ func TestParseDiffReviewVerdict_Malformed(t *testing.T) {
 // before the live API rejects the request with a confusing 400.
 func TestAnthropicRequestShape(t *testing.T) {
 	req := anthropicRequest{
-		Model:       "claude-3-5-haiku-latest",
+		Model:       "claude-haiku-4-5-20251001",
 		System:      "judge",
 		MaxTokens:   1024,
 		Temperature: 0.0,

--- a/eval/judge/diffreview_test.go
+++ b/eval/judge/diffreview_test.go
@@ -1,0 +1,111 @@
+package judge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestParseDiffReviewVerdict_HappyPath pins the model-side JSON
+// contract: a well-formed {"passed": true|false, "feedback": "..."}
+// round-trips into the expected JudgeVerdict shape.
+func TestParseDiffReviewVerdict_HappyPath(t *testing.T) {
+	cases := []struct {
+		name       string
+		response   string
+		wantPassed bool
+		wantReason string
+	}{
+		{
+			name:       "passed",
+			response:   `{"passed": true, "feedback": "looks good"}`,
+			wantPassed: true,
+			wantReason: "looks good",
+		},
+		{
+			name:       "failed",
+			response:   `{"passed": false, "feedback": "missing test"}`,
+			wantPassed: false,
+			wantReason: "missing test",
+		},
+		{
+			name:       "whitespace-trimmed",
+			response:   "  \n {\"passed\": true, \"feedback\": \"trimmed\"} \n ",
+			wantPassed: true,
+			wantReason: "trimmed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDiffReviewVerdict(tc.response)
+			if got.Passed != tc.wantPassed {
+				t.Errorf("Passed = %v, want %v", got.Passed, tc.wantPassed)
+			}
+			if got.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestParseDiffReviewVerdict_Malformed pins the malformed-response
+// posture: a parsed-as-FAIL verdict with the raw response in the
+// reason, never an error. This matches the verifier-side parser so
+// the eval framework's caller sees a consistent surface across
+// at-run-time and post-run judging.
+func TestParseDiffReviewVerdict_Malformed(t *testing.T) {
+	cases := []string{
+		`not json at all`,
+		`{"passed": "yes"}`,   // wrong type for passed
+		`{"feedback": "..."}`, // missing passed
+		``,
+	}
+	for _, response := range cases {
+		got := parseDiffReviewVerdict(response)
+		if response == `{"feedback": "..."}` {
+			// Missing "passed" decodes as zero-value (false), so the
+			// outer parser will return Passed=false with no error;
+			// that's a valid "model misbehaved → fail" verdict.
+			if got.Passed {
+				t.Errorf("response %q: got Passed=true, want false", response)
+			}
+			continue
+		}
+		if got.Passed {
+			t.Errorf("response %q: got Passed=true, want false", response)
+		}
+	}
+}
+
+// TestAnthropicRequestShape pins the wire shape the diff-review
+// judge POSTs. A regression in field names would surface here
+// before the live API rejects the request with a confusing 400.
+func TestAnthropicRequestShape(t *testing.T) {
+	req := anthropicRequest{
+		Model:       "claude-3-5-haiku-latest",
+		System:      "judge",
+		MaxTokens:   1024,
+		Temperature: 0.0,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "criteria + diff"},
+		},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(data)
+	for _, key := range []string{`"model":`, `"system":`, `"messages":`, `"max_tokens":`, `"temperature":`, `"role":`, `"content":`} {
+		if !strings.Contains(body, key) {
+			t.Errorf("missing key %q in request body: %s", key, body)
+		}
+	}
+	// Anthropic uses snake_case keys; a camelCase regression would
+	// emit "maxTokens" or "stopReason" and the API would reject
+	// the call. Anchor on the negative.
+	for _, bad := range []string{`"maxTokens"`, `"stopReason"`} {
+		if strings.Contains(body, bad) {
+			t.Errorf("unexpected camelCase key %q in request body", bad)
+		}
+	}
+}

--- a/eval/judge/judge.go
+++ b/eval/judge/judge.go
@@ -51,10 +51,7 @@ func Evaluate(ctx context.Context, j types.EvalJudge, jctx JudgeContext) (eval.J
 	case "file-contains":
 		return evaluateFileContains(j, jctx)
 	case "diff-review":
-		return eval.JudgeVerdict{
-			Passed: false,
-			Reason: "diff-review judge not yet implemented",
-		}, nil
+		return evaluateDiffReview(ctx, j, jctx)
 	case "composite":
 		return evaluateComposite(ctx, j, jctx)
 	default:

--- a/eval/judge/judge_test.go
+++ b/eval/judge/judge_test.go
@@ -276,11 +276,10 @@ func TestDiffReview_RequiresAPIKey(t *testing.T) {
 	if err := exec.Command("git", "-C", dir, "init", "-q").Run(); err != nil {
 		t.Skipf("git init unavailable: %v", err)
 	}
+	_ = exec.Command("git", "-C", dir, "config", "user.email", "ci@example.test").Run()
+	_ = exec.Command("git", "-C", dir, "config", "user.name", "ci").Run()
 	if err := exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", "init", "--quiet").Run(); err != nil {
-		// commit may fail on a system without git user config;
-		// give the test a chance to still exercise the api-key
-		// check by trying without it.
-		t.Logf("git commit failed (continuing): %v", err)
+		t.Skipf("git commit unavailable: %v", err)
 	}
 
 	t.Setenv("ANTHROPIC_API_KEY", "")

--- a/eval/judge/judge_test.go
+++ b/eval/judge/judge_test.go
@@ -3,7 +3,9 @@ package judge
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -246,18 +248,49 @@ func TestComposite_DefaultRequireAll(t *testing.T) {
 	}
 }
 
-func TestDiffReview_NotImplemented(t *testing.T) {
+// TestDiffReview_RequiresCriteria pins the input-validation contract:
+// the diff-review judge fails fast when its criteria string is empty,
+// without trying to make any API call. This is the "operator forgot
+// to fill in the judge block" error path.
+func TestDiffReview_RequiresCriteria(t *testing.T) {
 	dir := t.TempDir()
 	j := types.EvalJudge{Type: "diff-review"}
-	v, err := Evaluate(context.Background(), j, JudgeContext{WorkspaceDir: dir})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := Evaluate(context.Background(), j, JudgeContext{WorkspaceDir: dir})
+	if err == nil {
+		t.Fatal("expected error when criteria is empty")
 	}
-	if v.Passed {
-		t.Fatal("expected fail for unimplemented diff-review")
+	if !strings.Contains(err.Error(), "criteria") {
+		t.Errorf("error should mention criteria: %v", err)
 	}
-	if v.Reason != "diff-review judge not yet implemented" {
-		t.Fatalf("unexpected reason: %s", v.Reason)
+}
+
+// TestDiffReview_RequiresAPIKey pins the missing-secret error path:
+// with criteria set but ANTHROPIC_API_KEY unset, the judge returns
+// a clear error rather than crashing or silently passing.
+func TestDiffReview_RequiresAPIKey(t *testing.T) {
+	// Initialize a workspace as a git repo so captureDiff succeeds
+	// before the api-key check fires. Without `git init` the
+	// `git diff HEAD` call fails first; we want the test to pin
+	// the api-key error, not the missing-repo error.
+	dir := t.TempDir()
+	if err := exec.Command("git", "-C", dir, "init", "-q").Run(); err != nil {
+		t.Skipf("git init unavailable: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", "init", "--quiet").Run(); err != nil {
+		// commit may fail on a system without git user config;
+		// give the test a chance to still exercise the api-key
+		// check by trying without it.
+		t.Logf("git commit failed (continuing): %v", err)
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	j := types.EvalJudge{Type: "diff-review", Criteria: "be good"}
+	_, err := Evaluate(context.Background(), j, JudgeContext{WorkspaceDir: dir})
+	if err == nil {
+		t.Fatal("expected error when ANTHROPIC_API_KEY is unset")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("error should mention the env var: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

The previously-stubbed `diff-review` judge type now invokes an LLM (default `claude-3-5-haiku-latest`) with the workspace's `git diff HEAD` plus the operator's natural-language criteria, parses the model's JSON verdict, and returns a `JudgeVerdict`.

eval/* can't import harness/internal/* (CLAUDE.md boundary), so the API client is implemented locally against `api.anthropic.com/v1/messages` with stdlib `net/http` and an explicit 30-second timeout. The API key is sourced from `ANTHROPIC_API_KEY` at evaluation time — suites must not embed the secret in HCL.

Per #277, this is the foothold for the planned cost-control / budgeting work that depends on an LLM-driven judge already wired through the framework. The cheap-model default keeps diff-review affordable to run on every mined suite.

Closes #14.
Part of #277.
Stacked on #288.

## Test plan

- [x] `just` passes
- [x] `just lint` passes
- [x] `TestParseDiffReviewVerdict_HappyPath` / `_Malformed` — verdict parser
- [x] `TestAnthropicRequestShape` — pins snake_case wire shape
- [x] `TestDiffReview_RequiresCriteria` — empty criteria fails fast
- [x] `TestDiffReview_RequiresAPIKey` — missing env var surfaces clearly
- [ ] Live smoke against a real key (operator-side; not gated in CI to keep CI hermetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)