### PR TITLE
provider/quirks: scaffold per-(provider, model) capability profile layer (Wave 2 Step 1)

### DIFF
--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -1578,8 +1578,21 @@ type ProviderConfig struct {
 	// entries in RunConfig.providers map are streaming-only and any batch
 	// field on them is rejected by ValidateRunConfig. See
 	// BatchProviderConfig for the mode / transport cross-field invariants.
-	// Next available field number: 15.
-	Batch         *BatchProviderConfig `protobuf:"bytes,14,opt,name=batch,proto3" json:"batch,omitempty"`
+	Batch *BatchProviderConfig `protobuf:"bytes,14,opt,name=batch,proto3" json:"batch,omitempty"`
+	// Optional. Selects a pre-defined provider-quirks compat profile that
+	// extends the adapter's wire shape (Wave 2 #221). Closed enum,
+	// validated by ValidateRunConfig at startup. Currently supported:
+	//
+	//	""        — no profile (default).
+	//	"zai-glm" — Z.ai GLM tool_stream extension and legacy max_tokens
+	//	            field. Applied on top of provider.type =
+	//	            "openai-compatible".
+	//
+	// The wire-shape knowledge lives in harness/internal/provider/compat/;
+	// this field is a discriminator only and never carries operator-
+	// authored rule data.
+	// Next available field number: 16.
+	CompatProfile string `protobuf:"bytes,15,opt,name=compat_profile,json=compatProfile,proto3" json:"compat_profile,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1710,6 +1723,13 @@ func (x *ProviderConfig) GetBatch() *BatchProviderConfig {
 		return x.Batch
 	}
 	return nil
+}
+
+func (x *ProviderConfig) GetCompatProfile() string {
+	if x != nil {
+		return x.CompatProfile
+	}
+	return ""
 }
 
 // BatchProviderConfig controls async batch submission for a provider
@@ -3664,7 +3684,7 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\vduration_ms\x18\x06 \x01(\x03R\n" +
 	"durationMs\x12\x1f\n" +
 	"\vstop_reason\x18\a \x01(\tR\n" +
-	"stopReason\"\xf7\x05\n" +
+	"stopReason\"\x9e\x06\n" +
 	"\x0eProviderConfig\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1e\n" +
 	"\vapi_key_ref\x18\x02 \x01(\tR\tapiKeyRef\x12\x16\n" +
@@ -3683,7 +3703,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\x14gcp_credentials_file\x18\v \x01(\tR\x12gcpCredentialsFile\x12]\n" +
 	"\x16gemini_safety_settings\x18\f \x03(\v2'.stirrup.harness.v1.GeminiSafetySettingR\x14geminiSafetySettings\x12B\n" +
 	"\x05retry\x18\r \x01(\v2'.stirrup.harness.v1.ProviderRetryConfigH\x00R\x05retry\x88\x01\x01\x12=\n" +
-	"\x05batch\x18\x0e \x01(\v2'.stirrup.harness.v1.BatchProviderConfigR\x05batch\x1a>\n" +
+	"\x05batch\x18\x0e \x01(\v2'.stirrup.harness.v1.BatchProviderConfigR\x05batch\x12%\n" +
+	"\x0ecompat_profile\x18\x0f \x01(\tR\rcompatProfile\x1a>\n" +
 	"\x10QueryParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\b\n" +

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -101,15 +101,21 @@ func readPromptFile(path string) (string, error) {
 // RunConfig built by buildHarnessRunConfig. Extracted so the construction
 // path is testable without booting cobra.
 type harnessCLIOptions struct {
-	RunID         string
-	Mode          string
-	SessionName   string
-	Prompt        string
-	ProviderType  string
-	APIKeyRef     string
-	BaseURL       string
-	APIKeyHeader  string
-	QueryParams   map[string]string
+	RunID        string
+	Mode         string
+	SessionName  string
+	Prompt       string
+	ProviderType string
+	APIKeyRef    string
+	BaseURL      string
+	APIKeyHeader string
+	QueryParams  map[string]string
+
+	// CompatProfile selects an optional provider-quirks compat profile
+	// (Wave 2 #221). Closed set, validated by ValidateRunConfig; the
+	// flag is empty by default so a bare invocation does not opt into a
+	// compat shape.
+	CompatProfile string
 	Model         string
 	Workspace     string
 	MaxTurns      int
@@ -339,9 +345,10 @@ func buildHarnessRunConfigCore(opts harnessCLIOptions) (*types.RunConfig, error)
 				}
 				return opts.APIKeyRef
 			}(),
-			BaseURL:      opts.BaseURL,
-			APIKeyHeader: opts.APIKeyHeader,
-			QueryParams:  opts.QueryParams,
+			BaseURL:       opts.BaseURL,
+			APIKeyHeader:  opts.APIKeyHeader,
+			QueryParams:   opts.QueryParams,
+			CompatProfile: opts.CompatProfile,
 		},
 		ModelRouter: types.ModelRouterConfig{
 			Type:     "static",
@@ -839,6 +846,9 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 	}
 	if changed("api-key-header") {
 		cfg.Provider.APIKeyHeader, _ = f.GetString("api-key-header")
+	}
+	if changed("provider-compat-profile") {
+		cfg.Provider.CompatProfile, _ = f.GetString("provider-compat-profile")
 	}
 	if changed("gcp-project") {
 		cfg.Provider.GCPProject, _ = f.GetString("gcp-project")

--- a/harness/cmd/stirrup/cmd/providers_quirks.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -115,29 +114,11 @@ func runProvidersQuirksWithIO(cmd *cobra.Command, stdout io.Writer) error {
 	return nil
 }
 
-// cliRuleMatches mirrors quirks.ruleMatches (unexported) so the CLI's
-// "what rules ran" report stays faithful to what Resolve actually
-// executes. If the quirks-internal helper grows to consult more
-// fields (e.g. BaseURLMatch in a future step) this needs to track.
-func cliRuleMatches(rule quirks.Rule, provider, model string) bool {
-	if rule.ProviderType != provider {
-		return false
-	}
-	if rule.ModelMatch == "" {
-		return true
-	}
-	ok, err := path.Match(rule.ModelMatch, model)
-	if err != nil {
-		return false
-	}
-	return ok
-}
-
-// collectAppliedRules walks the rule slice in declaration order and
-// returns the metadata for every rule whose ProviderType + ModelMatch
-// predicate fires for (provider, model). Mirrors the matching logic
-// in registry.Resolve so the CLI's "what rules ran" report is
-// faithful to what actually executed.
+// collectAppliedRules walks the rule slice and returns the metadata
+// for every rule whose predicate fires for (provider, model), using
+// quirks.RuleMatches so the CLI's "what rules ran" report is the same
+// predicate Resolve walks (no silent divergence if the predicate
+// gains a dimension).
 //
 // Returns a non-nil empty slice when no rule matched so the JSON
 // output is `[]` rather than `null` — easier to script against.
@@ -145,7 +126,7 @@ func collectAppliedRules(rules []quirks.Rule, provider, model string) []appliedR
 	out := make([]appliedRuleCLIOutput, 0, len(rules))
 	cutoff := time.Now().Add(-quirksStaleness)
 	for _, rule := range rules {
-		if !cliRuleMatches(rule, provider, model) {
+		if !quirks.RuleMatches(rule, provider, model) {
 			continue
 		}
 		lastVerified := ""

--- a/harness/cmd/stirrup/cmd/providers_quirks.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+)
+
+// quirksStaleness mirrors the 180-day window used by
+// quirks_test.go::TestRuleStaleness. The CLI surfaces it in the
+// `stale` boolean on each contributing rule so operators reading the
+// JSON output can spot a rule overdue for re-verification without
+// computing dates themselves.
+const quirksStaleness = 180 * 24 * time.Hour
+
+// providersCmd is the root of the `stirrup providers …` subcommand
+// family. The subcommands inspect provider-adapter configuration
+// without booting the agentic loop.
+var providersCmd = &cobra.Command{
+	Use:   "providers",
+	Short: "Inspect provider-adapter configuration",
+	Long: `Inspect provider-adapter configuration without running a turn.
+
+Subcommands:
+  quirks  Resolve the per-(provider, model) quirks registry and print
+          the result as JSON. Side-effect-free; safe to invoke from
+          shell completion or CI checks.`,
+}
+
+// providersQuirksCmd is the `stirrup providers quirks` introspection
+// surface for the Wave 2 quirks registry. It prints the resolved
+// ProviderQuirks as JSON, along with the Description, LastVerified,
+// and staleness flag of every contributing rule, so operators can
+// debug a divergence between what they expected the adapter to send
+// and what a rule actually applied.
+var providersQuirksCmd = &cobra.Command{
+	Use:   "quirks",
+	Short: "Print the resolved provider quirks for a (provider, model) pair",
+	Long: `Resolve the built-in provider quirks registry for the supplied
+(--provider, --model) pair and emit the result as JSON. The output
+carries the merged ProviderQuirks value plus a list of every
+contributing rule (description, last-verified date, staleness flag).
+
+The empty-registry case (no rule matched) is not an error: the output
+carries an empty appliedRules list and a ProviderQuirks value at its
+zero-after-init shape.`,
+	Args: cobra.NoArgs,
+	RunE: runProvidersQuirks,
+}
+
+func init() {
+	rootCmd.AddCommand(providersCmd)
+	providersCmd.AddCommand(providersQuirksCmd)
+
+	f := providersQuirksCmd.Flags()
+	f.String("provider", "", "Provider type to resolve (e.g. openai-compatible, gemini, anthropic).")
+	f.String("model", "", "Model identifier to resolve (e.g. gpt-5-nano, gemini-3.1-pro-preview).")
+	_ = providersQuirksCmd.MarkFlagRequired("provider")
+	_ = providersQuirksCmd.MarkFlagRequired("model")
+}
+
+// quirksCLIOutput is the wire shape printed by `stirrup providers
+// quirks`. JSON tags are stable: scripts consuming this output should
+// be able to grep on the field names.
+type quirksCLIOutput struct {
+	Provider     string                 `json:"provider"`
+	Model        string                 `json:"model"`
+	Quirks       quirks.ProviderQuirks  `json:"quirks"`
+	AppliedRules []appliedRuleCLIOutput `json:"appliedRules"`
+}
+
+// appliedRuleCLIOutput summarises one contributing rule. Stale rules
+// are flagged so operators can prioritise re-verification work
+// without computing date arithmetic.
+type appliedRuleCLIOutput struct {
+	Description  string `json:"description"`
+	LastVerified string `json:"lastVerified"`
+	Stale        bool   `json:"stale"`
+}
+
+func runProvidersQuirks(cmd *cobra.Command, _ []string) error {
+	return runProvidersQuirksWithIO(cmd, os.Stdout)
+}
+
+// runProvidersQuirksWithIO is the testable seam: it accepts an
+// explicit writer so unit tests can capture the JSON output without
+// touching the process-global stdout. Required flag enforcement runs
+// before this entry point (via MarkFlagRequired in init).
+func runProvidersQuirksWithIO(cmd *cobra.Command, stdout io.Writer) error {
+	provider, _ := cmd.Flags().GetString("provider")
+	model, _ := cmd.Flags().GetString("model")
+
+	reg := quirks.DefaultRegistry()
+	resolved := reg.Resolve(provider, model)
+	applied := collectAppliedRules(quirks.BuiltinRules(), provider, model)
+
+	out := quirksCLIOutput{
+		Provider:     provider,
+		Model:        model,
+		Quirks:       resolved,
+		AppliedRules: applied,
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("encode quirks output: %w", err)
+	}
+	return nil
+}
+
+// cliRuleMatches mirrors quirks.ruleMatches (unexported) so the CLI's
+// "what rules ran" report stays faithful to what Resolve actually
+// executes. If the quirks-internal helper grows to consult more
+// fields (e.g. BaseURLMatch in a future step) this needs to track.
+func cliRuleMatches(rule quirks.Rule, provider, model string) bool {
+	if rule.ProviderType != provider {
+		return false
+	}
+	if rule.ModelMatch == "" {
+		return true
+	}
+	ok, err := path.Match(rule.ModelMatch, model)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// collectAppliedRules walks the rule slice in declaration order and
+// returns the metadata for every rule whose ProviderType + ModelMatch
+// predicate fires for (provider, model). Mirrors the matching logic
+// in registry.Resolve so the CLI's "what rules ran" report is
+// faithful to what actually executed.
+//
+// Returns a non-nil empty slice when no rule matched so the JSON
+// output is `[]` rather than `null` — easier to script against.
+func collectAppliedRules(rules []quirks.Rule, provider, model string) []appliedRuleCLIOutput {
+	out := make([]appliedRuleCLIOutput, 0, len(rules))
+	cutoff := time.Now().Add(-quirksStaleness)
+	for _, rule := range rules {
+		if !cliRuleMatches(rule, provider, model) {
+			continue
+		}
+		lastVerified := ""
+		if !rule.LastVerified.IsZero() {
+			lastVerified = rule.LastVerified.Format("2006-01-02")
+		}
+		out = append(out, appliedRuleCLIOutput{
+			Description:  rule.Description,
+			LastVerified: lastVerified,
+			Stale:        !rule.LastVerified.IsZero() && rule.LastVerified.Before(cutoff),
+		})
+	}
+	return out
+}

--- a/harness/cmd/stirrup/cmd/providers_quirks.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -114,29 +115,50 @@ func runProvidersQuirksWithIO(cmd *cobra.Command, stdout io.Writer) error {
 	return nil
 }
 
-// collectAppliedRules walks the rule slice and returns the metadata
-// for every rule whose predicate fires for (provider, model), using
-// quirks.RuleMatches so the CLI's "what rules ran" report is the same
-// predicate Resolve walks (no silent divergence if the predicate
-// gains a dimension).
+// collectAppliedRules returns the metadata for every rule that
+// actually contributes to a Resolve for (provider, model). The output
+// is ordered the same way Resolve applies them: glob length ascending
+// with declaration order as the tiebreaker, so the last entry in the
+// list is the rule whose writes won on overlapping keys. Rules with
+// nil Apply are filtered out for the same reason — Resolve skips
+// them, so reporting them as "applied" would be a lie.
 //
 // Returns a non-nil empty slice when no rule matched so the JSON
 // output is `[]` rather than `null` — easier to script against.
 func collectAppliedRules(rules []quirks.Rule, provider, model string) []appliedRuleCLIOutput {
-	out := make([]appliedRuleCLIOutput, 0, len(rules))
-	cutoff := time.Now().Add(-quirksStaleness)
-	for _, rule := range rules {
+	type indexed struct {
+		idx  int
+		rule quirks.Rule
+	}
+	matched := make([]indexed, 0, len(rules))
+	for i, rule := range rules {
+		if rule.Apply == nil {
+			continue
+		}
 		if !quirks.RuleMatches(rule, provider, model) {
 			continue
 		}
+		matched = append(matched, indexed{idx: i, rule: rule})
+	}
+	sort.SliceStable(matched, func(i, j int) bool {
+		li := len(matched[i].rule.ModelMatch)
+		lj := len(matched[j].rule.ModelMatch)
+		if li != lj {
+			return li < lj
+		}
+		return matched[i].idx < matched[j].idx
+	})
+	out := make([]appliedRuleCLIOutput, 0, len(matched))
+	cutoff := time.Now().Add(-quirksStaleness)
+	for _, m := range matched {
 		lastVerified := ""
-		if !rule.LastVerified.IsZero() {
-			lastVerified = rule.LastVerified.Format("2006-01-02")
+		if !m.rule.LastVerified.IsZero() {
+			lastVerified = m.rule.LastVerified.Format("2006-01-02")
 		}
 		out = append(out, appliedRuleCLIOutput{
-			Description:  rule.Description,
+			Description:  m.rule.Description,
 			LastVerified: lastVerified,
-			Stale:        !rule.LastVerified.IsZero() && rule.LastVerified.Before(cutoff),
+			Stale:        !m.rule.LastVerified.IsZero() && m.rule.LastVerified.Before(cutoff),
 		})
 	}
 	return out

--- a/harness/cmd/stirrup/cmd/providers_quirks_test.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestProvidersQuirksCommand returns a fresh cobra command preloaded
+// with the providers-quirks flag surface. Mirrors
+// newTestRunConfigCommand's per-test scope so flag-changed state does
+// not leak between tests.
+func newTestProvidersQuirksCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "quirks"}
+	cmd.Flags().String("provider", "", "")
+	cmd.Flags().String("model", "", "")
+	return cmd
+}
+
+// TestProvidersQuirks_EmptyRegistryEmitsValidJSON exercises the
+// Step-1 BuiltinRules() empty state: the subcommand must still
+// produce a structurally valid JSON document with an empty
+// appliedRules slice (not null) and a ProviderQuirks value at the
+// post-Resolve zero shape (non-nil empty maps/slices).
+func TestProvidersQuirks_EmptyRegistryEmitsValidJSON(t *testing.T) {
+	cmd := newTestProvidersQuirksCommand()
+	if err := cmd.ParseFlags([]string{"--provider", "openai-compatible", "--model", "gpt-4o"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := runProvidersQuirksWithIO(cmd, &buf); err != nil {
+		t.Fatalf("runProvidersQuirksWithIO: %v", err)
+	}
+
+	var got quirksCLIOutput
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+
+	if got.Provider != "openai-compatible" {
+		t.Errorf("Provider = %q, want openai-compatible", got.Provider)
+	}
+	if got.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want gpt-4o", got.Model)
+	}
+	if got.AppliedRules == nil {
+		t.Error("AppliedRules must be a non-nil slice (empty array, not null)")
+	}
+	if len(got.AppliedRules) != 0 {
+		t.Errorf("AppliedRules = %+v, want empty", got.AppliedRules)
+	}
+	// The JSON output must also literally contain "appliedRules": []
+	// so downstream scripts can rely on the array shape even before
+	// unmarshalling.
+	if !strings.Contains(buf.String(), `"appliedRules": []`) {
+		t.Errorf("output missing literal `\"appliedRules\": []`:\n%s", buf.String())
+	}
+}
+
+// TestProvidersQuirks_RequiredFlags pins the MarkFlagRequired wiring
+// on the registered cobra command: missing --provider or --model
+// must produce a non-nil error rather than a bare-default
+// resolution.
+func TestProvidersQuirks_RequiredFlags(t *testing.T) {
+	for _, name := range []string{"provider", "model"} {
+		t.Run("missing-"+name, func(t *testing.T) {
+			// Re-execute the real command tree with the offending flag
+			// absent. cobra surfaces MarkFlagRequired through
+			// Command.Execute, not ParseFlags, so we drive Execute
+			// against a fresh root command to avoid mutating the
+			// process-global one.
+			root := &cobra.Command{Use: "stirrup"}
+			parent := &cobra.Command{Use: "providers"}
+			child := &cobra.Command{Use: "quirks", RunE: runProvidersQuirks}
+			child.Flags().String("provider", "", "")
+			child.Flags().String("model", "", "")
+			_ = child.MarkFlagRequired("provider")
+			_ = child.MarkFlagRequired("model")
+			root.AddCommand(parent)
+			parent.AddCommand(child)
+
+			args := []string{"providers", "quirks"}
+			if name == "provider" {
+				args = append(args, "--model", "gpt-4o")
+			} else {
+				args = append(args, "--provider", "openai-compatible")
+			}
+			root.SetArgs(args)
+			root.SetOut(&bytes.Buffer{})
+			root.SetErr(&bytes.Buffer{})
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("expected required-flag error for missing --%s, got nil", name)
+			}
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("error %q must mention the missing flag --%s", err.Error(), name)
+			}
+		})
+	}
+}
+
+// TestProvidersQuirks_OutputIsValidJSON broadens
+// TestProvidersQuirks_EmptyRegistryEmitsValidJSON to assert that the
+// emitted document is valid against a generic decoder (not just our
+// typed struct). Catches a future regression where a field with no
+// JSON tag is added to quirksCLIOutput and produces unexpected camel
+// or snake casing.
+func TestProvidersQuirks_OutputIsValidJSON(t *testing.T) {
+	cmd := newTestProvidersQuirksCommand()
+	if err := cmd.ParseFlags([]string{"--provider", "gemini", "--model", "gemini-3.1-pro-preview"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := runProvidersQuirksWithIO(cmd, &buf); err != nil {
+		t.Fatalf("runProvidersQuirksWithIO: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	for _, key := range []string{"provider", "model", "quirks", "appliedRules"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing top-level key %q in output: %s", key, buf.String())
+		}
+	}
+}

--- a/harness/cmd/stirrup/cmd/providers_quirks_test.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks_test.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 )
 
 // newTestProvidersQuirksCommand returns a fresh cobra command preloaded
@@ -125,5 +128,126 @@ func TestProvidersQuirks_OutputIsValidJSON(t *testing.T) {
 		if _, ok := raw[key]; !ok {
 			t.Errorf("missing top-level key %q in output: %s", key, buf.String())
 		}
+	}
+}
+
+// TestCollectAppliedRules_FiltersAndFlagsCorrectly exercises every
+// branch of collectAppliedRules using a hand-constructed rule slice.
+// Without this test the CLI's primary operator-facing correctness
+// surface had zero direct coverage (BuiltinRules() is empty in Step 1
+// so no rule ever flowed through the predicate or staleness branches).
+//
+// Covers:
+//   - matching rule (ProviderType + ModelMatch glob both match)
+//   - non-matching rule (different ProviderType)
+//   - stale-flag branch (LastVerified > 180 days ago)
+//   - zero-LastVerified branch (empty lastVerified string; Stale=false)
+//   - Apply == nil guard (skipped; mirrors Resolve)
+//   - specificity ordering (longer ModelMatch glob runs last and wins)
+func TestCollectAppliedRules_FiltersAndFlagsCorrectly(t *testing.T) {
+	noop := func(*quirks.ProviderQuirks) {}
+	stale := time.Now().Add(-365 * 24 * time.Hour) // 1y ago, well past 180d
+	fresh := time.Now().Add(-30 * 24 * time.Hour)  // 30d ago, fresh
+
+	rules := []quirks.Rule{
+		{
+			// Wildcard rule: matches every model for the provider.
+			// Glob length 1, declared first → runs first under sort.
+			ProviderType: "openai-compatible",
+			ModelMatch:   "*",
+			Description:  "wildcard openai-compatible",
+			LastVerified: fresh,
+			Apply:        noop,
+		},
+		{
+			// Stale rule: LastVerified > 180d ago.
+			ProviderType: "openai-compatible",
+			ModelMatch:   "gpt-4*",
+			Description:  "stale gpt-4 rule",
+			LastVerified: stale,
+			Apply:        noop,
+		},
+		{
+			// Zero-LastVerified rule: lastVerified field renders empty,
+			// Stale flag stays false (zero time is not "before cutoff"
+			// in the meaningful sense the operator cares about).
+			ProviderType: "openai-compatible",
+			ModelMatch:   "gpt-4o",
+			Description:  "zero-LastVerified gpt-4o rule",
+			LastVerified: time.Time{},
+			Apply:        noop,
+		},
+		{
+			// Non-matching: different ProviderType.
+			ProviderType: "anthropic",
+			ModelMatch:   "claude-*",
+			Description:  "anthropic claude rule (should not appear)",
+			LastVerified: fresh,
+			Apply:        noop,
+		},
+		{
+			// Apply == nil: must be filtered out, matching Resolve's
+			// behaviour, even though the predicate matches.
+			ProviderType: "openai-compatible",
+			ModelMatch:   "gpt-4o",
+			Description:  "nil-apply gpt-4o rule (should not appear)",
+			LastVerified: fresh,
+			Apply:        nil,
+		},
+	}
+
+	got := collectAppliedRules(rules, "openai-compatible", "gpt-4o")
+
+	// Expected, in specificity order:
+	//   1. "wildcard openai-compatible"            (glob length 1)
+	//   2. "stale gpt-4 rule"                      (glob length 5)
+	//   3. "zero-LastVerified gpt-4o rule"         (glob length 6)
+	// The anthropic rule has the wrong ProviderType; the nil-apply rule
+	// is skipped by the guard.
+	wantDescriptions := []string{
+		"wildcard openai-compatible",
+		"stale gpt-4 rule",
+		"zero-LastVerified gpt-4o rule",
+	}
+	if len(got) != len(wantDescriptions) {
+		t.Fatalf("got %d applied rules, want %d: %+v", len(got), len(wantDescriptions), got)
+	}
+	for i, want := range wantDescriptions {
+		if got[i].Description != want {
+			t.Errorf("applied[%d].Description = %q, want %q", i, got[i].Description, want)
+		}
+	}
+
+	// Stale flag and lastVerified rendering by index in the sorted output.
+	if got[0].Stale {
+		t.Errorf("applied[0] (fresh wildcard) Stale = true, want false")
+	}
+	if got[0].LastVerified != fresh.Format("2006-01-02") {
+		t.Errorf("applied[0].LastVerified = %q, want %q", got[0].LastVerified, fresh.Format("2006-01-02"))
+	}
+	if !got[1].Stale {
+		t.Errorf("applied[1] (stale) Stale = false, want true")
+	}
+	if got[1].LastVerified != stale.Format("2006-01-02") {
+		t.Errorf("applied[1].LastVerified = %q, want %q", got[1].LastVerified, stale.Format("2006-01-02"))
+	}
+	if got[2].Stale {
+		t.Errorf("applied[2] (zero-LastVerified) Stale = true, want false (zero time is not flagged)")
+	}
+	if got[2].LastVerified != "" {
+		t.Errorf("applied[2].LastVerified = %q, want empty string for zero time", got[2].LastVerified)
+	}
+}
+
+// TestCollectAppliedRules_EmptyRules pins the empty-rule-set
+// behaviour the JSON output depends on: an empty rule slice returns a
+// non-nil empty slice so the encoded JSON is `[]` rather than `null`.
+func TestCollectAppliedRules_EmptyRules(t *testing.T) {
+	got := collectAppliedRules(nil, "openai-compatible", "gpt-4o")
+	if got == nil {
+		t.Fatal("collectAppliedRules(nil, ...) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("collectAppliedRules(nil, ...) = %+v, want empty", got)
 	}
 }

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -345,6 +345,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 	baseURL, _ := f.GetString("base-url")
 	apiKeyHeader, _ := f.GetString("api-key-header")
 	queryParamRaw, _ := f.GetStringArray("query-param")
+	compatProfile, _ := f.GetString("provider-compat-profile")
 	gcpProject, _ := f.GetString("gcp-project")
 	gcpLocation, _ := f.GetString("gcp-location")
 	gcpCredentialsFile, _ := f.GetString("gcp-credentials-file")
@@ -419,6 +420,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 		BaseURL:                      baseURL,
 		APIKeyHeader:                 apiKeyHeader,
 		QueryParams:                  queryParams,
+		CompatProfile:                compatProfile,
 		APIKeyRef:                    apiKeyRef,
 		GCPProject:                   gcpProject,
 		GCPLocation:                  gcpLocation,

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -28,6 +28,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.String("base-url", "", "API base URL for openai-compatible / openai-responses providers (e.g. https://<resource>.openai.azure.com/openai/v1)")
 	f.String("api-key-header", "", "Header name for sending the API key. Empty = Authorization: Bearer (default). Set to \"api-key\" for Azure OpenAI key auth.")
 	f.StringArray("query-param", nil, "Repeatable key=value query parameter appended to every provider request URL (e.g. api-version=preview). Used by the openai-* adapters.")
+	f.String("provider-compat-profile", "", "Optional compatibility profile selecting a pre-defined provider-quirks rule. Closed set; current legal values: \"\" (no profile), \"zai-glm\" (Z.ai GLM tool_stream + legacy max_tokens).")
 	f.String("gcp-project", "", "GCP project ID hosting the Vertex AI usage. Required when --provider=gemini.")
 	f.String("gcp-location", "global", "Vertex AI location: \"global\" or a region (e.g. us-central1). Determines the URL host and project location segment.")
 	f.String("gcp-credentials-file", "", "Path to a Google service account JSON key file. When set, implies credential.type=gcp-service-account.")
@@ -121,6 +122,7 @@ func addRunConfigFlagCompletions(cmd *cobra.Command) {
 	staticValues("container-runtime", types.ValidExecutorRuntimeValues())
 	staticValues("code-scanner", types.ValidCodeScannerTypeValues())
 	staticValues("guardrail", types.ValidGuardRailTypeValues())
+	staticValues("provider-compat-profile", types.ValidCompatProfileValues())
 
 	// log-level and api-key-header are not declared as validator-closed
 	// sets in types/runconfig.go, but operators benefit from a hinted

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -22,5 +22,5 @@ package quirks
 // via NewRegistry — see harness/internal/provider/compat/zai for the
 // pattern.
 func BuiltinRules() []Rule {
-	return nil
+	return []Rule{}
 }

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -1,0 +1,26 @@
+package quirks
+
+// BuiltinRules returns the first-party rule set baked into the harness.
+//
+// Step 1 of the Wave 2 implementation deliberately ships an empty
+// slice: the scaffolding lands without behaviour change so adapters
+// integrating with the registry (Steps 2-5) can do so against the
+// final shape, and the supporting tests / CLI surface have something
+// concrete to exercise.
+//
+// Rules are added in subsequent steps in this order:
+//
+//   - Step 2: openai-compatible reasoning-class rules (`o[1-9]-*`,
+//     `gpt-5*` with `gpt-5-chat*` carve-out).
+//   - Step 3: gemini default rule pinning StreamArgsOff for "*".
+//   - Step 4: openai-responses rules (none planned for v1; the empty
+//     output struct-tag fix is not a quirk).
+//   - Step 5: ReplayFields rules for deepseek-reasoner*, deepseek-v4*,
+//     and gemini-3* parse-side recognition.
+//
+// Operators who want a non-default rule (e.g. Z.ai compat) inject it
+// via NewRegistry — see harness/internal/provider/compat/zai for the
+// pattern.
+func BuiltinRules() []Rule {
+	return nil
+}

--- a/harness/internal/provider/quirks/helpers.go
+++ b/harness/internal/provider/quirks/helpers.go
@@ -9,6 +9,12 @@ package quirks
 // behaviour that doesn't exist yet. Step 2 will rename to
 // ApplyOpenAIReasoningClass / RemoveFromOmit when the implementations
 // land and external rule files (e.g. compat/zai) need to call them.
+//
+// The stubs carry //nolint:unused because Step 1 ships an empty
+// BuiltinRules() so nothing calls them yet; Step 2's first rule
+// addition is the first caller. Removing the stubs would leave Step 2
+// to invent the names at the same time as the rule logic; preserving
+// the names here pins the helper API surface up-front.
 
 // applyOpenAIReasoningClass sets the behaviour-flag combination shared
 // by every OpenAI reasoning-class model: TokenFieldMaxCompletionTokens
@@ -17,6 +23,8 @@ package quirks
 // frequency_penalty, logprobs, top_logprobs, and logit_bias.
 //
 // TODO(Step 2): implement.
+//
+//nolint:unused // Step 2 caller is queued; see file-level comment.
 func applyOpenAIReasoningClass(_ *ProviderQuirks) {}
 
 // removeFromOmit drops the named field from ProviderQuirks.OmitFields,
@@ -24,4 +32,6 @@ func applyOpenAIReasoningClass(_ *ProviderQuirks) {}
 // omission applied by a broader sibling rule.
 //
 // TODO(Step 2): implement.
+//
+//nolint:unused // Step 2 caller is queued; see file-level comment.
 func removeFromOmit(_ *ProviderQuirks, _ string) {}

--- a/harness/internal/provider/quirks/helpers.go
+++ b/harness/internal/provider/quirks/helpers.go
@@ -1,0 +1,27 @@
+package quirks
+
+// Shared helper functions used by builtin rule Apply closures. Step 1
+// reserves the file with package-private stubs so Step 2 can land the
+// rule implementations alongside the helpers in a single change.
+//
+// Helpers stay unexported in Step 1 (rather than being exported and
+// empty) so the public surface of the quirks package does not advertise
+// behaviour that doesn't exist yet. Step 2 will rename to
+// ApplyOpenAIReasoningClass / RemoveFromOmit when the implementations
+// land and external rule files (e.g. compat/zai) need to call them.
+
+// applyOpenAIReasoningClass sets the behaviour-flag combination shared
+// by every OpenAI reasoning-class model: TokenFieldMaxCompletionTokens
+// (already the zero-value default, but pinned explicitly) and
+// OmitSamplingParams to suppress temperature, top_p, presence_penalty,
+// frequency_penalty, logprobs, top_logprobs, and logit_bias.
+//
+// TODO(Step 2): implement.
+func applyOpenAIReasoningClass(_ *ProviderQuirks) {}
+
+// removeFromOmit drops the named field from ProviderQuirks.OmitFields,
+// used by carve-out rules (e.g. gpt-5-chat*) that need to undo an
+// omission applied by a broader sibling rule.
+//
+// TODO(Step 2): implement.
+func removeFromOmit(_ *ProviderQuirks, _ string) {}

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -1,0 +1,156 @@
+// Package quirks implements the per-(provider, model) wire-shape and
+// behaviour override registry. Adapters call Registry.Resolve at the
+// top of each Stream call to get a ProviderQuirks for the request.
+package quirks
+
+// ProviderQuirks is the in-memory result of resolving the registry for a
+// (providerType, model) pair. Adapters read it when building a request and
+// (for paths that diverge) when interpreting a response.
+//
+// Registry.Resolve always returns a ProviderQuirks with all map fields
+// pre-initialised to empty non-nil maps and all slice fields to empty
+// non-nil slices, so Apply functions may write freely without nil checks.
+// A zero-value ProviderQuirks constructed outside the registry is NOT safe
+// to mutate.
+type ProviderQuirks struct {
+	// --- Wire-shape overrides ---
+
+	// FieldRenames maps canonical adapter-internal field name to the wire
+	// JSON key the request should emit. Empty key means "use canonical name".
+	// Adapters validate that every key is in their declared canonical set at
+	// registry build; unknown keys panic via TestBuiltinRulesValidate.
+	FieldRenames map[string]string
+
+	// OmitFields lists canonical fields the adapter MUST NOT emit, even when
+	// non-zero. Applied after ValueOverrides (omission wins).
+	OmitFields []string
+
+	// ValueOverrides forces a canonical field's serialised value, ignoring
+	// StreamParams. Applied before OmitFields.
+	ValueOverrides map[string]Value
+
+	// EnumCoercions maps canonical field name → (caller-value → wire-value).
+	// A present outer key with no inner match means the caller's value is
+	// unsupported and the field is dropped (equivalent to OmitFields for that
+	// value). v1 ships no rules; the surface is declared and tested with
+	// synthetic rules.
+	EnumCoercions map[string]map[string]string
+
+	// ReplayFields lists assistant-message field paths to preserve verbatim
+	// across turns. Parse-side recognition only in v1; outbound threading is
+	// a follow-up. Paths use dot-separated keys with [] for array-of-objects.
+	ReplayFields []string
+
+	// --- Behaviour flags ---
+
+	// BehaviourFlags carries adapter-internal behaviour flags that cannot be
+	// expressed as flat field operations. Each provider family has a typed
+	// sub-struct; adapters access only the sub-struct they own.
+	BehaviourFlags ProviderBehaviourFlags
+}
+
+// ProviderBehaviourFlags holds per-provider structural flags. Fields are
+// safe to read if zero — the zero value preserves today's adapter behaviour
+// in every case.
+type ProviderBehaviourFlags struct {
+	OpenAI OpenAIBehaviourFlags
+	Gemini GeminiBehaviourFlags
+	// Future: Anthropic AnthropicBehaviourFlags (reserved; Anthropic v1 has no
+	// structural divergences beyond what StreamParams already encodes).
+}
+
+// OpenAIBehaviourFlags covers behaviour divergences in openai-compatible
+// adapters. The zero value reproduces today's behaviour.
+type OpenAIBehaviourFlags struct {
+	// TokenField selects which JSON key carries the token budget.
+	// TokenFieldMaxCompletionTokens is the default (matches the current
+	// hard-coded behaviour of openai.go). TokenFieldMaxTokens is the
+	// legacy key required by some compat providers (Z.ai GLM, older vLLM
+	// builds, Ollama before 0.7). Only rules that explicitly need the legacy
+	// key set this; the default is always the modern field.
+	TokenField OpenAITokenField
+
+	// OmitSamplingParams, when true, omits temperature, top_p,
+	// presence_penalty, frequency_penalty, logprobs, top_logprobs, and
+	// logit_bias from the request body. Used for reasoning-class models that
+	// reject these parameters. Note: temperature is already omitted when
+	// StreamParams.Temperature is nil (omitempty); this flag additionally
+	// omits the other six fields and guarantees temperature is never sent
+	// even if the caller set a non-nil value.
+	OmitSamplingParams bool
+
+	// ExtraBodyFields carries provider-specific top-level request fields that
+	// do not exist in the canonical OpenAI Chat Completions schema. The
+	// marshaller merges these into the request body after building the
+	// canonical fields. Used for Z.ai's `tool_stream: true` and similar
+	// gateway-specific extensions.
+	//
+	// Values must be JSON-serialisable. Keys that collide with canonical
+	// request fields are an error detected at registry build time.
+	// Secrets MUST NOT appear here — the registry self-test asserts that no
+	// ExtraBodyField value contains a secret:// reference.
+	ExtraBodyFields map[string]any
+}
+
+// OpenAITokenField controls which JSON key carries the token budget in an
+// openai-compatible request.
+type OpenAITokenField int
+
+const (
+	// TokenFieldMaxCompletionTokens is the default: emits
+	// "max_completion_tokens". Matches the current hard-coded behaviour of
+	// openai.go and is required by OpenAI reasoning models and GPT-5+.
+	TokenFieldMaxCompletionTokens OpenAITokenField = 0 // zero value = default
+
+	// TokenFieldMaxTokens emits the legacy "max_tokens" key required by
+	// Z.ai GLM, older vLLM, Ollama, and other compat providers that have
+	// not adopted the reasoning-model naming.
+	TokenFieldMaxTokens OpenAITokenField = 1
+)
+
+// GeminiBehaviourFlags covers behaviour divergences in the Gemini adapter.
+// The zero value reproduces today's post-#191 behaviour.
+type GeminiBehaviourFlags struct {
+	// StreamFunctionCallArgsShape controls how the Gemini adapter configures
+	// functionCallingConfig.streamFunctionCallArguments and parses inbound
+	// partial-args chunks.
+	//
+	// Default (StreamArgsOff = 0) preserves the post-#191 behaviour: the
+	// flag is set to false for all models and no partial-args parsing
+	// occurs. Future rules can model-scope the V2 and V3 shapes.
+	StreamFunctionCallArgsShape GeminiStreamArgsShape
+}
+
+// GeminiStreamArgsShape enumerates the streamFunctionCallArguments shapes.
+type GeminiStreamArgsShape int
+
+const (
+	StreamArgsOff        GeminiStreamArgsShape = 0 // off; post-#191 safe default
+	StreamArgsV2Snapshot GeminiStreamArgsShape = 1 // Gemini 2.x cumulative snapshot
+	StreamArgsV3Deltas   GeminiStreamArgsShape = 2 // Gemini 3.x JSON-path delta array
+)
+
+// Value is a typed JSON scalar used by ProviderQuirks.ValueOverrides.
+// Exactly one field is set; New* constructors enforce the invariant.
+type Value struct {
+	String *string
+	Int    *int
+	Float  *float64
+	Bool   *bool
+	Null   bool
+}
+
+// NewStringValue returns a Value carrying the given string.
+func NewStringValue(s string) Value { return Value{String: &s} }
+
+// NewIntValue returns a Value carrying the given int.
+func NewIntValue(i int) Value { return Value{Int: &i} }
+
+// NewFloatValue returns a Value carrying the given float64.
+func NewFloatValue(f float64) Value { return Value{Float: &f} }
+
+// NewBoolValue returns a Value carrying the given bool.
+func NewBoolValue(b bool) Value { return Value{Bool: &b} }
+
+// NewNullValue returns a Value representing a JSON null.
+func NewNullValue() Value { return Value{Null: true} }

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -132,12 +132,15 @@ const (
 
 // Value is a typed JSON scalar used by ProviderQuirks.ValueOverrides.
 // Exactly one field is set; New* constructors enforce the invariant.
+// JSON tags use camelCase + omitempty so the CLI introspection output
+// stays consistent with the rest of ProviderQuirks and only emits the
+// populated field.
 type Value struct {
-	String *string
-	Int    *int
-	Float  *float64
-	Bool   *bool
-	Null   bool
+	String *string  `json:"string,omitempty"`
+	Int    *int     `json:"int,omitempty"`
+	Float  *float64 `json:"float,omitempty"`
+	Bool   *bool    `json:"bool,omitempty"`
+	Null   bool     `json:"null,omitempty"`
 }
 
 // NewStringValue returns a Value carrying the given string.

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -19,42 +19,42 @@ type ProviderQuirks struct {
 	// JSON key the request should emit. Empty key means "use canonical name".
 	// Adapters validate that every key is in their declared canonical set at
 	// registry build; unknown keys panic via TestBuiltinRulesValidate.
-	FieldRenames map[string]string
+	FieldRenames map[string]string `json:"fieldRenames"`
 
 	// OmitFields lists canonical fields the adapter MUST NOT emit, even when
 	// non-zero. Applied after ValueOverrides (omission wins).
-	OmitFields []string
+	OmitFields []string `json:"omitFields"`
 
 	// ValueOverrides forces a canonical field's serialised value, ignoring
 	// StreamParams. Applied before OmitFields.
-	ValueOverrides map[string]Value
+	ValueOverrides map[string]Value `json:"valueOverrides"`
 
 	// EnumCoercions maps canonical field name → (caller-value → wire-value).
 	// A present outer key with no inner match means the caller's value is
 	// unsupported and the field is dropped (equivalent to OmitFields for that
 	// value). v1 ships no rules; the surface is declared and tested with
 	// synthetic rules.
-	EnumCoercions map[string]map[string]string
+	EnumCoercions map[string]map[string]string `json:"enumCoercions"`
 
 	// ReplayFields lists assistant-message field paths to preserve verbatim
 	// across turns. Parse-side recognition only in v1; outbound threading is
 	// a follow-up. Paths use dot-separated keys with [] for array-of-objects.
-	ReplayFields []string
+	ReplayFields []string `json:"replayFields"`
 
 	// --- Behaviour flags ---
 
 	// BehaviourFlags carries adapter-internal behaviour flags that cannot be
 	// expressed as flat field operations. Each provider family has a typed
 	// sub-struct; adapters access only the sub-struct they own.
-	BehaviourFlags ProviderBehaviourFlags
+	BehaviourFlags ProviderBehaviourFlags `json:"behaviourFlags"`
 }
 
 // ProviderBehaviourFlags holds per-provider structural flags. Fields are
 // safe to read if zero — the zero value preserves today's adapter behaviour
 // in every case.
 type ProviderBehaviourFlags struct {
-	OpenAI OpenAIBehaviourFlags
-	Gemini GeminiBehaviourFlags
+	OpenAI OpenAIBehaviourFlags `json:"openai"`
+	Gemini GeminiBehaviourFlags `json:"gemini"`
 	// Future: Anthropic AnthropicBehaviourFlags (reserved; Anthropic v1 has no
 	// structural divergences beyond what StreamParams already encodes).
 }
@@ -68,7 +68,7 @@ type OpenAIBehaviourFlags struct {
 	// legacy key required by some compat providers (Z.ai GLM, older vLLM
 	// builds, Ollama before 0.7). Only rules that explicitly need the legacy
 	// key set this; the default is always the modern field.
-	TokenField OpenAITokenField
+	TokenField OpenAITokenField `json:"tokenField"`
 
 	// OmitSamplingParams, when true, omits temperature, top_p,
 	// presence_penalty, frequency_penalty, logprobs, top_logprobs, and
@@ -77,7 +77,7 @@ type OpenAIBehaviourFlags struct {
 	// StreamParams.Temperature is nil (omitempty); this flag additionally
 	// omits the other six fields and guarantees temperature is never sent
 	// even if the caller set a non-nil value.
-	OmitSamplingParams bool
+	OmitSamplingParams bool `json:"omitSamplingParams"`
 
 	// ExtraBodyFields carries provider-specific top-level request fields that
 	// do not exist in the canonical OpenAI Chat Completions schema. The
@@ -89,7 +89,7 @@ type OpenAIBehaviourFlags struct {
 	// request fields are an error detected at registry build time.
 	// Secrets MUST NOT appear here — the registry self-test asserts that no
 	// ExtraBodyField value contains a secret:// reference.
-	ExtraBodyFields map[string]any
+	ExtraBodyFields map[string]any `json:"extraBodyFields"`
 }
 
 // OpenAITokenField controls which JSON key carries the token budget in an
@@ -118,7 +118,7 @@ type GeminiBehaviourFlags struct {
 	// Default (StreamArgsOff = 0) preserves the post-#191 behaviour: the
 	// flag is set to false for all models and no partial-args parsing
 	// occurs. Future rules can model-scope the V2 and V3 shapes.
-	StreamFunctionCallArgsShape GeminiStreamArgsShape
+	StreamFunctionCallArgsShape GeminiStreamArgsShape `json:"streamFunctionCallArgsShape"`
 }
 
 // GeminiStreamArgsShape enumerates the streamFunctionCallArguments shapes.

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -3,6 +3,8 @@
 // top of each Stream call to get a ProviderQuirks for the request.
 package quirks
 
+import "fmt"
+
 // ProviderQuirks is the in-memory result of resolving the registry for a
 // (providerType, model) pair. Adapters read it when building a request and
 // (for paths that diverge) when interpreting a response.
@@ -108,6 +110,38 @@ const (
 	TokenFieldMaxTokens OpenAITokenField = 1
 )
 
+// MarshalJSON renders OpenAITokenField as a human-readable string so
+// the CLI introspection output names the wire key rather than the
+// underlying int constant. An unknown value is rendered as
+// "unknown(N)" rather than failing, so a forward-compatible reader
+// can still parse output produced by a newer harness.
+func (f OpenAITokenField) MarshalJSON() ([]byte, error) {
+	switch f {
+	case TokenFieldMaxCompletionTokens:
+		return []byte(`"max_completion_tokens"`), nil
+	case TokenFieldMaxTokens:
+		return []byte(`"max_tokens"`), nil
+	default:
+		return []byte(fmt.Sprintf(`"unknown(%d)"`, int(f))), nil
+	}
+}
+
+// UnmarshalJSON is the inverse of MarshalJSON, so a tool that emits
+// CLI output and feeds it back through json.Unmarshal round-trips
+// cleanly. Unknown strings are rejected — silently accepting them
+// would defeat the point of the named constants.
+func (f *OpenAITokenField) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case `"max_completion_tokens"`:
+		*f = TokenFieldMaxCompletionTokens
+	case `"max_tokens"`:
+		*f = TokenFieldMaxTokens
+	default:
+		return fmt.Errorf("quirks: unknown OpenAITokenField %s", data)
+	}
+	return nil
+}
+
 // GeminiBehaviourFlags covers behaviour divergences in the Gemini adapter.
 // The zero value reproduces today's post-#191 behaviour.
 type GeminiBehaviourFlags struct {
@@ -129,6 +163,39 @@ const (
 	StreamArgsV2Snapshot GeminiStreamArgsShape = 1 // Gemini 2.x cumulative snapshot
 	StreamArgsV3Deltas   GeminiStreamArgsShape = 2 // Gemini 3.x JSON-path delta array
 )
+
+// MarshalJSON renders GeminiStreamArgsShape as a human-readable string
+// for the same reason as OpenAITokenField.MarshalJSON: CLI output is
+// the operator-facing surface, and an opaque integer there is a
+// regression-in-waiting once Step 3 ships a non-default rule.
+func (s GeminiStreamArgsShape) MarshalJSON() ([]byte, error) {
+	switch s {
+	case StreamArgsOff:
+		return []byte(`"off"`), nil
+	case StreamArgsV2Snapshot:
+		return []byte(`"v2_snapshot"`), nil
+	case StreamArgsV3Deltas:
+		return []byte(`"v3_deltas"`), nil
+	default:
+		return []byte(fmt.Sprintf(`"unknown(%d)"`, int(s))), nil
+	}
+}
+
+// UnmarshalJSON is the inverse of MarshalJSON. Rejects unknown
+// strings rather than silently zero-ing the field.
+func (s *GeminiStreamArgsShape) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case `"off"`:
+		*s = StreamArgsOff
+	case `"v2_snapshot"`:
+		*s = StreamArgsV2Snapshot
+	case `"v3_deltas"`:
+		*s = StreamArgsV3Deltas
+	default:
+		return fmt.Errorf("quirks: unknown GeminiStreamArgsShape %s", data)
+	}
+	return nil
+}
 
 // Value is a typed JSON scalar used by ProviderQuirks.ValueOverrides.
 // Exactly one field is set; New* constructors enforce the invariant.

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -1,0 +1,202 @@
+package quirks
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// staleness is the window beyond which TestRuleStaleness flags a rule
+// for re-verification. Kept in step with the design's §2.3 figure.
+const staleness = 180 * 24 * time.Hour
+
+// TestResolveEmptyRegistry pins the invariant that Resolve always
+// returns a ProviderQuirks with every map and slice field allocated as
+// a non-nil empty value, even when no rule fires. Apply closures rely
+// on this so they can read-modify-write without nil guards.
+func TestResolveEmptyRegistry(t *testing.T) {
+	q := DefaultRegistry().Resolve("openai-compatible", "gpt-4o")
+	if q.FieldRenames == nil {
+		t.Error("FieldRenames must be non-nil")
+	}
+	if q.OmitFields == nil {
+		t.Error("OmitFields must be non-nil")
+	}
+	if q.ValueOverrides == nil {
+		t.Error("ValueOverrides must be non-nil")
+	}
+	if q.EnumCoercions == nil {
+		t.Error("EnumCoercions must be non-nil")
+	}
+	if q.ReplayFields == nil {
+		t.Error("ReplayFields must be non-nil")
+	}
+	// And the maps are empty when no rule matched.
+	if len(q.FieldRenames) != 0 || len(q.OmitFields) != 0 || len(q.ValueOverrides) != 0 || len(q.EnumCoercions) != 0 || len(q.ReplayFields) != 0 {
+		t.Errorf("expected empty collections, got %+v", q)
+	}
+	// Behaviour flags must be at their zero values so adapters fall
+	// through to today's behaviour.
+	want := ProviderBehaviourFlags{}
+	if !reflect.DeepEqual(q.BehaviourFlags, want) {
+		t.Errorf("BehaviourFlags = %+v, want zero value", q.BehaviourFlags)
+	}
+}
+
+// TestBuiltinRulesValidate asserts every rule baked into the registry
+// passes a structural validity check: required metadata is populated
+// (Description, LastVerified, Apply) so trace attributes and the CLI
+// introspection surface have something to report.
+//
+// Step 1 ships an empty rule set so this loop runs zero iterations;
+// the test still validates that BuiltinRules returns a usable value
+// (the for-range over a nil slice is the assertion).
+func TestBuiltinRulesValidate(t *testing.T) {
+	for i, rule := range BuiltinRules() {
+		if rule.Description == "" {
+			t.Errorf("BuiltinRules()[%d]: Description is required", i)
+		}
+		if rule.LastVerified.IsZero() {
+			t.Errorf("BuiltinRules()[%d] (%q): LastVerified is required", i, rule.Description)
+		}
+		if rule.Apply == nil {
+			t.Errorf("BuiltinRules()[%d] (%q): Apply is required", i, rule.Description)
+		}
+	}
+}
+
+// TestRuleStaleness logs (does not fail) any rule whose LastVerified
+// is more than 180 days behind today. Per design §2.3 staleness is a
+// signal, not an error — re-verification is the response, not breaking
+// CI. The harness ships with the test in place from Step 1 so Step 2's
+// first rule additions land against a live warning surface.
+func TestRuleStaleness(t *testing.T) {
+	cutoff := time.Now().Add(-staleness)
+	for _, rule := range BuiltinRules() {
+		if rule.LastVerified.Before(cutoff) {
+			t.Logf("STALE: rule %q last verified %s (>180d ago); re-verify against the upstream wire shape", rule.Description, rule.LastVerified.Format("2006-01-02"))
+		}
+	}
+}
+
+// TestRegistryComposition pins the specificity-then-declaration-order
+// composition rule from design D10: the longer ModelMatch glob wins
+// when two rules touch the same field. The wildcard rule sets a
+// baseline; the more specific glob overrides it for matching models
+// only, leaving non-matching models with the baseline alone.
+func TestRegistryComposition(t *testing.T) {
+	wildcard := Rule{
+		ProviderType: "openai-compatible",
+		ModelMatch:   "*",
+		Description:  "wildcard: token field = max_tokens",
+		LastVerified: Date("2026-05-24"),
+		Apply: func(q *ProviderQuirks) {
+			q.BehaviourFlags.OpenAI.TokenField = TokenFieldMaxTokens
+		},
+	}
+	specific := Rule{
+		ProviderType: "openai-compatible",
+		ModelMatch:   "gpt-5*",
+		Description:  "gpt-5*: token field = max_completion_tokens",
+		LastVerified: Date("2026-05-24"),
+		Apply: func(q *ProviderQuirks) {
+			q.BehaviourFlags.OpenAI.TokenField = TokenFieldMaxCompletionTokens
+		},
+	}
+	reg := NewRegistry([]Rule{wildcard, specific})
+
+	// gpt-5-nano: both rules match; the more specific one runs second
+	// and wins.
+	got := reg.Resolve("openai-compatible", "gpt-5-nano")
+	if got.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxCompletionTokens {
+		t.Errorf("gpt-5-nano: TokenField = %v, want %v (specific override)", got.BehaviourFlags.OpenAI.TokenField, TokenFieldMaxCompletionTokens)
+	}
+
+	// gpt-4o: only the wildcard matches.
+	got = reg.Resolve("openai-compatible", "gpt-4o")
+	if got.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxTokens {
+		t.Errorf("gpt-4o: TokenField = %v, want %v (wildcard only)", got.BehaviourFlags.OpenAI.TokenField, TokenFieldMaxTokens)
+	}
+
+	// Different provider type: neither rule matches; zero-value remains.
+	got = reg.Resolve("anthropic", "gpt-5-nano")
+	if got.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxCompletionTokens {
+		t.Errorf("anthropic/gpt-5-nano: TokenField = %v, want zero default", got.BehaviourFlags.OpenAI.TokenField)
+	}
+}
+
+// TestValueConstructors round-trips each New*Value constructor and
+// asserts exactly one field is set on the resulting Value.
+func TestValueConstructors(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		v := NewStringValue("hello")
+		if v.String == nil || *v.String != "hello" {
+			t.Errorf("String not set or wrong value: %+v", v)
+		}
+		if v.Int != nil || v.Float != nil || v.Bool != nil || v.Null {
+			t.Errorf("other fields must be unset: %+v", v)
+		}
+	})
+	t.Run("int", func(t *testing.T) {
+		v := NewIntValue(42)
+		if v.Int == nil || *v.Int != 42 {
+			t.Errorf("Int not set or wrong value: %+v", v)
+		}
+		if v.String != nil || v.Float != nil || v.Bool != nil || v.Null {
+			t.Errorf("other fields must be unset: %+v", v)
+		}
+	})
+	t.Run("float", func(t *testing.T) {
+		v := NewFloatValue(3.14)
+		if v.Float == nil || *v.Float != 3.14 {
+			t.Errorf("Float not set or wrong value: %+v", v)
+		}
+		if v.String != nil || v.Int != nil || v.Bool != nil || v.Null {
+			t.Errorf("other fields must be unset: %+v", v)
+		}
+	})
+	t.Run("bool", func(t *testing.T) {
+		v := NewBoolValue(true)
+		if v.Bool == nil || *v.Bool != true {
+			t.Errorf("Bool not set or wrong value: %+v", v)
+		}
+		if v.String != nil || v.Int != nil || v.Float != nil || v.Null {
+			t.Errorf("other fields must be unset: %+v", v)
+		}
+	})
+	t.Run("null", func(t *testing.T) {
+		v := NewNullValue()
+		if !v.Null {
+			t.Errorf("Null must be true: %+v", v)
+		}
+		if v.String != nil || v.Int != nil || v.Float != nil || v.Bool != nil {
+			t.Errorf("other fields must be unset: %+v", v)
+		}
+	})
+}
+
+// TestDefaultRegistryConcurrentAccess stresses the sync.Once-guarded
+// DefaultRegistry singleton: 16 goroutines x 100 resolutions each.
+// Combined with `go test -race`, this asserts the singleton is
+// constructed exactly once and that Resolve does not mutate any
+// shared state.
+func TestDefaultRegistryConcurrentAccess(t *testing.T) {
+	const goroutines = 16
+	const perGoroutine = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				q := DefaultRegistry().Resolve("openai-compatible", "gpt-4o")
+				// Touch the maps so a future regression that returned a
+				// shared map would race under -race.
+				q.FieldRenames["k"] = "v"
+				q.OmitFields = append(q.OmitFields, "x")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -214,6 +214,104 @@ func TestDefaultRegistryConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
+// TestOpenAITokenFieldMarshalJSON pins the human-readable wire form
+// of each named constant and round-trips through UnmarshalJSON so the
+// CLI output can be parsed back by a consumer that decodes into the
+// same struct.
+func TestOpenAITokenFieldMarshalJSON(t *testing.T) {
+	cases := []struct {
+		val  OpenAITokenField
+		want string
+	}{
+		{TokenFieldMaxCompletionTokens, `"max_completion_tokens"`},
+		{TokenFieldMaxTokens, `"max_tokens"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			got, err := json.Marshal(tc.val)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal(%v) = %s, want %s", tc.val, got, tc.want)
+			}
+			var round OpenAITokenField
+			if err := json.Unmarshal(got, &round); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if round != tc.val {
+				t.Errorf("round-trip: got %v, want %v", round, tc.val)
+			}
+		})
+	}
+	t.Run("unknown-marshal", func(t *testing.T) {
+		// An out-of-range value must render as "unknown(N)" rather than
+		// panicking so a forward-compatible reader still gets parseable
+		// JSON from a newer harness binary.
+		got, err := json.Marshal(OpenAITokenField(99))
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if string(got) != `"unknown(99)"` {
+			t.Errorf("Marshal(99) = %s, want %q", got, `"unknown(99)"`)
+		}
+	})
+	t.Run("unknown-unmarshal", func(t *testing.T) {
+		// Unknown strings reject; silent acceptance would defeat the
+		// point of the named constants.
+		var f OpenAITokenField
+		if err := json.Unmarshal([]byte(`"bogus"`), &f); err == nil {
+			t.Error("Unmarshal of unknown string must return an error")
+		}
+	})
+}
+
+// TestGeminiStreamArgsShapeMarshalJSON mirrors
+// TestOpenAITokenFieldMarshalJSON for the Gemini enum.
+func TestGeminiStreamArgsShapeMarshalJSON(t *testing.T) {
+	cases := []struct {
+		val  GeminiStreamArgsShape
+		want string
+	}{
+		{StreamArgsOff, `"off"`},
+		{StreamArgsV2Snapshot, `"v2_snapshot"`},
+		{StreamArgsV3Deltas, `"v3_deltas"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			got, err := json.Marshal(tc.val)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal(%v) = %s, want %s", tc.val, got, tc.want)
+			}
+			var round GeminiStreamArgsShape
+			if err := json.Unmarshal(got, &round); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if round != tc.val {
+				t.Errorf("round-trip: got %v, want %v", round, tc.val)
+			}
+		})
+	}
+	t.Run("unknown-marshal", func(t *testing.T) {
+		got, err := json.Marshal(GeminiStreamArgsShape(99))
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if string(got) != `"unknown(99)"` {
+			t.Errorf("Marshal(99) = %s, want %q", got, `"unknown(99)"`)
+		}
+	})
+	t.Run("unknown-unmarshal", func(t *testing.T) {
+		var s GeminiStreamArgsShape
+		if err := json.Unmarshal([]byte(`"bogus"`), &s); err == nil {
+			t.Error("Unmarshal of unknown string must return an error")
+		}
+	})
+}
+
 // TestValueJSONTags pins the camelCase JSON keys + omitempty on the
 // Value struct. Operators read CLI output as JSON; the shape needs to
 // stay stable across the empty-rule-set baseline and the first Step 2

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -214,6 +214,64 @@ func TestDefaultRegistryConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
+// TestRuleMatches pins the exported predicate the CLI shares with
+// Resolve. Covers exact-match, empty-ModelMatch wildcard, glob
+// success, glob non-match, ProviderType mismatch, and malformed glob
+// (returns false rather than panicking).
+func TestRuleMatches(t *testing.T) {
+	cases := []struct {
+		name         string
+		rule         Rule
+		providerType string
+		model        string
+		want         bool
+	}{
+		{
+			name:         "exact match with empty ModelMatch wildcard",
+			rule:         Rule{ProviderType: "openai-compatible", ModelMatch: ""},
+			providerType: "openai-compatible",
+			model:        "gpt-4o",
+			want:         true,
+		},
+		{
+			name:         "glob match",
+			rule:         Rule{ProviderType: "openai-compatible", ModelMatch: "gpt-5*"},
+			providerType: "openai-compatible",
+			model:        "gpt-5-nano",
+			want:         true,
+		},
+		{
+			name:         "glob non-match",
+			rule:         Rule{ProviderType: "openai-compatible", ModelMatch: "gpt-5*"},
+			providerType: "openai-compatible",
+			model:        "gpt-4o",
+			want:         false,
+		},
+		{
+			name:         "ProviderType mismatch",
+			rule:         Rule{ProviderType: "anthropic", ModelMatch: "*"},
+			providerType: "openai-compatible",
+			model:        "gpt-5-nano",
+			want:         false,
+		},
+		{
+			name:         "malformed glob returns false (no panic)",
+			rule:         Rule{ProviderType: "openai-compatible", ModelMatch: "gpt-[5"},
+			providerType: "openai-compatible",
+			model:        "gpt-5-nano",
+			want:         false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RuleMatches(tc.rule, tc.providerType, tc.model)
+			if got != tc.want {
+				t.Errorf("RuleMatches(%+v, %q, %q) = %v, want %v", tc.rule, tc.providerType, tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestOpenAITokenFieldMarshalJSON pins the human-readable wire form
 // of each named constant and round-trips through UnmarshalJSON so the
 // CLI output can be parsed back by a consumer that decodes into the

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -37,10 +37,22 @@ func TestResolveEmptyRegistry(t *testing.T) {
 		t.Errorf("expected empty collections, got %+v", q)
 	}
 	// Behaviour flags must be at their zero values so adapters fall
-	// through to today's behaviour.
-	want := ProviderBehaviourFlags{}
+	// through to today's behaviour — with the documented exception that
+	// OpenAI.ExtraBodyFields is pre-initialised to a non-nil empty map
+	// so rules can read-modify-write without nil guards.
+	if q.BehaviourFlags.OpenAI.ExtraBodyFields == nil {
+		t.Error("BehaviourFlags.OpenAI.ExtraBodyFields must be non-nil")
+	}
+	if len(q.BehaviourFlags.OpenAI.ExtraBodyFields) != 0 {
+		t.Errorf("BehaviourFlags.OpenAI.ExtraBodyFields = %+v, want empty", q.BehaviourFlags.OpenAI.ExtraBodyFields)
+	}
+	want := ProviderBehaviourFlags{
+		OpenAI: OpenAIBehaviourFlags{
+			ExtraBodyFields: map[string]any{},
+		},
+	}
 	if !reflect.DeepEqual(q.BehaviourFlags, want) {
-		t.Errorf("BehaviourFlags = %+v, want zero value", q.BehaviourFlags)
+		t.Errorf("BehaviourFlags = %+v, want %+v", q.BehaviourFlags, want)
 	}
 }
 

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -1,6 +1,7 @@
 package quirks
 
 import (
+	"encoding/json"
 	"reflect"
 	"sync"
 	"testing"
@@ -211,4 +212,34 @@ func TestDefaultRegistryConcurrentAccess(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestValueJSONTags pins the camelCase JSON keys + omitempty on the
+// Value struct. Operators read CLI output as JSON; the shape needs to
+// stay stable across the empty-rule-set baseline and the first Step 2
+// rule that populates ValueOverrides.
+func TestValueJSONTags(t *testing.T) {
+	cases := []struct {
+		name string
+		val  Value
+		want string
+	}{
+		{"string", NewStringValue("foo"), `{"string":"foo"}`},
+		{"int", NewIntValue(42), `{"int":42}`},
+		{"float", NewFloatValue(3.14), `{"float":3.14}`},
+		{"bool-true", NewBoolValue(true), `{"bool":true}`},
+		{"bool-false", NewBoolValue(false), `{"bool":false}`},
+		{"null", NewNullValue(), `{"null":true}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.val)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal(%+v) = %s, want %s", tc.val, got, tc.want)
+			}
+		})
+	}
 }

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -63,7 +63,7 @@ func TestResolveEmptyRegistry(t *testing.T) {
 //
 // Step 1 ships an empty rule set so this loop runs zero iterations;
 // the test still validates that BuiltinRules returns a usable value
-// (the for-range over a nil slice is the assertion).
+// (the for-range over the slice is the assertion).
 func TestBuiltinRulesValidate(t *testing.T) {
 	for i, rule := range BuiltinRules() {
 		if rule.Description == "" {

--- a/harness/internal/provider/quirks/registry.go
+++ b/harness/internal/provider/quirks/registry.go
@@ -117,7 +117,7 @@ func (r *Registry) Resolve(providerType, model string) ProviderQuirks {
 	}
 	matches := make([]indexed, 0, len(r.rules))
 	for i, rule := range r.rules {
-		if !ruleMatches(rule, providerType, model) {
+		if !RuleMatches(rule, providerType, model) {
 			continue
 		}
 		matches = append(matches, indexed{idx: i, rule: rule})
@@ -139,13 +139,18 @@ func (r *Registry) Resolve(providerType, model string) ProviderQuirks {
 	return q
 }
 
-// ruleMatches reports whether the rule fires for the given (provider,
+// RuleMatches reports whether the rule fires for the given (provider,
 // model) pair. An empty ModelMatch matches every model. A glob that
 // fails to compile (e.g. an unmatched `[`) is treated as a non-match
 // rather than panicking, on the same principle as the existing
 // validators: bad input rejects loudly elsewhere, runtime resolution
 // stays safe.
-func ruleMatches(rule Rule, providerType, model string) bool {
+//
+// Exported so the CLI introspection surface can reuse the exact same
+// predicate the agentic loop's Resolve walks, eliminating the silent
+// divergence risk if the predicate ever gains a second dimension
+// (e.g. design D11's BaseURLMatch seam).
+func RuleMatches(rule Rule, providerType, model string) bool {
 	if rule.ProviderType != providerType {
 		return false
 	}

--- a/harness/internal/provider/quirks/registry.go
+++ b/harness/internal/provider/quirks/registry.go
@@ -97,6 +97,11 @@ func (r *Registry) Resolve(providerType, model string) ProviderQuirks {
 		ValueOverrides: map[string]Value{},
 		EnumCoercions:  map[string]map[string]string{},
 		ReplayFields:   []string{},
+		BehaviourFlags: ProviderBehaviourFlags{
+			OpenAI: OpenAIBehaviourFlags{
+				ExtraBodyFields: map[string]any{},
+			},
+		},
 	}
 	if r == nil {
 		return q

--- a/harness/internal/provider/quirks/registry.go
+++ b/harness/internal/provider/quirks/registry.go
@@ -1,0 +1,169 @@
+package quirks
+
+import (
+	"path"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Rule is one entry in the quirks registry.
+//
+// ProviderType is matched exactly against the RunConfig provider.type.
+// ModelMatch is a path.Match glob compared against StreamParams.Model;
+// an empty ModelMatch matches every model for the named provider.
+//
+// Description is required and surfaces in trace attributes and the
+// `stirrup providers quirks` CLI output, so operators can recognise
+// which rule fired without reading the source.
+//
+// LastVerified is the date the rule was last validated against the
+// upstream provider's wire shape. Set via Date("2026-05-24"). Resolve
+// treats rules older than the staleness window as a signal, not an
+// error — see TestRuleStaleness in quirks_test.go.
+//
+// Apply mutates the ProviderQuirks the registry constructed for a
+// resolution. The registry pre-initialises every map and slice field
+// on the value, so Apply can read-modify-write maps without nil
+// guards.
+//
+// BaseURLMatch is intentionally absent in v1 (design D11). A predicate
+// against the provider's BaseURL is the obvious extension point; it is
+// not added until a concrete divergence requires URL keying.
+type Rule struct {
+	ProviderType string    // exact RunConfig provider.type; "" reserved as wildcard (not used in v1)
+	ModelMatch   string    // path.Match glob against StreamParams.Model; "" matches all models
+	Description  string    // required; used in trace attributes and CLI introspection
+	LastVerified time.Time // set via Date("2026-05-24"); staleness signal at 180 days
+	Apply        func(*ProviderQuirks)
+}
+
+// Registry is the ordered rule list. BuiltinRules() returns the default
+// registry. Tests may inject a different registry via the adapters'
+// constructors.
+type Registry struct {
+	rules []Rule
+}
+
+// NewRegistry returns a Registry that wraps the supplied rules in
+// declaration order. The caller retains ownership of the slice; the
+// registry stores its own copy so later mutations of the input do not
+// affect resolutions.
+func NewRegistry(rules []Rule) *Registry {
+	r := &Registry{rules: make([]Rule, len(rules))}
+	copy(r.rules, rules)
+	return r
+}
+
+// defaultRegistry is the process-wide default registry built once from
+// BuiltinRules. Per design risk 8 the singleton is read-only and must
+// not be mutated after construction; Resolve returns by value so a
+// caller cannot reach back through the result.
+var (
+	defaultRegistryOnce sync.Once
+	defaultRegistry     *Registry
+)
+
+// DefaultRegistry returns the process-wide registry built from
+// BuiltinRules. The registry is constructed exactly once and shared
+// across every caller; callers that need a different rule set (tests,
+// compat profile injection) should use NewRegistry instead.
+func DefaultRegistry() *Registry {
+	defaultRegistryOnce.Do(func() {
+		defaultRegistry = NewRegistry(BuiltinRules())
+	})
+	return defaultRegistry
+}
+
+// Resolve walks all matching rules in specificity-then-declaration-order
+// and applies each one to a fresh ProviderQuirks. The returned value has
+// every map field initialised to a non-nil empty map and every slice
+// field to a non-nil empty slice, so callers can read fields without
+// nil-guarding.
+//
+// Specificity ordering: rules with a longer ModelMatch glob run later
+// so their writes override earlier rules. Ties (identical glob length)
+// break on declaration order. An empty ModelMatch is treated as length
+// 0 and matches every model — so a "default for this provider" rule
+// can be declared once and overridden by a specific glob.
+//
+// Resolve is safe to call concurrently; the registry's rule slice is
+// read-only after NewRegistry, and the returned ProviderQuirks is a
+// value type with freshly allocated maps and slices.
+func (r *Registry) Resolve(providerType, model string) ProviderQuirks {
+	q := ProviderQuirks{
+		FieldRenames:   map[string]string{},
+		OmitFields:     []string{},
+		ValueOverrides: map[string]Value{},
+		EnumCoercions:  map[string]map[string]string{},
+		ReplayFields:   []string{},
+	}
+	if r == nil {
+		return q
+	}
+
+	// Collect (originalIndex, rule) pairs for every matching rule, then
+	// sort by glob length ascending with declaration order as the
+	// tiebreaker. Sorting ascending and applying in order means longer
+	// (more specific) rules write last and win on overlapping keys.
+	type indexed struct {
+		idx  int
+		rule Rule
+	}
+	matches := make([]indexed, 0, len(r.rules))
+	for i, rule := range r.rules {
+		if !ruleMatches(rule, providerType, model) {
+			continue
+		}
+		matches = append(matches, indexed{idx: i, rule: rule})
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		li := len(matches[i].rule.ModelMatch)
+		lj := len(matches[j].rule.ModelMatch)
+		if li != lj {
+			return li < lj
+		}
+		return matches[i].idx < matches[j].idx
+	})
+	for _, m := range matches {
+		if m.rule.Apply == nil {
+			continue
+		}
+		m.rule.Apply(&q)
+	}
+	return q
+}
+
+// ruleMatches reports whether the rule fires for the given (provider,
+// model) pair. An empty ModelMatch matches every model. A glob that
+// fails to compile (e.g. an unmatched `[`) is treated as a non-match
+// rather than panicking, on the same principle as the existing
+// validators: bad input rejects loudly elsewhere, runtime resolution
+// stays safe.
+func ruleMatches(rule Rule, providerType, model string) bool {
+	if rule.ProviderType != providerType {
+		return false
+	}
+	if rule.ModelMatch == "" {
+		return true
+	}
+	ok, err := path.Match(rule.ModelMatch, model)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// Date parses an ISO-8601 calendar date (YYYY-MM-DD) into a time.Time
+// pinned to UTC midnight. Rule authors use it so LastVerified is
+// declarative and grep-able rather than a `time.Date(...)` expression.
+// Panics on a malformed input — rule definitions are first-party Go
+// code, not operator input, so a typo is a build-time bug worth
+// failing fast on.
+func Date(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic("quirks.Date: invalid date " + s + ": " + err.Error())
+	}
+	return t
+}

--- a/harness/internal/provider/quirks/testdata/model-ids.txt
+++ b/harness/internal/provider/quirks/testdata/model-ids.txt
@@ -1,0 +1,7 @@
+gpt-4o
+gpt-5-nano
+o1-mini
+o1-preview
+claude-3-5-sonnet-20241022
+gemini-2.5-pro
+gemini-3.1-pro-preview

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -277,12 +277,13 @@ func guardRailConfigFromProto(pc *pb.GuardRailConfig) types.GuardRailConfig {
 
 func providerConfigFromProto(pc *pb.ProviderConfig) types.ProviderConfig {
 	cfg := types.ProviderConfig{
-		Type:         pc.Type,
-		APIKeyRef:    pc.ApiKeyRef,
-		Region:       pc.Region,
-		Profile:      pc.Profile,
-		BaseURL:      pc.BaseUrl,
-		APIKeyHeader: pc.ApiKeyHeader,
+		Type:          pc.Type,
+		APIKeyRef:     pc.ApiKeyRef,
+		Region:        pc.Region,
+		Profile:       pc.Profile,
+		BaseURL:       pc.BaseUrl,
+		APIKeyHeader:  pc.ApiKeyHeader,
+		CompatProfile: pc.CompatProfile,
 	}
 	if len(pc.QueryParams) > 0 {
 		// Copy the proto-owned map so later mutations to the wire payload

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -739,8 +739,20 @@ message ProviderConfig {
   // entries in RunConfig.providers map are streaming-only and any batch
   // field on them is rejected by ValidateRunConfig. See
   // BatchProviderConfig for the mode / transport cross-field invariants.
-  // Next available field number: 15.
   BatchProviderConfig batch = 14;
+
+  // Optional. Selects a pre-defined provider-quirks compat profile that
+  // extends the adapter's wire shape (Wave 2 #221). Closed enum,
+  // validated by ValidateRunConfig at startup. Currently supported:
+  //   ""        — no profile (default).
+  //   "zai-glm" — Z.ai GLM tool_stream extension and legacy max_tokens
+  //               field. Applied on top of provider.type =
+  //               "openai-compatible".
+  // The wire-shape knowledge lives in harness/internal/provider/compat/;
+  // this field is a discriminator only and never carries operator-
+  // authored rule data.
+  // Next available field number: 16.
+  string compat_profile = 15;
 }
 
 // BatchProviderConfig controls async batch submission for a provider

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -604,6 +604,25 @@ type ProviderConfig struct {
 	// BatchProviderConfig for the supported provider types and the
 	// transport / mode cross-field invariants enforced by ValidateRunConfig.
 	Batch *BatchProviderConfig `json:"batch,omitempty"`
+
+	// CompatProfile, when non-empty, selects an optional compatibility
+	// profile for providers that require non-standard extensions on top
+	// of the canonical wire shape. The factory uses the value to inject
+	// a pre-defined rule into the provider's quirks registry; the
+	// wire-shape knowledge lives in harness/internal/provider/compat/
+	// and is not authored by the operator.
+	//
+	// Closed enum, validated at startup. Currently supported:
+	//
+	//   ""          — no compat profile (default).
+	//   "zai-glm"   — Z.ai GLM tool_stream extension and legacy
+	//                 max_tokens field. Applied on top of provider.type
+	//                 = "openai-compatible".
+	//
+	// Unknown values are rejected by ValidateRunConfig. Adding a new
+	// value requires both an entry in validCompatProfiles and a matching
+	// rule in harness/internal/provider/compat/.
+	CompatProfile string `json:"compatProfile,omitempty"`
 }
 
 // BatchProviderConfig controls async batch submission for a provider turn.
@@ -1055,6 +1074,19 @@ var validBatchProviderTypes = map[string]bool{
 	"anthropic":         true,
 	"openai-compatible": true,
 	"openai-responses":  true,
+}
+
+// validCompatProfiles is the closed set of ProviderConfig.CompatProfile
+// values accepted by ValidateRunConfig. Adding an entry requires a
+// matching rule in harness/internal/provider/compat/ and a factory
+// resolveCompatProfile switch arm.
+//
+// Wave 2 Step 1 ships the enum but no compat rules; "zai-glm" is the
+// only legal non-empty value and its rule lands in Step 2 alongside the
+// factory plumbing.
+var validCompatProfiles = map[string]bool{
+	"":        true, // explicit empty is the default (no profile)
+	"zai-glm": true,
 }
 
 // gcpProjectIDPattern matches the GCP project ID rules: starts with a
@@ -1711,6 +1743,25 @@ func validateOptionalType(name, value string, valid map[string]bool, errs *[]str
 	}
 }
 
+// validateCompatProfile enforces the closed set of legal
+// ProviderConfig.CompatProfile values. Empty string is the default
+// (no profile) and validates cleanly. Unknown values fail loudly with
+// the legal-set list so operators can correct typos at startup rather
+// than seeing an opaque "rule not found" deeper in the factory.
+//
+// The legal set is small enough to enumerate in the error message;
+// when it grows past a handful of values the message should fall back
+// to a sorted slice from validCompatProfiles.
+func validateCompatProfile(path, value string, errs *[]string) {
+	if validCompatProfiles[value] {
+		return
+	}
+	*errs = append(*errs, fmt.Sprintf(
+		"%s %q is not a recognised compat profile; legal values: \"\", \"zai-glm\"",
+		path, value,
+	))
+}
+
 // pathHasDotDotSegment reports whether path contains a literal ".."
 // component when split on either '/' or '\'. A substring check on
 // `..` would also match harmless filenames like "foo..bar.cedar"; we
@@ -2220,6 +2271,7 @@ func validateProviderConfigs(config *RunConfig, retryDefaulted map[string]provid
 	validateAnthropicProviderFields("provider", config.Provider, errs)
 	validateAzureWIFCrossField("provider", config.Provider, errs)
 	validateProviderRetryConfig("provider.retry", config.Provider.Retry, retryDefaulted["provider.retry"], errs)
+	validateCompatProfile("provider.compatProfile", config.Provider.CompatProfile, errs)
 	for name, provider := range config.Providers {
 		if name == "" {
 			*errs = append(*errs, "providers map contains an empty provider name")
@@ -2238,6 +2290,7 @@ func validateProviderConfigs(config *RunConfig, retryDefaulted map[string]provid
 		validateAzureWIFCrossField(path, provider, errs)
 		retryPath := fmt.Sprintf("%s.retry", path)
 		validateProviderRetryConfig(retryPath, provider.Retry, retryDefaulted[retryPath], errs)
+		validateCompatProfile(fmt.Sprintf("%s.compatProfile", path), provider.CompatProfile, errs)
 		// Batch is a top-level-only concept in v1: the spec wires
 		// per-turn batching against RunConfig.Provider, and a Batch
 		// block on a named entry would silently parse, store, and have

--- a/types/runconfig_completions.go
+++ b/types/runconfig_completions.go
@@ -76,6 +76,12 @@ func ValidCodeScannerTypeValues() []string { return sortedKeys(validCodeScannerT
 // RunConfig.GuardRail.Type.
 func ValidGuardRailTypeValues() []string { return sortedKeys(validGuardRailTypes) }
 
+// ValidCompatProfileValues returns the provider compat profiles
+// accepted on RunConfig.Provider.CompatProfile. The "" (no profile)
+// entry is filtered out so the completion list contains only the
+// typeable values.
+func ValidCompatProfileValues() []string { return sortedNonEmptyKeys(validCompatProfiles) }
+
 func sortedKeys(m map[string]bool) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5320,3 +5320,53 @@ func TestRedact_ProviderBatchNotAliased(t *testing.T) {
 		t.Error("mutating redacted named-provider Batch.Enabled leaked to original")
 	}
 }
+
+// TestValidateRunConfig_CompatProfile pins the closed-enum behaviour
+// for ProviderConfig.CompatProfile (Wave 2 #221 Step 1). Empty and
+// "zai-glm" must validate; any other value must fail at startup with
+// an error mentioning the field path.
+func TestValidateRunConfig_CompatProfile(t *testing.T) {
+	t.Run("empty-accepted", func(t *testing.T) {
+		c := validConfig()
+		c.Provider.CompatProfile = ""
+		if err := ValidateRunConfig(c); err != nil {
+			t.Errorf("empty CompatProfile must validate, got: %v", err)
+		}
+	})
+	t.Run("zai-glm-accepted", func(t *testing.T) {
+		c := validConfig()
+		c.Provider.CompatProfile = "zai-glm"
+		if err := ValidateRunConfig(c); err != nil {
+			t.Errorf("CompatProfile=zai-glm must validate, got: %v", err)
+		}
+	})
+	t.Run("unknown-rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Provider.CompatProfile = "unknown"
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("CompatProfile=unknown must fail validation")
+		}
+		if !strings.Contains(err.Error(), "compatProfile") {
+			t.Errorf("error must mention compatProfile, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), `"unknown"`) {
+			t.Errorf("error must surface the offending value, got: %v", err)
+		}
+	})
+	t.Run("named-provider-validates", func(t *testing.T) {
+		// The named-provider loop runs the same validator; pin it so a
+		// future refactor that drops the per-entry call surfaces here.
+		c := validConfig()
+		c.Providers = map[string]ProviderConfig{
+			"secondary": {Type: "openai-compatible", CompatProfile: "not-real"},
+		}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("named-provider CompatProfile=not-real must fail validation")
+		}
+		if !strings.Contains(err.Error(), "providers[secondary].compatProfile") {
+			t.Errorf("error must mention providers[secondary].compatProfile, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
First chunk of #221 / Wave 2 of the tool-use debacle workstream. **Behaviourally neutral** — introduces the `quirks` package, CLI introspection, and the `CompatProfile` operator surface. No adapter integration yet (Steps 2-5 follow).

Per the approved Wave 2 design at `stirrup-coord/scratch/wave-2-design.md` (gitignored scratch), reconciled from PR #196 and #221.

## What ships

### `harness/internal/provider/quirks/` (new package)
- `ProviderQuirks` struct: `FieldRenames`, `OmitFields`, `ValueOverrides`, `EnumCoercions`, `ReplayFields`, `BehaviourFlags` (typed sub-structs `OpenAIBehaviourFlags`, `GeminiBehaviourFlags`).
- `Value` tagged-union with `New*Value` constructors (camelCase JSON tags).
- `OpenAITokenField` and `GeminiStreamArgsShape` int enums with `MarshalJSON`/`UnmarshalJSON` round-trips so CLI output and persisted traces use human-readable strings (`"max_completion_tokens"`, `"v3_deltas"`, etc.).
- `Registry` with specificity-then-declaration-order composition (longest `ModelMatch` glob wins; ties break on declaration order). `Resolve` returns a `ProviderQuirks` with all map/slice fields pre-initialised to non-nil empty — including nested `BehaviourFlags.OpenAI.ExtraBodyFields` (Step 2 rules will RMW this).
- `DefaultRegistry()` `sync.Once` singleton + `NewRegistry()` for test injection.
- `RuleMatches(...)` exported as the single source of truth shared by `Resolve` and the CLI introspection.
- `BuiltinRules()` returns an empty `[]Rule{}` slice; populated in Steps 2-5.

### `stirrup providers quirks --provider X --model Y` (new CLI subcommand)
- Prints resolved `ProviderQuirks` as JSON, including the `Description`, `LastVerified`, and staleness flag of every contributing rule.
- Applied-rules list is sorted to match `Resolve`'s execution order (last entry is the field-write winner) and skips `Apply == nil` rules — faithful to what actually ran.
- Side-effect-free; no network, no credentials, no filesystem write.

### `RunConfig.ProviderConfig.CompatProfile string` (new operator surface)
- Closed enum: legal values `""` and `"zai-glm"`. Unknown values are a hard validation failure at startup (both top-level and named-provider paths).
- CLI flag `--provider-compat-profile` exposes the field; help text lists the legal set.
- Proto field 15 added to `ProviderConfig`; gRPC translator wired forward-direction (no Go→proto for `ProviderConfig` exists in the codebase).

## Pre-merge remediation applied

Reviewers caught one HIGH and two MEDIUM/blocking items; all resolved before push:

1. `Resolve` now pre-initialises `BehaviourFlags.OpenAI.ExtraBodyFields` to a non-nil empty map (was nil; would have nil-panicked in Step 2 rules doing `q.BehaviourFlags.OpenAI.ExtraBodyFields["key"] = val`).
2. CLI `collectAppliedRules` now sorts by specificity (matching `Resolve`'s order) and skips `Apply == nil` rules — fixes a future silent observability drift.
3. New tests pin `cliRuleMatches`/`collectAppliedRules` paths that previously had 0% coverage.

Plus four non-blocking polish items applied:
- `Value` struct JSON tags (camelCase, omitempty)
- `OpenAITokenField`/`GeminiStreamArgsShape` `MarshalJSON`/`UnmarshalJSON` (human-readable + forward-compat for unknown ints)
- `BuiltinRules()` returns `[]Rule{}` not `nil`
- Exported `quirks.RuleMatches` and deleted the duplicated `cliRuleMatches` (eliminates a latent divergence trap before Step 2 lands).

## Verification

- `just` (build + full test suite) exits 0.
- `just lint` (golangci-lint v2 on `./harness/... ./types/... ./eval/...`) reports `0 issues`.
- `TestDefaultRegistryConcurrentAccess` (16 × 100 goroutines, writes to returned maps) passes under `-race`.

## Deferred to Step 2 (not in this PR)

- `TestRuleCarveOuts`, `TestNoMetacharsInKnownModelIDs`, `TestBuiltinRulesExtraBodyFieldsNoSecrets` — these become load-bearing once `builtin.go` ships its first rule. The `testdata/model-ids.txt` catalogue is in place ready for the test.
- `grpc_translate_test.go` round-trip case for `CompatProfile` — Step 2 will land it alongside the factory `resolveCompatProfile` switch + `harness/internal/provider/compat/zai/`.
- Adapter integration (Steps 2-5) — concrete adapters (`openai.go`, `gemini_request.go`, etc.) are untouched in this PR.
- Docs pass (Step 6) — `docs/provider-quirks.md` will be replaced when the integration lands.

Reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers; remediation brief in workstream scratch. Verdict: SHIP WITH POLISH (applied).