### PR TITLE
edit: consolidate edit-strategy default to multi via ValidateRunConfig

### DIFF
--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -283,14 +283,12 @@ func buildHarnessRunConfigCore(opts harnessCLIOptions) (*types.RunConfig, error)
 	if executorType == "" {
 		executorType = "local"
 	}
+	// EditStrategyType intentionally not defaulted here: an empty value
+	// flows into RunConfig.EditStrategy.Type and is filled with "multi"
+	// by types.ValidateRunConfig via applyEditStrategyDefault. Keeping the
+	// default in one place (validation) means CLI, gRPC, and direct
+	// RunConfig embedding all land on the same edit-tool surface.
 	editStrategyType := opts.EditStrategyType
-	if editStrategyType == "" {
-		// "multi" is the default because the multi-strategy edit tool is the
-		// highest-leverage edit configuration for production. Callers asking
-		// for write_file/search_replace/apply_diff are aliased to the
-		// multi-strategy's edit_file tool by core/factory.go::editToolEnabled.
-		editStrategyType = "multi"
-	}
 	verifierType := opts.VerifierType
 	if verifierType == "" {
 		verifierType = "none"

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -376,6 +376,12 @@ func TestBuildHarnessRunConfig_ComponentSelections(t *testing.T) {
 // fallback values for component-selection fields. These defaults are the
 // shipped CLI behaviour; tests pin them explicitly so a refactor that
 // changes them by accident fails loudly.
+//
+// EditStrategy.Type is deliberately not asserted here: it is defaulted
+// by types.ValidateRunConfig (via applyEditStrategyDefault), not by the
+// CLI-layer buildHarnessRunConfig path, so empty in / empty out at this
+// layer is the correct behaviour. End-to-end CLI defaulting is covered
+// by TestBuildRunConfig_EmptyEditStrategyResolvesToMulti.
 func TestBuildHarnessRunConfig_EmptyComponentDefaults(t *testing.T) {
 	cfg, err := buildHarnessRunConfig(harnessCLIOptions{
 		RunID:         "test-run",
@@ -395,9 +401,6 @@ func TestBuildHarnessRunConfig_EmptyComponentDefaults(t *testing.T) {
 	}
 	if cfg.Executor.Type != "local" {
 		t.Errorf("default executor should be 'local', got %q", cfg.Executor.Type)
-	}
-	if cfg.EditStrategy.Type != "multi" {
-		t.Errorf("default edit strategy should be 'multi', got %q", cfg.EditStrategy.Type)
 	}
 	if cfg.Verifier.Type != "none" {
 		t.Errorf("default verifier should be 'none', got %q", cfg.Verifier.Type)

--- a/harness/cmd/stirrup/cmd/runconfig_test.go
+++ b/harness/cmd/stirrup/cmd/runconfig_test.go
@@ -349,3 +349,48 @@ func TestRunRunConfigWithIO_TableDriven(t *testing.T) {
 		})
 	}
 }
+
+// TestRunRunConfig_EmptyEditStrategyDefaultsToMulti pins the
+// stirrup run-config subcommand's edit-strategy default behaviour.
+// With --validate (ResolveAll), the emitted document must carry
+// EditStrategy.Type = "multi" because the validation layer is the
+// single normalization point. Without --validate (ResolveBase), the
+// emitted document deliberately preserves the empty value so chained
+// `run-config | run-config | ...` stages remain idempotent and a
+// later stage can layer one more override on top.
+func TestRunRunConfig_EmptyEditStrategyDefaultsToMulti(t *testing.T) {
+	t.Run("validate fills default", func(t *testing.T) {
+		out, err := runRunConfigForTest(t, []string{
+			"--validate",
+			"--mode", "execution",
+			"--prompt", "test",
+		}, "")
+		if err != nil {
+			t.Fatalf("runRunConfig: %v", err)
+		}
+		var cfg types.RunConfig
+		if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+			t.Fatalf("unparseable JSON: %v\n%s", err, out)
+		}
+		if cfg.EditStrategy.Type != "multi" {
+			t.Errorf("EditStrategy.Type = %q, want multi (subcommand default must match CLI and validation)", cfg.EditStrategy.Type)
+		}
+	})
+
+	t.Run("base mode preserves empty for chaining", func(t *testing.T) {
+		out, err := runRunConfigForTest(t, []string{
+			"--mode", "execution",
+			"--prompt", "test",
+		}, "")
+		if err != nil {
+			t.Fatalf("runRunConfig: %v", err)
+		}
+		var cfg types.RunConfig
+		if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+			t.Fatalf("unparseable JSON: %v\n%s", err, out)
+		}
+		if cfg.EditStrategy.Type != "" {
+			t.Errorf("EditStrategy.Type = %q, want empty (ResolveBase must not apply defaults a downstream stage could override)", cfg.EditStrategy.Type)
+		}
+	})
+}

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -1053,3 +1053,57 @@ func TestBuildRunConfig_EnvVarLeadingWhitespaceTrimmed(t *testing.T) {
 		t.Errorf("RunID = %q, want from-file (trimmed env path should resolve)", cfg.RunID)
 	}
 }
+
+// TestBuildRunConfig_EmptyEditStrategyResolvesToMulti pins the
+// end-to-end CLI default for the edit strategy. A bare flag-only
+// invocation (no --edit-strategy flag) must land on "multi" after the
+// full Resolve == ResolveAll pipeline, matching direct RunConfig
+// embedding (TestValidateRunConfig_EditStrategyDefaultsToMulti) and the
+// run-config subcommand (TestRunRunConfig_EmptyEditStrategyDefaultsToMulti).
+// Tests fail if CLI and validation defaults ever diverge again.
+func TestBuildRunConfig_EmptyEditStrategyResolvesToMulti(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--mode", "execution",
+		"--prompt", "test",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveAll,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.EditStrategy.Type != "multi" {
+		t.Errorf("EditStrategy.Type = %q, want multi (CLI default must match validation default)", cfg.EditStrategy.Type)
+	}
+}
+
+// TestBuildRunConfig_ExplicitEditStrategyPreserved confirms the
+// override path: an operator who selects --edit-strategy explicitly
+// still gets their selection rather than being silently rewritten to
+// the validation default.
+func TestBuildRunConfig_ExplicitEditStrategyPreserved(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--mode", "execution",
+		"--prompt", "test",
+		"--edit-strategy", "whole-file",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveAll,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.EditStrategy.Type != "whole-file" {
+		t.Errorf("EditStrategy.Type = %q, want whole-file (explicit selection must survive defaulting)", cfg.EditStrategy.Type)
+	}
+}

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -55,7 +55,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.String("name", "", "Human-readable session label (metadata only, not injected into prompt)")
 
 	f.String("executor", "local", "Executor: local, container, api")
-	f.String("edit-strategy", "", "Edit strategy: whole-file, search-replace, udiff, multi (composite available only via --config). Empty defers to the RunConfig default (multi).")
+	f.String("edit-strategy", "", "Edit strategy: whole-file, search-replace, udiff, multi (composite available only via --config). Defaults to multi when unset.")
 	f.String("verifier", "none", "Verifier: none, test-runner, llm-judge (composite available only via --config)")
 	f.String("git-strategy", "none", "Git strategy: none, deterministic")
 	f.String("trace-emitter", "jsonl", "Trace emitter: jsonl, otel, gcs")

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -55,7 +55,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.String("name", "", "Human-readable session label (metadata only, not injected into prompt)")
 
 	f.String("executor", "local", "Executor: local, container, api")
-	f.String("edit-strategy", "multi", "Edit strategy: whole-file, search-replace, udiff, multi (composite available only via --config)")
+	f.String("edit-strategy", "", "Edit strategy: whole-file, search-replace, udiff, multi (composite available only via --config). Empty defers to the RunConfig default (multi).")
 	f.String("verifier", "none", "Verifier: none, test-runner, llm-judge (composite available only via --config)")
 	f.String("git-strategy", "none", "Git strategy: none, deterministic")
 	f.String("trace-emitter", "jsonl", "Trace emitter: jsonl, otel, gcs")

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -963,6 +963,12 @@ func wireEditMetrics(es edit.EditStrategy, metrics *observability.Metrics) {
 	}
 }
 
+// buildEditStrategy maps the (already-defaulted) EditStrategyConfig to
+// a concrete EditStrategy. types.ValidateRunConfig is the single
+// normalization point that fills an empty Type with "multi", so the
+// empty-string case is never expected here; the default branch routes
+// to MultiStrategy as a defence-in-depth fallback for callers that
+// bypass validation entirely.
 func buildEditStrategy(cfg types.EditStrategyConfig) edit.EditStrategy {
 	fuzzyThreshold := 0.80
 	if cfg.FuzzyThreshold != nil {
@@ -970,7 +976,7 @@ func buildEditStrategy(cfg types.EditStrategyConfig) edit.EditStrategy {
 	}
 
 	switch cfg.Type {
-	case "whole-file", "":
+	case "whole-file":
 		return edit.NewWholeFileStrategy()
 	case "search-replace":
 		return edit.NewSearchReplaceStrategy()
@@ -979,7 +985,7 @@ func buildEditStrategy(cfg types.EditStrategyConfig) edit.EditStrategy {
 	case "multi":
 		return edit.NewMultiStrategy(fuzzyThreshold)
 	default:
-		return edit.NewWholeFileStrategy()
+		return edit.NewMultiStrategy(fuzzyThreshold)
 	}
 }
 

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -303,10 +303,17 @@ func TestBuildEditStrategy_WholeFile(t *testing.T) {
 	}
 }
 
+// TestBuildEditStrategy_Empty pins the defence-in-depth behaviour of
+// buildEditStrategy for callers that bypass types.ValidateRunConfig.
+// The validator fills an empty EditStrategy.Type with "multi" before
+// the factory is reached, so this branch should never trigger in a
+// validated run — but if it does, the factory must not silently fall
+// back to a strategy that exposes a different write-tool surface than
+// every validated entrypoint.
 func TestBuildEditStrategy_Empty(t *testing.T) {
 	es := buildEditStrategy(types.EditStrategyConfig{})
-	if _, ok := es.(*edit.WholeFileStrategy); !ok {
-		t.Fatalf("expected WholeFileStrategy for empty type, got %T", es)
+	if _, ok := es.(*edit.MultiStrategy); !ok {
+		t.Fatalf("expected MultiStrategy for empty type, got %T", es)
 	}
 }
 
@@ -341,8 +348,8 @@ func TestBuildEditStrategy_CustomFuzzyThreshold(t *testing.T) {
 
 func TestBuildEditStrategy_UnknownFallsBack(t *testing.T) {
 	es := buildEditStrategy(types.EditStrategyConfig{Type: "nonexistent"})
-	if _, ok := es.(*edit.WholeFileStrategy); !ok {
-		t.Fatalf("expected WholeFileStrategy for unknown type, got %T", es)
+	if _, ok := es.(*edit.MultiStrategy); !ok {
+		t.Fatalf("expected MultiStrategy for unknown type, got %T", es)
 	}
 }
 

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -1441,14 +1441,14 @@ func TestBuildLoopWithTransport_EmptyEditStrategyDefaultsToMulti(t *testing.T) {
 
 	timeout := 30
 	config := &types.RunConfig{
-		RunID:            "factory-test-edit-default",
-		Mode:             "execution",
-		Prompt:           "hello",
-		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
-		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
-		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
-		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
-		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		RunID:           "factory-test-edit-default",
+		Mode:            "execution",
+		Prompt:          "hello",
+		Provider:        types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:        types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
 		// EditStrategy intentionally omitted: the whole point of this
 		// test is the empty-type → "multi" default chain.
 		Verifier:         types.VerifierConfig{Type: "none"},

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -1419,6 +1419,72 @@ func TestBuildLoopWithTransport_MinimalValidConfig(t *testing.T) {
 	}
 }
 
+// TestBuildLoopWithTransport_EmptyEditStrategyDefaultsToMulti pins the
+// full composition — ValidateRunConfig → applyEditStrategyDefault →
+// buildEditStrategy → wrapWithCodeScanner — across the BuildLoopWithTransport
+// seam. The two halves are exercised independently elsewhere
+// (TestValidateRunConfig_EditStrategyDefaultsToMulti in
+// types/runconfig_test.go and TestBuildEditStrategy_Empty above), but
+// either side could regress without breaking the other: e.g. removing
+// the applyEditStrategyDefault call from ValidateRunConfig while
+// re-adding case "" to buildEditStrategy would leave both unit tests
+// green. This test fails in that scenario because the factory's
+// buildEditStrategy now returns MultiStrategy for an empty type
+// (defence-in-depth) — so we need a non-multi explicit choice in the
+// other tests to detect a missed default. With execution mode, the
+// "patterns" CodeScanner default wraps the base strategy in a
+// ScannedStrategy whose Inner() is the MultiStrategy.
+func TestBuildLoopWithTransport_EmptyEditStrategyDefaultsToMulti(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-edit-default",
+		Mode:             "execution",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		// EditStrategy intentionally omitted: the whole point of this
+		// test is the empty-type → "multi" default chain.
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	// ValidateRunConfig should have written "multi" into the (otherwise
+	// empty) EditStrategy.Type before the factory ran.
+	if config.EditStrategy.Type != "multi" {
+		t.Errorf("expected ValidateRunConfig to default EditStrategy.Type to \"multi\", got %q", config.EditStrategy.Type)
+	}
+
+	// Execution mode defaults CodeScanner.Type to "patterns", which
+	// wraps the base strategy in a ScannedStrategy. Unwrap once before
+	// asserting the inner type.
+	got := loop.Edit
+	if scanned, ok := got.(*edit.ScannedStrategy); ok {
+		got = scanned.Inner()
+	}
+	if _, ok := got.(*edit.MultiStrategy); !ok {
+		t.Fatalf("expected loop.Edit to resolve to *edit.MultiStrategy (possibly via ScannedStrategy wrapper), got %T", loop.Edit)
+	}
+}
+
 func TestBuildLoopWithTransport_InjectedTransportSkipsBuild(t *testing.T) {
 	t.Setenv("TEST_OPENAI_KEY", "test-key")
 	server := newOpenAIServer(t, nil, nil, nil)

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1549,13 +1549,17 @@ type ModePreset struct {
 // CodeScannerConfig when the caller has left it nil, so downstream
 // consumers always see a populated value: "patterns" for execution
 // mode (active scanning) and "none" for read-only modes (no edits
-// happen anyway). Also applies ProviderRetryConfig defaults to
-// Provider.Retry and each entry in Providers so adapters never have
-// to nil-check the per-call retry policy.
+// happen anyway). It also fills EditStrategy.Type with "multi" when
+// the caller has not selected a strategy, so every entrypoint (CLI,
+// gRPC, direct RunConfig embedding) lands on the same edit-tool
+// surface. ProviderRetryConfig defaults are applied to Provider.Retry
+// and each entry in Providers so adapters never have to nil-check the
+// per-call retry policy.
 //
 // Note: ValidateRunConfig mutates its argument in place to apply
 // per-provider defaults (Provider.Retry fields, Provider.Batch.MaxWaitSeconds
-// when Batch.Enabled=true, CodeScanner type). Callers that need an
+// when Batch.Enabled=true, CodeScanner type, EditStrategy.Type — the
+// last applied by applyEditStrategyDefault). Callers that need an
 // unmodified copy must clone before calling. Redact() deep-copies the
 // affected pointer fields so a snapshot taken before validation does
 // not alias the live config.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1561,6 +1561,7 @@ type ModePreset struct {
 // not alias the live config.
 func ValidateRunConfig(config *RunConfig) error {
 	applyCodeScannerDefault(config)
+	applyEditStrategyDefault(config)
 	retryDefaulted := applyProviderRetryDefaults(config)
 
 	var errs []string
@@ -1981,6 +1982,20 @@ func applyCodeScannerDefault(config *RunConfig) {
 		return
 	}
 	config.CodeScanner = &CodeScannerConfig{Type: "patterns"}
+}
+
+// applyEditStrategyDefault fills EditStrategy.Type with "multi" when
+// the caller has not set one. "multi" is the canonical default
+// because the multi-strategy edit tool is the highest-leverage edit
+// configuration for production. Defaulting here — rather than at the
+// CLI or factory layer — means every entrypoint (CLI, gRPC, direct
+// RunConfig embedding) lands on the same edit-tool surface for a
+// given config, and read-only mode policy stays consistent across
+// callers.
+func applyEditStrategyDefault(config *RunConfig) {
+	if config.EditStrategy.Type == "" {
+		config.EditStrategy.Type = "multi"
+	}
 }
 
 // validateCodeScannerConfig enforces the closed-set Type and the

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -1795,6 +1795,43 @@ func TestValidateRunConfig_CodeScannerExplicitOverridesDefault(t *testing.T) {
 	}
 }
 
+// --- EditStrategy default ---
+
+// TestValidateRunConfig_EditStrategyDefaultsToMulti pins the
+// single-normalization-point contract for the edit strategy: a
+// directly-embedded RunConfig with an empty EditStrategy.Type lands on
+// "multi" after validation, matching the CLI and gRPC entrypoints. Prior
+// to this default, the same caller would have reached the factory with
+// an empty Type and silently received the whole-file strategy, which
+// exposes a different write-tool surface than the CLI default.
+func TestValidateRunConfig_EditStrategyDefaultsToMulti(t *testing.T) {
+	c := validConfig() // EditStrategy.Type deliberately left empty
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("validation failed: %v", err)
+	}
+	if c.EditStrategy.Type != "multi" {
+		t.Errorf("expected EditStrategy.Type to default to %q, got %q", "multi", c.EditStrategy.Type)
+	}
+}
+
+// TestValidateRunConfig_EditStrategyExplicitPreserved confirms that an
+// operator who selects whole-file, search-replace, or udiff explicitly
+// is not silently rewritten to "multi" by the defaulting pass.
+func TestValidateRunConfig_EditStrategyExplicitPreserved(t *testing.T) {
+	for _, strategy := range []string{"whole-file", "search-replace", "udiff", "multi"} {
+		t.Run(strategy, func(t *testing.T) {
+			c := validConfig()
+			c.EditStrategy = EditStrategyConfig{Type: strategy}
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("validation failed: %v", err)
+			}
+			if c.EditStrategy.Type != strategy {
+				t.Errorf("expected explicit %q to be preserved, got %q", strategy, c.EditStrategy.Type)
+			}
+		})
+	}
+}
+
 // --- Rule of Two ---
 
 // boolRef is a tiny helper for the *bool fields that gate a Rule-of-Two


### PR DESCRIPTION
Closes #226.

Moves the `EditStrategy.Type = "multi"` default from two locations — the CLI builder (`harness.go`) and the factory fallback branch (`factory.go`) — into a single `applyEditStrategyDefault` function called unconditionally from `types.ValidateRunConfig`.

Previously the factory returned `WholeFileStrategy` for an empty type string, while the CLI layer defaulted to `"multi"` before the config reached the factory. Any caller that bypassed the CLI (gRPC, direct embedding) could land on `whole-file` rather than `multi`. This consolidation ensures all entrypoints agree.

## Changes
- `types/runconfig.go`: add `applyEditStrategyDefault`; call it from `ValidateRunConfig` before validation loops.
- `harness/internal/core/factory.go`: remove `case "":` from `buildEditStrategy`; route `default:` to `MultiStrategy` (explicit defence-in-depth for callers that bypass validation).
- `harness/cmd/stirrup/cmd/harness.go`, `runconfigflags.go`: remove CLI-layer empty-string guard; flag default is now `""` with help text "Defaults to multi when unset."

## Pre-merge polish
- `types/runconfig.go`: extended `ValidateRunConfig` mutation note to document the new `EditStrategy.Type` side-effect (3-reviewer consensus: was missing from the existing list of `Provider.Retry`, `Batch.MaxWaitSeconds`, `CodeScanner type`).
- `harness/internal/core/factory_test.go`: added `TestBuildLoopWithTransport_EmptyEditStrategyDefaultsToMulti` pinning the full validation→factory composition through the public `BuildLoopWithTransport` seam.

## Verification
- `just` (build + full test suite) exits 0.
- Tests pinned: `TestValidateRunConfig_EditStrategyDefaultsToMulti`, `TestBuildRunConfig_EmptyEditStrategyResolvesToMulti`, `TestRunRunConfig_EmptyEditStrategyDefaultsToMulti`, `TestBuildEditStrategy_Empty`, `TestBuildLoopWithTransport_EmptyEditStrategyDefaultsToMulti`.

## Deferred (follow-up issues)
- Stale `EditStrategy: types.EditStrategyConfig{Type: "whole-file"}` literals in `factory_test.go` test helpers (~15 sites) — explicit test-isolation selections, not defaults; cosmetic cleanup separate from this PR.
- Proto comment gap: `harness.proto:1177` field comment should mention the `multi` default.
- `Executor.Type` and `Verifier.Type` still defaulted at the CLI layer, not in `ValidateRunConfig` — pre-existing inconsistency; candidate for Wave 2 capability-profile work.

Reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers; remediation brief in workstream scratch. Verdict: SHIP WITH POLISH (applied).