### PR TITLE
eval: wire Anthropic WIF into eval-gate CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # id-token: write is required for Anthropic Workload Identity
+    # Federation: actions/checkout's runner exposes
+    # ACTIONS_ID_TOKEN_REQUEST_URL / ACTIONS_ID_TOKEN_REQUEST_TOKEN
+    # only when this permission is granted. The harness then exchanges
+    # the OIDC token for an Anthropic access token using the four
+    # `--anthropic-*` flags forwarded below. No static API key is in
+    # scope. See .github/workflows/smoke-anthropic.yml for the
+    # established WIF pattern and #130 for the original rollout.
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -60,10 +69,48 @@ jobs:
             echo "No eval suites found — skipping eval gate"
           fi
 
-      - name: Run eval suite
+      # Pre-flight credential guard. Without it, a misconfigured
+      # workflow (no static key, WIF wiring accidentally removed)
+      # would silently fail every harness invocation with an auth
+      # error buried in per-task output, and the compare step would
+      # report a 5/5 → 0/5 "regression" that is really an auth gap.
+      # Mirrors the check-suites step's shape so an operator
+      # reviewing the job log sees the same skip-with-warning
+      # pattern for both prerequisites. The WIF posture today is
+      # always-on (the run step forwards the four
+      # --anthropic-* flags unconditionally), so this guard is
+      # mainly defensive against a future regression that strips
+      # the flags or drops `id-token: write`.
+      - name: Check Anthropic credentials
+        id: check-creds
         if: steps.check-suites.outputs.has_suites == 'true'
         shell: bash
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # ANTHROPIC_USE_WIF is hard-coded "true" because this job
+          # always forwards the four --anthropic-* flags below;
+          # surfacing it as a variable keeps the gate's logic
+          # readable rather than burying the rationale in a long
+          # boolean expression.
+          ANTHROPIC_USE_WIF=true
+          if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ "$ANTHROPIC_USE_WIF" = "true" ]; then
+            echo "has_credentials=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_credentials=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No Anthropic credentials configured (neither ANTHROPIC_API_KEY nor WIF). Skipping live eval runs."
+          fi
+
+      - name: Run eval suite
+        if: steps.check-suites.outputs.has_suites == 'true' && steps.check-creds.outputs.has_credentials == 'true'
+        shell: bash
+        env:
+          # Forwarded for backwards compatibility: if a static key is
+          # ever reintroduced (e.g. a fork that wants to opt out of
+          # WIF), the harness already prefers an explicit
+          # ANTHROPIC_API_KEY over the WIF flags. In the canonical
+          # CI configuration this is empty and the harness uses WIF
+          # exclusively.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           shopt -s nullglob
@@ -73,15 +120,31 @@ jobs:
             name="${name%.*}"
             # JUnit XML is an annotation/artifact only; the eval gate
             # is enforced by the `compare` step below.
+            #
+            # The four --anthropic-* flags are non-secret per
+            # Anthropic's WIF documentation (see
+            # .github/workflows/smoke-anthropic.yml). The harness
+            # exchanges the GitHub Actions OIDC token for an Anthropic
+            # access token inside the subprocess; no static key is in
+            # scope.
             ./stirrup-eval run \
               --suite "$suite" \
               --harness ./stirrup \
               --output "eval/results/${name}" \
-              --junit "eval/results/${name}/junit.xml"
+              --junit "eval/results/${name}/junit.xml" \
+              --anthropic-federation-rule-id fdrl_01QJMFE86qFDdWzQXEekhYjY \
+              --anthropic-organization-id 5848ccdc-495f-490b-9275-2caab9db344d \
+              --anthropic-service-account-id svac_01Tf7i7VwZm6WRAFjNAawPw9 \
+              --anthropic-from-github-actions
           done
 
       - name: Compare against baseline
-        if: steps.check-suites.outputs.has_suites == 'true'
+        # Gated on has_credentials in addition to has_suites: without
+        # credentials the Run eval suite step is skipped, so there is
+        # no result.json to compare. Without this guard the loop body
+        # would skip silently (nullglob), but the explicit gate makes
+        # the dependency between the two steps readable in the job log.
+        if: steps.check-suites.outputs.has_suites == 'true' && steps.check-creds.outputs.has_credentials == 'true'
         shell: bash
         run: |
           shopt -s nullglob
@@ -103,7 +166,9 @@ jobs:
         # an unrelated failure (e.g. compare step regression exit, future
         # secondary-artifact steps). The eval-gate's pass/fail signal is
         # carried by the compare step's exit code, not artifact presence.
-        if: always() && steps.check-suites.outputs.has_suites == 'true'
+        # Gated on has_credentials so a credentials-skipped run does not
+        # upload an empty artifact directory.
+        if: always() && steps.check-suites.outputs.has_suites == 'true' && steps.check-creds.outputs.has_credentials == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: eval-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,17 +88,18 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          # ANTHROPIC_USE_WIF is hard-coded "true" because this job
-          # always forwards the four --anthropic-* flags below;
-          # surfacing it as a variable keeps the gate's logic
-          # readable rather than burying the rationale in a long
-          # boolean expression.
-          ANTHROPIC_USE_WIF=true
-          if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ "$ANTHROPIC_USE_WIF" = "true" ]; then
+          # Check whether a real credential source is available.
+          # GitHub Actions sets ACTIONS_ID_TOKEN_REQUEST_URL only when
+          # id-token: write is in scope and the OIDC subsystem is
+          # operational. If neither a static key nor WIF is present,
+          # skip the run steps and emit a warning so the missing
+          # credential is visible in the job log rather than buried as
+          # per-task auth errors.
+          if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
             echo "has_credentials=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_credentials=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No Anthropic credentials configured (neither ANTHROPIC_API_KEY nor WIF). Skipping live eval runs."
+            echo "::warning::No Anthropic credentials configured (neither ANTHROPIC_API_KEY nor ACTIONS_ID_TOKEN_REQUEST_URL). Skipping live eval runs."
           fi
 
       - name: Run eval suite

--- a/eval/cmd/eval/completion.go
+++ b/eval/cmd/eval/completion.go
@@ -162,12 +162,14 @@ _stirrup_eval() {
     local -a subcommands modes
     subcommands=(`)
 	for _, sub := range evalCompletionSubcommands {
-		b.WriteString(" " + sub)
+		b.WriteString(" ")
+		b.WriteString(sub)
 	}
 	b.WriteString(` )
     modes=(`)
 	for _, m := range evalCompletionRunModes {
-		b.WriteString(" " + m)
+		b.WriteString(" ")
+		b.WriteString(m)
 	}
 	b.WriteString(` )
 
@@ -265,7 +267,9 @@ Register-ArgumentCompleter -Native -CommandName stirrup-eval -ScriptBlock {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString("'" + sub + "'")
+		b.WriteString("'")
+		b.WriteString(sub)
+		b.WriteString("'")
 	}
 	b.WriteString(`)
     $modes = @(`)
@@ -273,7 +277,9 @@ Register-ArgumentCompleter -Native -CommandName stirrup-eval -ScriptBlock {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString("'" + m + "'")
+		b.WriteString("'")
+		b.WriteString(m)
+		b.WriteString("'")
 	}
 	b.WriteString(`)
 

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -127,6 +127,17 @@ func cmdRun(args []string) {
 	dryRun := fs.Bool("dry-run", false, "Validate suite without executing tasks")
 	junitPath := fs.String("junit", "", "Write JUnit XML to this path after result.json (default: disabled)")
 	acceptQuarantine := fs.Bool("accept-quarantine", false, "Permit execution of suites whose QuarantineFlags is non-empty. Without this flag, mined-from-production suites that carry classified content are refused. See #115.")
+	// Anthropic Workload Identity Federation flags. The runner forwards
+	// these verbatim to every `stirrup harness` invocation so the
+	// eval-gate CI job can authenticate via WIF instead of a static
+	// ANTHROPIC_API_KEY. The four identifiers are non-secret per
+	// Anthropic's WIF docs (see #130 and .github/workflows/smoke-anthropic.yml);
+	// the actual OIDC exchange happens inside the harness using the
+	// GitHub Actions runner environment.
+	anthropicFederationRuleID := fs.String("anthropic-federation-rule-id", "", "Anthropic federation rule ID (`fdrl_...`). Forwarded to every harness invocation. Non-secret: identifies the federation rule but cannot itself authenticate.")
+	anthropicOrganizationID := fs.String("anthropic-organization-id", "", "Anthropic organisation UUID. Forwarded to every harness invocation. Required alongside --anthropic-federation-rule-id when WIF is in use.")
+	anthropicServiceAccountID := fs.String("anthropic-service-account-id", "", "Anthropic service account ID (`svac_...`). Forwarded to every harness invocation. Required alongside --anthropic-federation-rule-id when WIF is in use.")
+	anthropicFromGitHubActions := fs.Bool("anthropic-from-github-actions", false, "Forward --anthropic-from-github-actions to every harness invocation. The harness then sources the OIDC token from ACTIONS_ID_TOKEN_REQUEST_URL / ACTIONS_ID_TOKEN_REQUEST_TOKEN.")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
@@ -165,6 +176,12 @@ func cmdRun(args []string) {
 		OutputDir:   *outputDir,
 		Concurrency: *concurrency,
 		DryRun:      *dryRun,
+		AnthropicWIF: runner.AnthropicWIFConfig{
+			FederationRuleID:  *anthropicFederationRuleID,
+			OrganizationID:    *anthropicOrganizationID,
+			ServiceAccountID:  *anthropicServiceAccountID,
+			FromGitHubActions: *anthropicFromGitHubActions,
+		},
 	})
 	if err != nil {
 		log.Fatalf("running suite: %v", err)

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -680,10 +680,7 @@ func sampleTraces(traces []types.RunTrace, sampleBy string, limit int) []types.R
 
 	out := make([]types.RunTrace, 0, limit)
 	for _, a := range allocs {
-		n := a.quota
-		if n > len(a.members) {
-			n = len(a.members)
-		}
+		n := min(a.quota, len(a.members))
 		out = append(out, a.members[:n]...)
 	}
 	return out
@@ -1241,8 +1238,8 @@ func parseDuration(s string) (time.Duration, error) {
 	}
 
 	// Handle "Nd" suffix for days.
-	if strings.HasSuffix(s, "d") {
-		days, err := strconv.ParseFloat(strings.TrimSuffix(s, "d"), 64)
+	if trimmed, ok := strings.CutSuffix(s, "d"); ok {
+		days, err := strconv.ParseFloat(trimmed, 64)
 		if err != nil {
 			return 0, fmt.Errorf("cannot parse %q as duration", s)
 		}

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -210,14 +210,12 @@ func runTasksConcurrently(ctx context.Context, tasks []types.EvalTask, cfg RunCo
 	jobs := make(chan job)
 
 	var wg sync.WaitGroup
-	for w := 0; w < concurrency; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range concurrency {
+		wg.Go(func() {
 			for j := range jobs {
 				results[j.idx] = runTask(ctx, j.task, cfg, suiteArtifactDir, baseline)
 			}
-		}()
+		})
 	}
 
 	// Feed jobs; honour ctx cancellation so we don't deadlock if all workers

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -47,6 +47,59 @@ type RunConfig struct {
 
 	// DryRun if true, validates the suite without executing tasks.
 	DryRun bool
+
+	// AnthropicWIF, when populated, instructs the runner to forward
+	// Anthropic Workload Identity Federation flags to every harness
+	// invocation. The four identifiers are non-secret per Anthropic's
+	// WIF documentation (they identify the federation rule, the
+	// organisation, and the service account, but cannot themselves
+	// authenticate to the API) — see .github/workflows/smoke-anthropic.yml
+	// for the established CI pattern. The harness performs the OIDC
+	// token exchange at runtime using ACTIONS_ID_TOKEN_REQUEST_URL /
+	// ACTIONS_ID_TOKEN_REQUEST_TOKEN from the GitHub Actions runner
+	// environment; no static API key is ever materialised in the
+	// runner's process, the RunConfig, or this struct.
+	AnthropicWIF AnthropicWIFConfig
+}
+
+// AnthropicWIFConfig carries the four CLI flags `stirrup harness`
+// accepts to authenticate via Workload Identity Federation. The values
+// are GitHub Actions OIDC-exchange identifiers, NOT secrets: storing
+// them on RunConfig (rather than fetching them through SecretStore at
+// runtime, which is the pattern reserved for API keys) does not violate
+// the project's "no secrets in RunConfig" invariant. The struct is
+// passthrough-only — the runner forwards values verbatim to the
+// subprocess and performs no exchange of its own.
+type AnthropicWIFConfig struct {
+	// FederationRuleID is the `fdrl_...` identifier of the Anthropic
+	// federation rule bound to this GitHub repository.
+	FederationRuleID string
+
+	// OrganizationID is the Anthropic organisation UUID the federation
+	// rule targets.
+	OrganizationID string
+
+	// ServiceAccountID is the `svac_...` identifier of the Anthropic
+	// service account the WIF exchange produces a token for.
+	ServiceAccountID string
+
+	// FromGitHubActions, when true, instructs the harness to source the
+	// OIDC token from the GitHub Actions runner environment
+	// (ACTIONS_ID_TOKEN_REQUEST_URL / ACTIONS_ID_TOKEN_REQUEST_TOKEN).
+	// This is the boolean toggle that flips the harness from "static
+	// key" to "WIF exchange" — the three identifiers above are inert
+	// without it.
+	FromGitHubActions bool
+}
+
+// configured reports whether any WIF field is populated. The runner
+// uses this to decide whether to emit any --anthropic-* flags at all,
+// preserving the legacy invocation shape for suites that do not opt in.
+func (c AnthropicWIFConfig) configured() bool {
+	return c.FederationRuleID != "" ||
+		c.OrganizationID != "" ||
+		c.ServiceAccountID != "" ||
+		c.FromGitHubActions
 }
 
 // RunSuite executes all tasks in a suite and returns the aggregate result.
@@ -361,6 +414,17 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 		args = append(args, "--timeout", fmt.Sprintf("%d", defaultTaskTimeoutSeconds))
 	}
 
+	// Forward Anthropic WIF identifiers verbatim to every harness
+	// invocation. The four flags are non-secret per Anthropic's WIF
+	// documentation; the actual OIDC exchange happens inside the
+	// harness using the GitHub Actions runner environment variables.
+	// Emitting them unconditionally when configured (rather than gated
+	// on configPath, like --trace/--mode/--timeout) is intentional:
+	// credential posture is orthogonal to the suite's --config opt-in,
+	// and a suite that bundles a RunConfig but no provider credential
+	// still needs WIF identifiers passed on the command line.
+	args = appendAnthropicWIFArgs(args, cfg.AnthropicWIF)
+
 	cmd := exec.CommandContext(ctx, cfg.HarnessPath, args...)
 	cmd.Dir = workspaceDir
 
@@ -410,6 +474,36 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 	}
 
 	return buildResult(task.ID, start, trace, verdict)
+}
+
+// appendAnthropicWIFArgs adds the four `stirrup harness` flags that
+// configure Anthropic Workload Identity Federation when the operator
+// has set any of them. Each identifier flag is emitted only when
+// non-empty so a partial configuration (e.g. WIF rule ID without a
+// service account) still reaches the harness, where ValidateRunConfig
+// can produce a single coherent error rather than the runner silently
+// dropping fields. The boolean --anthropic-from-github-actions has no
+// value argument; it is appended when the toggle is set.
+//
+// The flag spellings here MUST match `harness/cmd/stirrup/cmd/runconfigflags.go`
+// exactly — the runner forwards them verbatim to the subprocess.
+func appendAnthropicWIFArgs(args []string, wif AnthropicWIFConfig) []string {
+	if !wif.configured() {
+		return args
+	}
+	if wif.FederationRuleID != "" {
+		args = append(args, "--anthropic-federation-rule-id", wif.FederationRuleID)
+	}
+	if wif.OrganizationID != "" {
+		args = append(args, "--anthropic-organization-id", wif.OrganizationID)
+	}
+	if wif.ServiceAccountID != "" {
+		args = append(args, "--anthropic-service-account-id", wif.ServiceAccountID)
+	}
+	if wif.FromGitHubActions {
+		args = append(args, "--anthropic-from-github-actions")
+	}
+	return args
 }
 
 // retainArtifacts copies the per-task harness output and trace into the

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -813,7 +813,7 @@ func TestAppendAnthropicWIFArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "boolean only — exchange-disabled identifiers still forwarded",
+			name: "boolean-only toggle — no identifiers set, only the flag forwarded",
 			wif: AnthropicWIFConfig{
 				FromGitHubActions: true,
 			},

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -780,3 +780,151 @@ func collectOutcomes(results []eval.TaskResult) []string {
 	}
 	return out
 }
+
+// TestAppendAnthropicWIFArgs pins the on-the-wire flag spellings the
+// runner forwards to `stirrup harness`. The flag names MUST match the
+// harness side (harness/cmd/stirrup/cmd/runconfigflags.go) — a drift
+// here would silently break CI auth, since the harness would treat an
+// unrecognised flag name as a fatal error.
+func TestAppendAnthropicWIFArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		wif  AnthropicWIFConfig
+		want []string
+	}{
+		{
+			name: "empty config emits nothing",
+			wif:  AnthropicWIFConfig{},
+			want: nil,
+		},
+		{
+			name: "full config emits all four flags in canonical order",
+			wif: AnthropicWIFConfig{
+				FederationRuleID:  "fdrl_test",
+				OrganizationID:    "org-uuid",
+				ServiceAccountID:  "svac_test",
+				FromGitHubActions: true,
+			},
+			want: []string{
+				"--anthropic-federation-rule-id", "fdrl_test",
+				"--anthropic-organization-id", "org-uuid",
+				"--anthropic-service-account-id", "svac_test",
+				"--anthropic-from-github-actions",
+			},
+		},
+		{
+			name: "boolean only — exchange-disabled identifiers still forwarded",
+			wif: AnthropicWIFConfig{
+				FromGitHubActions: true,
+			},
+			want: []string{"--anthropic-from-github-actions"},
+		},
+		{
+			name: "partial config forwards what is set (harness produces the error)",
+			wif: AnthropicWIFConfig{
+				FederationRuleID: "fdrl_only",
+			},
+			want: []string{"--anthropic-federation-rule-id", "fdrl_only"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendAnthropicWIFArgs(nil, tc.wif)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("arg[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestRunSuite_ForwardsAnthropicWIFFlags exercises the runner end-to-end
+// with a fake harness that captures its argv to disk. This is the
+// load-bearing test for issue #293: it pins that a configured
+// AnthropicWIFConfig actually reaches the subprocess argv (and not
+// merely the RunConfig struct). If this test goes green but CI auth
+// fails, the regression is in the harness flag parser, not the runner.
+func TestRunSuite_ForwardsAnthropicWIFFlags(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake harness assumes POSIX sh")
+	}
+	harnessDir := t.TempDir()
+	harnessPath := filepath.Join(harnessDir, "fake-harness")
+	argvCapture := filepath.Join(harnessDir, "argv.txt")
+
+	// The fake harness records its argv (one arg per line) to a
+	// predetermined path and writes a minimal success trace so the
+	// runner reaches the artifact-retention path without errors.
+	script := fmt.Sprintf(`#!/bin/sh
+for a in "$@"; do printf '%%s\n' "$a"; done > %q
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$TRACE" ]; then
+  echo '{"id":"run-1","turns":1,"cost":0.01,"outcome":"success"}' > "$TRACE"
+fi
+`, argvCapture)
+	if err := os.WriteFile(harnessPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The judge type is irrelevant to this test: the fake harness
+	// captures argv before the runner ever invokes a judge. Using
+	// file-exists against an unused path produces a fail/error
+	// outcome, but the assertion below cares only about the captured
+	// argv.
+	suite := types.EvalSuite{
+		ID: "wif-suite",
+		Tasks: []types.EvalTask{
+			{
+				ID:     "wif-task",
+				Prompt: "noop",
+				Judge: types.EvalJudge{
+					Type:  "file-exists",
+					Paths: []string{"unused-by-wif-test.txt"},
+				},
+			},
+		},
+	}
+
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harnessPath,
+		AnthropicWIF: AnthropicWIFConfig{
+			FederationRuleID:  "fdrl_01TEST",
+			OrganizationID:    "00000000-0000-0000-0000-000000000000",
+			ServiceAccountID:  "svac_01TEST",
+			FromGitHubActions: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSuite returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(argvCapture)
+	if err != nil {
+		t.Fatalf("reading captured argv: %v", err)
+	}
+	captured := string(data)
+	wantFragments := []string{
+		"--anthropic-federation-rule-id",
+		"fdrl_01TEST",
+		"--anthropic-organization-id",
+		"00000000-0000-0000-0000-000000000000",
+		"--anthropic-service-account-id",
+		"svac_01TEST",
+		"--anthropic-from-github-actions",
+	}
+	for _, frag := range wantFragments {
+		if !strings.Contains(captured, frag+"\n") {
+			t.Errorf("captured argv missing %q\nfull capture:\n%s", frag, captured)
+		}
+	}
+}


### PR DESCRIPTION
Closes #293. Stacked on #290 (`feat/v01-13-first-mined-suite`).

## Why this PR exists

The eval-gate job in `ci.yml` currently authenticates to Anthropic via `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, but the project does not store a static key as a repo secret — Anthropic access in CI is wired up via Workload Identity Federation (see #130 and `.github/workflows/smoke-anthropic.yml`). Once #290 lands `eval/suites/dogfood-seed.hcl`, the gate would discover the suite, find an empty key, fail all five tasks at the auth layer, and the `compare` step would report a 5/5 → 0/5 "regression" that is really an auth gap — breaking main on the merge.

This PR fixes that gap before #290 lands. It is independent of #292 (shared provider library research).

## Summary

- **`stirrup-eval run` (Go)**: four new flags (`--anthropic-federation-rule-id`, `--anthropic-organization-id`, `--anthropic-service-account-id`, `--anthropic-from-github-actions`) stored on `runner.AnthropicWIFConfig` and forwarded verbatim to every `stirrup harness` invocation built by `runTask`. The single arg-builder point covers both the legacy five-flag path and the merged-config path.
- **`eval-gate` job (`ci.yml`)**: gains `permissions.id-token: write` (the minimum scope the OIDC exchange needs) and passes the four `--anthropic-*` flags to the `Run eval suite` step. Identifier values are the same ones already in `smoke-anthropic.yml`.
- **Credentials guard**: a new `check-creds` step (analogous to `check-suites`) short-circuits the run/compare/upload steps with a `::warning::` annotation when neither `ANTHROPIC_API_KEY` nor WIF (`ACTIONS_ID_TOKEN_REQUEST_URL`) is configured. The guard checks the actual runtime environment variable GitHub Actions sets when `id-token: write` is in scope, so a future regression that strips the flags or drops the permission will produce a visible skip rather than a silent 0/N score.

## Test plan

- [x] `just build` — both binaries build clean
- [x] `just test` — full suite green including two new tests:
  - `TestAppendAnthropicWIFArgs` (table-driven, pins on-the-wire flag spellings)
  - `TestRunSuite_ForwardsAnthropicWIFFlags` (end-to-end fake-harness argv capture)
- [x] `just lint` — `golangci-lint v2` clean
- [x] `actionlint .github/workflows/ci.yml` — clean
- [ ] After merge: confirm the eval-gate job on main authenticates via WIF and the dogfood-seed suite runs end-to-end. (Cannot exercise on a PR branch — the job's `if:` gates on `refs/heads/main`.)

## Notes & deferred items

- The four WIF identifiers are non-secret per Anthropic's WIF docs. They are stored as plain values in `runner.AnthropicWIFConfig` (NOT in `types.RunConfig`, so the `Redact()` invariant is untouched). The actual OIDC exchange happens inside the harness subprocess using the GitHub Actions runner environment variables; no static key is in scope.
- The `diff-review` judge (`eval/judge/diffreview.go`) still reads `ANTHROPIC_API_KEY` from env. It is not exercised by `dogfood-seed.hcl` (which uses only `file-exists` / `file-contains` / `test-command` / `composite` judges), so this PR does not block on it. A follow-up to give the judge the same WIF treatment would be welcome but is out of scope here.
- The WIF identifier values are now duplicated between `smoke-anthropic.yml` and `ci.yml`. A future DRY pass (reusable workflow or composite action) is worth considering if a third caller appears.
- The `actions/checkout@v6` and `actions/setup-go@v6` references in `eval-gate` are floating-tag (not SHA-pinned), which is inconsistent with the `publish-container` job convention. That pre-existing gap is out of scope here; tracked separately.

Refs #293, #290, #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)