### PR TITLE
docs: clarify tool permission semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,14 +117,15 @@ end-of-run. Each turn the loop asks the `ModelRouter` which
 provider+model to use and the `ContextStrategy` for the message
 history (compacting if the budget is tight), then streams the request
 through the chosen `ProviderAdapter`. Tool calls in the response are
-resolved by the `ToolRegistry`; tools flagged `WorkspaceMutating` or
-`RequiresApproval` are gated by the `PermissionPolicy` before
-dispatch, while read-only tools go straight to the `Executor`. The
-`edit_file` tool dispatches through the `EditStrategy`, which uses
-the Executor for file I/O (and is transparently wrapped by the
-post-edit code scanner). At end-of-run the `Verifier` validates
-output. The `Transport` carries events to and from the control plane;
-the `TraceEmitter` records spans and metrics throughout.
+resolved by the `ToolRegistry`; the `PermissionPolicy` interprets each
+tool's `WorkspaceMutating` and `RequiresApproval` flags before
+dispatch. Read-only tools with neither flag go straight to the
+`Executor`. The `edit_file` tool dispatches through the
+`EditStrategy`, which uses the Executor for file I/O (and is
+transparently wrapped by the post-edit code scanner). At end-of-run
+the `Verifier` validates output. The `Transport` carries events to
+and from the control plane; the `TraceEmitter` records spans and
+metrics throughout.
 
 ## Modes
 
@@ -311,8 +312,8 @@ Four implementations gate side-effecting tool calls:
 - **`deny-side-effects`** — workspace-mutating tools (`write_file`,
   `run_command`, `edit_file`) are blocked outright. Read-only tools
   with network or budget exposure (`web_fetch`, `spawn_agent`) are
-  still allowed and gated separately by `ask-upstream`. Default for
-  read-only modes.
+  still allowed; choose `ask-upstream` when those tools should prompt.
+  Default for read-only modes.
 - **`ask-upstream`** — tools whose `RequiresApproval` flag is set
   prompt the control plane via a `permission_request` event before
   dispatch. Only useful with the `grpc` transport; `stdio` has no
@@ -323,8 +324,9 @@ Four implementations gate side-effecting tool calls:
   Starter policies live in [`examples/policies/`](../examples/policies/).
 
 The `policy-engine` policy is one of the five safety rings; see
-[`safety-rings.md`](safety-rings.md) for the operator-facing
-walkthrough.
+[`safety-rings.md`](safety-rings.md) for the safety walkthrough and
+[`configuration.md#tool-permission-flags`](configuration.md#tool-permission-flags)
+for the operator-facing flag matrix.
 
 ## Context strategies
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,6 +321,40 @@ configuration space — the common cases. Anything below requires
 
 The CLI flags for each of these set the *type* selection only.
 
+## Tool permission flags
+
+Tools carry two independent permission flags:
+
+- `WorkspaceMutating` means the tool changes workspace state: files,
+  processes, or other on-disk artefacts. Read-only modes reject these
+  tools structurally before the loop starts.
+- `RequiresApproval` means the operator may want an upstream approval
+  prompt before the tool runs. It includes mutating tools, but also
+  covers non-mutating sensitive tools such as `web_fetch` and
+  `spawn_agent`.
+
+`RequiresApproval` does not by itself mean "always prompt". The active
+`permissionPolicy` decides how to interpret the flag:
+
+| Tool examples | Flags | `allow-all` | `deny-side-effects` | `ask-upstream` |
+|---|---|---|---|---|
+| `read_file`, `list_directory`, `search_files` | neither flag | Allow | Allow | Allow |
+| `web_fetch`, `spawn_agent` | `RequiresApproval` only | Allow | Allow | Prompt |
+| `run_command` | `WorkspaceMutating` + `RequiresApproval` | Allow | Deny | Prompt |
+| `edit_file`, `write_file` | `WorkspaceMutating` + `RequiresApproval` | Allow | Deny | Prompt |
+
+`policy-engine` evaluates the Cedar policy first. When Cedar returns
+no decision, the configured fallback (`deny-side-effects` by default)
+applies exactly the same rules as the corresponding non-Cedar policy.
+For example, a policy engine with `fallback: "deny-side-effects"`
+still allows `web_fetch` and `spawn_agent` unless a Cedar `forbid`
+matches them, because neither tool mutates the workspace.
+
+Choose `ask-upstream` when every `RequiresApproval` tool must prompt.
+Choose `deny-side-effects` when the goal is to block workspace
+mutation while still allowing non-mutating tools that may have network
+or budget exposure.
+
 ## Read-only modes
 
 `planning`, `review`, `research`, and `toil` enforce a structural
@@ -335,11 +369,16 @@ shell capability and the `deny-side-effects` permission policy.
 Operators wanting the editable, shell-capable behaviour opt in
 explicitly with `--mode execution` (or by selecting one of the
 restrictive `permissionPolicy` types in [`safety-rings.md`](safety-rings.md)
-for finer-grained control). The read-only modes differ from each
-other only in prompt template: `planning` for "describe and reason
-before acting" first-touch use, `review` for change-review tasks,
-`research` for investigation across a codebase or the web, and
-`toil` for structured-briefing workflows.
+for finer-grained control). Because read-only enforcement is based on
+`WorkspaceMutating`, a read-only mode can still include non-mutating
+sensitive tools such as `web_fetch`; under the default
+`deny-side-effects` policy those tools run without prompting. Switch
+to `ask-upstream` when those calls should require operator approval.
+
+The read-only modes differ from each other only in prompt template:
+`planning` for "describe and reason before acting" first-touch use,
+`review` for change-review tasks, `research` for investigation across
+a codebase or the web, and `toil` for structured-briefing workflows.
 
 ## Limits and budgets
 

--- a/docs/safety-rings.md
+++ b/docs/safety-rings.md
@@ -294,7 +294,7 @@ flowchart TB
   Eval -->|permit + no forbid| Allowed[Allow<br/>policy_decision event]
   Eval -->|no match| Fallback{Fallback policy<br/>policy_decision event in either case}
   Fallback -->|allow-all| AllowedFallback[Allow]
-  Fallback -->|deny-side-effects| MaybeDeny{Workspace mutating<br/>or RequiresApproval?}
+  Fallback -->|deny-side-effects| MaybeDeny{Workspace mutating?}
   MaybeDeny -->|yes| DenyFallback[Deny]
   MaybeDeny -->|no| AllowedFallback
   Fallback -->|ask-upstream| AskOp[Ask operator<br/>via transport correlator]
@@ -654,7 +654,7 @@ RunConfig snippet that validates against `ValidateRunConfig`.
 | **Dev** | Permissive — `allow-all`, no scanner, no network | Local iteration on a trusted machine, fastest feedback |
 | **Defaults** | Recommended baseline — `deny-side-effects`, `patterns` scanner, no network | Most production runs against trusted prompts |
 | **Hardened** | Maximum — `policy-engine`, gVisor, allowlisted egress, composite scanner | High-stakes runs, untrusted inputs, multi-tenant infra |
-| **Read-only** | `ask-upstream`, no edits, no network | Research / planning / review modes |
+| **Read-only** | `deny-side-effects` by default, no edits; `ask-upstream` when approval prompts are required | Research / planning / review modes |
 
 ### Dev — local iteration, no isolation
 
@@ -773,7 +773,7 @@ both pattern and semgrep scanners run on every edit.
   "executor": { "type": "container", "image": "ghcr.io/rxbynerd/stirrup:latest", "runtime": "runc", "network": { "mode": "none" } },
   "editStrategy": { "type": "multi" },
   "verifier": { "type": "none" },
-  "permissionPolicy": { "type": "ask-upstream", "timeout": 60 },
+  "permissionPolicy": { "type": "deny-side-effects" },
   "gitStrategy": { "type": "none" },
   "transport": { "type": "stdio" },
   "traceEmitter": { "type": "jsonl" },
@@ -784,12 +784,16 @@ both pattern and semgrep scanners run on every edit.
 }
 ```
 
-`ask-upstream` + `runc` + `network.mode: none` + no scanner.
+`deny-side-effects` + `runc` + `network.mode: none` + no scanner.
 Read-only modes (`planning`, `review`, `research`, `toil`) cannot
 enable write-capable tools (enforced by `ValidateRunConfig`); the
-scanner is unused because no edits happen. `ask-upstream` is the
-documented Rule-of-Two-compatible policy when `web_fetch` +
-secret-named API key + MCP servers may all be present.
+scanner is unused because no edits happen. Their default permission
+policy is `deny-side-effects`, which blocks workspace mutation but
+allows non-mutating sensitive tools such as `web_fetch` and
+`spawn_agent`. `ask-upstream` is the stricter Rule-of-Two-compatible
+choice when those `RequiresApproval` tools should ask the operator
+before running; use it with `grpc` transport, since `stdio` has no
+upstream control plane to answer permission requests.
 
 The `editStrategy` field is set out of habit but inert here — no
 `edit_file` tool is registered when `tools.builtIn` excludes it, so


### PR DESCRIPTION
Closes #232.

## Summary

- Adds an operator-facing `WorkspaceMutating` vs `RequiresApproval` section to `docs/configuration.md`.
- Documents how `allow-all`, `deny-side-effects`, `ask-upstream`, and `policy-engine` fallback treat common built-in tools.
- Aligns the architecture and safety-rings docs with the current `deny-side-effects` behavior for non-mutating approval-required tools.

## Tests

- `go test ./harness/internal/permission/...`
- `git diff --check`

## Notes

- Docs-only change; no runtime behavior changed.
- Beads: `stirrup-128` closed locally after verification.