### PR TITLE
security, types: harden secret redaction coverage

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -17,8 +17,8 @@ different class of attack at a different point in the run.
 **Secrets never live in `RunConfig`.** API keys are `secret://`
 references resolved through env vars, files, or AWS SSM. The
 `slog.Handler` that writes logs runs every string through a
-seven-pattern scrubber before any handler sees it — secret leakage
-through logs is structurally impossible.
+credential-pattern scrubber before any handler sees it — secret
+leakage through logs is structurally impossible.
 
 **Cross-cloud credential federation.** GKE Workload Identity, AWS
 IRSA, Azure IMDS, GitHub Actions OIDC, Anthropic WIF, and Azure

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,22 +40,29 @@ AWS-SDK initialisation cost.
 
 Before any trace, recording, or persistent log writes the
 `RunConfig`, it is run through `Redact()` which strips every
-`secret://` reference and every header value that resolves through
-one (notably `traceEmitter.headers`). The persisted artifact never
-contains anything that could be replayed against a provider.
+`secret://` reference, normalises provider and MCP URLs to their
+origin, redacts provider API-key header names, and redacts
+non-allowlisted provider query parameters. The persisted artifact
+never contains anything that could be replayed against a provider.
 
 ### `LogScrubber`
 
 The `harness/internal/observability/ScrubHandler` wraps any
 `slog.Handler` and runs `security.Scrub()` on every string attribute
-value before delegation. Seven regex patterns are scrubbed:
+value before delegation. Nineteen regex patterns are scrubbed,
+covering:
 
 - Anthropic API keys
-- OpenAI API keys
+- OpenAI and Stripe API keys
 - GitHub PATs and app tokens
-- AWS access keys
+- AWS access key IDs and key/value-anchored AWS secret access keys
+- Slack tokens
+- GCP API keys and OAuth2 access tokens
+- Key/value-anchored Azure storage keys
 - Bearer tokens including JWTs (Authorization headers; Basic auth)
 - PEM-encoded private keys
+- API-key header values
+- Key/value-anchored 32-character hex secrets
 - `secret://` references themselves
 
 Because the scrubber sits at the `slog.Handler` boundary, secret

--- a/harness/internal/security/logscrubber.go
+++ b/harness/internal/security/logscrubber.go
@@ -23,9 +23,18 @@ var secretPatterns = []namedPattern{
 	{"anthropic_wif_token", regexp.MustCompile(`sk-ant-oat01-[a-zA-Z0-9_-]+`)},
 	{"anthropic_api_key", regexp.MustCompile(`sk-ant-[a-zA-Z0-9_-]+`)},
 	{"openai_api_key", regexp.MustCompile(`sk-[A-Za-z0-9_-]{16,}`)},
+	{"stripe_live_key", regexp.MustCompile(`sk_live_[A-Za-z0-9]{16,}`)},
 	{"github_pat", regexp.MustCompile(`ghp_[a-zA-Z0-9]+`)},
 	{"github_app_token", regexp.MustCompile(`ghs_[a-zA-Z0-9]+`)},
 	{"aws_access_key_id", regexp.MustCompile(`AKIA[A-Z0-9]{16}`)},
+	// AWS secret access keys and Azure storage keys have high-entropy
+	// base64-ish shapes but no distinctive prefix. Keep them anchored to
+	// well-known key/value field names so ordinary hashes, IDs, and trace
+	// fragments are not scrubbed just because they share an alphabet.
+	{"aws_secret_access_key", regexp.MustCompile(`(?i)\baws_secret_access_key\b\s*[:=]\s*["']?[A-Za-z0-9/+=]{40}["']?`)},
+	{"azure_storage_key", regexp.MustCompile(`(?i)\b(?:azure_storage_account_key|storage_account_key|account_key|accountKey|primary_access_key|secondary_access_key)\b\s*[:=]\s*["']?[A-Za-z0-9+/]{40,88}={0,2}["']?`)},
+	{"slack_token", regexp.MustCompile(`xox[abprs]-[A-Za-z0-9-]{10,}`)},
+	{"gcp_api_key", regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`)},
 	// basic_auth precedes bearer_token so the two HTTP-auth families
 	// scrub independently. Grafana Cloud's documented credential
 	// format is `Basic <base64(instanceID:apiToken)>` (see
@@ -46,6 +55,7 @@ var secretPatterns = []namedPattern{
 	// know stirrup emits — adding more variants here is preferable to a
 	// permissive token catch-all.
 	{"api_key_header", regexp.MustCompile(`(?i)\b(?:api-key|x-api-key|Ocp-Apim-Subscription-Key)\s*:\s*[A-Za-z0-9._~+/=-]+`)},
+	{"generic_hex_secret", regexp.MustCompile(`(?i)\b(?:api[_-]?key|token|secret|client[_-]?secret|access[_-]?token|auth[_-]?token|password)\b\s*[:=]\s*["']?[a-f0-9]{32}["']?`)},
 	// oidc_jwt matches a three-segment JWT whose header begins with
 	// "eyJ" (the base64url prefix of `{"`). Federation flows propagate
 	// runner OIDC tokens, AWS web-identity tokens, and GCP STS subject

--- a/harness/internal/security/logscrubber_test.go
+++ b/harness/internal/security/logscrubber_test.go
@@ -2,6 +2,18 @@ package security
 
 import "testing"
 
+func slackTokenFixture() string {
+	return "xox" + "b-123456789012-123456789012-abcdefghijklmnopqrstuvwx"
+}
+
+func stripeLiveKeyFixture() string {
+	return "sk_" + "live_51J1234567890abcdefghijklmnopqrstuvwxyz"
+}
+
+func gcpAPIKeyFixture() string {
+	return "AI" + "zaA2345678901234567890123456789012345"
+}
+
 func TestScrub_AnthropicKey(t *testing.T) {
 	input := "key is sk-ant-abc123_DEF-456"
 	got := Scrub(input)
@@ -35,6 +47,74 @@ func TestScrub_AWSAccessKey(t *testing.T) {
 	want := "[REDACTED]"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestScrub_AWSSecretAccessKey(t *testing.T) {
+	input := "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	got := Scrub(input)
+	want := "[REDACTED]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestScrub_SlackToken(t *testing.T) {
+	input := "SLACK_BOT_TOKEN=" + slackTokenFixture()
+	got := Scrub(input)
+	want := "SLACK_BOT_TOKEN=[REDACTED]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestScrub_StripeLiveKey(t *testing.T) {
+	input := "stripe " + stripeLiveKeyFixture()
+	got := Scrub(input)
+	want := "stripe [REDACTED]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestScrub_GCPAPIKey(t *testing.T) {
+	input := "gcp=" + gcpAPIKeyFixture()
+	got := Scrub(input)
+	want := "gcp=[REDACTED]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestScrub_AzureStorageKey(t *testing.T) {
+	input := "primary_access_key: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ="
+	got := Scrub(input)
+	want := "[REDACTED]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestScrub_GenericHexSecret(t *testing.T) {
+	input := "client_secret=0123456789abcdef0123456789abcdef"
+	got := Scrub(input)
+	want := "[REDACTED]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestScrub_AnchoredPatternsAvoidCommonFalsePositives(t *testing.T) {
+	cases := []string{
+		"sha256=0123456789abcdef0123456789abcdef",
+		"trace_id=0123456789abcdef0123456789abcdef",
+		"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ=",
+	}
+	for _, input := range cases {
+		if got := Scrub(input); got != input {
+			t.Errorf("Scrub(%q) = %q, want unchanged", input, got)
+		}
 	}
 }
 
@@ -262,6 +342,31 @@ func TestScrubWithStats_PatternNames(t *testing.T) {
 			pattern: "aws_access_key_id",
 		},
 		{
+			name:    "aws_secret_access_key",
+			input:   "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			pattern: "aws_secret_access_key",
+		},
+		{
+			name:    "azure_storage_key",
+			input:   "primary_access_key: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ=",
+			pattern: "azure_storage_key",
+		},
+		{
+			name:    "slack_token",
+			input:   slackTokenFixture(),
+			pattern: "slack_token",
+		},
+		{
+			name:    "stripe_live_key",
+			input:   stripeLiveKeyFixture(),
+			pattern: "stripe_live_key",
+		},
+		{
+			name:    "gcp_api_key",
+			input:   gcpAPIKeyFixture(),
+			pattern: "gcp_api_key",
+		},
+		{
 			name:    "bearer_token",
 			input:   "Bearer eyJhbGciOiJSUzI1NiJ9.abc",
 			pattern: "bearer_token",
@@ -300,6 +405,11 @@ func TestScrubWithStats_PatternNames(t *testing.T) {
 			name:    "gcp_access_token",
 			input:   "ya29.AbCdEfGhIjKl",
 			pattern: "gcp_access_token",
+		},
+		{
+			name:    "generic_hex_secret",
+			input:   "client_secret=0123456789abcdef0123456789abcdef",
+			pattern: "generic_hex_secret",
 		},
 	}
 	for _, tc := range cases {

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -413,46 +413,11 @@ type GuardRailConfig struct {
 // image.
 func (rc RunConfig) Redact() RunConfig {
 	redacted := rc
-	if redacted.Provider.APIKeyRef != "" {
-		redacted.Provider.APIKeyRef = "secret://[REDACTED]"
-	}
-	// Deep-copy Provider.Retry so a downstream consumer holding the
-	// redacted config cannot reach back into the live RunConfig via the
-	// shared pointer. Redact() does not mutate Retry today, but every
-	// other pointer field it touches is deep-copied; matching the
-	// established pattern closes the aliasing window before a Wave 2
-	// retry-helper that mutates Retry could silently corrupt the live
-	// config it was handed a "safe copy" of.
-	if redacted.Provider.Retry != nil {
-		retry := *redacted.Provider.Retry
-		redacted.Provider.Retry = &retry
-	}
-	// Mirror the Retry deep-copy for Provider.Batch. The aliasing risk
-	// is concrete: validateBatchConfig mutates Batch.MaxWaitSeconds in
-	// place to apply the default, and the phase-2 BatchAdapter (#135)
-	// is expected to hold a reference to the Redact()-derived snapshot
-	// across the run. Without the deep copy, a later default-apply
-	// write would reach the redacted copy through the shared pointer
-	// and break the snapshot contract.
-	if redacted.Provider.Batch != nil {
-		batch := *redacted.Provider.Batch
-		redacted.Provider.Batch = &batch
-	}
+	redacted.Provider = redactProviderConfig(redacted.Provider)
 	if len(redacted.Providers) > 0 {
 		providers := make(map[string]ProviderConfig, len(redacted.Providers))
 		for name, provider := range redacted.Providers {
-			if provider.APIKeyRef != "" {
-				provider.APIKeyRef = "secret://[REDACTED]"
-			}
-			if provider.Retry != nil {
-				retry := *provider.Retry
-				provider.Retry = &retry
-			}
-			if provider.Batch != nil {
-				batch := *provider.Batch
-				provider.Batch = &batch
-			}
-			providers[name] = provider
+			providers[name] = redactProviderConfig(provider)
 		}
 		redacted.Providers = providers
 	}
@@ -465,6 +430,9 @@ func (rc RunConfig) Redact() RunConfig {
 		servers := make([]MCPServerConfig, len(redacted.Tools.MCPServers))
 		copy(servers, redacted.Tools.MCPServers)
 		for i := range servers {
+			if servers[i].URI != "" {
+				servers[i].URI = redactURLToOrigin(servers[i].URI)
+			}
 			if servers[i].APIKeyRef != "" {
 				servers[i].APIKeyRef = "secret://[REDACTED]"
 			}
@@ -508,6 +476,68 @@ func (rc RunConfig) Redact() RunConfig {
 		redacted.ResultSink = &sink
 	}
 	return redacted
+}
+
+func redactProviderConfig(provider ProviderConfig) ProviderConfig {
+	if provider.APIKeyRef != "" {
+		provider.APIKeyRef = "secret://[REDACTED]"
+	}
+	if provider.BaseURL != "" {
+		provider.BaseURL = redactURLToOrigin(provider.BaseURL)
+	}
+	if provider.APIKeyHeader != "" {
+		provider.APIKeyHeader = "[REDACTED]"
+	}
+	if len(provider.QueryParams) > 0 {
+		provider.QueryParams = redactProviderQueryParams(provider.QueryParams)
+	}
+	// Deep-copy Provider.Retry so a downstream consumer holding the
+	// redacted config cannot reach back into the live RunConfig via the
+	// shared pointer. Redact() does not mutate Retry today, but every
+	// other pointer field it touches is deep-copied; matching the
+	// established pattern closes the aliasing window before a Wave 2
+	// retry-helper that mutates Retry could silently corrupt the live
+	// config it was handed a "safe copy" of.
+	if provider.Retry != nil {
+		retry := *provider.Retry
+		provider.Retry = &retry
+	}
+	// Mirror the Retry deep-copy for Provider.Batch. The aliasing risk
+	// is concrete: validateBatchConfig mutates Batch.MaxWaitSeconds in
+	// place to apply the default, and the phase-2 BatchAdapter (#135)
+	// is expected to hold a reference to the Redact()-derived snapshot
+	// across the run. Without the deep copy, a later default-apply
+	// write would reach the redacted copy through the shared pointer
+	// and break the snapshot contract.
+	if provider.Batch != nil {
+		batch := *provider.Batch
+		provider.Batch = &batch
+	}
+	return provider
+}
+
+func redactURLToOrigin(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "[REDACTED]"
+	}
+	return (&url.URL{Scheme: u.Scheme, Host: u.Host}).String()
+}
+
+func redactProviderQueryParams(params map[string]string) map[string]string {
+	out := make(map[string]string, len(params))
+	for key, value := range params {
+		if isRedactSafeProviderQueryParam(key) {
+			out[key] = value
+		} else {
+			out[key] = "[REDACTED]"
+		}
+	}
+	return out
+}
+
+func isRedactSafeProviderQueryParam(key string) bool {
+	return strings.EqualFold(key, "api-version")
 }
 
 // ProviderConfig selects the model provider implementation.

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -59,22 +59,100 @@ func TestRedact_ProvidersAPIKeys(t *testing.T) {
 	}
 }
 
+func TestRedact_ProviderConnectionFields(t *testing.T) {
+	rc := RunConfig{
+		Provider: ProviderConfig{
+			Type:         "openai-compatible",
+			BaseURL:      "https://user:pass@llm-gateway.internal.corp/openai/v1?api-key=raw",
+			APIKeyHeader: "x-api-key",
+			QueryParams: map[string]string{
+				"api-version": "2024-10-21",
+				"api-key":     "raw-query-key",
+				"tenant":      "internal-team",
+			},
+		},
+		Providers: map[string]ProviderConfig{
+			"backup": {
+				Type:         "openai-responses",
+				BaseURL:      "https://backup.internal.example/v1/responses?token=raw",
+				APIKeyHeader: "api-key",
+				QueryParams: map[string]string{
+					"api-version": "preview",
+					"token":       "raw-token",
+				},
+			},
+		},
+	}
+
+	redacted := rc.Redact()
+
+	if got := redacted.Provider.BaseURL; got != "https://llm-gateway.internal.corp" {
+		t.Errorf("Provider.BaseURL = %q, want origin only", got)
+	}
+	if got := redacted.Provider.APIKeyHeader; got != "[REDACTED]" {
+		t.Errorf("Provider.APIKeyHeader = %q, want [REDACTED]", got)
+	}
+	if got := redacted.Provider.QueryParams["api-version"]; got != "2024-10-21" {
+		t.Errorf("Provider.QueryParams[api-version] = %q, want preserved allowlisted value", got)
+	}
+	if got := redacted.Provider.QueryParams["api-key"]; got != "[REDACTED]" {
+		t.Errorf("Provider.QueryParams[api-key] = %q, want [REDACTED]", got)
+	}
+	if got := redacted.Provider.QueryParams["tenant"]; got != "[REDACTED]" {
+		t.Errorf("Provider.QueryParams[tenant] = %q, want [REDACTED]", got)
+	}
+
+	backup := redacted.Providers["backup"]
+	if got := backup.BaseURL; got != "https://backup.internal.example" {
+		t.Errorf("Providers[backup].BaseURL = %q, want origin only", got)
+	}
+	if got := backup.APIKeyHeader; got != "[REDACTED]" {
+		t.Errorf("Providers[backup].APIKeyHeader = %q, want [REDACTED]", got)
+	}
+	if got := backup.QueryParams["api-version"]; got != "preview" {
+		t.Errorf("Providers[backup].QueryParams[api-version] = %q, want preserved allowlisted value", got)
+	}
+	if got := backup.QueryParams["token"]; got != "[REDACTED]" {
+		t.Errorf("Providers[backup].QueryParams[token] = %q, want [REDACTED]", got)
+	}
+
+	redacted.Provider.QueryParams["tenant"] = "mutated"
+	if got := rc.Provider.BaseURL; got != "https://user:pass@llm-gateway.internal.corp/openai/v1?api-key=raw" {
+		t.Errorf("Redact mutated original Provider.BaseURL: %q", got)
+	}
+	if got := rc.Provider.APIKeyHeader; got != "x-api-key" {
+		t.Errorf("Redact mutated original Provider.APIKeyHeader: %q", got)
+	}
+	if got := rc.Provider.QueryParams["tenant"]; got != "internal-team" {
+		t.Errorf("Redact mutated original Provider.QueryParams: %q", got)
+	}
+}
+
 func TestRedact_MCPServersAPIKeys(t *testing.T) {
 	rc := RunConfig{
 		Tools: ToolsConfig{
 			MCPServers: []MCPServerConfig{
-				{URI: "http://a", APIKeyRef: "secret://key1"},
+				{URI: "https://user:pass@mcp-a.internal.example/mcp?api_key=raw", APIKeyRef: "secret://key1"},
 				{URI: "http://b", APIKeyRef: ""},
-				{URI: "http://c", APIKeyRef: "secret://key2"},
+				{URI: "http://c/path?token=raw", APIKeyRef: "secret://key2"},
 			},
 		},
 	}
 	redacted := rc.Redact()
+	if redacted.Tools.MCPServers[0].URI != "https://mcp-a.internal.example" {
+		t.Errorf("MCPServers[0].URI = %q, want origin only", redacted.Tools.MCPServers[0].URI)
+	}
 	if redacted.Tools.MCPServers[0].APIKeyRef != "secret://[REDACTED]" {
 		t.Errorf("MCPServers[0].APIKeyRef = %q, want redacted", redacted.Tools.MCPServers[0].APIKeyRef)
 	}
+	if redacted.Tools.MCPServers[1].URI != "http://b" {
+		t.Errorf("MCPServers[1].URI = %q, want unchanged origin", redacted.Tools.MCPServers[1].URI)
+	}
 	if redacted.Tools.MCPServers[1].APIKeyRef != "" {
 		t.Errorf("MCPServers[1].APIKeyRef = %q, want empty", redacted.Tools.MCPServers[1].APIKeyRef)
+	}
+	if redacted.Tools.MCPServers[2].URI != "http://c" {
+		t.Errorf("MCPServers[2].URI = %q, want origin only", redacted.Tools.MCPServers[2].URI)
 	}
 	if redacted.Tools.MCPServers[2].APIKeyRef != "secret://[REDACTED]" {
 		t.Errorf("MCPServers[2].APIKeyRef = %q, want redacted", redacted.Tools.MCPServers[2].APIKeyRef)
@@ -82,6 +160,9 @@ func TestRedact_MCPServersAPIKeys(t *testing.T) {
 	// Original unchanged.
 	if rc.Tools.MCPServers[0].APIKeyRef != "secret://key1" {
 		t.Error("Redact mutated original MCPServers")
+	}
+	if rc.Tools.MCPServers[0].URI != "https://user:pass@mcp-a.internal.example/mcp?api_key=raw" {
+		t.Error("Redact mutated original MCPServers URI")
 	}
 }
 


### PR DESCRIPTION
Closes #114.

## Summary
- Adds LogScrubber coverage for Slack tokens, Stripe live keys, GCP API keys, and key/value-anchored AWS secret access keys, Azure storage keys, and 32-character hex secrets.
- Extends `RunConfig.Redact()` to normalise provider and MCP URLs to origin-only values, redact provider API-key header names, and redact non-allowlisted provider query parameters while preserving `api-version`.
- Updates stale LogScrubber documentation to reflect the current 19-pattern scrubber and the broader `RunConfig.Redact()` behaviour.

## Tests
- `go test ./harness/internal/security ./types`
- `go test ./harness/... ./types/... ./eval/...`

## Residual Risk
- AWS secret access keys, Azure storage keys, and generic 32-character hex secrets are intentionally key/value anchored. Standalone values with no field-name context may remain unscrubbed to avoid broad false positives on hashes, trace IDs, and ordinary base64 output.