### PR TITLE
trace: count permission denials in run stats

### DIFF
--- a/docs/trace-inspection.md
+++ b/docs/trace-inspection.md
@@ -140,6 +140,7 @@ trace stats
   total turns:      12
   tokens in / out:  18432 / 4116
   tool calls:       45 (errors: 3)
+  permission denials: 2
   verifications:    1 run (passed: 1, failed: 0)
   longest call ms:  2811
   wall clock:       42.317s
@@ -183,6 +184,7 @@ and is intended as a dashboard / report ingestion shape:
   "tokensOutput": 4116,
   "toolCalls": 45,
   "toolErrors": 3,
+  "permissionDenials": 2,
   "toolCallsByName": {"edit_file": 18, "grep": 14, ...},
   "toolErrorsByName": {"run_command": 3},
   "outcomes": {"success": 1},

--- a/harness/cmd/stirrup/cmd/trace_stats.go
+++ b/harness/cmd/stirrup/cmd/trace_stats.go
@@ -99,6 +99,7 @@ type TraceStats struct {
 	TokensOutput        int                `json:"tokensOutput"`
 	ToolCalls           int                `json:"toolCalls"`
 	ToolErrors          int                `json:"toolErrors"`
+	PermissionDenials   int                `json:"permissionDenials"`
 	ToolCallsByName     map[string]int     `json:"toolCallsByName,omitempty"`
 	ToolErrorsByName    map[string]int     `json:"toolErrorsByName,omitempty"`
 	SubAgentToolCalls   int                `json:"subAgentToolCalls,omitempty"`
@@ -149,6 +150,7 @@ func (s *TraceStats) absorb(t *types.RunTrace) {
 	s.TotalTurns += t.Turns
 	s.TokensInput += t.TokenUsage.Input
 	s.TokensOutput += t.TokenUsage.Output
+	s.PermissionDenials += t.PermissionDenials
 
 	for _, tc := range t.ToolCalls {
 		s.ToolCalls++
@@ -232,6 +234,7 @@ func writeStatsText(out io.Writer, s *TraceStats, top int) error {
 	fmt.Fprintf(&b, "  total turns:      %d\n", s.TotalTurns)
 	fmt.Fprintf(&b, "  tokens in / out:  %d / %d\n", s.TokensInput, s.TokensOutput)
 	fmt.Fprintf(&b, "  tool calls:       %d (errors: %d)\n", s.ToolCalls, s.ToolErrors)
+	fmt.Fprintf(&b, "  permission denials: %d\n", s.PermissionDenials)
 	if s.SubAgentToolCalls > 0 {
 		fmt.Fprintf(&b, "  sub-agent calls:  %d (of total tool calls)\n", s.SubAgentToolCalls)
 	}

--- a/harness/cmd/stirrup/cmd/trace_test.go
+++ b/harness/cmd/stirrup/cmd/trace_test.go
@@ -49,6 +49,7 @@ func sampleTraces() []types.RunTrace {
 			{Name: "run_command", DurationMs: 500, Success: false, ErrorReason: "exit 1"},
 			{Name: "edit_file", DurationMs: 25, Success: true},
 		},
+		PermissionDenials:   2,
 		VerificationResults: []types.VerificationResult{{Passed: true, Feedback: "all green"}},
 		Outcome:             "success",
 	}}
@@ -108,6 +109,9 @@ func TestTraceStats_JSONOutput(t *testing.T) {
 	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &stats); err != nil {
 		t.Fatalf("decode stats: %v", err)
 	}
+	if !strings.Contains(out.String(), `"permissionDenials":2`) {
+		t.Fatalf("stats JSON missing permissionDenials field: %s", out.String())
+	}
 
 	if stats.TotalTurns != 3 {
 		t.Errorf("TotalTurns = %d, want 3", stats.TotalTurns)
@@ -117,6 +121,9 @@ func TestTraceStats_JSONOutput(t *testing.T) {
 	}
 	if stats.ToolCalls != 3 || stats.ToolErrors != 1 {
 		t.Errorf("ToolCalls/Errors = %d/%d, want 3/1", stats.ToolCalls, stats.ToolErrors)
+	}
+	if stats.PermissionDenials != 2 {
+		t.Errorf("PermissionDenials = %d, want 2", stats.PermissionDenials)
 	}
 	if stats.LongestToolCallMs != 500 {
 		t.Errorf("LongestToolCallMs = %d, want 500", stats.LongestToolCallMs)
@@ -148,7 +155,7 @@ func TestTraceStats_TextOutput(t *testing.T) {
 		t.Fatalf("stats text: %v", err)
 	}
 	s := out.String()
-	for _, want := range []string{"trace stats", "run-1", "total turns:", "tokens in / out:", "edit_file", "outcomes:", "success"} {
+	for _, want := range []string{"trace stats", "run-1", "total turns:", "tokens in / out:", "permission denials:", "2", "edit_file", "outcomes:", "success"} {
 		if !strings.Contains(s, want) {
 			t.Errorf("text stats missing %q\n%s", want, s)
 		}

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -533,6 +533,13 @@ func TestDispatchToolCall_PermissionDenied(t *testing.T) {
 	if !strings.Contains(output, "Permission denied") {
 		t.Errorf("expected output to contain 'Permission denied', got %q", output)
 	}
+	rt, err := loop.Trace.Finish(context.Background(), "error")
+	if err != nil {
+		t.Fatalf("finish trace: %v", err)
+	}
+	if rt.PermissionDenials != 1 {
+		t.Errorf("PermissionDenials = %d, want 1", rt.PermissionDenials)
+	}
 
 	// Assert the SecurityLogger was actually called. Without this, a
 	// regression that nil-skips the call would silently pass.

--- a/harness/internal/core/subagent_test.go
+++ b/harness/internal/core/subagent_test.go
@@ -33,10 +33,11 @@ import (
 // RecordTurn / RecordToolCall call so tests can assert on forwarding
 // behaviour from the NestedJSONLEmitter into the parent's emitter.
 type recordingTraceEmitter struct {
-	mu          sync.Mutex
-	turns       []types.TurnTrace
-	turnRecords []types.TurnRecord
-	toolCalls   []types.ToolCallTrace
+	mu                sync.Mutex
+	turns             []types.TurnTrace
+	turnRecords       []types.TurnRecord
+	toolCalls         []types.ToolCallTrace
+	permissionDenials int
 }
 
 func (r *recordingTraceEmitter) Start(_ string, _ *types.RunConfig) {}
@@ -57,6 +58,12 @@ func (r *recordingTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.toolCalls = append(r.toolCalls, call)
+}
+
+func (r *recordingTraceEmitter) RecordPermissionDenial() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.permissionDenials++
 }
 
 func (r *recordingTraceEmitter) Finish(_ context.Context, _ string) (*types.RunTrace, error) {

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -279,6 +279,9 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 			if l.Security != nil {
 				l.Security.PermissionDenied(call.Name, result.Reason)
 			}
+			if l.Trace != nil {
+				l.Trace.RecordPermissionDenial()
+			}
 			return "Permission denied: " + result.Reason, false
 		}
 	}

--- a/harness/internal/trace/gcs.go
+++ b/harness/internal/trace/gcs.go
@@ -62,12 +62,13 @@ type GCSTraceEmitter struct {
 	httpClient      *http.Client
 	endpointBaseURL string // override for tests
 
-	mu        sync.Mutex
-	runID     string
-	config    *types.RunConfig
-	startedAt time.Time
-	turns     []types.TurnTrace
-	toolCalls []types.ToolCallTrace
+	mu                sync.Mutex
+	runID             string
+	config            *types.RunConfig
+	startedAt         time.Time
+	turns             []types.TurnTrace
+	toolCalls         []types.ToolCallTrace
+	permissionDenials int
 }
 
 // GCSTraceEmitterOptions configures a GCSTraceEmitter. Bucket is
@@ -143,6 +144,7 @@ func (e *GCSTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.startedAt = time.Now()
 	e.turns = nil
 	e.toolCalls = nil
+	e.permissionDenials = 0
 }
 
 // RecordTurn appends a turn trace.
@@ -166,6 +168,13 @@ func (e *GCSTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	e.toolCalls = append(e.toolCalls, call)
 }
 
+// RecordPermissionDenial increments the run-level permission denial count.
+func (e *GCSTraceEmitter) RecordPermissionDenial() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.permissionDenials++
+}
+
 // Finish builds the final RunTrace, marshals it as a single JSONL
 // line, and PUTs the bytes to gs://{bucket}/{objectPrefix}/{runID}.jsonl.
 // A run with zero turns still produces a single valid JSON line —
@@ -186,6 +195,7 @@ func (e *GCSTraceEmitter) Finish(ctx context.Context, outcome string) (*types.Ru
 	startedAt := e.startedAt
 	turns := append([]types.TurnTrace(nil), e.turns...)
 	toolCalls := append([]types.ToolCallTrace(nil), e.toolCalls...)
+	permissionDenials := e.permissionDenials
 	e.mu.Unlock()
 
 	now := time.Now()
@@ -207,14 +217,15 @@ func (e *GCSTraceEmitter) Finish(ctx context.Context, outcome string) (*types.Ru
 	}
 
 	trace := &types.RunTrace{
-		ID:          runID,
-		Config:      redactedConfig,
-		StartedAt:   startedAt,
-		CompletedAt: now,
-		Turns:       len(turns),
-		TokenUsage:  totalTokens,
-		ToolCalls:   summaries,
-		Outcome:     outcome,
+		ID:                runID,
+		Config:            redactedConfig,
+		StartedAt:         startedAt,
+		CompletedAt:       now,
+		Turns:             len(turns),
+		TokenUsage:        totalTokens,
+		ToolCalls:         summaries,
+		PermissionDenials: permissionDenials,
+		Outcome:           outcome,
 	}
 
 	data, err := json.Marshal(trace)

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -41,8 +41,9 @@ type JSONLTraceEmitter struct {
 	// canonical RunTrace (token totals, tool call summaries, outcome)
 	// for the in-process caller (harness factory, eval runner) that
 	// reads it directly without re-parsing the file.
-	turns     []types.TurnTrace
-	toolCalls []types.ToolCallTrace
+	turns             []types.TurnTrace
+	toolCalls         []types.ToolCallTrace
+	permissionDenials int
 }
 
 // NewJSONLTraceEmitter creates a streaming trace emitter that writes to w.
@@ -88,6 +89,7 @@ func (e *JSONLTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.startedAt = time.Now()
 	e.turns = nil
 	e.toolCalls = nil
+	e.permissionDenials = 0
 
 	startedAt := e.startedAt
 	var redacted types.RunConfig
@@ -174,6 +176,13 @@ func (e *JSONLTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	_ = e.writeLineLocked(ev)
 }
 
+// RecordPermissionDenial increments the run-level permission denial count.
+func (e *JSONLTraceEmitter) RecordPermissionDenial() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.permissionDenials++
+}
+
 // Finish builds the canonical RunTrace summary, writes the
 // run_finished event, and returns the summary. A run with zero turns
 // still produces a valid run_finished line.
@@ -200,14 +209,15 @@ func (e *JSONLTraceEmitter) Finish(_ context.Context, outcome string) (*types.Ru
 	}
 
 	trace := &types.RunTrace{
-		ID:          e.runID,
-		Config:      redactedConfig,
-		StartedAt:   e.startedAt,
-		CompletedAt: now,
-		Turns:       len(e.turns),
-		TokenUsage:  totalTokens,
-		ToolCalls:   summaries,
-		Outcome:     outcome,
+		ID:                e.runID,
+		Config:            redactedConfig,
+		StartedAt:         e.startedAt,
+		CompletedAt:       now,
+		Turns:             len(e.turns),
+		TokenUsage:        totalTokens,
+		ToolCalls:         summaries,
+		PermissionDenials: e.permissionDenials,
+		Outcome:           outcome,
 	}
 
 	ev := Event{

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -93,6 +93,8 @@ func TestJSONLTraceEmitter_FullLifecycle(t *testing.T) {
 		DurationMs: 25,
 		Success:    true,
 	})
+	emitter.RecordPermissionDenial()
+	emitter.RecordPermissionDenial()
 
 	trace, err := emitter.Finish(context.Background(), "success")
 	if err != nil {
@@ -114,6 +116,9 @@ func TestJSONLTraceEmitter_FullLifecycle(t *testing.T) {
 	}
 	if trace.Outcome != "success" {
 		t.Errorf("Outcome: got %q, want %q", trace.Outcome, "success")
+	}
+	if trace.PermissionDenials != 2 {
+		t.Errorf("PermissionDenials: got %d, want 2", trace.PermissionDenials)
 	}
 	if trace.Config.Provider.APIKeyRef != "secret://[REDACTED]" {
 		t.Errorf("APIKeyRef should be redacted, got %q", trace.Config.Provider.APIKeyRef)
@@ -159,6 +164,9 @@ func TestJSONLTraceEmitter_FullLifecycle(t *testing.T) {
 	}
 	if finished.Trace.Outcome != "success" {
 		t.Errorf("run_finished outcome: got %q, want success", finished.Trace.Outcome)
+	}
+	if finished.Trace.PermissionDenials != 2 {
+		t.Errorf("run_finished permission denials: got %d, want 2", finished.Trace.PermissionDenials)
 	}
 }
 

--- a/harness/internal/trace/nested_jsonl.go
+++ b/harness/internal/trace/nested_jsonl.go
@@ -38,12 +38,13 @@ type NestedJSONLEmitter struct {
 	parent      TraceEmitter
 	parentRunID string
 
-	mu        sync.Mutex
-	runID     string
-	config    *types.RunConfig
-	startedAt time.Time
-	turns     []types.TurnTrace
-	toolCalls []types.ToolCallTrace
+	mu                sync.Mutex
+	runID             string
+	config            *types.RunConfig
+	startedAt         time.Time
+	turns             []types.TurnTrace
+	toolCalls         []types.ToolCallTrace
+	permissionDenials int
 }
 
 // NewNestedJSONLEmitter returns an emitter that forwards Turn/ToolCall
@@ -70,6 +71,7 @@ func (e *NestedJSONLEmitter) Start(runID string, config *types.RunConfig) {
 	e.startedAt = time.Now()
 	e.turns = nil
 	e.toolCalls = nil
+	e.permissionDenials = 0
 }
 
 // RecordTurn appends to the child's local trace and forwards a tagged
@@ -120,6 +122,19 @@ func (e *NestedJSONLEmitter) RecordToolCall(call types.ToolCallTrace) {
 	e.parent.RecordToolCall(tagged)
 }
 
+// RecordPermissionDenial records the child's local count and forwards the
+// denial into the parent aggregate, matching nested tool-call forwarding.
+func (e *NestedJSONLEmitter) RecordPermissionDenial() {
+	e.mu.Lock()
+	e.permissionDenials++
+	e.mu.Unlock()
+
+	if e.parent == nil {
+		return
+	}
+	e.parent.RecordPermissionDenial()
+}
+
 // Finish builds and returns the child's RunTrace. It does NOT call
 // parent.Finish: the parent's own Run finishes its emitter exactly
 // once when the outer run completes; calling it from a child would
@@ -147,13 +162,14 @@ func (e *NestedJSONLEmitter) Finish(_ context.Context, outcome string) (*types.R
 	}
 
 	return &types.RunTrace{
-		ID:          e.runID,
-		Config:      redactedConfig,
-		StartedAt:   e.startedAt,
-		CompletedAt: now,
-		Turns:       len(e.turns),
-		TokenUsage:  totalTokens,
-		ToolCalls:   summaries,
-		Outcome:     outcome,
+		ID:                e.runID,
+		Config:            redactedConfig,
+		StartedAt:         e.startedAt,
+		CompletedAt:       now,
+		Turns:             len(e.turns),
+		TokenUsage:        totalTokens,
+		ToolCalls:         summaries,
+		PermissionDenials: e.permissionDenials,
+		Outcome:           outcome,
 	}, nil
 }

--- a/harness/internal/trace/nested_jsonl_test.go
+++ b/harness/internal/trace/nested_jsonl_test.go
@@ -12,15 +12,16 @@ import (
 // without writing anywhere. Used to assert forwarding behaviour on the
 // NestedJSONLEmitter without coupling tests to a particular wire format.
 type recordingEmitter struct {
-	mu          sync.Mutex
-	starts      []startCall
-	turns       []types.TurnTrace
-	turnRecords []types.TurnRecord
-	toolCalls   []types.ToolCallTrace
-	finishes    []string
-	finishErr   error
-	finishRet   *types.RunTrace
-	finishCtxs  []context.Context
+	mu                sync.Mutex
+	starts            []startCall
+	turns             []types.TurnTrace
+	turnRecords       []types.TurnRecord
+	toolCalls         []types.ToolCallTrace
+	permissionDenials int
+	finishes          []string
+	finishErr         error
+	finishRet         *types.RunTrace
+	finishCtxs        []context.Context
 }
 
 type startCall struct {
@@ -52,6 +53,12 @@ func (r *recordingEmitter) RecordToolCall(call types.ToolCallTrace) {
 	r.toolCalls = append(r.toolCalls, call)
 }
 
+func (r *recordingEmitter) RecordPermissionDenial() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.permissionDenials++
+}
+
 func (r *recordingEmitter) Finish(ctx context.Context, outcome string) (*types.RunTrace, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -77,12 +84,16 @@ func TestNestedJSONLEmitter_ForwardsTurnsAndToolCalls(t *testing.T) {
 		DurationMs: 5,
 		Success:    true,
 	})
+	child.RecordPermissionDenial()
 
 	if len(parent.turns) != 1 {
 		t.Fatalf("expected 1 forwarded turn, got %d", len(parent.turns))
 	}
 	if len(parent.toolCalls) != 1 {
 		t.Fatalf("expected 1 forwarded tool call, got %d", len(parent.toolCalls))
+	}
+	if parent.permissionDenials != 1 {
+		t.Fatalf("expected 1 forwarded permission denial, got %d", parent.permissionDenials)
 	}
 	if parent.turns[0].RunID != "sub-run-1" {
 		t.Errorf("forwarded turn RunID: got %q, want %q", parent.turns[0].RunID, "sub-run-1")
@@ -154,6 +165,8 @@ func TestNestedJSONLEmitter_FinishReturnsLocalRunTrace(t *testing.T) {
 		DurationMs: 2,
 		Success:    true,
 	})
+	child.RecordPermissionDenial()
+	child.RecordPermissionDenial()
 
 	rt, err := child.Finish(context.Background(), "success")
 	if err != nil {
@@ -174,6 +187,9 @@ func TestNestedJSONLEmitter_FinishReturnsLocalRunTrace(t *testing.T) {
 	if len(rt.ToolCalls) != 1 {
 		t.Errorf("RunTrace.ToolCalls: got %d, want 1", len(rt.ToolCalls))
 	}
+	if rt.PermissionDenials != 2 {
+		t.Errorf("RunTrace.PermissionDenials: got %d, want 2", rt.PermissionDenials)
+	}
 	if rt.Outcome != "success" {
 		t.Errorf("RunTrace.Outcome: got %q, want %q", rt.Outcome, "success")
 	}
@@ -189,6 +205,7 @@ func TestNestedJSONLEmitter_NilParentIsSafe(t *testing.T) {
 	child.Start("sub-run-1", nil)
 	child.RecordTurn(types.TurnTrace{Turn: 0})
 	child.RecordToolCall(types.ToolCallTrace{Name: "t"})
+	child.RecordPermissionDenial()
 	if _, err := child.Finish(context.Background(), "success"); err != nil {
 		t.Fatalf("Finish with nil parent: %v", err)
 	}

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -74,14 +74,15 @@ type OTelTraceEmitter struct {
 	provider *sdktrace.TracerProvider
 	tracer   oteltrace.Tracer
 
-	mu        sync.Mutex
-	runID     string
-	config    *types.RunConfig
-	startedAt time.Time
-	rootSpan  oteltrace.Span
-	rootCtx   context.Context
-	turns     []types.TurnTrace
-	toolCalls []types.ToolCallTrace
+	mu                sync.Mutex
+	runID             string
+	config            *types.RunConfig
+	startedAt         time.Time
+	rootSpan          oteltrace.Span
+	rootCtx           context.Context
+	turns             []types.TurnTrace
+	toolCalls         []types.ToolCallTrace
+	permissionDenials int
 }
 
 // NewOTelTraceEmitter creates an OTel trace emitter that exports spans to
@@ -261,6 +262,7 @@ func (e *OTelTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.startedAt = time.Now()
 	e.turns = nil
 	e.toolCalls = nil
+	e.permissionDenials = 0
 
 	ctx := context.Background()
 	// NOTE: gen_ai.agent.id is intentionally NOT emitted. The OTel GenAI spec
@@ -380,6 +382,13 @@ func (e *OTelTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	span.End(oteltrace.WithTimestamp(spanEnd))
 }
 
+// RecordPermissionDenial increments the run-level permission denial count.
+func (e *OTelTraceEmitter) RecordPermissionDenial() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.permissionDenials++
+}
+
 // Finish sets the outcome on the root span, ends it, flushes the exporter,
 // and returns the aggregated RunTrace.
 func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.RunTrace, error) {
@@ -393,6 +402,7 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 		e.rootSpan.SetAttributes(
 			attribute.String("run.outcome", outcome),
 			attribute.Int("run.turns", len(e.turns)),
+			attribute.Int("run.permission_denials", e.permissionDenials),
 		)
 		e.rootSpan.End()
 	}
@@ -431,14 +441,15 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 	}
 
 	trace := &types.RunTrace{
-		ID:          e.runID,
-		Config:      redactedConfig,
-		StartedAt:   e.startedAt,
-		CompletedAt: now,
-		Turns:       len(e.turns),
-		TokenUsage:  totalTokens,
-		ToolCalls:   summaries,
-		Outcome:     outcome,
+		ID:                e.runID,
+		Config:            redactedConfig,
+		StartedAt:         e.startedAt,
+		CompletedAt:       now,
+		Turns:             len(e.turns),
+		TokenUsage:        totalTokens,
+		ToolCalls:         summaries,
+		PermissionDenials: e.permissionDenials,
+		Outcome:           outcome,
 	}
 
 	return trace, nil

--- a/harness/internal/trace/trace.go
+++ b/harness/internal/trace/trace.go
@@ -30,6 +30,11 @@ type TraceEmitter interface {
 	// RecordToolCall appends a tool call trace to the current run.
 	RecordToolCall(call types.ToolCallTrace)
 
+	// RecordPermissionDenial increments the run-level permission-denial
+	// counter. Callers should invoke it at the policy denial site, not
+	// infer denials later from tool error strings.
+	RecordPermissionDenial()
+
 	// Finish finalises the trace, writes it to the backing store, and
 	// returns the completed RunTrace.
 	Finish(ctx context.Context, outcome string) (*types.RunTrace, error)

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -27,6 +27,7 @@ type RunTrace struct {
 	Turns               int                  `json:"turns"`
 	TokenUsage          TokenUsage           `json:"tokenUsage"`
 	ToolCalls           []ToolCallSummary    `json:"toolCalls"`
+	PermissionDenials   int                  `json:"permissionDenials,omitempty"`
 	VerificationResults []VerificationResult `json:"verificationResults"`
 	Outcome             string               `json:"outcome"` // "success" | "error" | "max_turns" | "verification_failed" | "verification_error" | "budget_exceeded" | "stalled" | "tool_failures" | "cancelled" | "timeout" | "max_tokens"
 }

--- a/types/runtrace_test.go
+++ b/types/runtrace_test.go
@@ -137,3 +137,29 @@ func TestTurnTrace_LegacyJSON_DeserialisesToEmptyMode(t *testing.T) {
 		t.Errorf("legacy trace decode lost data: %+v", tt)
 	}
 }
+
+func TestRunTracePermissionDenialsJSONCompatibility(t *testing.T) {
+	var oldTrace RunTrace
+	if err := json.Unmarshal([]byte(`{"id":"run-1","turns":2}`), &oldTrace); err != nil {
+		t.Fatalf("unmarshal old RunTrace shape: %v", err)
+	}
+	if oldTrace.PermissionDenials != 0 {
+		t.Errorf("missing permissionDenials should decode as zero, got %d", oldTrace.PermissionDenials)
+	}
+
+	zeroBytes, err := json.Marshal(RunTrace{ID: "run-1"})
+	if err != nil {
+		t.Fatalf("marshal zero-denial RunTrace: %v", err)
+	}
+	if strings.Contains(string(zeroBytes), "permissionDenials") {
+		t.Errorf("zero permissionDenials should be omitted for compatibility, got %s", zeroBytes)
+	}
+
+	nonZeroBytes, err := json.Marshal(RunTrace{ID: "run-1", PermissionDenials: 2})
+	if err != nil {
+		t.Fatalf("marshal non-zero-denial RunTrace: %v", err)
+	}
+	if !strings.Contains(string(nonZeroBytes), `"permissionDenials":2`) {
+		t.Errorf("non-zero permissionDenials should be emitted, got %s", nonZeroBytes)
+	}
+}


### PR DESCRIPTION
Closes #260.

Summary:
- Add `RunTrace.PermissionDenials` as a backward-compatible aggregate counter.
- Increment the counter at the permission-policy denial path and carry it through JSONL, GCS, OTel, and nested trace emitters.
- Surface permission denials in `stirrup trace stats` text and JSON output, with docs and tests updated.

Tests:
- `go test ./types`
- `go test ./harness/internal/trace`
- `go test ./harness/cmd/stirrup/cmd`
- `go test ./harness/internal/core`

Residual risk:
- This intentionally records only a single aggregate denial count, not a per-policy or per-rule breakdown.