### PR TITLE
provider, tool/toolname: add per-provider tool-name normalization wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ stirrup/
       prompt/                # PromptBuilder: per-mode templates, composed fragments, overrides
       context/               # ContextStrategy: sliding window, summarise, offload-to-file
       tool/                  # ToolRegistry + built-in tools, including spawn_agent
+      tool/toolname/         # Per-provider tool-name normalization + collision detection (#223)
       executor/              # Executor: local, container (Docker/Podman), API (GitHub), replay
       edit/                  # EditStrategy: whole-file, search-replace, udiff, multi-strategy
       verifier/              # Verifier: none, test-runner, composite, llm-judge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,6 +289,38 @@ to avoid collisions. Tools default to `sideEffects: true`. Connection
 failures log a warning and skip that server's tools rather than
 failing the entire run.
 
+### Provider-facing tool name normalization
+
+Provider tool/function names have stricter constraints than what the
+registry enforces — MCP-derived names with hyphens, dots, spaces or
+non-ASCII can be registered locally but rejected by a provider on the
+wire. The `harness/internal/tool/toolname` package centralises a
+per-provider naming policy and is applied by a `NormalizingAdapter`
+that wraps every `ProviderAdapter` at factory time (the outermost
+wrap, outside any batch wrapper). The wrapper rewrites tool
+definitions and `tool_use` block names on egress and reverse-maps
+inbound `tool_call` events back to the registry-side name so dispatch
+continues to resolve by the original identifier.
+
+Effective rules per provider type:
+
+- **Anthropic / OpenAI (Chat Completions and Responses) / Bedrock** —
+  `[A-Za-z0-9_-]{1,64}`. Leading digits allowed.
+- **Gemini (Vertex AI)** — `[A-Za-z_][A-Za-z0-9_]{0,63}`. Hyphens are
+  not allowed and a leading digit is replaced with `_<digit>`.
+- **Unknown providers** — fall through to the strictest policy
+  (Gemini's) so a new adapter cannot regress until its policy is
+  added.
+
+Substitution replaces every disallowed character with `_`. Names that
+exceed the length cap are hard-truncated; names that collide after
+sanitization gain a deterministic six-hex-character SHA-256 suffix
+derived from the internal name so two long names that share a common
+prefix stay distinguishable. A collision that cannot be resolved
+(e.g. the same internal name registered twice) fails the stream
+before any request is issued — silent aliasing would route a
+tool_call to the wrong handler.
+
 ### Sub-agent spawning
 
 The `spawn_agent` tool creates a fresh `AgenticLoop` with its own

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -433,6 +433,42 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		providers[config.Provider.Type] = prov
 	}
 
+	// 14c. Wrap every loop-facing provider adapter with the tool-name
+	// normalizer. Applied as the outermost wrap (after batch and any
+	// fallback wraps) so the loop's inbound tool_call reverse-mapping
+	// reaches the wire-event stream before any consumer touches the
+	// name. Skipping a provider that already happens to use only
+	// well-formed names is intentional: every adapter goes through the
+	// wrapper so the invariant ("provider never sees an invalid name")
+	// holds for any future MCP server or operator-defined tool. See
+	// issue #223.
+	prov = provider.NewNormalizingAdapter(prov, config.Provider.Type)
+	wrappedProviders := make(map[string]provider.ProviderAdapter, len(providers))
+	for name, p := range providers {
+		// The default provider's wrap above already pinned the type to
+		// config.Provider.Type; mirror that for any additional providers
+		// declared in config.Providers — their key is unique by name but
+		// the policy must come from their declared Type, not their map
+		// key (which may differ from the type discriminator).
+		providerType := config.Provider.Type
+		if name != config.Provider.Type {
+			if cfg, ok := config.Providers[name]; ok {
+				providerType = cfg.Type
+			}
+		}
+		if name == config.Provider.Type {
+			// The default-provider entry was just rebuilt above; reuse
+			// that exact wrapper so identity is preserved across the
+			// loop.Provider and loop.Providers[default] references —
+			// some call sites (router fallback, guardrail) compare by
+			// pointer.
+			wrappedProviders[name] = prov
+			continue
+		}
+		wrappedProviders[name] = provider.NewNormalizingAdapter(p, providerType)
+	}
+	providers = wrappedProviders
+
 	loop := &AgenticLoop{
 		Provider:     prov,
 		Providers:    providers,

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -2508,6 +2508,120 @@ func TestBuildLoopWithTransport_BatchOnStdioAcceptsOpenAI(t *testing.T) {
 	}
 }
 
+// --- normalizer wrap pinned at loop seam (#223) ---
+
+// TestBuildLoopWithTransport_NormalizingAdapterWrapsGeminiProvider
+// asserts the outermost wrap on a Gemini-built loop is the
+// NormalizingAdapter. Existing Gemini factory tests call buildProvider
+// directly, which returns _before_ the step 14c wrap in
+// BuildLoopWithTransport; a refactor that dropped the Gemini wrap
+// branch would not have been caught by them. This test reaches the
+// loop seam end-to-end so the invariant is pinned where it matters —
+// the only ProviderAdapter the loop ever calls Stream on.
+func TestBuildLoopWithTransport_NormalizingAdapterWrapsGeminiProvider(t *testing.T) {
+	keyPath := writeFakeServiceAccountJSON(t, t.TempDir())
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyPath)
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-gemini-normalizer",
+		Mode:             "planning",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "gemini", GCPProject: "test-project", GCPLocation: "us-central1"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "gemini", Model: "gemini-2.5-pro"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	// Outermost-wrap assertion: type-assert directly to
+	// *provider.NormalizingAdapter rather than going through
+	// unwrapNormalizer. The synthesis brief calls this out — the
+	// invariant is "the loop sees the normalizer", not merely "a
+	// normalizer exists somewhere in the chain".
+	n, ok := loop.Provider.(*provider.NormalizingAdapter)
+	if !ok {
+		t.Fatalf("loop.Provider type = %T, want *provider.NormalizingAdapter (outermost wrap for gemini)", loop.Provider)
+	}
+	if _, ok := n.Unwrap().(*provider.GeminiAdapter); !ok {
+		t.Errorf("unwrapped inner type = %T, want *provider.GeminiAdapter", n.Unwrap())
+	}
+	mapped, ok := loop.Providers[config.Provider.Type]
+	if !ok {
+		t.Fatalf("loop.Providers[%q] missing", config.Provider.Type)
+	}
+	if mapped != loop.Provider {
+		t.Errorf("loop.Providers[%q] is not the same wrapper as loop.Provider (pointer identity broken)", config.Provider.Type)
+	}
+}
+
+// TestBuildLoopWithTransport_NormalizingAdapterWrapsBedrockProvider
+// asserts the outermost wrap on a Bedrock-built loop is the
+// NormalizingAdapter. Bedrock's AWS SDK config loader is lazy: it
+// constructs the client without hitting the network, so the factory
+// build succeeds even without real AWS credentials — sufficient to
+// pin step 14c's wrap for the Bedrock branch.
+func TestBuildLoopWithTransport_NormalizingAdapterWrapsBedrockProvider(t *testing.T) {
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-bedrock-normalizer",
+		Mode:             "planning",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "bedrock", Region: "us-east-1"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "bedrock", Model: "anthropic.claude-3-5-sonnet-20241022-v2:0"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	n, ok := loop.Provider.(*provider.NormalizingAdapter)
+	if !ok {
+		t.Fatalf("loop.Provider type = %T, want *provider.NormalizingAdapter (outermost wrap for bedrock)", loop.Provider)
+	}
+	if _, ok := n.Unwrap().(*provider.BedrockAdapter); !ok {
+		t.Errorf("unwrapped inner type = %T, want *provider.BedrockAdapter", n.Unwrap())
+	}
+	mapped, ok := loop.Providers[config.Provider.Type]
+	if !ok {
+		t.Fatalf("loop.Providers[%q] missing", config.Provider.Type)
+	}
+	if mapped != loop.Provider {
+		t.Errorf("loop.Providers[%q] is not the same wrapper as loop.Provider (pointer identity broken)", config.Provider.Type)
+	}
+}
+
 // --- stubSecretStore ---
 
 type stubSecretStore struct {

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -1976,9 +1976,9 @@ func TestBuildLoopWithTransport_OpenAICompatibleAdapterHasLogger(t *testing.T) {
 	}
 	defer func() { _ = loop.Close() }()
 
-	adapter, ok := loop.Provider.(*provider.OpenAICompatibleAdapter)
+	adapter, ok := unwrapNormalizer(loop.Provider).(*provider.OpenAICompatibleAdapter)
 	if !ok {
-		t.Fatalf("loop.Provider type = %T, want *provider.OpenAICompatibleAdapter", loop.Provider)
+		t.Fatalf("loop.Provider (after unwrap) type = %T, want *provider.OpenAICompatibleAdapter", unwrapNormalizer(loop.Provider))
 	}
 	if adapter.Logger == nil {
 		t.Error("OpenAICompatibleAdapter.Logger is nil; factory should inject the ScrubHandler-backed logger so retry warnings get scrubbed")
@@ -2314,6 +2314,20 @@ func TestBuildProvider_OpenAIResponsesNilBearerErrors(t *testing.T) {
 // dependency just for a one-off literal pointer.
 func intPtr(v int) *int { return &v }
 
+// unwrapNormalizer peels off the *provider.NormalizingAdapter the
+// factory now applies as the outermost wrap (#223), returning the
+// inner adapter. Tests that assert on a specific concrete adapter
+// type (BatchAdapter, OpenAICompatibleAdapter, …) use this so the
+// assertion still describes the meaningful structural invariant
+// (batch wrapping is present, logger is wired, …) without being
+// coupled to the normalizer's existence.
+func unwrapNormalizer(p provider.ProviderAdapter) provider.ProviderAdapter {
+	if n, ok := p.(*provider.NormalizingAdapter); ok {
+		return n.Unwrap()
+	}
+	return p
+}
+
 // TestBuildLoopWithTransport_BatchAdapterWiredWhenEnabled asserts the
 // gRPC + batch.enabled wiring path in the factory: the top-level provider
 // and the entry in the providers map are both replaced with a
@@ -2357,15 +2371,15 @@ func TestBuildLoopWithTransport_BatchAdapterWiredWhenEnabled(t *testing.T) {
 	}
 	defer func() { _ = loop.Close() }()
 
-	ba, ok := loop.Provider.(*provider.BatchAdapter)
+	ba, ok := unwrapNormalizer(loop.Provider).(*provider.BatchAdapter)
 	if !ok {
-		t.Fatalf("loop.Provider: got %T, want *provider.BatchAdapter", loop.Provider)
+		t.Fatalf("loop.Provider (after unwrap): got %T, want *provider.BatchAdapter", unwrapNormalizer(loop.Provider))
 	}
 	mapped, ok := loop.Providers[config.Provider.Type]
 	if !ok {
 		t.Fatalf("loop.Providers[%q] missing", config.Provider.Type)
 	}
-	if mapped != ba {
+	if unwrapNormalizer(mapped) != ba {
 		t.Errorf("loop.Providers[%q]: %T %p, want same *BatchAdapter %p", config.Provider.Type, mapped, mapped, ba)
 	}
 }
@@ -2415,12 +2429,12 @@ func TestBuildLoopWithTransport_BatchAdapterWiredOnStdio(t *testing.T) {
 	}
 	defer func() { _ = loop.Close() }()
 
-	ba, ok := loop.Provider.(*provider.BatchAdapter)
+	ba, ok := unwrapNormalizer(loop.Provider).(*provider.BatchAdapter)
 	if !ok {
-		t.Fatalf("loop.Provider: got %T, want *provider.BatchAdapter", loop.Provider)
+		t.Fatalf("loop.Provider (after unwrap): got %T, want *provider.BatchAdapter", unwrapNormalizer(loop.Provider))
 	}
 	mapped := loop.Providers[config.Provider.Type]
-	if mapped != ba {
+	if unwrapNormalizer(mapped) != ba {
 		t.Errorf("loop.Providers[%q]: %T %p, want same *BatchAdapter %p", config.Provider.Type, mapped, mapped, ba)
 	}
 }
@@ -2474,19 +2488,20 @@ func TestBuildLoopWithTransport_BatchOnStdioAcceptsOpenAI(t *testing.T) {
 			}
 
 			// loop.Provider must be the BatchAdapter wrapper for the
-			// stdio batch path; the providers map entry for this
-			// provider type must point at the same wrapper so a
-			// model-router that picks the default provider by type
-			// routes through batching rather than bypassing it.
-			ba, ok := loop.Provider.(*provider.BatchAdapter)
+			// stdio batch path (unwrapped from the outer NormalizingAdapter
+			// added by #223); the providers map entry for this provider
+			// type must point at the same wrapper so a model-router that
+			// picks the default provider by type routes through batching
+			// rather than bypassing it.
+			ba, ok := unwrapNormalizer(loop.Provider).(*provider.BatchAdapter)
 			if !ok {
-				t.Fatalf("loop.Provider: got %T, want *provider.BatchAdapter", loop.Provider)
+				t.Fatalf("loop.Provider (after unwrap): got %T, want *provider.BatchAdapter", unwrapNormalizer(loop.Provider))
 			}
 			mapped, ok := loop.Providers[config.Provider.Type]
 			if !ok {
 				t.Fatalf("loop.Providers[%q] missing", config.Provider.Type)
 			}
-			if mapped != ba {
+			if unwrapNormalizer(mapped) != ba {
 				t.Errorf("loop.Providers[%q]: %T %p, want same *BatchAdapter %p", config.Provider.Type, mapped, mapped, ba)
 			}
 		})

--- a/harness/internal/provider/normalizer.go
+++ b/harness/internal/provider/normalizer.go
@@ -131,6 +131,15 @@ func (a *NormalizingAdapter) LastBatchID() string {
 // buildMapping centralises the policy lookup so tests can construct a
 // NormalizingAdapter against a fake inner adapter and exercise the
 // same translation logic the production wiring uses.
+//
+// BuildSorted (rather than Build) is used so collision-resolution is
+// independent of the input slice's order. The registry's List() is
+// stable today, but a future change to MCP server connection ordering,
+// alias resolution, or a registry rebuild between turns could shift
+// the input order and silently re-assign which colliding tool gets
+// the hash-suffix disambiguation. Sorting first pins the external
+// name for a given internal name to the policy + name set, never to
+// the order they happened to be passed in.
 func (a *NormalizingAdapter) buildMapping(tools []types.ToolDefinition) (*toolname.Mapping, error) {
 	if len(tools) == 0 {
 		return &toolname.Mapping{
@@ -142,7 +151,7 @@ func (a *NormalizingAdapter) buildMapping(tools []types.ToolDefinition) (*toolna
 	for i, t := range tools {
 		names[i] = t.Name
 	}
-	return toolname.Build(names, toolname.PolicyFor(a.providerType))
+	return toolname.BuildSorted(names, toolname.PolicyFor(a.providerType))
 }
 
 // rewriteParams returns a copy of params with tool names normalised on

--- a/harness/internal/provider/normalizer.go
+++ b/harness/internal/provider/normalizer.go
@@ -1,0 +1,188 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/rxbynerd/stirrup/harness/internal/tool/toolname"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// NormalizingAdapter wraps a ProviderAdapter and applies per-request
+// tool-name normalization between the agentic loop and the wrapped
+// adapter's wire serialisation. It is the single source of truth for
+// "the provider sees a name the provider accepts" — adapters
+// themselves remain naïve and serialise whatever string is on
+// types.ToolDefinition / types.ContentBlock.
+//
+// Lifecycle of a single Stream call:
+//
+//  1. Build a toolname.Mapping from the names in params.Tools using
+//     the policy for the wrapped provider type. Two distinct internal
+//     names that normalise to the same external name fail the call
+//     before any wire request is issued — silently aliasing would
+//     route a tool call to the wrong handler on the inbound path.
+//  2. Rewrite params.Tools[*].Name and the Name on every tool_use
+//     ContentBlock in params.Messages to the external (normalised)
+//     form so the adapter's allowlist wire types receive a string
+//     that matches what was declared.
+//  3. Forward the rewritten params to the inner adapter.
+//  4. Intercept the streamed events: on tool_call, translate
+//     event.Name back to the internal name so the loop's
+//     ToolRegistry.Resolve continues to work unchanged. Every other
+//     event is forwarded verbatim.
+//
+// Wrapping is applied at factory build time and sits on the outside
+// of any BatchAdapter wrap so the loop's batch-mode detection still
+// observes batch state through the wrapper's LastBatchID
+// pass-through.
+type NormalizingAdapter struct {
+	inner        ProviderAdapter
+	providerType string
+}
+
+// NewNormalizingAdapter constructs a NormalizingAdapter that applies
+// the policy registered for providerType to every request. A
+// providerType the toolname package does not recognise still gets a
+// safe (strictest) policy from toolname.PolicyFor — the wrapper never
+// no-ops.
+func NewNormalizingAdapter(inner ProviderAdapter, providerType string) *NormalizingAdapter {
+	return &NormalizingAdapter{inner: inner, providerType: providerType}
+}
+
+// Compile-time assertion that NormalizingAdapter satisfies the
+// ProviderAdapter contract. Kept in this form (rather than `var _
+// ProviderAdapter = &NormalizingAdapter{}`) so the linter's
+// suggestion to use the concrete value does not subtly weaken the
+// guard — see CLAUDE.md "Known false positives".
+var _ ProviderAdapter = (*NormalizingAdapter)(nil)
+
+// Stream rewrites params, forwards to the inner adapter, and
+// reverse-rewrites tool_call events on the inbound side.
+func (a *NormalizingAdapter) Stream(ctx context.Context, params types.StreamParams) (<-chan types.StreamEvent, error) {
+	mapping, err := a.buildMapping(params.Tools)
+	if err != nil {
+		return nil, fmt.Errorf("tool name normalization: %w", err)
+	}
+
+	rewritten := a.rewriteParams(params, mapping)
+	innerCh, err := a.inner.Stream(ctx, rewritten)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fan the inner stream through a translator goroutine. Buffer of 1
+	// keeps the translator from blocking the inner producer past one
+	// event when the loop's consumer pauses; matches the rate-control
+	// pattern in streamEventsToResult.
+	out := make(chan types.StreamEvent, 1)
+	go func() {
+		defer close(out)
+		for ev := range innerCh {
+			if ev.Type == "tool_call" {
+				ev.Name = mapping.Reverse(ev.Name)
+			}
+			select {
+			case out <- ev:
+			case <-ctx.Done():
+				// Drain the inner channel so the inner adapter's
+				// goroutine can exit cleanly; otherwise an unbuffered
+				// send on the producer side would leak the goroutine
+				// when the consumer abandoned the stream.
+				for range innerCh {
+				}
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// Unwrap returns the inner ProviderAdapter the normalizer wraps. It
+// is intended for tests that need to assert on the concrete adapter
+// type (e.g. that batch wrapping is present) without coupling them to
+// the wrapper's existence. Production code should not unwrap — the
+// normalizer is the single source of truth for the on-wire name
+// invariant and bypassing it would be a regression.
+func (a *NormalizingAdapter) Unwrap() ProviderAdapter {
+	return a.inner
+}
+
+// LastBatchID exposes the wrapped adapter's batch identifier when the
+// inner adapter implements batchModeAdapter. The loop type-asserts
+// against this method to populate TurnTrace.BatchID; without the
+// pass-through, wrapping a BatchAdapter would silently downgrade every
+// batch turn's trace to TurnModeStreaming.
+//
+// The interface is duck-typed (defined in core/loop.go) so we do not
+// import it here; the loop's type assertion succeeds via Go's
+// structural interface satisfaction on this single-method shape.
+func (a *NormalizingAdapter) LastBatchID() string {
+	type lastBatchID interface {
+		LastBatchID() string
+	}
+	if b, ok := a.inner.(lastBatchID); ok {
+		return b.LastBatchID()
+	}
+	return ""
+}
+
+// buildMapping centralises the policy lookup so tests can construct a
+// NormalizingAdapter against a fake inner adapter and exercise the
+// same translation logic the production wiring uses.
+func (a *NormalizingAdapter) buildMapping(tools []types.ToolDefinition) (*toolname.Mapping, error) {
+	if len(tools) == 0 {
+		return &toolname.Mapping{
+			ExternalFor: map[string]string{},
+			InternalFor: map[string]string{},
+		}, nil
+	}
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
+	}
+	return toolname.Build(names, toolname.PolicyFor(a.providerType))
+}
+
+// rewriteParams returns a copy of params with tool names normalised on
+// both the tool definitions and any tool_use ContentBlocks carried in
+// the message history. The Messages and Tools slices are cloned so
+// mutating the wrapper's view cannot race with a caller that retains
+// the original params (notably the batch adapter, which marshals
+// params on a background goroutine).
+func (a *NormalizingAdapter) rewriteParams(params types.StreamParams, mapping *toolname.Mapping) types.StreamParams {
+	out := params
+	out.Tools = make([]types.ToolDefinition, len(params.Tools))
+	for i, t := range params.Tools {
+		t.Name = mapping.Translate(t.Name)
+		out.Tools[i] = t
+	}
+	out.Messages = cloneMessagesWithTranslatedToolNames(params.Messages, mapping)
+	return out
+}
+
+// cloneMessagesWithTranslatedToolNames returns a copy of messages with
+// every tool_use ContentBlock's Name translated through the mapping.
+// Other block types pass through unchanged; the slice copy makes the
+// rewrite safe against caller-side aliasing.
+func cloneMessagesWithTranslatedToolNames(messages []types.Message, mapping *toolname.Mapping) []types.Message {
+	if len(messages) == 0 {
+		return messages
+	}
+	out := make([]types.Message, len(messages))
+	for i, m := range messages {
+		out[i] = m
+		if len(m.Content) == 0 {
+			continue
+		}
+		blocks := slices.Clone(m.Content)
+		for j, b := range blocks {
+			if b.Type == "tool_use" {
+				blocks[j].Name = mapping.Translate(b.Name)
+			}
+		}
+		out[i].Content = blocks
+	}
+	return out
+}

--- a/harness/internal/provider/normalizer_test.go
+++ b/harness/internal/provider/normalizer_test.go
@@ -129,6 +129,54 @@ func TestNormalizingAdapter_InboundToolCallReverseTranslated(t *testing.T) {
 	}
 }
 
+func TestNormalizingAdapter_MultipleToolCallsInBatchReverseTranslated(t *testing.T) {
+	// A streamed response can carry several tool_call events in a
+	// single turn (parallel tool use). The wrapper's per-event reverse
+	// translation must apply to every one, not just the first — the
+	// goroutine that drains innerCh loops over the channel but no test
+	// previously scripted more than one tool_call. Gemini's policy is
+	// the strictest, so two MCP-prefixed names with hyphens and dots
+	// force normalisation on the outbound side and assert the inbound
+	// reverse-mapping restores both originals independently and in
+	// order.
+	inner := &fakeAdapter{
+		scripted: []types.StreamEvent{
+			{Type: "text_delta", Text: "running both"},
+			{Type: "tool_call", ID: "call_1", Name: "mcp_jira_create_issue"},
+			{Type: "tool_call", ID: "call_2", Name: "mcp_slack_post_message"},
+			{Type: "message_complete", StopReason: "tool_use"},
+		},
+	}
+	w := NewNormalizingAdapter(inner, "gemini")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "mcp_jira_create-issue", InputSchema: json.RawMessage(`{}`)},
+			{Name: "mcp_slack_post.message", InputSchema: json.RawMessage(`{}`)},
+		},
+	}
+	ch, err := w.Stream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var toolCallNames []string
+	for ev := range ch {
+		if ev.Type == "tool_call" {
+			toolCallNames = append(toolCallNames, ev.Name)
+		}
+	}
+	wantNames := []string{"mcp_jira_create-issue", "mcp_slack_post.message"}
+	if len(toolCallNames) != len(wantNames) {
+		t.Fatalf("got %d tool_call events, want %d (names=%v)", len(toolCallNames), len(wantNames), toolCallNames)
+	}
+	for i, want := range wantNames {
+		if toolCallNames[i] != want {
+			t.Errorf("tool_call[%d].Name = %q, want internal %q", i, toolCallNames[i], want)
+		}
+	}
+}
+
 func TestNormalizingAdapter_MessageHistoryToolUseNamesRewritten(t *testing.T) {
 	// A prior assistant turn produced a tool_use block whose Name
 	// carries the internal (registry) name. On the next turn the

--- a/harness/internal/provider/normalizer_test.go
+++ b/harness/internal/provider/normalizer_test.go
@@ -1,0 +1,292 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+var errFake = errors.New("fake provider error")
+
+// fakeAdapter is a recording stub that captures the StreamParams it
+// receives and replays a caller-supplied script of StreamEvents. Used
+// by the normalizer tests to assert "what the wrapped provider saw on
+// the wire" without bringing up real HTTP transport.
+type fakeAdapter struct {
+	receivedParams types.StreamParams
+	scripted       []types.StreamEvent
+	streamErr      error
+	batchID        string
+}
+
+func (f *fakeAdapter) Stream(_ context.Context, params types.StreamParams) (<-chan types.StreamEvent, error) {
+	f.receivedParams = params
+	if f.streamErr != nil {
+		return nil, f.streamErr
+	}
+	ch := make(chan types.StreamEvent, len(f.scripted))
+	for _, ev := range f.scripted {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+// fakeBatchAdapter implements both ProviderAdapter and the batchModeAdapter
+// duck-typed interface so the wrapper's pass-through is exercised.
+type fakeBatchAdapter struct {
+	fakeAdapter
+}
+
+func (f *fakeBatchAdapter) LastBatchID() string { return f.batchID }
+
+func TestNormalizingAdapter_OutboundToolsRewritten_OpenAI(t *testing.T) {
+	inner := &fakeAdapter{}
+	w := NewNormalizingAdapter(inner, "openai-compatible")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "read_file", InputSchema: json.RawMessage(`{}`)},
+			{Name: "mcp_jira_create-issue", InputSchema: json.RawMessage(`{}`)},
+		},
+	}
+	_, err := w.Stream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if got := inner.receivedParams.Tools[0].Name; got != "read_file" {
+		t.Errorf("tools[0].Name = %q, want unchanged", got)
+	}
+	// OpenAI allows hyphens — name passes through verbatim.
+	if got := inner.receivedParams.Tools[1].Name; got != "mcp_jira_create-issue" {
+		t.Errorf("tools[1].Name = %q, want unchanged for OpenAI", got)
+	}
+}
+
+func TestNormalizingAdapter_OutboundToolsRewritten_Gemini(t *testing.T) {
+	inner := &fakeAdapter{}
+	w := NewNormalizingAdapter(inner, "gemini")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "mcp_jira_create-issue", InputSchema: json.RawMessage(`{}`)},
+			{Name: "mcp_slack_post.message", InputSchema: json.RawMessage(`{}`)},
+		},
+	}
+	_, err := w.Stream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for i, td := range inner.receivedParams.Tools {
+		if strings.ContainsAny(td.Name, "-.") {
+			t.Errorf("tools[%d].Name = %q still contains disallowed char for Gemini", i, td.Name)
+		}
+	}
+}
+
+func TestNormalizingAdapter_InboundToolCallReverseTranslated(t *testing.T) {
+	inner := &fakeAdapter{
+		scripted: []types.StreamEvent{
+			{Type: "text_delta", Text: "hello"},
+			{Type: "tool_call", ID: "call_1", Name: "mcp_jira_create_issue"},
+			{Type: "message_complete", StopReason: "tool_use"},
+		},
+	}
+	w := NewNormalizingAdapter(inner, "gemini")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "mcp_jira_create-issue", InputSchema: json.RawMessage(`{}`)},
+		},
+	}
+	ch, err := w.Stream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	// The provider saw the normalised "mcp_jira_create_issue".
+	if got := inner.receivedParams.Tools[0].Name; got != "mcp_jira_create_issue" {
+		t.Fatalf("outbound tool name = %q, want %q", got, "mcp_jira_create_issue")
+	}
+
+	// Drain the stream and assert the tool_call event was de-normalised.
+	var sawToolCall bool
+	for ev := range ch {
+		if ev.Type == "tool_call" {
+			sawToolCall = true
+			if ev.Name != "mcp_jira_create-issue" {
+				t.Errorf("inbound tool_call Name = %q, want internal %q",
+					ev.Name, "mcp_jira_create-issue")
+			}
+		}
+	}
+	if !sawToolCall {
+		t.Fatal("expected to observe a tool_call event")
+	}
+}
+
+func TestNormalizingAdapter_MessageHistoryToolUseNamesRewritten(t *testing.T) {
+	// A prior assistant turn produced a tool_use block whose Name
+	// carries the internal (registry) name. On the next turn the
+	// wrapper must rewrite that Name to the provider-facing form so
+	// the provider can correlate the round-tripped block back to its
+	// declared tool.
+	inner := &fakeAdapter{}
+	w := NewNormalizingAdapter(inner, "gemini")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "mcp_jira_create-issue", InputSchema: json.RawMessage(`{}`)},
+		},
+		Messages: []types.Message{
+			{
+				Role: "assistant",
+				Content: []types.ContentBlock{
+					{Type: "text", Text: "I'll create the issue."},
+					{Type: "tool_use", ID: "call_1", Name: "mcp_jira_create-issue", Input: json.RawMessage(`{}`)},
+				},
+			},
+			{
+				Role: "user",
+				Content: []types.ContentBlock{
+					{Type: "tool_result", ToolUseID: "call_1", Content: "OK"},
+				},
+			},
+		},
+	}
+
+	if _, err := w.Stream(context.Background(), params); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	got := inner.receivedParams.Messages[0].Content[1]
+	if got.Type != "tool_use" {
+		t.Fatalf("block 1 type = %q, want tool_use", got.Type)
+	}
+	if got.Name != "mcp_jira_create_issue" {
+		t.Errorf("rewritten tool_use Name = %q, want %q", got.Name, "mcp_jira_create_issue")
+	}
+	// Unrelated blocks must be unchanged.
+	if inner.receivedParams.Messages[0].Content[0].Text != "I'll create the issue." {
+		t.Errorf("text block was mutated")
+	}
+	if inner.receivedParams.Messages[1].Content[0].Type != "tool_result" {
+		t.Errorf("tool_result block was mutated")
+	}
+}
+
+func TestNormalizingAdapter_CallerParamsNotMutated(t *testing.T) {
+	// The wrapper must not write through to the caller's StreamParams
+	// — the loop reuses params construction state and the batch
+	// adapter retains the slice across goroutines.
+	inner := &fakeAdapter{}
+	w := NewNormalizingAdapter(inner, "gemini")
+
+	tools := []types.ToolDefinition{
+		{Name: "mcp_jira_create-issue", InputSchema: json.RawMessage(`{}`)},
+	}
+	messages := []types.Message{
+		{
+			Role: "assistant",
+			Content: []types.ContentBlock{
+				{Type: "tool_use", ID: "call_1", Name: "mcp_jira_create-issue"},
+			},
+		},
+	}
+	params := types.StreamParams{Tools: tools, Messages: messages}
+
+	if _, err := w.Stream(context.Background(), params); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	if tools[0].Name != "mcp_jira_create-issue" {
+		t.Errorf("caller tools slice was mutated: %q", tools[0].Name)
+	}
+	if messages[0].Content[0].Name != "mcp_jira_create-issue" {
+		t.Errorf("caller messages slice was mutated: %q", messages[0].Content[0].Name)
+	}
+}
+
+func TestNormalizingAdapter_CollisionAfterNormalisationFailsClosed(t *testing.T) {
+	// Two distinct internal names that normalise to the same external
+	// name under the Gemini policy. The wrapper must refuse the
+	// stream rather than silently aliasing — silent aliasing would
+	// route an inbound tool_call to the wrong handler.
+	inner := &fakeAdapter{}
+	w := NewNormalizingAdapter(inner, "gemini")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "mcp_jira-issue", InputSchema: json.RawMessage(`{}`)},
+			{Name: "mcp_jira.issue", InputSchema: json.RawMessage(`{}`)},
+		},
+	}
+	// Names collide on first sanitization but a hash suffix
+	// disambiguates them. Confirm the stream still works (this is
+	// the deterministic-resolution path, not the unresolvable case).
+	if _, err := w.Stream(context.Background(), params); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	a := inner.receivedParams.Tools[0].Name
+	b := inner.receivedParams.Tools[1].Name
+	if a == b {
+		t.Fatalf("collision not resolved: both normalised to %q", a)
+	}
+}
+
+func TestNormalizingAdapter_InnerStreamError_Propagated(t *testing.T) {
+	inner := &fakeAdapter{streamErr: errFake}
+	w := NewNormalizingAdapter(inner, "anthropic")
+	_, err := w.Stream(context.Background(), types.StreamParams{})
+	if err == nil {
+		t.Fatal("expected error to propagate from inner adapter")
+	}
+}
+
+func TestNormalizingAdapter_LastBatchIDPassThrough(t *testing.T) {
+	inner := &fakeBatchAdapter{}
+	inner.batchID = "batch-xyz"
+	w := NewNormalizingAdapter(inner, "anthropic")
+	if got := w.LastBatchID(); got != "batch-xyz" {
+		t.Errorf("LastBatchID = %q, want %q", got, "batch-xyz")
+	}
+}
+
+func TestNormalizingAdapter_LastBatchIDEmptyWhenInnerNotBatch(t *testing.T) {
+	w := NewNormalizingAdapter(&fakeAdapter{}, "anthropic")
+	if got := w.LastBatchID(); got != "" {
+		t.Errorf("LastBatchID for non-batch inner = %q, want empty", got)
+	}
+}
+
+func TestNormalizingAdapter_RoundTripDispatch_OpenAIResponses(t *testing.T) {
+	// Integration-style: a full request/response cycle on a provider
+	// type that permits hyphens. Both directions must preserve the
+	// internal name unchanged so dispatch still resolves the handler
+	// by its original identifier.
+	inner := &fakeAdapter{
+		scripted: []types.StreamEvent{
+			{Type: "tool_call", ID: "1", Name: "mcp_jira_create-issue"},
+		},
+	}
+	w := NewNormalizingAdapter(inner, "openai-responses")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "mcp_jira_create-issue", InputSchema: json.RawMessage(`{}`)},
+		},
+	}
+	ch, err := w.Stream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for ev := range ch {
+		if ev.Type == "tool_call" && ev.Name != "mcp_jira_create-issue" {
+			t.Errorf("round-trip altered name: got %q, want unchanged", ev.Name)
+		}
+	}
+}

--- a/harness/internal/provider/normalizer_test.go
+++ b/harness/internal/provider/normalizer_test.go
@@ -259,11 +259,14 @@ func TestNormalizingAdapter_CallerParamsNotMutated(t *testing.T) {
 	}
 }
 
-func TestNormalizingAdapter_CollisionAfterNormalisationFailsClosed(t *testing.T) {
-	// Two distinct internal names that normalise to the same external
-	// name under the Gemini policy. The wrapper must refuse the
-	// stream rather than silently aliasing — silent aliasing would
-	// route an inbound tool_call to the wrong handler.
+func TestNormalizingAdapter_CollisionResolvedByDisambiguation(t *testing.T) {
+	// Two distinct internal names that sanitize to the same external
+	// name under the Gemini policy, but the hash-suffix disambiguation
+	// keeps them distinct. This is the happy path through the
+	// collision branch — the wrapper does not refuse, and the inner
+	// adapter sees two distinct names. The fail-closed path (where
+	// disambiguation itself cannot resolve the collision) is covered
+	// by TestNormalizingAdapter_IrresolvableCollisionFailsClosed.
 	inner := &fakeAdapter{}
 	w := NewNormalizingAdapter(inner, "gemini")
 
@@ -273,9 +276,6 @@ func TestNormalizingAdapter_CollisionAfterNormalisationFailsClosed(t *testing.T)
 			{Name: "mcp_jira.issue", InputSchema: json.RawMessage(`{}`)},
 		},
 	}
-	// Names collide on first sanitization but a hash suffix
-	// disambiguates them. Confirm the stream still works (this is
-	// the deterministic-resolution path, not the unresolvable case).
 	if _, err := w.Stream(context.Background(), params); err != nil {
 		t.Fatalf("Stream: %v", err)
 	}
@@ -283,6 +283,46 @@ func TestNormalizingAdapter_CollisionAfterNormalisationFailsClosed(t *testing.T)
 	b := inner.receivedParams.Tools[1].Name
 	if a == b {
 		t.Fatalf("collision not resolved: both normalised to %q", a)
+	}
+}
+
+func TestNormalizingAdapter_IrresolvableCollisionFailsClosed(t *testing.T) {
+	// Pin the wrapper's fail-closed guarantee end-to-end: when
+	// buildMapping returns a non-nil error, Stream must return that
+	// error wrapped in "tool name normalization: ..." and must not
+	// reach the inner adapter. Without this assertion a refactor that
+	// dropped the early-return at normalizer.go:64-67 would silently
+	// pass a half-built mapping (or no mapping at all) into the wire
+	// path.
+	//
+	// All five production provider policies have MaxLen=64, which keeps
+	// the hash-suffix branch wide enough that two distinct internal
+	// names cannot reach the stillCollides return through Build's
+	// disambiguate path. The reachable adapter-level failure mode is
+	// therefore Build's duplicate-internal-name guard — two tool
+	// definitions that share an identical Name field. The deeper
+	// stillCollides branch is covered at the package level by
+	// TestBuild_IrresolvableCollisionErrors with a synthetic
+	// short-MaxLen policy; this test pins the adapter seam.
+	inner := &fakeAdapter{}
+	w := NewNormalizingAdapter(inner, "gemini")
+
+	params := types.StreamParams{
+		Tools: []types.ToolDefinition{
+			{Name: "duplicate_tool", InputSchema: json.RawMessage(`{}`)},
+			{Name: "duplicate_tool", InputSchema: json.RawMessage(`{}`)},
+		},
+	}
+	_, err := w.Stream(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error from buildMapping, got nil")
+	}
+	if !strings.Contains(err.Error(), "tool name normalization") {
+		t.Errorf("expected wrapper's fail-closed error wording, got: %v", err)
+	}
+	// Critical: no wire request must have been issued.
+	if inner.receivedParams.Tools != nil || inner.receivedParams.Model != "" {
+		t.Errorf("inner adapter was called despite normalization failure: receivedParams=%+v", inner.receivedParams)
 	}
 }
 

--- a/harness/internal/tool/toolname/toolname.go
+++ b/harness/internal/tool/toolname/toolname.go
@@ -1,0 +1,307 @@
+// Package toolname provides per-provider normalization and collision
+// detection for tool/function names that flow from the registry into a
+// provider request.
+//
+// Provider tool-name constraints are stricter than what Stirrup's
+// registration boundaries enforce. MCP-derived names in particular can
+// contain hyphens, dots, spaces, or non-ASCII codepoints that one
+// provider accepts and another rejects, so a registered tool can become
+// an un-callable function name on the wire. This package centralises
+// those constraints into a single Policy table and produces a
+// deterministic, round-trip-safe Mapping between the internal name a
+// handler is registered under and the external name a provider sees.
+//
+// The normalization layer is intentionally provider-agnostic: callers
+// pass a provider-type discriminator and receive a Mapping, never the
+// concrete Policy. Adapters do not import this package — the
+// normalization wrapper in harness/internal/provider sits between the
+// loop and the concrete adapter and is the only consumer.
+//
+// TODO(#221): when the capability-profile work lands, fold PolicyFor
+// into the profile so each provider declares its own naming rules
+// alongside its other capabilities.
+package toolname
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Policy describes the per-provider function-name constraints applied
+// during normalization. The defaults pick the strictest commonly-
+// supported character set so a name produced under one policy is
+// likely to be acceptable under another.
+//
+// MaxLen bounds the externalised name after character substitution. A
+// name that exceeds MaxLen is truncated and disambiguated with a short
+// stable hash suffix derived from the internal name so two long names
+// that share a common prefix do not collide silently.
+//
+// AllowHyphen / AllowLeadingDigit toggle the two real differences
+// across the providers Stirrup targets today. Gemini disallows hyphens
+// in function names entirely and requires the first character to be a
+// letter or underscore; OpenAI and Anthropic accept both.
+type Policy struct {
+	MaxLen            int
+	AllowHyphen       bool
+	AllowLeadingDigit bool
+}
+
+// PolicyFor returns the Policy that applies to the given provider type
+// string (the discriminator used in RunConfig.Provider.Type and in the
+// providers map). Unknown providers fall through to the strictest
+// policy so an adapter added without updating this table degrades to
+// "still serialises a name the provider will accept" rather than
+// "crashes the first turn".
+//
+// TODO(#221): move the per-provider data into the capability profile so
+// each adapter declares its rules in one place.
+func PolicyFor(providerType string) Policy {
+	switch providerType {
+	case "anthropic":
+		// Anthropic accepts [a-zA-Z0-9_-]{1,64} on the Messages API
+		// tool name. Leading digits are permitted; hyphens are
+		// permitted.
+		return Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+	case "openai-compatible", "openai-responses":
+		// Chat Completions and the Responses API both enforce
+		// ^[a-zA-Z0-9_-]{1,64}$ on function names. Leading digits are
+		// permitted in practice; hyphens are permitted.
+		return Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+	case "bedrock":
+		// Bedrock Converse API mirrors the Anthropic constraint for
+		// the Anthropic-backed models that dominate today's deployment
+		// and matches the OpenAI rule for the Mistral/Llama-backed
+		// models. [a-zA-Z0-9_-]{1,64} is the safe union.
+		return Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+	case "gemini":
+		// Vertex AI function declarations require the name to match
+		// `[a-zA-Z_][a-zA-Z0-9_]*` with a 64-character cap. Hyphens
+		// are rejected and a leading digit is rejected.
+		return Policy{MaxLen: 64, AllowHyphen: false, AllowLeadingDigit: false}
+	default:
+		// Unknown provider: pick the strictest constraint set so a new
+		// adapter cannot regress on naming until its policy is
+		// registered here.
+		return Policy{MaxLen: 64, AllowHyphen: false, AllowLeadingDigit: false}
+	}
+}
+
+// Mapping records the bidirectional translation between internal
+// (registry-side) names and external (provider-facing) names for a
+// single request. Both directions are pre-built so dispatch does not
+// have to recompute the normalization for every inbound tool_call
+// event.
+//
+// A name absent from ExternalFor is one the caller never passed in;
+// callers should fall back to the original string in that case rather
+// than treating absence as an error, so untouched fields (e.g. a
+// tool_use block on a message from a prior turn whose tool has since
+// been unregistered) round-trip unchanged.
+type Mapping struct {
+	// ExternalFor maps internal name → external name.
+	ExternalFor map[string]string
+	// InternalFor maps external name → internal name. This is the
+	// inverse of ExternalFor and is what the adapter wrapper consults
+	// when translating an inbound tool_call event back to the name
+	// the registry knows the tool by.
+	InternalFor map[string]string
+}
+
+// Translate returns the external name for an internal one, falling
+// back to the input when the name is not in the mapping. The fallback
+// keeps adapter wrappers terse — a missing entry is exactly the case
+// where no normalization is required.
+func (m *Mapping) Translate(internal string) string {
+	if m == nil {
+		return internal
+	}
+	if ext, ok := m.ExternalFor[internal]; ok {
+		return ext
+	}
+	return internal
+}
+
+// Reverse returns the internal name for an external one, falling back
+// to the input on a miss. See Translate for the rationale on
+// pass-through.
+func (m *Mapping) Reverse(external string) string {
+	if m == nil {
+		return external
+	}
+	if internal, ok := m.InternalFor[external]; ok {
+		return internal
+	}
+	return external
+}
+
+// Build produces a Mapping for the given internal tool names under the
+// supplied Policy. The returned mapping is deterministic: two
+// invocations with the same name set and the same Policy produce
+// identical external names and identical collision detection.
+//
+// Build returns an error when two distinct internal names normalise
+// to the same external name and the disambiguation suffix cannot
+// resolve the collision (e.g. caller passed the same internal name
+// twice). Failing closed is the correct behaviour for the loop: a
+// silent alias would route a tool call to the wrong handler.
+func Build(internalNames []string, policy Policy) (*Mapping, error) {
+	m := &Mapping{
+		ExternalFor: make(map[string]string, len(internalNames)),
+		InternalFor: make(map[string]string, len(internalNames)),
+	}
+
+	// Deduplicate — a single internal name passed twice is a caller
+	// bug, not a collision. The registry contract is that names are
+	// unique, but tests and embedding callers may bypass it; surface
+	// the duplicate as an explicit error rather than silently
+	// overwriting the first entry.
+	seen := make(map[string]struct{}, len(internalNames))
+	for _, n := range internalNames {
+		if _, dup := seen[n]; dup {
+			return nil, fmt.Errorf("toolname: duplicate internal tool name %q", n)
+		}
+		seen[n] = struct{}{}
+	}
+
+	// First pass: compute the candidate external name for every
+	// internal name. Iterate the input order so the mapping building
+	// is deterministic for a given input.
+	candidates := make([]string, len(internalNames))
+	for i, name := range internalNames {
+		candidates[i] = sanitize(name, policy)
+	}
+
+	// Second pass: detect collisions among the candidates. When two
+	// candidates collide, derive a disambiguating suffix from the
+	// internal name's SHA-256 hash. This is deterministic, keeps the
+	// suffix short, and survives reordering of the input slice.
+	//
+	// The suffix is appended within the MaxLen budget — sanitize may
+	// produce a name shorter than MaxLen, in which case the suffix is
+	// added directly; if sanitize already returned a MaxLen-truncated
+	// name, the truncation is shortened to make room.
+	used := make(map[string]string, len(candidates)) // external → internal
+	for i, ext := range candidates {
+		internal := internalNames[i]
+		if existing, taken := used[ext]; taken && existing != internal {
+			ext = disambiguate(ext, internal, policy)
+			if other, stillCollides := used[ext]; stillCollides && other != internal {
+				return nil, fmt.Errorf(
+					"toolname: cannot resolve collision between %q and %q (both normalise to %q under policy MaxLen=%d AllowHyphen=%v AllowLeadingDigit=%v)",
+					internal, other, ext, policy.MaxLen, policy.AllowHyphen, policy.AllowLeadingDigit,
+				)
+			}
+		}
+		used[ext] = internal
+		m.ExternalFor[internal] = ext
+		m.InternalFor[ext] = internal
+	}
+
+	return m, nil
+}
+
+// BuildSorted is a convenience wrapper for callers that hold a
+// ToolDefinition-like slice and want a deterministic Mapping
+// independent of registration order. The caller may want this when
+// the registry's order is operator-controlled (e.g. via a config
+// file) but the Mapping is consumed by trace persistence where order
+// drift between runs would inflate diffs.
+func BuildSorted(internalNames []string, policy Policy) (*Mapping, error) {
+	names := make([]string, len(internalNames))
+	copy(names, internalNames)
+	sort.Strings(names)
+	return Build(names, policy)
+}
+
+// sanitize lowers a single name onto the policy's character set and
+// length budget. It does not handle collisions — Build composes
+// sanitize with disambiguate above.
+func sanitize(name string, policy Policy) string {
+	if name == "" {
+		// An empty internal name is a registration bug, but reach this
+		// branch defensively rather than emit "" to the wire (every
+		// provider rejects it). Use a stable placeholder so collision
+		// detection can still flag the duplicate if it happens twice.
+		return "_unnamed"
+	}
+
+	var b strings.Builder
+	b.Grow(len(name))
+	for i, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			if i == 0 && !policy.AllowLeadingDigit {
+				// Prepend an underscore the first time we see a
+				// leading digit; the digit itself is still preserved.
+				b.WriteByte('_')
+			}
+			b.WriteRune(r)
+		case r == '_':
+			b.WriteRune(r)
+		case r == '-' && policy.AllowHyphen:
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+
+	out := b.String()
+
+	// Enforce length cap. A name that exceeds MaxLen is hard-truncated
+	// here; Build's disambiguation pass adds a hash suffix when the
+	// truncated form collides with another truncated form.
+	if policy.MaxLen > 0 && len(out) > policy.MaxLen {
+		out = out[:policy.MaxLen]
+	}
+	return out
+}
+
+// disambiguate produces a deterministic disambiguating form of ext for
+// the given internal name, keeping the result within the policy's
+// length budget. The suffix is derived from the SHA-256 of the
+// internal name so the same internal name always maps to the same
+// disambiguated form regardless of the order in which collisions are
+// detected.
+//
+// Suffix layout: "_" + first 6 hex chars of SHA-256(internal). 7
+// characters total. When MaxLen is short enough that suffix + truncated
+// prefix do not fit, the prefix is trimmed further to make room.
+func disambiguate(ext, internal string, policy Policy) string {
+	const suffixHexChars = 6
+	suffix := nameHashSuffix(internal, suffixHexChars)
+	prefix := ext
+
+	if policy.MaxLen > 0 {
+		budget := policy.MaxLen - len(suffix)
+		if budget < 1 {
+			// Pathological MaxLen — return just the suffix so we still
+			// produce a deterministic name. Build's caller-side
+			// collision detection will then surface this as a hard
+			// error if it cannot be made unique.
+			return suffix[:min(len(suffix), policy.MaxLen)]
+		}
+		if len(prefix) > budget {
+			prefix = prefix[:budget]
+		}
+	}
+
+	return prefix + suffix
+}
+
+// nameHashSuffix returns "_" followed by the first hexChars hex
+// characters of the SHA-256 digest of name. Used by disambiguate to
+// generate a deterministic, collision-resistant tag.
+func nameHashSuffix(name string, hexChars int) string {
+	sum := sha256.Sum256([]byte(name))
+	enc := hex.EncodeToString(sum[:])
+	if hexChars > len(enc) {
+		hexChars = len(enc)
+	}
+	return "_" + enc[:hexChars]
+}

--- a/harness/internal/tool/toolname/toolname_test.go
+++ b/harness/internal/tool/toolname/toolname_test.go
@@ -1,0 +1,284 @@
+package toolname
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPolicyFor_KnownProviders(t *testing.T) {
+	cases := []struct {
+		providerType      string
+		wantMaxLen        int
+		wantAllowHyphen   bool
+		wantAllowLeading0 bool
+	}{
+		{"anthropic", 64, true, true},
+		{"openai-compatible", 64, true, true},
+		{"openai-responses", 64, true, true},
+		{"bedrock", 64, true, true},
+		{"gemini", 64, false, false},
+		// Unknown providers fall through to the strictest policy.
+		{"made-up-provider", 64, false, false},
+		{"", 64, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.providerType, func(t *testing.T) {
+			p := PolicyFor(tc.providerType)
+			if p.MaxLen != tc.wantMaxLen {
+				t.Errorf("MaxLen = %d, want %d", p.MaxLen, tc.wantMaxLen)
+			}
+			if p.AllowHyphen != tc.wantAllowHyphen {
+				t.Errorf("AllowHyphen = %v, want %v", p.AllowHyphen, tc.wantAllowHyphen)
+			}
+			if p.AllowLeadingDigit != tc.wantAllowLeading0 {
+				t.Errorf("AllowLeadingDigit = %v, want %v", p.AllowLeadingDigit, tc.wantAllowLeading0)
+			}
+		})
+	}
+}
+
+func TestSanitize_PunctuationAndSpaces(t *testing.T) {
+	p := Policy{MaxLen: 64, AllowHyphen: false, AllowLeadingDigit: true}
+	got := sanitize("mcp_server.tool name/with stuff", p)
+	want := "mcp_server_tool_name_with_stuff"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSanitize_HyphenAllowedAndDisallowed(t *testing.T) {
+	t.Run("allowed", func(t *testing.T) {
+		p := Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+		got := sanitize("mcp-server-tool", p)
+		if got != "mcp-server-tool" {
+			t.Errorf("got %q, want hyphens preserved", got)
+		}
+	})
+	t.Run("disallowed", func(t *testing.T) {
+		p := Policy{MaxLen: 64, AllowHyphen: false, AllowLeadingDigit: true}
+		got := sanitize("mcp-server-tool", p)
+		if got != "mcp_server_tool" {
+			t.Errorf("got %q, want hyphens substituted", got)
+		}
+	})
+}
+
+func TestSanitize_LeadingDigitUnderscorePrepend(t *testing.T) {
+	p := Policy{MaxLen: 64, AllowHyphen: false, AllowLeadingDigit: false}
+	got := sanitize("123abc", p)
+	if got != "_123abc" {
+		t.Errorf("got %q, want underscore prepended", got)
+	}
+}
+
+func TestSanitize_LeadingDigitWhenAllowed(t *testing.T) {
+	p := Policy{MaxLen: 64, AllowHyphen: false, AllowLeadingDigit: true}
+	got := sanitize("123abc", p)
+	if got != "123abc" {
+		t.Errorf("got %q, want digits preserved verbatim", got)
+	}
+}
+
+func TestSanitize_NonASCIIReplaced(t *testing.T) {
+	p := Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+	got := sanitize("café_tool", p)
+	// "é" is two bytes in UTF-8; sanitize replaces each invalid byte
+	// with one underscore, so multi-byte runes flatten to underscores.
+	if !strings.HasPrefix(got, "caf") || !strings.HasSuffix(got, "_tool") {
+		t.Errorf("got %q, want non-ASCII rune substituted", got)
+	}
+}
+
+func TestSanitize_TruncatesAtMaxLen(t *testing.T) {
+	p := Policy{MaxLen: 16, AllowHyphen: true, AllowLeadingDigit: true}
+	got := sanitize("a_very_long_tool_name_well_over_sixteen_chars", p)
+	if len(got) != 16 {
+		t.Errorf("got %q (len=%d), want length 16", got, len(got))
+	}
+}
+
+func TestSanitize_EmptyNamePlaceholder(t *testing.T) {
+	p := Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+	got := sanitize("", p)
+	if got != "_unnamed" {
+		t.Errorf("got %q, want placeholder", got)
+	}
+}
+
+func TestBuild_RoundTripPreservesIdentity(t *testing.T) {
+	names := []string{"read_file", "list_directory", "search_files"}
+	m, err := Build(names, PolicyFor("openai-compatible"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, n := range names {
+		ext := m.Translate(n)
+		if ext != n {
+			t.Errorf("Translate(%q) = %q, want unchanged", n, ext)
+		}
+		if got := m.Reverse(ext); got != n {
+			t.Errorf("Reverse(%q) = %q, want %q", ext, got, n)
+		}
+	}
+}
+
+func TestBuild_MCPNamesNormalizedForGemini(t *testing.T) {
+	names := []string{
+		"mcp_jira_create-issue",
+		"mcp_jira_search.tickets",
+		"mcp_slack_post message",
+	}
+	m, err := Build(names, PolicyFor("gemini"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	for _, n := range names {
+		ext := m.Translate(n)
+		// Gemini policy forbids hyphens and disallows whitespace and
+		// punctuation outside [a-zA-Z0-9_].
+		if strings.ContainsAny(ext, "-. ") {
+			t.Errorf("Translate(%q) = %q still contains a disallowed character", n, ext)
+		}
+		// Round-trip must restore the original internal name.
+		if got := m.Reverse(ext); got != n {
+			t.Errorf("Reverse(%q) = %q, want %q", ext, got, n)
+		}
+	}
+}
+
+func TestBuild_CollisionAfterNormalizationIsResolvedDeterministically(t *testing.T) {
+	// Both names normalise to "mcp_jira_issue" under the gemini policy
+	// (different punctuation but identical sanitized form). The
+	// collision must be resolved via a hash suffix derived from the
+	// internal name so the resolution is stable.
+	names := []string{"mcp_jira-issue", "mcp_jira.issue"}
+	policy := PolicyFor("gemini")
+
+	m1, err := Build(names, policy)
+	if err != nil {
+		t.Fatalf("Build(first): %v", err)
+	}
+	m2, err := Build(names, policy)
+	if err != nil {
+		t.Fatalf("Build(second): %v", err)
+	}
+
+	for _, n := range names {
+		if m1.Translate(n) != m2.Translate(n) {
+			t.Errorf("non-deterministic translation for %q: %q vs %q",
+				n, m1.Translate(n), m2.Translate(n))
+		}
+		if got := m1.Reverse(m1.Translate(n)); got != n {
+			t.Errorf("round-trip failed for %q: got %q", n, got)
+		}
+	}
+
+	// The two external names must differ; otherwise the collision was
+	// not resolved.
+	if m1.Translate(names[0]) == m1.Translate(names[1]) {
+		t.Fatalf("collision not resolved: both names normalised to %q",
+			m1.Translate(names[0]))
+	}
+}
+
+func TestBuild_DuplicateInternalNameRejected(t *testing.T) {
+	names := []string{"read_file", "read_file"}
+	if _, err := Build(names, PolicyFor("anthropic")); err == nil {
+		t.Fatal("expected error for duplicate internal name, got nil")
+	}
+}
+
+func TestBuild_LongNamesGetHashSuffixWhenColliding(t *testing.T) {
+	// Two long names that share a 64-char prefix would collide after
+	// hard truncation; the hash suffix must keep them distinct.
+	base := strings.Repeat("a", 60) + "_x"
+	names := []string{base + "_one", base + "_two"}
+	m, err := Build(names, Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	a, b := m.Translate(names[0]), m.Translate(names[1])
+	if a == b {
+		t.Fatalf("collision not resolved: both names normalised to %q", a)
+	}
+	if len(a) > 64 || len(b) > 64 {
+		t.Errorf("disambiguation exceeded MaxLen: %d, %d", len(a), len(b))
+	}
+	for _, n := range names {
+		if got := m.Reverse(m.Translate(n)); got != n {
+			t.Errorf("round-trip failed for %q: got %q", n, got)
+		}
+	}
+}
+
+func TestBuild_DeterministicAcrossOrderings(t *testing.T) {
+	a := []string{"mcp_jira-issue", "mcp_jira.issue", "read_file"}
+	b := []string{"read_file", "mcp_jira.issue", "mcp_jira-issue"}
+
+	m1, err := BuildSorted(a, PolicyFor("gemini"))
+	if err != nil {
+		t.Fatalf("BuildSorted(a): %v", err)
+	}
+	m2, err := BuildSorted(b, PolicyFor("gemini"))
+	if err != nil {
+		t.Fatalf("BuildSorted(b): %v", err)
+	}
+	for _, n := range a {
+		if m1.Translate(n) != m2.Translate(n) {
+			t.Errorf("BuildSorted is order-sensitive for %q: %q vs %q",
+				n, m1.Translate(n), m2.Translate(n))
+		}
+	}
+}
+
+func TestMapping_NilSafePassThrough(t *testing.T) {
+	var m *Mapping
+	if got := m.Translate("anything"); got != "anything" {
+		t.Errorf("nil Mapping.Translate returned %q, want pass-through", got)
+	}
+	if got := m.Reverse("anything"); got != "anything" {
+		t.Errorf("nil Mapping.Reverse returned %q, want pass-through", got)
+	}
+}
+
+func TestMapping_MissingKeyPassThrough(t *testing.T) {
+	m, err := Build([]string{"a", "b"}, PolicyFor("anthropic"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := m.Translate("not_registered"); got != "not_registered" {
+		t.Errorf("Translate of missing key returned %q, want pass-through", got)
+	}
+	if got := m.Reverse("not_registered"); got != "not_registered" {
+		t.Errorf("Reverse of missing key returned %q, want pass-through", got)
+	}
+}
+
+func TestBuild_AcceptsAllProviderNamesForCommonRegistry(t *testing.T) {
+	// Smoke test: a realistic registry should normalise cleanly under
+	// every provider's policy.
+	names := []string{
+		"read_file", "list_directory", "search_files",
+		"write_file", "edit_file", "run_command", "web_fetch",
+		"spawn_agent",
+		"mcp_jira_create-issue", "mcp_slack_post.message",
+	}
+	for _, p := range []string{"anthropic", "openai-compatible", "openai-responses", "bedrock", "gemini"} {
+		t.Run(p, func(t *testing.T) {
+			m, err := Build(names, PolicyFor(p))
+			if err != nil {
+				t.Fatalf("Build for %s: %v", p, err)
+			}
+			for _, n := range names {
+				ext := m.Translate(n)
+				if ext == "" {
+					t.Errorf("%s: empty external name for %q", p, n)
+				}
+				if got := m.Reverse(ext); got != n {
+					t.Errorf("%s: Reverse(%q) = %q, want %q", p, ext, got, n)
+				}
+			}
+		})
+	}
+}

--- a/harness/internal/tool/toolname/toolname_test.go
+++ b/harness/internal/tool/toolname/toolname_test.go
@@ -189,6 +189,32 @@ func TestBuild_DuplicateInternalNameRejected(t *testing.T) {
 	}
 }
 
+func TestBuild_IrresolvableCollisionErrors(t *testing.T) {
+	// Force the stillCollides branch in Build: three distinct internal
+	// names that all sanitize to the same single-character form under
+	// MaxLen=1. The first wins the bare name; the second's
+	// disambiguation suffix is the pathological-budget branch in
+	// disambiguate (budget = MaxLen - len(suffix) < 1), which falls
+	// back to a one-character truncated suffix. The third name's
+	// disambiguation truncates to the same one character, so the
+	// post-disambiguation external name collides with what the second
+	// already claimed — the only legitimate way to reach the
+	// stillCollides return at toolname.go:194.
+	//
+	// This is the spec's fail-closed guarantee: irresolvable collisions
+	// must surface as an error before any wire request is issued, so a
+	// silent alias cannot route a tool call to the wrong handler.
+	names := []string{"aa", "ab", "ac"}
+	policy := Policy{MaxLen: 1, AllowHyphen: false, AllowLeadingDigit: true}
+	_, err := Build(names, policy)
+	if err == nil {
+		t.Fatal("expected error for irresolvable collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve collision") {
+		t.Errorf("expected stillCollides error wording, got: %v", err)
+	}
+}
+
 func TestBuild_LongNamesGetHashSuffixWhenColliding(t *testing.T) {
 	// Two long names that share a 64-char prefix would collide after
 	// hard truncation; the hash suffix must keep them distinct.


### PR DESCRIPTION
Closes #223.

Introduces a centralised `NormalizingAdapter` that wraps every loop-facing `ProviderAdapter` at factory build time. Outbound tool names are rewritten into each provider's accepted character set; inbound `tool_call` events are reverse-mapped to the registry-internal name before the dispatcher sees them. Policy rules live in a single `toolname.PolicyFor` switch with `TODO(#221)` markers for the capability-profile migration.

## Key properties
- **Fail-closed**: irresolvable collisions after hash-suffix disambiguation return an error before any wire request is issued.
- **Round-trip**: `Reverse(Translate(name)) == name` for all five provider policies (OpenAI Chat, OpenAI Responses, Anthropic, Gemini, Bedrock) across all tested name forms (MCP-prefixed, dots, hyphens, non-ASCII).
- **Non-mutating**: caller-supplied `Tools` and `Messages` slices are cloned before mutation; caller params are unchanged.
- **Adapter-invariant**: no concrete adapter imports `toolname`; the wrapper is the sole enforcement point.
- **`LastBatchID` pass-through**: preserves the `batchModeAdapter` duck-type through the new outer layer.
- **Deterministic ordering**: `buildMapping` uses `BuildSorted` so colliding names get stable external names across runs (matters once dynamic MCP re-discovery or registry rebuilds are added).

## Changes
- `harness/internal/tool/toolname/` (new package): `Policy`, `PolicyFor`, `Mapping`, `Build`, `BuildSorted`.
- `harness/internal/provider/normalizer.go` (new): `NormalizingAdapter` with `Stream`, `LastBatchID`, `Unwrap`.
- `harness/internal/core/factory.go`: step 14c wraps every provider with `NewNormalizingAdapter` after the optional batch wrap.
- `docs/architecture.md`, `AGENTS.md`: new "Provider-facing tool name normalization" section.

## Pre-merge remediation
- `provider/normalizer.go`: switched `buildMapping` from `Build` to `BuildSorted` (4-reviewer latent-ordering finding).
- `toolname/toolname_test.go`: added `TestBuild_IrresolvableCollisionErrors` exercising the `stillCollides` branch at `toolname.go:194`.
- `provider/normalizer_test.go`: added `TestNormalizingAdapter_IrresolvableCollisionFailsClosed` and `TestNormalizingAdapter_MultipleToolCallsInBatchReverseTranslated`; renamed the misnamed `..._CollisionAfterNormalisationFailsClosed` to `..._CollisionResolvedByDisambiguation`.
- `core/factory_test.go`: added `TestBuildLoopWithTransport_NormalizingAdapterWrapsGeminiProvider` and `..._WrapsBedrockProvider` pinning the outermost-wrap invariant.

## Verification
- `just` (build + full test suite) exits 0; `just lint` clean.
- Failure-closed paths exercised at both `toolname` package level (`MaxLen=1`) and adapter level.

## Deferred (follow-up issues)
- Unexport `Mapping.ExternalFor`/`InternalFor` and provide `toolname.EmptyMapping()` constructor — defer to #221 capability-profile migration.
- `Unwrap()` dedicated unit test, non-ASCII end-to-end through wrapper, pathological-MaxLen branch coverage, `Unwrap()` doc-comment clarification.
- Bedrock policy assumption (`[A-Za-z0-9_-]{1,64}` is the union of Anthropic + OpenAI-compatible rules) should be noted in `docs/architecture.md` Bedrock row.
- Inaccurate UTF-8 comment in `toolname_test.go:85`.
- `factory.go:453` `providerType` shadow readability.

Reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers; remediation brief in workstream scratch. Verdict: NEEDS REMEDIATION (applied).