### PR TITLE
provider/quirks: wire openai-compatible quirks + Z.ai compat + Responses plumbing (Wave 2 Step 2+4)

### DIFF
--- a/harness/cmd/stirrup/cmd/providers_quirks.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -98,14 +97,13 @@ func runProvidersQuirksWithIO(cmd *cobra.Command, stdout io.Writer) error {
 	model, _ := cmd.Flags().GetString("model")
 
 	reg := quirks.DefaultRegistry()
-	resolved := reg.Resolve(provider, model)
-	applied := collectAppliedRules(quirks.BuiltinRules(), provider, model)
+	resolved, applied := reg.ResolveWithRules(provider, model)
 
 	out := quirksCLIOutput{
 		Provider:     provider,
 		Model:        model,
 		Quirks:       resolved,
-		AppliedRules: applied,
+		AppliedRules: formatAppliedRules(applied),
 	}
 	enc := json.NewEncoder(stdout)
 	enc.SetIndent("", "  ")
@@ -115,50 +113,26 @@ func runProvidersQuirksWithIO(cmd *cobra.Command, stdout io.Writer) error {
 	return nil
 }
 
-// collectAppliedRules returns the metadata for every rule that
-// actually contributes to a Resolve for (provider, model). The output
-// is ordered the same way Resolve applies them: glob length ascending
-// with declaration order as the tiebreaker, so the last entry in the
-// list is the rule whose writes won on overlapping keys. Rules with
-// nil Apply are filtered out for the same reason — Resolve skips
-// them, so reporting them as "applied" would be a lie.
+// formatAppliedRules projects the rule list returned by
+// ResolveWithRules into the CLI-facing summary shape. The registry
+// orders the input the same way Resolve applies the rules — glob
+// length ascending with declaration order as the tiebreaker — so the
+// last entry is the rule whose writes won on overlapping keys.
 //
 // Returns a non-nil empty slice when no rule matched so the JSON
 // output is `[]` rather than `null` — easier to script against.
-func collectAppliedRules(rules []quirks.Rule, provider, model string) []appliedRuleCLIOutput {
-	type indexed struct {
-		idx  int
-		rule quirks.Rule
-	}
-	matched := make([]indexed, 0, len(rules))
-	for i, rule := range rules {
-		if rule.Apply == nil {
-			continue
-		}
-		if !quirks.RuleMatches(rule, provider, model) {
-			continue
-		}
-		matched = append(matched, indexed{idx: i, rule: rule})
-	}
-	sort.SliceStable(matched, func(i, j int) bool {
-		li := len(matched[i].rule.ModelMatch)
-		lj := len(matched[j].rule.ModelMatch)
-		if li != lj {
-			return li < lj
-		}
-		return matched[i].idx < matched[j].idx
-	})
-	out := make([]appliedRuleCLIOutput, 0, len(matched))
+func formatAppliedRules(rules []quirks.Rule) []appliedRuleCLIOutput {
+	out := make([]appliedRuleCLIOutput, 0, len(rules))
 	cutoff := time.Now().Add(-quirksStaleness)
-	for _, m := range matched {
+	for _, r := range rules {
 		lastVerified := ""
-		if !m.rule.LastVerified.IsZero() {
-			lastVerified = m.rule.LastVerified.Format("2006-01-02")
+		if !r.LastVerified.IsZero() {
+			lastVerified = r.LastVerified.Format("2006-01-02")
 		}
 		out = append(out, appliedRuleCLIOutput{
-			Description:  m.rule.Description,
+			Description:  r.Description,
 			LastVerified: lastVerified,
-			Stale:        !m.rule.LastVerified.IsZero() && m.rule.LastVerified.Before(cutoff),
+			Stale:        !r.LastVerified.IsZero() && r.LastVerified.Before(cutoff),
 		})
 	}
 	return out

--- a/harness/cmd/stirrup/cmd/providers_quirks_test.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks_test.go
@@ -196,7 +196,9 @@ func TestCollectAppliedRules_FiltersAndFlagsCorrectly(t *testing.T) {
 		},
 	}
 
-	got := collectAppliedRules(rules, "openai-compatible", "gpt-4o")
+	reg := quirks.NewRegistry(rules)
+	_, applied := reg.ResolveWithRules("openai-compatible", "gpt-4o")
+	got := formatAppliedRules(applied)
 
 	// Expected, in specificity order:
 	//   1. "wildcard openai-compatible"            (glob length 1)
@@ -243,11 +245,11 @@ func TestCollectAppliedRules_FiltersAndFlagsCorrectly(t *testing.T) {
 // behaviour the JSON output depends on: an empty rule slice returns a
 // non-nil empty slice so the encoded JSON is `[]` rather than `null`.
 func TestCollectAppliedRules_EmptyRules(t *testing.T) {
-	got := collectAppliedRules(nil, "openai-compatible", "gpt-4o")
+	got := formatAppliedRules(nil)
 	if got == nil {
-		t.Fatal("collectAppliedRules(nil, ...) returned nil; want non-nil empty slice")
+		t.Fatal("formatAppliedRules(nil) returned nil; want non-nil empty slice")
 	}
 	if len(got) != 0 {
-		t.Errorf("collectAppliedRules(nil, ...) = %+v, want empty", got)
+		t.Errorf("formatAppliedRules(nil) = %+v, want empty", got)
 	}
 }

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -25,6 +25,8 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
 	"github.com/rxbynerd/stirrup/harness/internal/provider"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/compat/zai"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/security/codescanner"
@@ -582,7 +584,22 @@ func buildProvider(ctx context.Context, cfg types.ProviderConfig, secrets securi
 		// nil pointer defensively in case a non-CLI caller bypasses the
 		// validator.
 		retry := provider.RetryPolicyFromConfig(cfg.Retry)
-		return provider.NewOpenAICompatibleAdapter(cred.BearerToken, cfg.BaseURL, auth, retry), nil
+		adapter := provider.NewOpenAICompatibleAdapter(cred.BearerToken, cfg.BaseURL, auth, retry)
+		// Inject a compat rule into the adapter's registry when the
+		// operator selected a compatProfile. The default registry is
+		// already attached by the constructor; we replace it with a
+		// new registry containing the compat rule appended after
+		// BuiltinRules so the compat rule's specificity ordering wins
+		// against any first-party glob it overlaps.
+		if cfg.CompatProfile != "" {
+			extra, err := resolveCompatProfile(cfg.CompatProfile)
+			if err != nil {
+				return nil, fmt.Errorf("resolve compat profile: %w", err)
+			}
+			rules := append(quirks.BuiltinRules(), extra)
+			adapter.Registry = quirks.NewRegistry(rules)
+		}
+		return adapter, nil
 	case "openai-responses":
 		if cred.BearerToken == nil {
 			return nil, fmt.Errorf("openai-responses provider requires a bearer credential but the credential source produced none")
@@ -1409,6 +1426,27 @@ func buildGCSTraceCredentialSource(cfg *types.CredentialConfig) (credential.Sour
 			"credential.type=%q is not supported for the gcs trace emitter; "+
 				"expected \"gcp-workload-identity\" or \"gcp-default\"",
 			cfg.Type)
+	}
+}
+
+// resolveCompatProfile maps the closed enum of supported
+// compatProfile names to the rule the corresponding compat package
+// exports. The set must stay aligned with validCompatProfiles in
+// types/runconfig.go — ValidateRunConfig rejects unknown values at
+// startup, so an unknown value reaching this switch is a defence-in-
+// depth signal that the validator was bypassed (e.g. by a non-CLI
+// caller).
+//
+// New entries here require a corresponding compat package under
+// harness/internal/provider/compat/<name>/ and an addition to
+// validCompatProfiles. Adding a name to the validator without a rule
+// would silently no-op for runs that selected the new profile.
+func resolveCompatProfile(profile string) (quirks.Rule, error) {
+	switch profile {
+	case "zai-glm":
+		return zai.CompatRule(), nil
+	default:
+		return quirks.Rule{}, fmt.Errorf("unknown compat profile %q (supported: zai-glm)", profile)
 	}
 }
 

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -343,6 +343,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		case *provider.OpenAIResponsesAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics
+			pa.Logger = logger
 		case *provider.BedrockAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -427,7 +427,21 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 			return nil, fmt.Errorf("batch is not supported for transport type %q", config.Transport.Type)
 		}
 
-		prov = provider.NewBatchAdapter(prov, batchClient, config.Provider.Batch, config.Provider.Type, config.RunID)
+		batchAdapter := provider.NewBatchAdapter(prov, batchClient, config.Provider.Batch, config.Provider.Type, config.RunID)
+		// Thread the streaming inner adapter's quirks registry into
+		// the BatchAdapter so the batch body-marshal path produces the
+		// same wire shape the streaming path would have produced for
+		// the same (provider, model) pair. Without this, a future
+		// batch allow-list expansion that admits a compat-profile
+		// provider (e.g. Z.ai) would silently use the default
+		// registry and miss the compat rule's extras. v1's
+		// validateBatchConfig allow-list does not include any compat-
+		// profile provider today, but the wiring is unconditional so
+		// the gap cannot reappear.
+		if compatible, ok := prov.(*provider.OpenAICompatibleAdapter); ok {
+			batchAdapter.Registry = compatible.Registry
+		}
+		prov = batchAdapter
 		// Replace the entry in the providers map so model-router lookups
 		// route to the batched wrapper rather than the raw streaming
 		// adapter (#194-style cross-routing risk: a router that picks

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
 	"github.com/rxbynerd/stirrup/harness/internal/provider"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
@@ -2008,6 +2009,71 @@ func TestBuildProvider_OpenAICompatibleWithRetryConfig(t *testing.T) {
 	}
 	if got, want := adapter.RetryPolicy.WallClockBudget, 60*time.Second; got != want {
 		t.Errorf("RetryPolicy.WallClockBudget = %v, want %v", got, want)
+	}
+}
+
+// TestBuildProvider_OpenAICompatibleWithCompatProfile_ZAI pins the
+// factory's resolveCompatProfile dispatch for the openai-compatible
+// + CompatProfile="zai-glm" combination. Without this test the
+// production injection path is uncovered (the zai package's own
+// test mounts the rule on a hand-rolled registry rather than going
+// through the factory), so a regression that drops the
+// resolveCompatProfile call from buildProvider would not be caught.
+//
+// The assertion uses the adapter's exported Registry field to
+// resolve the GLM model end-to-end: the registry returned by the
+// factory must include zai.CompatRule, so a glm-4-plus resolution
+// produces TokenFieldMaxTokens and the tool_stream extra body field.
+func TestBuildProvider_OpenAICompatibleWithCompatProfile_ZAI(t *testing.T) {
+	secrets := &stubSecretStore{secrets: map[string]string{"secret://OPENAI_KEY": "sk-test"}}
+	prov, err := buildProvider(context.Background(), types.ProviderConfig{
+		Type:          "openai-compatible",
+		APIKeyRef:     "secret://OPENAI_KEY",
+		BaseURL:       "https://api.z.ai/api/coding/paas/v4",
+		CompatProfile: "zai-glm",
+	}, secrets)
+	if err != nil {
+		t.Fatalf("buildProvider returned error: %v", err)
+	}
+	adapter, ok := prov.(*provider.OpenAICompatibleAdapter)
+	if !ok {
+		t.Fatalf("buildProvider type = %T, want *provider.OpenAICompatibleAdapter", prov)
+	}
+	if adapter.Registry == nil {
+		t.Fatal("adapter.Registry is nil; factory should have injected a registry containing the Z.ai compat rule")
+	}
+	q := adapter.Registry.Resolve("openai-compatible", "glm-4-plus")
+	if got, want := q.BehaviourFlags.OpenAI.TokenField, quirks.TokenFieldMaxTokens; got != want {
+		t.Errorf("glm-4-plus resolution: TokenField = %v, want %v (Z.ai compat rule did not fire — check resolveCompatProfile dispatch)", got, want)
+	}
+	v, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"]
+	if !ok {
+		t.Errorf("glm-4-plus resolution: ExtraBodyFields[tool_stream] missing; Z.ai rule should set it")
+	} else if b, isBool := v.(bool); !isBool || !b {
+		t.Errorf("glm-4-plus resolution: ExtraBodyFields[tool_stream] = %v (type %T), want true", v, v)
+	}
+}
+
+// TestBuildProvider_OpenAICompatibleWithUnknownCompatProfile_Errors
+// pins the defence-in-depth arm in resolveCompatProfile. The validator
+// at types/runconfig.go rejects unknown compatProfile values at
+// startup, but the factory still has a switch that returns an error
+// for an unrecognised name (in case a non-CLI caller bypasses the
+// validator). This test exercises that arm so a regression replacing
+// it with a silent fallthrough is caught.
+func TestBuildProvider_OpenAICompatibleWithUnknownCompatProfile_Errors(t *testing.T) {
+	secrets := &stubSecretStore{secrets: map[string]string{"secret://OPENAI_KEY": "sk-test"}}
+	_, err := buildProvider(context.Background(), types.ProviderConfig{
+		Type:          "openai-compatible",
+		APIKeyRef:     "secret://OPENAI_KEY",
+		BaseURL:       "https://api.example.com/v1",
+		CompatProfile: "not-a-real-profile",
+	}, secrets)
+	if err == nil {
+		t.Fatal("buildProvider with unknown compatProfile returned nil error; expected dispatch failure")
+	}
+	if !strings.Contains(err.Error(), "not-a-real-profile") {
+		t.Errorf("error %q does not name the bad profile; operator could not locate the misconfiguration", err.Error())
 	}
 }
 

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -151,6 +151,16 @@ type BatchAdapter struct {
 	provType  string
 	runID     string
 	turnCount atomic.Int64
+	// Registry resolves per-(provider, model) quirks for the request
+	// body marshalling path. The factory plumbs the compat-profile-
+	// aware registry from the wrapped streaming adapter here so a
+	// batch run against a compat-profile provider sees the same
+	// wire shape the streaming path would have produced. Nil falls
+	// back to quirks.DefaultRegistry() so tests and callers that do
+	// not depend on a compat profile get the built-in rule set
+	// without setting the field. Exported (not a constructor arg)
+	// to avoid churn on every NewBatchAdapter call site in tests.
+	Registry *quirks.Registry
 	// lastBatchID stores the provider-assigned batch identifier from the
 	// most recent successful Submit. The agentic loop reads it via
 	// LastBatchID() after streamEventsToResult returns to populate
@@ -236,20 +246,25 @@ func (a *BatchAdapter) LastBatchID() string {
 // marshalRequestBody projects params into the wire body for the
 // configured provider type. Unsupported provider types surface as a
 // marshal-time error so the caller can emit a single error StreamEvent.
+//
+// The Registry field, set by the factory from the wrapped streaming
+// adapter, drives the openai-compatible projection. When a compat
+// profile is active (e.g. CompatProfile=zai-glm) the registry carries
+// the compat rule, so a batch body emitted here uses the same wire
+// shape the streaming path would have produced. Nil falls back to
+// quirks.DefaultRegistry() — the built-in rule set only — which is
+// the correct behaviour for the v1 allow-listed batch providers
+// (anthropic plus the two OpenAI dialects without a compat profile).
 func (a *BatchAdapter) marshalRequestBody(params types.StreamParams) (json.RawMessage, error) {
 	switch a.provType {
 	case "anthropic":
 		return json.Marshal(buildAnthropicRequest(params, false))
 	case "openai-compatible":
-		// Batch path resolves quirks via DefaultRegistry only — compat
-		// profiles (Z.ai etc.) are not wired into BatchAdapter in Wave
-		// 2, so a batch run against a compat-profile provider would
-		// not pick up its extras. Streaming inner adapters honour the
-		// compat profile; the factory sets BatchProviderConfig only
-		// when allow-list permits, and v1 explicitly allowed-lists
-		// anthropic plus the two OpenAI dialects (no compat profile
-		// is approved for batch yet).
-		q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+		registry := a.Registry
+		if registry == nil {
+			registry = quirks.DefaultRegistry()
+		}
+		q := registry.Resolve("openai-compatible", params.Model)
 		return json.Marshal(buildOpenAIRequest(params, false, q))
 	case "openai-responses":
 		return json.Marshal(buildResponsesRequest(params))

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/transport"
 	"github.com/rxbynerd/stirrup/types"
@@ -240,7 +241,16 @@ func (a *BatchAdapter) marshalRequestBody(params types.StreamParams) (json.RawMe
 	case "anthropic":
 		return json.Marshal(buildAnthropicRequest(params, false))
 	case "openai-compatible":
-		return json.Marshal(buildOpenAIRequest(params, false))
+		// Batch path resolves quirks via DefaultRegistry only — compat
+		// profiles (Z.ai etc.) are not wired into BatchAdapter in Wave
+		// 2, so a batch run against a compat-profile provider would
+		// not pick up its extras. Streaming inner adapters honour the
+		// compat profile; the factory sets BatchProviderConfig only
+		// when allow-list permits, and v1 explicitly allowed-lists
+		// anthropic plus the two OpenAI dialects (no compat profile
+		// is approved for batch yet).
+		q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+		return json.Marshal(buildOpenAIRequest(params, false, q))
 	case "openai-responses":
 		return json.Marshal(buildResponsesRequest(params))
 	default:

--- a/harness/internal/provider/batch_test.go
+++ b/harness/internal/provider/batch_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -348,6 +349,78 @@ func TestBatchAdapter_marshalRequestBody_OpenAICompatible(t *testing.T) {
 		t.Errorf("openai-compatible body must carry stream=false: %s", body)
 	} else if string(raw["stream"]) != "false" {
 		t.Errorf("openai-compatible body must carry stream=false; got %s", raw["stream"])
+	}
+}
+
+// TestBatchAdapter_MarshalUsesInjectedRegistry pins the Registry
+// field plumbing: a BatchAdapter constructed with a registry that
+// includes a compat rule (e.g. Z.ai's TokenFieldMaxTokens +
+// tool_stream) must produce a batch body matching the rule's wire
+// shape. Without this test the factory's
+// `batchAdapter.Registry = compatible.Registry` line could be
+// deleted and the batch path would silently fall back to the
+// default registry — a future Z.ai-via-batch run would emit
+// max_completion_tokens (wrong key) and omit tool_stream.
+//
+// The test injects a registry containing only a synthetic compat-
+// like rule rather than depending on the real Z.ai package, to
+// keep batch_test self-contained.
+func TestBatchAdapter_MarshalUsesInjectedRegistry(t *testing.T) {
+	customRule := quirks.Rule{
+		ProviderType: "openai-compatible",
+		ModelMatch:   "synthetic-*",
+		Description:  "test rule: max_tokens + tool_stream",
+		LastVerified: quirks.Date("2026-05-24"),
+		Apply: func(q *quirks.ProviderQuirks) {
+			q.BehaviourFlags.OpenAI.TokenField = quirks.TokenFieldMaxTokens
+			q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"] = true
+		},
+	}
+	a := NewBatchAdapter(nil, &fakeBatchClient{}, &types.BatchProviderConfig{Enabled: true}, "openai-compatible", "run-test")
+	a.Registry = quirks.NewRegistry([]quirks.Rule{customRule})
+
+	body, err := a.marshalRequestBody(types.StreamParams{
+		Model:     "synthetic-foo",
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}}},
+		MaxTokens: 256,
+	})
+	if err != nil {
+		t.Fatalf("marshalRequestBody: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, ok := raw["max_tokens"]; !ok {
+		t.Errorf("body missing 'max_tokens' (injected registry rule did not apply): %s", body)
+	}
+	if _, ok := raw["max_completion_tokens"]; ok {
+		t.Errorf("body contains 'max_completion_tokens'; injected rule should have switched the key: %s", body)
+	}
+	if v, ok := raw["tool_stream"]; !ok || v != true {
+		t.Errorf("body missing 'tool_stream':true (injected rule did not populate ExtraBodyFields): %s", body)
+	}
+}
+
+// TestBatchAdapter_MarshalFallsBackToDefaultRegistryWhenNil pins the
+// nil-registry fallback in marshalRequestBody. The vast majority of
+// BatchAdapter call sites (every test in the package, every existing
+// production code path) leave Registry unset; the fallback to
+// quirks.DefaultRegistry() preserves their behaviour.
+func TestBatchAdapter_MarshalFallsBackToDefaultRegistryWhenNil(t *testing.T) {
+	a := NewBatchAdapter(nil, &fakeBatchClient{}, &types.BatchProviderConfig{Enabled: true}, "openai-compatible", "run-test")
+	// Registry intentionally left nil.
+	body, err := a.marshalRequestBody(types.StreamParams{
+		Model:     "o1-mini", // matches the builtin reasoning-class rule
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}}},
+		MaxTokens: 256,
+	})
+	if err != nil {
+		t.Fatalf("marshalRequestBody: %v", err)
+	}
+	s := string(body)
+	if !strings.Contains(s, `"max_completion_tokens"`) {
+		t.Errorf("nil-registry fallback failed: body missing max_completion_tokens: %s", s)
 	}
 }
 

--- a/harness/internal/provider/compat/zai/zai.go
+++ b/harness/internal/provider/compat/zai/zai.go
@@ -1,0 +1,52 @@
+// Package zai provides the Z.ai GLM compatibility rule for the
+// openai-compatible adapter. Z.ai exposes an OpenAI-compatible Chat
+// Completions endpoint but with two divergences from the canonical
+// upstream:
+//
+//   - It requires the legacy "max_tokens" key, not
+//     "max_completion_tokens" (which OpenAI's reasoning models now
+//     mandate).
+//   - It accepts an extension flag "tool_stream: true" that enables
+//     streaming of tool-call results.
+//
+// Z.ai is a compatibility-only target (design D3): there is no
+// peer "zai" ProviderType. Operators using Z.ai configure
+// provider.type = "openai-compatible" and set
+// provider.compatProfile = "zai-glm" in their RunConfig; the
+// factory injects CompatRule() into the adapter's registry.
+//
+// The rule is intentionally not part of BuiltinRules() — its
+// activation is operator-gated through the CompatProfile field.
+package zai
+
+import (
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+)
+
+// CompatRule returns the Z.ai-specific quirks rule for injection
+// into an openai-compatible adapter's registry. The rule targets
+// every GLM model under "glm-*" (the only family Z.ai serves today);
+// operators using a custom alias must register a tailored rule
+// themselves.
+//
+// Design risk 5 notes that the precise inbound-side semantics of
+// tool_stream:true are not fully documented; the conservative
+// assumption is that it is a send-side request flag with no impact
+// on the parse-side SSE event shape. If a real Z.ai endpoint is
+// later observed to emit a different event shape when tool_stream
+// is true, an additional parse-side flag will be needed on
+// OpenAIBehaviourFlags.
+func CompatRule() quirks.Rule {
+	return quirks.Rule{
+		ProviderType: "openai-compatible",
+		ModelMatch:   "glm-*",
+		Description:  "Z.ai GLM: legacy max_tokens field and tool_stream extension",
+		LastVerified: quirks.Date("2026-05-24"),
+		Apply: func(q *quirks.ProviderQuirks) {
+			q.BehaviourFlags.OpenAI.TokenField = quirks.TokenFieldMaxTokens
+			// ExtraBodyFields is pre-initialised by Resolve to an
+			// empty non-nil map, so direct assignment is safe.
+			q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"] = true
+		},
+	}
+}

--- a/harness/internal/provider/compat/zai/zai_test.go
+++ b/harness/internal/provider/compat/zai/zai_test.go
@@ -1,0 +1,121 @@
+package zai_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/compat/zai"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// staticBearer mirrors the harness-internal helper of the same name
+// without crossing the provider package boundary; the compat/zai
+// package lives outside `package provider` so it can't reach
+// staticBearer directly.
+func staticBearer(s string) func(context.Context) (string, error) {
+	return func(_ context.Context) (string, error) {
+		return s, nil
+	}
+}
+
+// TestZAICompatRule_AppliesTokenFieldAndExtraBody pins the two
+// divergences the Z.ai compat profile enforces: TokenFieldMaxTokens
+// (so the wire body uses "max_tokens" rather than the modern
+// "max_completion_tokens") and the "tool_stream": true extra body
+// field. The test injects the rule into a registry, attaches it to
+// an OpenAICompatibleAdapter, fires a request against an httptest
+// server, and inspects the captured body — the same end-to-end
+// path a real Z.ai run takes.
+func TestZAICompatRule_AppliesTokenFieldAndExtraBody(t *testing.T) {
+	captured := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			return
+		}
+		captured <- b
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	adapter := provider.NewOpenAICompatibleAdapter(
+		staticBearer("test-key"),
+		srv.URL,
+		provider.OpenAIAuthConfig{},
+		provider.RetryPolicy{},
+	)
+	// Inject the Z.ai compat rule on top of BuiltinRules so this
+	// test mirrors what core/factory.go does for compatProfile=zai-glm.
+	rules := append(quirks.BuiltinRules(), zai.CompatRule())
+	adapter.Registry = quirks.NewRegistry(rules)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "glm-4-plus",
+		MaxTokens: 4096,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+	body := <-captured
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, body)
+	}
+
+	// Legacy token field present, modern key absent.
+	if _, ok := got["max_tokens"]; !ok {
+		t.Errorf("Z.ai body missing 'max_tokens' (legacy field required): %s", body)
+	}
+	if _, ok := got["max_completion_tokens"]; ok {
+		t.Errorf("Z.ai body contains 'max_completion_tokens' (rule failed to switch field): %s", body)
+	}
+	// tool_stream extra body field present and true.
+	v, ok := got["tool_stream"]
+	if !ok {
+		t.Errorf("Z.ai body missing 'tool_stream' extension: %s", body)
+	}
+	if b, isBool := v.(bool); !isBool || !b {
+		t.Errorf("Z.ai 'tool_stream' = %v (type %T), want true (bool)", v, v)
+	}
+}
+
+// TestZAICompatRule_DoesNotAffectNonGLMModels guards against the
+// rule's ModelMatch leaking to non-GLM models served from the same
+// adapter. If an operator multiplexes openai-compatible against
+// multiple base URLs with the same registry, a non-GLM model
+// resolution must keep the modern token field.
+func TestZAICompatRule_DoesNotAffectNonGLMModels(t *testing.T) {
+	rules := append(quirks.BuiltinRules(), zai.CompatRule())
+	reg := quirks.NewRegistry(rules)
+
+	// gpt-4o is not a glm-* model; the rule should not fire.
+	q := reg.Resolve("openai-compatible", "gpt-4o")
+	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxCompletionTokens {
+		t.Errorf("gpt-4o under zai-registered registry: TokenField = %v, want max_completion_tokens", q.BehaviourFlags.OpenAI.TokenField)
+	}
+	if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"]; ok {
+		t.Errorf("gpt-4o under zai-registered registry: tool_stream leaked into ExtraBodyFields")
+	}
+
+	// Sanity-check the rule actually fires for the GLM model.
+	q = reg.Resolve("openai-compatible", "glm-4-plus")
+	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
+		t.Errorf("glm-4-plus: TokenField = %v, want max_tokens (rule should fire)", q.BehaviourFlags.OpenAI.TokenField)
+	}
+}

--- a/harness/internal/provider/compat/zai/zai_test.go
+++ b/harness/internal/provider/compat/zai/zai_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/harness/internal/provider"
@@ -117,5 +118,35 @@ func TestZAICompatRule_DoesNotAffectNonGLMModels(t *testing.T) {
 	q = reg.Resolve("openai-compatible", "glm-4-plus")
 	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
 		t.Errorf("glm-4-plus: TokenField = %v, want max_tokens (rule should fire)", q.BehaviourFlags.OpenAI.TokenField)
+	}
+}
+
+// TestCompatRuleExtraBodyFieldsNoSecrets is the per-compat-package
+// mirror of quirks.TestBuiltinRulesExtraBodyFieldsNoSecrets: it
+// materialises the Z.ai rule into a fresh ProviderQuirks and walks
+// every ExtraBodyFields value for the secret:// prefix. The map is
+// serialised verbatim into the request body, and RunConfig.Redact()
+// never reaches inside a quirks rule, so a secret reference embedded
+// here would propagate to every wire request without redaction.
+//
+// The current rule stores a bool (tool_stream: true) so the check
+// is trivially satisfied today. The test is structural insurance
+// for the next time the rule grows — and the pattern is intended
+// for every future compat package to copy: each compat package
+// must contribute its own version of this test against its own
+// CompatRule, because the quirks_test.go version only walks
+// BuiltinRules() and cannot reach compat rules that are not part
+// of the registry default.
+func TestCompatRuleExtraBodyFieldsNoSecrets(t *testing.T) {
+	q := quirks.NewRegistry([]quirks.Rule{zai.CompatRule()}).Resolve("openai-compatible", "glm-4-plus")
+	for k, v := range q.BehaviourFlags.OpenAI.ExtraBodyFields {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(s, "secret://") {
+			t.Errorf("Z.ai CompatRule ExtraBodyFields[%q] = %q contains a secret:// reference; "+
+				"compat rule values are serialised verbatim and bypass RunConfig.Redact()", k, s)
+		}
 	}
 }

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -129,23 +129,25 @@ func NewOpenAICompatibleAdapter(bearer credential.BearerTokenFunc, baseURL strin
 // StreamParams.Temperature pointer type so the unset-vs-explicit-zero
 // distinction survives marshalling. See issue #200.
 //
-// TokenField and OmitSampling carry the resolved quirks for this
-// request and drive MarshalJSON, which is the single point that
+// TokenField and OmitSamplingParams carry the resolved quirks for
+// this request and drive MarshalJSON, which is the single point that
 // translates the canonical struct into the wire-shape selected by the
-// rule. ExtraBodyFields carries provider-specific top-level keys
-// (e.g. Z.ai's "tool_stream") that are merged after the canonical
-// fields. None of these three are serialised under their own JSON
-// keys — they steer the MarshalJSON projection only.
+// rule. The field name mirrors quirks.OpenAIBehaviourFlags.OmitSamplingParams
+// so a search for either form finds both sides of the projection.
+// ExtraBodyFields carries provider-specific top-level keys (e.g.
+// Z.ai's "tool_stream") that are merged after the canonical fields.
+// None of these three are serialised under their own JSON keys —
+// they steer the MarshalJSON projection only.
 type openaiRequest struct {
-	Model           string          `json:"-"`
-	Messages        []openaiMessage `json:"-"`
-	Tools           []openaiTool    `json:"-"`
-	MaxTokens       int             `json:"-"`
-	Temperature     *float64        `json:"-"`
-	Stream          bool            `json:"-"`
-	TokenField      quirks.OpenAITokenField
-	OmitSampling    bool
-	ExtraBodyFields map[string]any
+	Model              string          `json:"-"`
+	Messages           []openaiMessage `json:"-"`
+	Tools              []openaiTool    `json:"-"`
+	MaxTokens          int             `json:"-"`
+	Temperature        *float64        `json:"-"`
+	Stream             bool            `json:"-"`
+	TokenField         quirks.OpenAITokenField
+	OmitSamplingParams bool
+	ExtraBodyFields    map[string]any
 }
 
 // MarshalJSON projects the canonical openaiRequest into the wire body
@@ -158,15 +160,15 @@ type openaiRequest struct {
 //     "max_completion_tokens" (default) or "max_tokens" (Z.ai compat
 //     and similar legacy gateways). The value is always emitted, even
 //     at zero, matching the prior struct-tag behaviour.
-//   - "temperature" — emitted only when both OmitSampling is false
-//     AND Temperature is non-nil. OmitSampling = true guarantees the
-//     field is suppressed even when the caller supplied a non-nil
-//     value (per design risk 2, the adapter's Stream call logs a
-//     warning when this suppression fires).
+//   - "temperature" — emitted only when both OmitSamplingParams is
+//     false AND Temperature is non-nil. OmitSamplingParams = true
+//     guarantees the field is suppressed even when the caller supplied
+//     a non-nil value (per design risk 2, the adapter's Stream call
+//     logs a warning when this suppression fires).
 //   - Other sampling params (top_p, presence_penalty,
 //     frequency_penalty, logprobs, top_logprobs, logit_bias) are not
 //     yet first-class struct fields; they will be omitted by default
-//     once added if OmitSampling is true. The flag's contract is
+//     once added if OmitSamplingParams is true. The flag's contract is
 //     declared in OpenAIBehaviourFlags doc comments.
 //   - ExtraBodyFields — merged into the body after canonical fields.
 //     Key collision with a canonical key is rejected as an error
@@ -184,7 +186,7 @@ func (r openaiRequest) MarshalJSON() ([]byte, error) {
 	if len(r.Tools) > 0 {
 		out["tools"] = r.Tools
 	}
-	if !r.OmitSampling && r.Temperature != nil {
+	if !r.OmitSamplingParams && r.Temperature != nil {
 		out["temperature"] = *r.Temperature
 	}
 	for k, v := range r.ExtraBodyFields {
@@ -554,15 +556,15 @@ func mapFinishReason(reason string) string {
 // apply a batch-specific projection here.
 func buildOpenAIRequest(params types.StreamParams, stream bool, q quirks.ProviderQuirks) openaiRequest {
 	return openaiRequest{
-		Model:           params.Model,
-		Messages:        translateMessages(params.System, params.Messages),
-		Tools:           translateTools(params.Tools),
-		MaxTokens:       params.MaxTokens,
-		Temperature:     params.Temperature,
-		Stream:          stream,
-		TokenField:      q.BehaviourFlags.OpenAI.TokenField,
-		OmitSampling:    q.BehaviourFlags.OpenAI.OmitSamplingParams,
-		ExtraBodyFields: q.BehaviourFlags.OpenAI.ExtraBodyFields,
+		Model:              params.Model,
+		Messages:           translateMessages(params.System, params.Messages),
+		Tools:              translateTools(params.Tools),
+		MaxTokens:          params.MaxTokens,
+		Temperature:        params.Temperature,
+		Stream:             stream,
+		TokenField:         q.BehaviourFlags.OpenAI.TokenField,
+		OmitSamplingParams: q.BehaviourFlags.OpenAI.OmitSamplingParams,
+		ExtraBodyFields:    q.BehaviourFlags.OpenAI.ExtraBodyFields,
 	}
 }
 

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -301,6 +301,18 @@ func openAIWireTokenKey(f quirks.OpenAITokenField) string {
 	return "max_completion_tokens"
 }
 
+// ruleDescriptions returns the Description field of each rule in the
+// supplied slice, preserving order. Returned as a non-nil empty slice
+// when the input is empty so the slog.Any attribute renders as `[]`
+// rather than `null` — easier to grep and parse downstream.
+func ruleDescriptions(rules []quirks.Rule) []string {
+	out := make([]string, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, r.Description)
+	}
+	return out
+}
+
 // canonicalOpenAIFields enumerates the top-level Chat Completions
 // request fields the adapter knows how to emit. ExtraBodyFields rules
 // must not collide with any of these — the registry self-test guards
@@ -588,21 +600,40 @@ func (o *OpenAICompatibleAdapter) Stream(ctx context.Context, params types.Strea
 	if registry == nil {
 		registry = quirks.DefaultRegistry()
 	}
-	q := registry.Resolve("openai-compatible", params.Model)
+	q, appliedRules := registry.ResolveWithRules("openai-compatible", params.Model)
+
+	logger := o.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Debug-level log lists the descriptions of every rule that
+	// contributed to this resolution (design §5). Emitted even when
+	// the list is empty so an operator grepping for the line knows
+	// the resolution ran; an absent entry would be ambiguous between
+	// "no rule fired" and "the log line was suppressed". The list is
+	// in apply order — the last entry is the rule that won on
+	// overlapping fields.
+	logger.DebugContext(ctx, "openai quirks resolved",
+		slog.String("provider.type", "openai-compatible"),
+		slog.String("provider.model", params.Model),
+		slog.Any("rules", ruleDescriptions(appliedRules)),
+	)
 
 	// Warn-level log when a caller-supplied non-nil Temperature is
-	// suppressed by a quirk rule (design risk 2). The reasoning-class
-	// rules omit temperature outright; without this signal an operator
-	// who set --temperature would silently observe greedy decoding.
+	// suppressed by a quirk rule (design risk 2, §9). The reasoning-
+	// class rules omit temperature outright; without this signal an
+	// operator who set --temperature would silently observe greedy
+	// decoding. The rule descriptions are attached so the operator
+	// can name the rule that fired without grepping the source. The
+	// suppressed value itself is intentionally NOT logged — it is the
+	// caller's input and surfacing it here would leak the value into
+	// any log sink that captures warn-level records.
 	if q.BehaviourFlags.OpenAI.OmitSamplingParams && params.Temperature != nil {
-		logger := o.Logger
-		if logger == nil {
-			logger = slog.Default()
-		}
 		logger.WarnContext(ctx, "openai quirks suppressed caller temperature",
 			slog.String("provider.type", "openai-compatible"),
 			slog.String("provider.model", params.Model),
-			slog.Float64("temperature.suppressed", *params.Temperature),
+			slog.Any("quirk.rules", ruleDescriptions(appliedRules)),
 		)
 	}
 

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -62,6 +63,13 @@ type OpenAICompatibleAdapter struct {
 	Metrics      *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
 	RetryPolicy  RetryPolicy            // optional, set by factory; zero value disables retry
 	Logger       *slog.Logger           // optional, set by factory; nil falls back to slog.Default()
+	// Registry resolves per-(provider, model) wire-shape and behaviour
+	// overrides at the top of every Stream call. The constructor seeds
+	// this with quirks.DefaultRegistry() so callers that ignore the
+	// field still get the built-in rule set. Tests and the factory's
+	// compat-profile injection path overwrite it directly; the public
+	// API of the adapter does not need a WithRegistry option.
+	Registry *quirks.Registry
 }
 
 // NewOpenAICompatibleAdapter creates an adapter for an OpenAI-compatible
@@ -99,6 +107,7 @@ func NewOpenAICompatibleAdapter(bearer credential.BearerTokenFunc, baseURL strin
 		apiKeyHeader: auth.APIKeyHeader,
 		queryParams:  auth.QueryParams,
 		RetryPolicy:  retry,
+		Registry:     quirks.DefaultRegistry(),
 	}
 }
 
@@ -119,13 +128,195 @@ func NewOpenAICompatibleAdapter(bearer credential.BearerTokenFunc, baseURL strin
 // explicit 0.0 for greedy decoding. This mirrors the upstream
 // StreamParams.Temperature pointer type so the unset-vs-explicit-zero
 // distinction survives marshalling. See issue #200.
+//
+// TokenField and OmitSampling carry the resolved quirks for this
+// request and drive MarshalJSON, which is the single point that
+// translates the canonical struct into the wire-shape selected by the
+// rule. ExtraBodyFields carries provider-specific top-level keys
+// (e.g. Z.ai's "tool_stream") that are merged after the canonical
+// fields. None of these three are serialised under their own JSON
+// keys — they steer the MarshalJSON projection only.
 type openaiRequest struct {
-	Model               string          `json:"model"`
-	Messages            []openaiMessage `json:"messages"`
-	Tools               []openaiTool    `json:"tools,omitempty"`
-	MaxCompletionTokens int             `json:"max_completion_tokens"`
-	Temperature         *float64        `json:"temperature,omitempty"`
-	Stream              bool            `json:"stream"`
+	Model           string          `json:"-"`
+	Messages        []openaiMessage `json:"-"`
+	Tools           []openaiTool    `json:"-"`
+	MaxTokens       int             `json:"-"`
+	Temperature     *float64        `json:"-"`
+	Stream          bool            `json:"-"`
+	TokenField      quirks.OpenAITokenField
+	OmitSampling    bool
+	ExtraBodyFields map[string]any
+}
+
+// MarshalJSON projects the canonical openaiRequest into the wire body
+// the resolved quirks selected. The projection rules are:
+//
+//   - "model", "messages", "stream" — always emitted.
+//   - "tools" — emitted only when non-empty (matches the prior
+//     omitempty behaviour).
+//   - The token-budget field uses the key selected by TokenField:
+//     "max_completion_tokens" (default) or "max_tokens" (Z.ai compat
+//     and similar legacy gateways). The value is always emitted, even
+//     at zero, matching the prior struct-tag behaviour.
+//   - "temperature" — emitted only when both OmitSampling is false
+//     AND Temperature is non-nil. OmitSampling = true guarantees the
+//     field is suppressed even when the caller supplied a non-nil
+//     value (per design risk 2, the adapter's Stream call logs a
+//     warning when this suppression fires).
+//   - Other sampling params (top_p, presence_penalty,
+//     frequency_penalty, logprobs, top_logprobs, logit_bias) are not
+//     yet first-class struct fields; they will be omitted by default
+//     once added if OmitSampling is true. The flag's contract is
+//     declared in OpenAIBehaviourFlags doc comments.
+//   - ExtraBodyFields — merged into the body after canonical fields.
+//     Key collision with a canonical key is rejected as an error
+//     (a misconfigured rule should fail loudly rather than silently
+//     overwrite a struct field). The collision set is the canonical
+//     OpenAI Chat Completions field surface this adapter emits.
+func (r openaiRequest) MarshalJSON() ([]byte, error) {
+	tokenKey := openAIWireTokenKey(r.TokenField)
+	out := map[string]any{
+		"model":    r.Model,
+		"messages": r.Messages,
+		"stream":   r.Stream,
+		tokenKey:   r.MaxTokens,
+	}
+	if len(r.Tools) > 0 {
+		out["tools"] = r.Tools
+	}
+	if !r.OmitSampling && r.Temperature != nil {
+		out["temperature"] = *r.Temperature
+	}
+	for k, v := range r.ExtraBodyFields {
+		if _, exists := out[k]; exists {
+			return nil, fmt.Errorf("openai quirk extra body field %q collides with canonical request field", k)
+		}
+		// Also reject collisions against canonical fields we elide
+		// above (temperature when suppressed, tools when empty): the
+		// rule author shouldn't be able to sneak a field past via the
+		// extras map.
+		if isCanonicalOpenAIField(k) {
+			return nil, fmt.Errorf("openai quirk extra body field %q collides with canonical request field", k)
+		}
+		out[k] = v
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON is the inverse of MarshalJSON: it reads either
+// "max_completion_tokens" or "max_tokens" into MaxTokens (setting
+// TokenField accordingly) and populates the canonical fields. Used by
+// tests that round-trip the wire body through the same struct that
+// produced it. Any non-canonical top-level keys are collected into
+// ExtraBodyFields so the round-trip is loss-free.
+func (r *openaiRequest) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	// Canonical fields with simple types.
+	if v, ok := raw["model"]; ok {
+		if err := json.Unmarshal(v, &r.Model); err != nil {
+			return fmt.Errorf("openaiRequest.model: %w", err)
+		}
+		delete(raw, "model")
+	}
+	if v, ok := raw["messages"]; ok {
+		if err := json.Unmarshal(v, &r.Messages); err != nil {
+			return fmt.Errorf("openaiRequest.messages: %w", err)
+		}
+		delete(raw, "messages")
+	}
+	if v, ok := raw["tools"]; ok {
+		if err := json.Unmarshal(v, &r.Tools); err != nil {
+			return fmt.Errorf("openaiRequest.tools: %w", err)
+		}
+		delete(raw, "tools")
+	}
+	if v, ok := raw["stream"]; ok {
+		if err := json.Unmarshal(v, &r.Stream); err != nil {
+			return fmt.Errorf("openaiRequest.stream: %w", err)
+		}
+		delete(raw, "stream")
+	}
+	if v, ok := raw["temperature"]; ok {
+		var t float64
+		if err := json.Unmarshal(v, &t); err != nil {
+			return fmt.Errorf("openaiRequest.temperature: %w", err)
+		}
+		r.Temperature = &t
+		delete(raw, "temperature")
+	}
+	// Token budget under either canonical key. Both should never be
+	// present simultaneously; if they are, the later (longer-glob)
+	// key wins in the same way MarshalJSON would only emit one.
+	if v, ok := raw["max_completion_tokens"]; ok {
+		if err := json.Unmarshal(v, &r.MaxTokens); err != nil {
+			return fmt.Errorf("openaiRequest.max_completion_tokens: %w", err)
+		}
+		r.TokenField = quirks.TokenFieldMaxCompletionTokens
+		delete(raw, "max_completion_tokens")
+	}
+	if v, ok := raw["max_tokens"]; ok {
+		if err := json.Unmarshal(v, &r.MaxTokens); err != nil {
+			return fmt.Errorf("openaiRequest.max_tokens: %w", err)
+		}
+		r.TokenField = quirks.TokenFieldMaxTokens
+		delete(raw, "max_tokens")
+	}
+	// Remaining keys are provider-specific extras.
+	if len(raw) > 0 {
+		extra := make(map[string]any, len(raw))
+		for k, v := range raw {
+			var anyV any
+			if err := json.Unmarshal(v, &anyV); err != nil {
+				return fmt.Errorf("openaiRequest.%s: %w", k, err)
+			}
+			extra[k] = anyV
+		}
+		r.ExtraBodyFields = extra
+	}
+	return nil
+}
+
+// openAIWireTokenKey returns the wire JSON key for the resolved token
+// field. Defaults to "max_completion_tokens" — the zero value of
+// OpenAITokenField — to preserve the established behaviour of openai.go
+// on main. TestNoRegressionMaxCompletionTokensDefault pins this.
+func openAIWireTokenKey(f quirks.OpenAITokenField) string {
+	if f == quirks.TokenFieldMaxTokens {
+		return "max_tokens"
+	}
+	return "max_completion_tokens"
+}
+
+// canonicalOpenAIFields enumerates the top-level Chat Completions
+// request fields the adapter knows how to emit. ExtraBodyFields rules
+// must not collide with any of these — the registry self-test guards
+// the relationship at build time.
+var canonicalOpenAIFields = map[string]struct{}{
+	"model":                 {},
+	"messages":              {},
+	"tools":                 {},
+	"max_completion_tokens": {},
+	"max_tokens":            {},
+	"temperature":           {},
+	"top_p":                 {},
+	"presence_penalty":      {},
+	"frequency_penalty":     {},
+	"logprobs":              {},
+	"top_logprobs":          {},
+	"logit_bias":            {},
+	"stream":                {},
+}
+
+// isCanonicalOpenAIField reports whether the given top-level request
+// key is owned by the canonical openaiRequest projection. The check
+// gates ExtraBodyFields merges to prevent a rule from overriding a
+// struct-mediated field by way of the extras map.
+func isCanonicalOpenAIField(k string) bool {
+	_, ok := canonicalOpenAIFields[k]
+	return ok
 }
 
 // openaiMessage is a single message in OpenAI's Chat Completions format.
@@ -341,18 +532,28 @@ func mapFinishReason(reason string) string {
 // non-streaming caller (batch submission, phase 2 of issue #133) can reuse
 // the same projection without duplicating field-by-field copying.
 //
+// q carries the resolved quirks for the (provider, model) pair. The zero
+// value reproduces today's behaviour: max_completion_tokens emitted,
+// temperature handled by Temperature *float64 omitempty semantics, no
+// extra body fields. Pass quirks.DefaultRegistry().Resolve(...) at call
+// sites that have access to a registry; the zero-value path remains
+// valid for callers that intentionally skip resolution.
+//
 // TODO(batch): if the batch endpoint rejects fields the streaming endpoint
 // accepts (e.g. top_p on Responses, equivalent constraints on Chat
 // Completions), change the return type to (json.RawMessage, error) and
 // apply a batch-specific projection here.
-func buildOpenAIRequest(params types.StreamParams, stream bool) openaiRequest {
+func buildOpenAIRequest(params types.StreamParams, stream bool, q quirks.ProviderQuirks) openaiRequest {
 	return openaiRequest{
-		Model:               params.Model,
-		Messages:            translateMessages(params.System, params.Messages),
-		Tools:               translateTools(params.Tools),
-		MaxCompletionTokens: params.MaxTokens,
-		Temperature:         params.Temperature,
-		Stream:              stream,
+		Model:           params.Model,
+		Messages:        translateMessages(params.System, params.Messages),
+		Tools:           translateTools(params.Tools),
+		MaxTokens:       params.MaxTokens,
+		Temperature:     params.Temperature,
+		Stream:          stream,
+		TokenField:      q.BehaviourFlags.OpenAI.TokenField,
+		OmitSampling:    q.BehaviourFlags.OpenAI.OmitSamplingParams,
+		ExtraBodyFields: q.BehaviourFlags.OpenAI.ExtraBodyFields,
 	}
 }
 
@@ -366,7 +567,35 @@ func (o *OpenAICompatibleAdapter) Stream(ctx context.Context, params types.Strea
 		attribute.String("provider.model", params.Model),
 	)
 
-	reqBody := buildOpenAIRequest(params, true)
+	// Resolve quirks for this (provider, model) pair. The registry is
+	// per-stream by design (D4): the same run can switch models turn
+	// to turn under a dynamic router. The zero-value Registry shouldn't
+	// happen for adapters built through the factory, but tolerate it
+	// for callers that construct the adapter directly without going
+	// through NewOpenAICompatibleAdapter.
+	registry := o.Registry
+	if registry == nil {
+		registry = quirks.DefaultRegistry()
+	}
+	q := registry.Resolve("openai-compatible", params.Model)
+
+	// Warn-level log when a caller-supplied non-nil Temperature is
+	// suppressed by a quirk rule (design risk 2). The reasoning-class
+	// rules omit temperature outright; without this signal an operator
+	// who set --temperature would silently observe greedy decoding.
+	if q.BehaviourFlags.OpenAI.OmitSamplingParams && params.Temperature != nil {
+		logger := o.Logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.WarnContext(ctx, "openai quirks suppressed caller temperature",
+			slog.String("provider.type", "openai-compatible"),
+			slog.String("provider.model", params.Model),
+			slog.Float64("temperature.suppressed", *params.Temperature),
+		)
+	}
+
+	reqBody := buildOpenAIRequest(params, true, q)
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -247,9 +247,18 @@ func (r *openaiRequest) UnmarshalJSON(data []byte) error {
 		r.Temperature = &t
 		delete(raw, "temperature")
 	}
-	// Token budget under either canonical key. Both should never be
-	// present simultaneously; if they are, the later (longer-glob)
-	// key wins in the same way MarshalJSON would only emit one.
+	// Token budget: accept either canonical key. MarshalJSON emits
+	// exactly one key, so a valid request body should not contain
+	// both simultaneously. If both are present the input is a caller
+	// error (likely a hand-crafted body or a misconfigured rule) and
+	// is rejected here rather than silently letting one overwrite the
+	// other; without this guard the second decode would clobber the
+	// first depending on decode order.
+	_, hasMCT := raw["max_completion_tokens"]
+	_, hasMT := raw["max_tokens"]
+	if hasMCT && hasMT {
+		return fmt.Errorf("openaiRequest: both max_completion_tokens and max_tokens present")
+	}
 	if v, ok := raw["max_completion_tokens"]; ok {
 		if err := json.Unmarshal(v, &r.MaxTokens); err != nil {
 			return fmt.Errorf("openaiRequest.max_completion_tokens: %w", err)

--- a/harness/internal/provider/openai_builder_test.go
+++ b/harness/internal/provider/openai_builder_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -137,7 +138,8 @@ func TestBuildOpenAIRequest_MatchesStream(t *testing.T) {
 			}
 			captured := <-capturedCh
 
-			built := buildOpenAIRequest(tc.params, true)
+			q := quirks.DefaultRegistry().Resolve("openai-compatible", tc.params.Model)
+			built := buildOpenAIRequest(tc.params, true, q)
 			builtBytes, err := json.Marshal(built)
 			if err != nil {
 				t.Fatalf("marshal builder output: %v", err)
@@ -166,20 +168,21 @@ func TestBuildOpenAIRequest_StreamFlag(t *testing.T) {
 		MaxTokens: 1024,
 		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
 	}
-	if got := buildOpenAIRequest(params, true).Stream; got != true {
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if got := buildOpenAIRequest(params, true, q).Stream; got != true {
 		t.Errorf("stream=true argument: got Stream=%v, want true", got)
 	}
-	if got := buildOpenAIRequest(params, false).Stream; got != false {
+	if got := buildOpenAIRequest(params, false, q).Stream; got != false {
 		t.Errorf("stream=false argument: got Stream=%v, want false", got)
 	}
-	trueBody, err := json.Marshal(buildOpenAIRequest(params, true))
+	trueBody, err := json.Marshal(buildOpenAIRequest(params, true, q))
 	if err != nil {
 		t.Fatalf("marshal stream=true body: %v", err)
 	}
 	if !strings.Contains(string(trueBody), `"stream":true`) {
 		t.Errorf(`expected "stream":true in stream=true body: %s`, trueBody)
 	}
-	falseBody, err := json.Marshal(buildOpenAIRequest(params, false))
+	falseBody, err := json.Marshal(buildOpenAIRequest(params, false, q))
 	if err != nil {
 		t.Fatalf("marshal stream=false body: %v", err)
 	}

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -113,7 +113,12 @@ func TestOpenAIQuirks_GPT4oNoQuirksApply(t *testing.T) {
 //
 // The assertion is exhaustive: every (model) combination from the
 // shared canonical-params table plus a no-rule-match model produces
-// the modern key and never the legacy key in the same body.
+// the modern key and never the legacy key in the same body. Reasoning-
+// class models additionally assert temperature is absent from the
+// wire body, because quirksCanonicalParams supplies a non-nil
+// Temperature: the suppression path is the live contract for those
+// models and the negative assertion here closes the gap with the
+// dedicated O1MiniOmitsSamplingParams test.
 func TestNoRegressionMaxCompletionTokensDefault(t *testing.T) {
 	models := []string{
 		"gpt-4o",            // no rule
@@ -139,6 +144,155 @@ func TestNoRegressionMaxCompletionTokensDefault(t *testing.T) {
 			if strings.Contains(s, `"max_tokens"`) {
 				t.Errorf("model %q: body contains legacy 'max_tokens' (regression): %s", model, s)
 			}
+			if q.BehaviourFlags.OpenAI.OmitSamplingParams && strings.Contains(s, `"temperature"`) {
+				t.Errorf("model %q: body contains 'temperature' despite OmitSamplingParams=true (suppression failed): %s", model, s)
+			}
 		})
 	}
+}
+
+// TestOpenAIRequest_MarshalJSON_ExtraBodyFieldCollision pins the two
+// error-return arms in MarshalJSON that guard against a rule author
+// bypassing the canonical field set via ExtraBodyFields. Without
+// these guards, a rule could side-channel a value for a canonical
+// field (e.g. force temperature back on after suppression, or replace
+// the model name) by writing to ExtraBodyFields instead of the
+// canonical OpenAIBehaviourFlags slots. Each sub-case asserts the
+// error fires and that the message contains a substring pinning the
+// guard's identity so a refactor cannot silently weaken the check.
+func TestOpenAIRequest_MarshalJSON_ExtraBodyFieldCollision(t *testing.T) {
+	const wantSubstring = "collides with canonical request field"
+	cases := []struct {
+		name string
+		req  openaiRequest
+	}{
+		{
+			name: "model-key collision (already-emitted canonical field)",
+			req: openaiRequest{
+				Model:           "gpt-4o",
+				MaxTokens:       100,
+				ExtraBodyFields: map[string]any{"model": "evil-override"},
+			},
+		},
+		{
+			name: "temperature collision against canonical guard when suppressed",
+			req: openaiRequest{
+				Model:              "o1-mini",
+				MaxTokens:          100,
+				OmitSamplingParams: true,
+				ExtraBodyFields:    map[string]any{"temperature": 0.5},
+			},
+		},
+		{
+			name: "max_completion_tokens collision (canonical token field)",
+			req: openaiRequest{
+				Model:           "gpt-4o",
+				MaxTokens:       100,
+				ExtraBodyFields: map[string]any{"max_completion_tokens": 99},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := json.Marshal(tc.req)
+			if err == nil {
+				t.Fatalf("MarshalJSON returned no error; expected collision")
+			}
+			if !strings.Contains(err.Error(), wantSubstring) {
+				t.Errorf("error message = %q, want substring %q", err.Error(), wantSubstring)
+			}
+		})
+	}
+}
+
+// TestOpenAIRequest_UnmarshalJSON covers the decode paths that
+// MarshalJSON's tests would not exercise: the legacy max_tokens
+// branch (Z.ai's wire shape), the extras-catch-all that preserves
+// non-canonical top-level keys for round-trip stability, and the
+// dual-key error guard introduced alongside this test.
+func TestOpenAIRequest_UnmarshalJSON(t *testing.T) {
+	t.Run("legacy max_tokens decodes to TokenFieldMaxTokens", func(t *testing.T) {
+		raw := []byte(`{"model":"glm-4-plus","messages":[],"stream":true,"max_tokens":4096}`)
+		var req openaiRequest
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if req.TokenField != quirks.TokenFieldMaxTokens {
+			t.Errorf("TokenField = %v, want TokenFieldMaxTokens", req.TokenField)
+		}
+		if req.MaxTokens != 4096 {
+			t.Errorf("MaxTokens = %d, want 4096", req.MaxTokens)
+		}
+	})
+
+	t.Run("modern max_completion_tokens decodes to TokenFieldMaxCompletionTokens", func(t *testing.T) {
+		raw := []byte(`{"model":"o1-mini","messages":[],"stream":true,"max_completion_tokens":2048}`)
+		var req openaiRequest
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if req.TokenField != quirks.TokenFieldMaxCompletionTokens {
+			t.Errorf("TokenField = %v, want TokenFieldMaxCompletionTokens", req.TokenField)
+		}
+		if req.MaxTokens != 2048 {
+			t.Errorf("MaxTokens = %d, want 2048", req.MaxTokens)
+		}
+	})
+
+	t.Run("non-canonical top-level key surfaces in ExtraBodyFields", func(t *testing.T) {
+		raw := []byte(`{"model":"glm-4-plus","messages":[],"stream":true,"max_tokens":4096,"tool_stream":true}`)
+		var req openaiRequest
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if v, ok := req.ExtraBodyFields["tool_stream"]; !ok || v != true {
+			t.Errorf("ExtraBodyFields[tool_stream] = %v (ok=%v), want true", v, ok)
+		}
+	})
+
+	t.Run("dual token keys are rejected", func(t *testing.T) {
+		raw := []byte(`{"model":"gpt-4o","messages":[],"stream":true,"max_completion_tokens":100,"max_tokens":200}`)
+		var req openaiRequest
+		err := json.Unmarshal(raw, &req)
+		if err == nil {
+			t.Fatalf("Unmarshal returned no error; expected dual-key rejection")
+		}
+		if !strings.Contains(err.Error(), "both max_completion_tokens and max_tokens present") {
+			t.Errorf("error = %q, want substring 'both max_completion_tokens and max_tokens present'", err.Error())
+		}
+	})
+
+	t.Run("round-trip with ExtraBodyFields preserves shape", func(t *testing.T) {
+		original := openaiRequest{
+			Model:           "glm-4-plus",
+			Messages:        []openaiMessage{{Role: "user", Content: "hi"}},
+			MaxTokens:       4096,
+			Stream:          true,
+			TokenField:      quirks.TokenFieldMaxTokens,
+			ExtraBodyFields: map[string]any{"tool_stream": true},
+		}
+		out, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		var round openaiRequest
+		if err := json.Unmarshal(out, &round); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if round.Model != original.Model {
+			t.Errorf("Model: got %q, want %q", round.Model, original.Model)
+		}
+		if round.MaxTokens != original.MaxTokens {
+			t.Errorf("MaxTokens: got %d, want %d", round.MaxTokens, original.MaxTokens)
+		}
+		if round.TokenField != original.TokenField {
+			t.Errorf("TokenField: got %v, want %v", round.TokenField, original.TokenField)
+		}
+		if round.Stream != original.Stream {
+			t.Errorf("Stream: got %v, want %v", round.Stream, original.Stream)
+		}
+		if v, ok := round.ExtraBodyFields["tool_stream"]; !ok || v != true {
+			t.Errorf("ExtraBodyFields[tool_stream] = %v (ok=%v), want true", v, ok)
+		}
+	})
 }

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -1,7 +1,14 @@
 package provider
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -295,4 +302,133 @@ func TestOpenAIRequest_UnmarshalJSON(t *testing.T) {
 			t.Errorf("ExtraBodyFields[tool_stream] = %v (ok=%v), want true", v, ok)
 		}
 	})
+}
+
+// quirksLogStubServer returns an httptest server that drains the
+// request body and returns an empty [DONE] SSE stream. Used by the
+// logging tests so the Stream call completes the full warn/debug
+// path without touching a real OpenAI endpoint.
+func quirksLogStubServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+}
+
+// TestOpenAIAdapter_OmitSamplingParams_WarnsOnSuppressedTemperatureWithRuleDescription
+// pins design risk 2: when OmitSamplingParams suppresses a caller-
+// supplied non-nil Temperature, the warn log must (a) fire, (b) name
+// the rule that caused the suppression so an operator can identify
+// the source without reading code, and (c) NOT include the suppressed
+// value itself (sidechannel concern — the caller's value would
+// otherwise propagate into any log sink that captures warn records).
+func TestOpenAIAdapter_OmitSamplingParams_WarnsOnSuppressedTemperatureWithRuleDescription(t *testing.T) {
+	srv := quirksLogStubServer(t)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:       "o1-mini",
+		MaxTokens:   4096,
+		Temperature: types.Float64Ptr(0.5),
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "openai quirks suppressed caller temperature") {
+		t.Errorf("warn log message absent from output: %s", logOutput)
+	}
+	// The reasoning-class rule description must appear in the warn
+	// record so the operator can trace which rule fired. The exact
+	// substring is the rule's Description field — if the rule text
+	// changes the substring below must change with it.
+	const wantRule = "OpenAI reasoning-class"
+	if !strings.Contains(logOutput, wantRule) {
+		t.Errorf("warn log missing rule description substring %q: %s", wantRule, logOutput)
+	}
+	// The suppressed value must NOT appear in the log. The number
+	// "0.5" alone could collide with a metric value or a duration, so
+	// pin against the named attribute key as well.
+	if strings.Contains(logOutput, "temperature.suppressed") {
+		t.Errorf("warn log contains legacy 'temperature.suppressed' attribute; the suppressed value must not leak: %s", logOutput)
+	}
+}
+
+// TestOpenAIAdapter_DebugLogListsAppliedRules pins the per-Stream
+// debug line from design §5: the line fires at the top of every
+// Stream call and lists the descriptions of the rules that
+// contributed to the resolution. Empty rule list is still logged so a
+// future grep against the line never misses a resolution.
+func TestOpenAIAdapter_DebugLogListsAppliedRules(t *testing.T) {
+	srv := quirksLogStubServer(t)
+	defer srv.Close()
+
+	cases := []struct {
+		name  string
+		model string
+		// Substrings the debug record must contain. Empty means no
+		// rule fired — the debug record fires anyway with `rules:[]`.
+		wantRuleSubstrings []string
+	}{
+		{
+			name:               "reasoning-class rule fires",
+			model:              "o1-mini",
+			wantRuleSubstrings: []string{"OpenAI reasoning-class"},
+		},
+		{
+			name:               "no rule fires for gpt-4o",
+			model:              "gpt-4o",
+			wantRuleSubstrings: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+			adapter.Logger = logger
+
+			ch, err := adapter.Stream(context.Background(), types.StreamParams{
+				Model:     tc.model,
+				MaxTokens: 4096,
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Stream: %v", err)
+			}
+			for range ch {
+			}
+
+			logOutput := buf.String()
+			if !strings.Contains(logOutput, "openai quirks resolved") {
+				t.Errorf("debug log message absent: %s", logOutput)
+			}
+			for _, want := range tc.wantRuleSubstrings {
+				if !strings.Contains(logOutput, want) {
+					t.Errorf("debug log missing rule substring %q: %s", want, logOutput)
+				}
+			}
+		})
+	}
 }

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirkstest"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fixtureRoot is the relative path from this _test.go file to the
+// per-model fixture directories. Tests run in their package's source
+// directory so the path is relative to harness/internal/provider/.
+const fixtureRoot = "testdata/quirks/openai-compatible"
+
+// quirksCanonicalParams returns a representative StreamParams whose
+// shape exercises the fields driven by the quirks layer (model,
+// max_tokens, temperature, messages). The same shape is reused across
+// every contract test so a fixture for a different model differs only
+// in the parts the rules actually change.
+func quirksCanonicalParams(model string) types.StreamParams {
+	return types.StreamParams{
+		Model:       model,
+		MaxTokens:   4096,
+		Temperature: types.Float64Ptr(0.5),
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hello"}}},
+		},
+	}
+}
+
+// TestOpenAIQuirks_O1MiniOmitsSamplingParams pins the o-series
+// reasoning-class wire shape: max_completion_tokens emitted at the
+// canonical key, sampling params (temperature) omitted even when the
+// caller supplies a non-nil value. The fixture is the source of truth
+// for the expected shape; AssertWireEqual normalises both sides.
+func TestOpenAIQuirks_O1MiniOmitsSamplingParams(t *testing.T) {
+	params := quirksCanonicalParams("o1-mini")
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+		t.Fatalf("o1-mini: expected OmitSamplingParams=true, got false (rule not firing)")
+	}
+	body, err := json.Marshal(buildOpenAIRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath(fixtureRoot, "o1-mini", "request.json"), body)
+}
+
+// TestOpenAIQuirks_GPT5NanoOmitsSamplingParams mirrors the o1-mini
+// case for the gpt-5 family. Same canonical-form body; pinned by the
+// gpt-5* rule.
+func TestOpenAIQuirks_GPT5NanoOmitsSamplingParams(t *testing.T) {
+	params := quirksCanonicalParams("gpt-5-nano")
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+		t.Fatalf("gpt-5-nano: expected OmitSamplingParams=true, got false (rule not firing)")
+	}
+	body, err := json.Marshal(buildOpenAIRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath(fixtureRoot, "gpt-5-nano", "request.json"), body)
+}
+
+// TestOpenAIQuirks_GPT5ChatLatestKeepsSamplingParams pins the carve-out
+// in design D10: gpt-5-chat-latest matches both gpt-5* and
+// gpt-5-chat*; the longer glob runs last and clears
+// OmitSamplingParams, so temperature is on the wire. This test is the
+// load-bearing assertion that the composition order works in
+// practice, not just in the unit test in quirks_test.go.
+func TestOpenAIQuirks_GPT5ChatLatestKeepsSamplingParams(t *testing.T) {
+	params := quirksCanonicalParams("gpt-5-chat-latest")
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if q.BehaviourFlags.OpenAI.OmitSamplingParams {
+		t.Fatalf("gpt-5-chat-latest: expected OmitSamplingParams=false after carve-out, got true (specificity order broken)")
+	}
+	body, err := json.Marshal(buildOpenAIRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath(fixtureRoot, "gpt-5-chat-latest", "request.json"), body)
+}
+
+// TestOpenAIQuirks_GPT4oNoQuirksApply pins the negative case: gpt-4o
+// matches none of the openai-compatible rules. The wire body is
+// therefore the canonical openaiRequest projection: max_completion_tokens,
+// temperature transmitted, no extra body fields.
+func TestOpenAIQuirks_GPT4oNoQuirksApply(t *testing.T) {
+	params := quirksCanonicalParams("gpt-4o")
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if q.BehaviourFlags.OpenAI.OmitSamplingParams {
+		t.Fatalf("gpt-4o: expected OmitSamplingParams=false, got true (rule misfire)")
+	}
+	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxCompletionTokens {
+		t.Fatalf("gpt-4o: expected TokenField=max_completion_tokens, got %v", q.BehaviourFlags.OpenAI.TokenField)
+	}
+	body, err := json.Marshal(buildOpenAIRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath(fixtureRoot, "gpt-4o", "request.json"), body)
+}
+
+// TestNoRegressionMaxCompletionTokensDefault pins design risk 1: the
+// default openai-compatible body MUST emit max_completion_tokens, NOT
+// the legacy max_tokens, regardless of whether a quirk rule fired.
+// The current main branch hard-codes max_completion_tokens; this test
+// guards against a regression where a future rule accidentally
+// restores the legacy field for non-Z.ai providers.
+//
+// The assertion is exhaustive: every (model) combination from the
+// shared canonical-params table plus a no-rule-match model produces
+// the modern key and never the legacy key in the same body.
+func TestNoRegressionMaxCompletionTokensDefault(t *testing.T) {
+	models := []string{
+		"gpt-4o",            // no rule
+		"gpt-3.5-turbo",     // no rule
+		"o1-mini",           // reasoning-class rule applies
+		"gpt-5-nano",        // gpt-5* rule applies
+		"gpt-5-chat-latest", // gpt-5-chat* carve-out applies
+		"claude-3-opus",     // wrong-provider sanity check
+		"random-model-xyz",  // forward-compatible no-rule sanity
+	}
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			params := quirksCanonicalParams(model)
+			q := quirks.DefaultRegistry().Resolve("openai-compatible", model)
+			body, err := json.Marshal(buildOpenAIRequest(params, true, q))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			s := string(body)
+			if !strings.Contains(s, `"max_completion_tokens"`) {
+				t.Errorf("model %q: body missing 'max_completion_tokens': %s", model, s)
+			}
+			if strings.Contains(s, `"max_tokens"`) {
+				t.Errorf("model %q: body contains legacy 'max_tokens' (regression): %s", model, s)
+			}
+		})
+	}
+}

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
@@ -54,6 +55,7 @@ type OpenAIResponsesAdapter struct {
 	queryParams  map[string]string
 	Tracer       oteltrace.Tracer       // optional, set by factory for span instrumentation
 	Metrics      *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
+	Logger       *slog.Logger           // optional, set by factory; nil falls back to slog.Default()
 	// Registry resolves per-(provider, model) quirks at the top of
 	// every Stream call. No rules target openai-responses in v1; the
 	// field exists so the integration point is in place when a
@@ -500,7 +502,22 @@ func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.Stream
 	if registry == nil {
 		registry = quirks.DefaultRegistry()
 	}
-	_ = registry.Resolve("openai-responses", params.Model)
+	_, appliedRules := registry.ResolveWithRules("openai-responses", params.Model)
+
+	logger := o.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	// Debug-level log mirrors the chat adapter so an operator gets the
+	// same trace surface regardless of which OpenAI endpoint is in
+	// use. Empty rules list today (no openai-responses rule); the line
+	// fires anyway so a future rule landing here is immediately
+	// visible in debug output.
+	logger.DebugContext(ctx, "openai-responses quirks resolved",
+		slog.String("provider.type", "openai-responses"),
+		slog.String("provider.model", params.Model),
+		slog.Any("rules", ruleDescriptions(appliedRules)),
+	)
 
 	reqBody := buildResponsesRequest(params)
 	reqBody.Stream = true

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -53,6 +54,12 @@ type OpenAIResponsesAdapter struct {
 	queryParams  map[string]string
 	Tracer       oteltrace.Tracer       // optional, set by factory for span instrumentation
 	Metrics      *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
+	// Registry resolves per-(provider, model) quirks at the top of
+	// every Stream call. No rules target openai-responses in v1; the
+	// field exists so the integration point is in place when a
+	// Responses-specific divergence is added (design §7 Step 4). The
+	// constructor defaults it to quirks.DefaultRegistry().
+	Registry *quirks.Registry
 }
 
 // NewOpenAIResponsesAdapter creates an adapter for the OpenAI Responses API.
@@ -85,6 +92,7 @@ func NewOpenAIResponsesAdapter(bearer credential.BearerTokenFunc, baseURL string
 		baseURL:      baseURL,
 		apiKeyHeader: auth.APIKeyHeader,
 		queryParams:  auth.QueryParams,
+		Registry:     quirks.DefaultRegistry(),
 	}
 }
 
@@ -483,6 +491,16 @@ func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.Stream
 		attribute.String("provider.type", "openai-responses"),
 		attribute.String("provider.model", params.Model),
 	)
+
+	// Resolve quirks for this (provider, model) pair. No rule
+	// targets openai-responses in v1, but the resolution is wired
+	// here so a future rule (e.g. a Responses-specific sampling-param
+	// omission) lands without re-shaping the Stream method.
+	registry := o.Registry
+	if registry == nil {
+		registry = quirks.DefaultRegistry()
+	}
+	_ = registry.Resolve("openai-responses", params.Model)
 
 	reqBody := buildResponsesRequest(params)
 	reqBody.Stream = true

--- a/harness/internal/provider/openai_test.go
+++ b/harness/internal/provider/openai_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -308,8 +309,11 @@ func TestOpenAIAdapter_RequestBody(t *testing.T) {
 	if received.Model != "gpt-4o" {
 		t.Errorf("model = %q, want gpt-4o", received.Model)
 	}
-	if received.MaxCompletionTokens != 4096 {
-		t.Errorf("max_completion_tokens = %d, want 4096", received.MaxCompletionTokens)
+	if received.MaxTokens != 4096 {
+		t.Errorf("max_completion_tokens = %d, want 4096", received.MaxTokens)
+	}
+	if received.TokenField != quirks.TokenFieldMaxCompletionTokens {
+		t.Errorf("token field = %v, want max_completion_tokens (default)", received.TokenField)
 	}
 	if received.Temperature == nil || *received.Temperature != 0.5 {
 		t.Errorf("temperature = %v, want *=0.5", received.Temperature)
@@ -406,8 +410,15 @@ func TestOpenAIAdapter_RawBodyShape(t *testing.T) {
 
 			adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
 
+			// Use gpt-4o so the test exercises the no-quirk default
+			// path: the openai-compatible reasoning-class rules apply to
+			// gpt-5* and o[1-9]-*, which would suppress temperature
+			// (the intended new behaviour). The shape pins the
+			// max_completion_tokens default and the nil-vs-pointer
+			// Temperature semantics, both of which must survive on
+			// non-reasoning models exactly as before #200.
 			ch, err := adapter.Stream(context.Background(), types.StreamParams{
-				Model:       "gpt-5.4",
+				Model:       "gpt-4o",
 				MaxTokens:   tc.maxTokens,
 				Temperature: tc.temperature,
 			})

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -2,25 +2,58 @@ package quirks
 
 // BuiltinRules returns the first-party rule set baked into the harness.
 //
-// Step 1 of the Wave 2 implementation deliberately ships an empty
-// slice: the scaffolding lands without behaviour change so adapters
-// integrating with the registry (Steps 2-5) can do so against the
-// final shape, and the supporting tests / CLI surface have something
-// concrete to exercise.
+// Rules are added in the order they take effect under
+// specificity-then-declaration-order (design D10): longer ModelMatch
+// globs run last and win on overlapping fields. The current set:
 //
-// Rules are added in subsequent steps in this order:
+//   - openai-compatible / "o[1-9]-*"      — reasoning class (o1, o3,
+//     o4-mini ...): omit sampling params via applyOpenAIReasoningClass.
+//   - openai-compatible / "gpt-5*"        — reasoning class: same
+//     behaviour as the o-series.
+//   - openai-compatible / "gpt-5-chat*"   — carve-out: gpt-5-chat-latest
+//     is a chat-class fork of the gpt-5 family and accepts the standard
+//     sampling parameters. This rule undoes the gpt-5* omission for
+//     models matching the longer glob.
 //
-//   - Step 2: openai-compatible reasoning-class rules (`o[1-9]-*`,
-//     `gpt-5*` with `gpt-5-chat*` carve-out).
-//   - Step 3: gemini default rule pinning StreamArgsOff for "*".
-//   - Step 4: openai-responses rules (none planned for v1; the empty
-//     output struct-tag fix is not a quirk).
-//   - Step 5: ReplayFields rules for deepseek-reasoner*, deepseek-v4*,
-//     and gemini-3* parse-side recognition.
+// Composition example:
+//   - "gpt-5-nano"        — matches "gpt-5*" only; OmitSamplingParams = true.
+//   - "gpt-5-chat-latest" — matches "gpt-5*" then "gpt-5-chat*"; the
+//     longer carve-out runs last and sets OmitSamplingParams = false.
+//   - "gpt-4o"            — matches neither; zero-value behaviour.
 //
 // Operators who want a non-default rule (e.g. Z.ai compat) inject it
 // via NewRegistry — see harness/internal/provider/compat/zai for the
 // pattern.
 func BuiltinRules() []Rule {
-	return []Rule{}
+	return []Rule{
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "o[1-9]-*",
+			Description:  "OpenAI reasoning-class (o1-o9): omit sampling params",
+			LastVerified: Date("2026-05-24"),
+			Apply:        applyOpenAIReasoningClass,
+		},
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "gpt-5*",
+			Description:  "OpenAI gpt-5 family: omit sampling params (reasoning-class)",
+			LastVerified: Date("2026-05-24"),
+			Apply:        applyOpenAIReasoningClass,
+		},
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "gpt-5-chat*",
+			Description:  "OpenAI gpt-5-chat carve-out: chat-class accepts sampling params",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// gpt-5-chat-latest is a chat-class fork of the gpt-5
+				// family and accepts temperature / top_p / penalties.
+				// The broader gpt-5* rule above set
+				// OmitSamplingParams = true; clearing it here is the
+				// carve-out. Specificity ordering (D10) guarantees this
+				// rule runs after gpt-5*.
+				q.BehaviourFlags.OpenAI.OmitSamplingParams = false
+			},
+		},
+	}
 }

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -6,8 +6,13 @@ package quirks
 // specificity-then-declaration-order (design D10): longer ModelMatch
 // globs run last and win on overlapping fields. The current set:
 //
-//   - openai-compatible / "o[1-9]-*"      — reasoning class (o1, o3,
-//     o4-mini ...): omit sampling params via applyOpenAIReasoningClass.
+//   - openai-compatible / "o[1-9]*"       — reasoning class. Matches
+//     both bare aliases ("o1", "o3", "o4") and dash-suffixed variants
+//     ("o1-mini", "o3-mini", "o4-mini"). Omits sampling params via
+//     applyOpenAIReasoningClass. The "[1-9]" class requires the
+//     leading digit be 1-9; two-digit series like "o10-mini" also
+//     match because the trailing "*" consumes the second digit, so
+//     forward-compat with a future o10+ alias is automatic.
 //   - openai-compatible / "gpt-5*"        — reasoning class: same
 //     behaviour as the o-series.
 //   - openai-compatible / "gpt-5-chat*"   — carve-out: gpt-5-chat-latest
@@ -28,8 +33,8 @@ func BuiltinRules() []Rule {
 	return []Rule{
 		{
 			ProviderType: "openai-compatible",
-			ModelMatch:   "o[1-9]-*",
-			Description:  "OpenAI reasoning-class (o1-o9): omit sampling params",
+			ModelMatch:   "o[1-9]*",
+			Description:  "OpenAI reasoning-class (o-series, single-digit prefix): omit sampling params",
 			LastVerified: Date("2026-05-24"),
 			Apply:        applyOpenAIReasoningClass,
 		},

--- a/harness/internal/provider/quirks/helpers.go
+++ b/harness/internal/provider/quirks/helpers.go
@@ -1,37 +1,43 @@
 package quirks
 
-// Shared helper functions used by builtin rule Apply closures. Step 1
-// reserves the file with package-private stubs so Step 2 can land the
-// rule implementations alongside the helpers in a single change.
-//
-// Helpers stay unexported in Step 1 (rather than being exported and
-// empty) so the public surface of the quirks package does not advertise
-// behaviour that doesn't exist yet. Step 2 will rename to
-// ApplyOpenAIReasoningClass / RemoveFromOmit when the implementations
-// land and external rule files (e.g. compat/zai) need to call them.
-//
-// The stubs carry //nolint:unused because Step 1 ships an empty
-// BuiltinRules() so nothing calls them yet; Step 2's first rule
-// addition is the first caller. Removing the stubs would leave Step 2
-// to invent the names at the same time as the rule logic; preserving
-// the names here pins the helper API surface up-front.
+// Shared helper functions used by builtin rule Apply closures. Each
+// helper encapsulates a behaviour-flag mutation that is shared across
+// more than one rule so the rules themselves stay declarative.
 
 // applyOpenAIReasoningClass sets the behaviour-flag combination shared
 // by every OpenAI reasoning-class model: TokenFieldMaxCompletionTokens
-// (already the zero-value default, but pinned explicitly) and
-// OmitSamplingParams to suppress temperature, top_p, presence_penalty,
-// frequency_penalty, logprobs, top_logprobs, and logit_bias.
-//
-// TODO(Step 2): implement.
-//
-//nolint:unused // Step 2 caller is queued; see file-level comment.
-func applyOpenAIReasoningClass(_ *ProviderQuirks) {}
+// (already the zero-value default, pinned explicitly for clarity) and
+// OmitSamplingParams = true to suppress temperature, top_p,
+// presence_penalty, frequency_penalty, logprobs, top_logprobs, and
+// logit_bias from the request body. Reasoning models reject every one
+// of these fields with HTTP 400, so the omission is mandatory rather
+// than a tunable.
+func applyOpenAIReasoningClass(q *ProviderQuirks) {
+	q.BehaviourFlags.OpenAI.TokenField = TokenFieldMaxCompletionTokens
+	q.BehaviourFlags.OpenAI.OmitSamplingParams = true
+}
 
-// removeFromOmit drops the named field from ProviderQuirks.OmitFields,
-// used by carve-out rules (e.g. gpt-5-chat*) that need to undo an
-// omission applied by a broader sibling rule.
+// removeFromOmit drops the named field from ProviderQuirks.OmitFields.
+// Used by carve-out rules (e.g. gpt-5-chat*) that need to undo an
+// omission applied by a broader sibling rule. A no-op if the field is
+// not present so callers can use it defensively.
 //
-// TODO(Step 2): implement.
-//
-//nolint:unused // Step 2 caller is queued; see file-level comment.
-func removeFromOmit(_ *ProviderQuirks, _ string) {}
+// This helper is reserved for OmitFields-driven omissions. The current
+// reasoning-class carve-out (gpt-5-chat*) toggles
+// OmitSamplingParams = false directly rather than touching OmitFields,
+// because the batch suppression is expressed as a boolean rather than
+// seven individual entries. removeFromOmit remains because future
+// rules that omit a single non-standard field may need a carve-out
+// for it on a sibling model glob.
+func removeFromOmit(q *ProviderQuirks, name string) {
+	if len(q.OmitFields) == 0 {
+		return
+	}
+	out := q.OmitFields[:0]
+	for _, f := range q.OmitFields {
+		if f != name {
+			out = append(out, f)
+		}
+	}
+	q.OmitFields = out
+}

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -228,6 +228,35 @@ func TestRuleCarveOuts(t *testing.T) {
 			t.Errorf("gpt-5-chat-mini: OmitSamplingParams = true; expected false (carve-out should cover the family)")
 		}
 	})
+	// Bare o-series aliases (o1, o3, o4) are shipped by OpenAI as
+	// production model IDs alongside their dash-suffixed variants. The
+	// glob "o[1-9]*" must cover both forms; a previous "o[1-9]-*"
+	// dash-required form silently bypassed the rule for the bare form
+	// and produced HTTP 400 responses. Each bare ID is asserted
+	// individually so a regression names the specific alias.
+	for _, bare := range []string{"o1", "o3", "o4"} {
+		bare := bare
+		t.Run("bare "+bare+" omits sampling params", func(t *testing.T) {
+			q := DefaultRegistry().Resolve("openai-compatible", bare)
+			if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+				t.Errorf("%s: OmitSamplingParams = false; expected true (o-series rule must cover the bare alias)", bare)
+			}
+		})
+	}
+	// Two-digit series (e.g. o10-mini) match the "o[1-9]*" glob because
+	// [1-9] consumes the leading "1" and the trailing "*" consumes
+	// "0-mini". This is the safer default for forward-compatibility:
+	// any future o10+ alias that ships will inherit the reasoning-class
+	// behaviour rather than silently regressing to greedy decoding +
+	// HTTP 400. Pinned so a future tightening of the glob is a
+	// deliberate edit that breaks this test rather than a silent
+	// behaviour change.
+	t.Run("o10-mini also omits sampling params (forward-compat)", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "o10-mini")
+		if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+			t.Errorf("o10-mini: OmitSamplingParams = false; expected true (o[1-9]* should match two-digit aliases)")
+		}
+	})
 }
 
 // TestNoMetacharsInKnownModelIDs reads the catalogue at

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -117,12 +117,12 @@ func TestBuiltinRulesValidate(t *testing.T) {
 			continue
 		}
 		q := ProviderQuirks{
-			FieldRenames:    map[string]string{},
-			OmitFields:      []string{},
-			ValueOverrides:  map[string]Value{},
-			EnumCoercions:   map[string]map[string]string{},
-			ReplayFields:    []string{},
-			BehaviourFlags:  ProviderBehaviourFlags{OpenAI: OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}}},
+			FieldRenames:   map[string]string{},
+			OmitFields:     []string{},
+			ValueOverrides: map[string]Value{},
+			EnumCoercions:  map[string]map[string]string{},
+			ReplayFields:   []string{},
+			BehaviourFlags: ProviderBehaviourFlags{OpenAI: OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}}},
 		}
 		rule.Apply(&q)
 		for key := range q.FieldRenames {
@@ -168,6 +168,38 @@ func TestBuiltinRulesExtraBodyFieldsNoSecrets(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestRemoveFromOmit covers the helper's three observable states:
+// removing an entry that is present, a no-op when absent, and a
+// no-op when the slice is nil. The helper is kept available for
+// future OmitFields-driven carve-outs even though Step 2's only
+// carve-out toggles OmitSamplingParams directly; the test exists so
+// the lint surface doesn't flag the helper as dead code.
+func TestRemoveFromOmit(t *testing.T) {
+	t.Run("removes present entry", func(t *testing.T) {
+		q := &ProviderQuirks{OmitFields: []string{"temperature", "top_p", "logprobs"}}
+		removeFromOmit(q, "top_p")
+		got := strings.Join(q.OmitFields, ",")
+		want := "temperature,logprobs"
+		if got != want {
+			t.Errorf("OmitFields = %q, want %q", got, want)
+		}
+	})
+	t.Run("no-op when absent", func(t *testing.T) {
+		q := &ProviderQuirks{OmitFields: []string{"temperature"}}
+		removeFromOmit(q, "top_p")
+		if len(q.OmitFields) != 1 || q.OmitFields[0] != "temperature" {
+			t.Errorf("OmitFields = %v, want [temperature]", q.OmitFields)
+		}
+	})
+	t.Run("no-op when nil slice", func(t *testing.T) {
+		q := &ProviderQuirks{}
+		removeFromOmit(q, "top_p")
+		if len(q.OmitFields) != 0 {
+			t.Errorf("OmitFields = %v, want empty", q.OmitFields)
+		}
+	})
 }
 
 // TestRuleCarveOuts pins the gpt-5-chat carve-out behaviour. The
@@ -261,7 +293,6 @@ func TestKnownModelIDsResolutionSmoke(t *testing.T) {
 	}
 	t.Logf("rule resolution smoke: %d (provider,model) pairs produced a non-default ProviderQuirks", resolved)
 }
-
 
 // TestRuleStaleness logs (does not fail) any rule whose LastVerified
 // is more than 180 days behind today. Per design §2.3 staleness is a

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -170,13 +170,17 @@ func TestBuiltinRulesExtraBodyFieldsNoSecrets(t *testing.T) {
 	}
 }
 
-// TestRemoveFromOmit covers the helper's three observable states:
-// removing an entry that is present, a no-op when absent, and a
-// no-op when the slice is nil. The helper is kept available for
-// future OmitFields-driven carve-outs even though Step 2's only
-// carve-out toggles OmitSamplingParams directly; the test exists so
-// the lint surface doesn't flag the helper as dead code.
-func TestRemoveFromOmit(t *testing.T) {
+// TestRemoveFromOmit_ReservedHelper covers the helper's three
+// observable states: removing an entry that is present, a no-op
+// when absent, and a no-op when the slice is nil. The helper is
+// kept available for future OmitFields-driven carve-outs even
+// though Step 2's only carve-out toggles OmitSamplingParams
+// directly. The test exists primarily so the linter does not flag
+// the helper as dead code; the "ReservedHelper" suffix on the test
+// name signals this to a future reader who wonders why a tested
+// helper has no production caller, so they don't delete the
+// function thinking it is genuinely unused.
+func TestRemoveFromOmit_ReservedHelper(t *testing.T) {
 	t.Run("removes present entry", func(t *testing.T) {
 		q := &ProviderQuirks{OmitFields: []string{"temperature", "top_p", "logprobs"}}
 		removeFromOmit(q, "top_p")

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -1,8 +1,11 @@
 package quirks
 
 import (
+	"bufio"
 	"encoding/json"
+	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -57,14 +60,38 @@ func TestResolveEmptyRegistry(t *testing.T) {
 	}
 }
 
+// canonicalOpenAIFieldNames mirrors the canonical Chat Completions
+// field surface enumerated by harness/internal/provider/openai.go's
+// isCanonicalOpenAIField. The duplication is intentional: a rule's
+// FieldRenames key set must be a subset of this; the source-of-truth
+// is the adapter, but the test cross-checks rules without crossing
+// the package boundary (the adapter's set is unexported).
+//
+// When the adapter learns a new canonical field, add it here too.
+// TestBuiltinRulesValidate catches a rule that renames a field
+// neither side knows about, so the asymmetry stays observable.
+var canonicalOpenAIFieldNames = map[string]bool{
+	"model":                 true,
+	"messages":              true,
+	"tools":                 true,
+	"max_completion_tokens": true,
+	"max_tokens":            true,
+	"temperature":           true,
+	"top_p":                 true,
+	"presence_penalty":      true,
+	"frequency_penalty":     true,
+	"logprobs":              true,
+	"top_logprobs":          true,
+	"logit_bias":            true,
+	"stream":                true,
+}
+
 // TestBuiltinRulesValidate asserts every rule baked into the registry
 // passes a structural validity check: required metadata is populated
 // (Description, LastVerified, Apply) so trace attributes and the CLI
-// introspection surface have something to report.
-//
-// Step 1 ships an empty rule set so this loop runs zero iterations;
-// the test still validates that BuiltinRules returns a usable value
-// (the for-range over the slice is the assertion).
+// introspection surface have something to report, and every
+// FieldRenames key is in the declared canonical field surface so a
+// typo in a rule cannot silently rename a non-existent field.
 func TestBuiltinRulesValidate(t *testing.T) {
 	for i, rule := range BuiltinRules() {
 		if rule.Description == "" {
@@ -76,8 +103,165 @@ func TestBuiltinRulesValidate(t *testing.T) {
 		if rule.Apply == nil {
 			t.Errorf("BuiltinRules()[%d] (%q): Apply is required", i, rule.Description)
 		}
+		// Canonical-field check: materialise the rule's effect on a
+		// fresh ProviderQuirks and assert every FieldRenames key
+		// (the source side of the rename) is in the canonical set.
+		// Rules that don't touch FieldRenames are no-ops here.
+		if rule.Apply == nil {
+			continue
+		}
+		if rule.ProviderType != "openai-compatible" {
+			// Per-provider canonical sets will arrive when Gemini/
+			// Anthropic-targeted rules land in Step 3. Until then,
+			// the openai-compatible set is the only one to enforce.
+			continue
+		}
+		q := ProviderQuirks{
+			FieldRenames:    map[string]string{},
+			OmitFields:      []string{},
+			ValueOverrides:  map[string]Value{},
+			EnumCoercions:   map[string]map[string]string{},
+			ReplayFields:    []string{},
+			BehaviourFlags:  ProviderBehaviourFlags{OpenAI: OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}}},
+		}
+		rule.Apply(&q)
+		for key := range q.FieldRenames {
+			if !canonicalOpenAIFieldNames[key] {
+				t.Errorf("BuiltinRules()[%d] (%q): FieldRenames key %q is not in the canonical openai field set", i, rule.Description, key)
+			}
+		}
 	}
 }
+
+// TestBuiltinRulesExtraBodyFieldsNoSecrets pins design risk 4:
+// ExtraBodyFields values must not carry secret:// references. The
+// map is serialised directly into the request body; a rule that
+// accidentally stored a secret reference there would bypass
+// RunConfig.Redact() entirely. This test materialises every rule's
+// effect and walks the resulting ExtraBodyFields for string values
+// that contain the secret:// prefix.
+//
+// The current Z.ai rule stores a bool (tool_stream: true) so the
+// check is trivially satisfied today; the test is structural
+// insurance for future rules.
+func TestBuiltinRulesExtraBodyFieldsNoSecrets(t *testing.T) {
+	for i, rule := range BuiltinRules() {
+		if rule.Apply == nil {
+			continue
+		}
+		q := ProviderQuirks{
+			FieldRenames:   map[string]string{},
+			OmitFields:     []string{},
+			ValueOverrides: map[string]Value{},
+			EnumCoercions:  map[string]map[string]string{},
+			ReplayFields:   []string{},
+			BehaviourFlags: ProviderBehaviourFlags{OpenAI: OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}}},
+		}
+		rule.Apply(&q)
+		for k, v := range q.BehaviourFlags.OpenAI.ExtraBodyFields {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			if strings.Contains(s, "secret://") {
+				t.Errorf("BuiltinRules()[%d] (%q): ExtraBodyFields[%q] = %q contains a secret:// reference", i, rule.Description, k, s)
+			}
+		}
+	}
+}
+
+// TestRuleCarveOuts pins the gpt-5-chat carve-out behaviour. The
+// gpt-5* reasoning-class rule sets OmitSamplingParams=true; the
+// gpt-5-chat* rule overrides it back to false because chat-class
+// models accept sampling params. Specificity ordering (D10) is
+// load-bearing: if a future edit reorders the rules or weakens the
+// glob, this test fails loudly rather than silently breaking the
+// gpt-5-chat-latest wire shape.
+func TestRuleCarveOuts(t *testing.T) {
+	t.Run("gpt-5-chat-latest keeps sampling params", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "gpt-5-chat-latest")
+		if q.BehaviourFlags.OpenAI.OmitSamplingParams {
+			t.Errorf("gpt-5-chat-latest: OmitSamplingParams = true after carve-out; expected false")
+		}
+	})
+	t.Run("gpt-5-nano omits sampling params", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "gpt-5-nano")
+		if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+			t.Errorf("gpt-5-nano: OmitSamplingParams = false; expected true (gpt-5* rule should fire)")
+		}
+	})
+	t.Run("gpt-5-chat-mini also keeps sampling params", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "gpt-5-chat-mini")
+		if q.BehaviourFlags.OpenAI.OmitSamplingParams {
+			t.Errorf("gpt-5-chat-mini: OmitSamplingParams = true; expected false (carve-out should cover the family)")
+		}
+	})
+}
+
+// TestNoMetacharsInKnownModelIDs reads the catalogue at
+// testdata/model-ids.txt and asserts every entry is a literal model
+// identifier — no glob metacharacters. The catalogue exists to spot-
+// check that the rules in builtin.go don't accidentally glob-match
+// real model names with `[`, `?`, or `*` in them; an entry with a
+// metachar in it is either a typo or a model name that breaks the
+// path.Match dispatch. Either case should fail the test loudly.
+func TestNoMetacharsInKnownModelIDs(t *testing.T) {
+	f, err := os.Open("testdata/model-ids.txt")
+	if err != nil {
+		t.Fatalf("open model-ids.txt: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.ContainsAny(line, "*?[]") {
+			t.Errorf("testdata/model-ids.txt:%d: model id %q contains a glob metachar", lineNo, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan model-ids.txt: %v", err)
+	}
+}
+
+// rulesMatchAtLeastOne sanity-checks that the catalogue and the rule
+// set agree: every model id in testdata/model-ids.txt that matches a
+// builtin rule resolves to a non-zero ProviderQuirks state. This is
+// a forward-compatible smoke test for the catalogue, not a contract
+// — entries that match no rule (e.g. gpt-4o, claude-3-*) are
+// expected and produce a zero-value ProviderQuirks.
+//
+// Not promoted to a load-bearing assertion because the catalogue's
+// purpose is the metachar guard above; the resolution count is
+// informational only and surfaces via t.Logf rather than t.Errorf.
+func TestKnownModelIDsResolutionSmoke(t *testing.T) {
+	f, err := os.Open("testdata/model-ids.txt")
+	if err != nil {
+		t.Skip("model-ids.txt unavailable")
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	provs := []string{"openai-compatible", "gemini", "anthropic"}
+	resolved := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		for _, prov := range provs {
+			q := DefaultRegistry().Resolve(prov, line)
+			if q.BehaviourFlags.OpenAI.OmitSamplingParams || q.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxCompletionTokens || q.BehaviourFlags.Gemini.StreamFunctionCallArgsShape != StreamArgsOff {
+				resolved++
+			}
+		}
+	}
+	t.Logf("rule resolution smoke: %d (provider,model) pairs produced a non-default ProviderQuirks", resolved)
+}
+
 
 // TestRuleStaleness logs (does not fail) any rule whose LastVerified
 // is more than 180 days behind today. Per design §2.3 staleness is a

--- a/harness/internal/provider/quirks/registry.go
+++ b/harness/internal/provider/quirks/registry.go
@@ -90,7 +90,32 @@ func DefaultRegistry() *Registry {
 // Resolve is safe to call concurrently; the registry's rule slice is
 // read-only after NewRegistry, and the returned ProviderQuirks is a
 // value type with freshly allocated maps and slices.
+//
+// Resolve delegates to ResolveWithRules and discards the contributing
+// rule list. Call ResolveWithRules directly when the caller also needs
+// to log or surface which rules fired (e.g. the per-Stream debug line
+// in the OpenAI adapters that pins which rule caused a suppression).
 func (r *Registry) Resolve(providerType, model string) ProviderQuirks {
+	q, _ := r.ResolveWithRules(providerType, model)
+	return q
+}
+
+// ResolveWithRules is Resolve plus the ordered list of rules that
+// actually contributed to the result. The returned []Rule is sorted
+// in the same specificity-then-declaration order that Apply was
+// invoked in, so the last entry is the rule whose writes won on
+// overlapping fields. Rules with a nil Apply are filtered out — they
+// did not run, so reporting them as "applied" would be a lie that
+// undermines the trace-attribute use case.
+//
+// The slice is freshly allocated on every call and safe for the
+// caller to mutate; the registry's internal rule slice is not
+// shared.
+//
+// Use this when the caller needs to surface contributing rules in
+// trace attributes, debug logs, or CLI introspection. Use Resolve
+// when the rule list is not needed.
+func (r *Registry) ResolveWithRules(providerType, model string) (ProviderQuirks, []Rule) {
 	q := ProviderQuirks{
 		FieldRenames:   map[string]string{},
 		OmitFields:     []string{},
@@ -104,7 +129,7 @@ func (r *Registry) Resolve(providerType, model string) ProviderQuirks {
 		},
 	}
 	if r == nil {
-		return q
+		return q, nil
 	}
 
 	// Collect (originalIndex, rule) pairs for every matching rule, then
@@ -130,13 +155,15 @@ func (r *Registry) Resolve(providerType, model string) ProviderQuirks {
 		}
 		return matches[i].idx < matches[j].idx
 	})
+	applied := make([]Rule, 0, len(matches))
 	for _, m := range matches {
 		if m.rule.Apply == nil {
 			continue
 		}
 		m.rule.Apply(&q)
+		applied = append(applied, m.rule)
 	}
-	return q
+	return q, applied
 }
 
 // RuleMatches reports whether the rule fires for the given (provider,

--- a/harness/internal/provider/quirks/testdata/model-ids.txt
+++ b/harness/internal/provider/quirks/testdata/model-ids.txt
@@ -2,9 +2,12 @@ gpt-4o
 gpt-5-nano
 gpt-5-chat-latest
 gpt-5-chat-mini
+o1
 o1-mini
 o1-preview
+o3
 o3-mini
+o4
 o4-mini
 claude-3-5-sonnet-20241022
 gemini-2.5-pro

--- a/harness/internal/provider/quirks/testdata/model-ids.txt
+++ b/harness/internal/provider/quirks/testdata/model-ids.txt
@@ -1,7 +1,13 @@
 gpt-4o
 gpt-5-nano
+gpt-5-chat-latest
+gpt-5-chat-mini
 o1-mini
 o1-preview
+o3-mini
+o4-mini
 claude-3-5-sonnet-20241022
 gemini-2.5-pro
 gemini-3.1-pro-preview
+glm-4-plus
+glm-4-air

--- a/harness/internal/provider/quirkstest/quirkstest.go
+++ b/harness/internal/provider/quirkstest/quirkstest.go
@@ -1,0 +1,199 @@
+// Package quirkstest provides the shared test helpers used by the
+// Wave 2 wire-shape contract tests across the provider package and
+// the compat/* sub-packages. It is a *_test-adjacent package (not
+// _test-only) so both `package provider` test files and
+// `package zai_test` files can import it.
+//
+// The helpers cover three responsibilities:
+//
+//   - AssertWireEqual: canonical-form equality between a captured
+//     fixture and an actual marshalled body. Unmarshal-then-marshal
+//     normalises both sides so key ordering and whitespace don't
+//     produce false negatives.
+//   - ScrubFixture: redacts known-sensitive substrings (Bearer
+//     tokens, project IDs, session IDs) so a fixture committed to
+//     the repository never carries upstream credentials.
+//   - LoadFixture: reads a fixture file, scrubs it, and returns the
+//     bytes. Synthetic fixtures (those carrying a leading
+//     "# synthetic: ..." comment) have the comment line stripped
+//     before parsing so they remain JSON-valid.
+package quirkstest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// AssertWireEqual fails the test if the JSON in got does not match
+// the JSON in the fixture at wantPath after canonical normalisation.
+// Both sides are unmarshalled into interface{} then re-marshalled
+// with go-sorted keys so the comparison ignores key ordering and
+// whitespace. The diff message includes both bodies in their
+// canonical form to make a failure easy to inspect.
+func AssertWireEqual(t *testing.T, wantPath string, got []byte) {
+	t.Helper()
+	wantRaw, err := LoadFixture(wantPath)
+	if err != nil {
+		t.Fatalf("load fixture %s: %v", wantPath, err)
+	}
+	wantCanonical, err := canonicalise(wantRaw)
+	if err != nil {
+		t.Fatalf("canonicalise fixture %s: %v", wantPath, err)
+	}
+	gotCanonical, err := canonicalise(got)
+	if err != nil {
+		t.Fatalf("canonicalise actual body: %v\nbody: %s", err, got)
+	}
+	if !bytes.Equal(wantCanonical, gotCanonical) {
+		t.Errorf("wire body mismatch for fixture %s\n want: %s\n got:  %s", wantPath, wantCanonical, gotCanonical)
+	}
+}
+
+// LoadFixture reads the file at path, strips any leading
+// "# synthetic: ..." comment line, and returns the bytes. Synthetic
+// fixtures carry the comment per design §6 so a reader can tell at a
+// glance that the bytes are not a real upstream capture. The comment
+// is stripped before parsing because JSON has no comment syntax.
+func LoadFixture(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// Strip a leading "# synthetic: ..." line if present so JSON
+	// fixtures stay JSON-parseable. Only the first line is stripped;
+	// subsequent comment-like lines would be a bug worth surfacing.
+	if bytes.HasPrefix(raw, []byte("# synthetic:")) {
+		if idx := bytes.IndexByte(raw, '\n'); idx >= 0 {
+			raw = raw[idx+1:]
+		} else {
+			raw = nil
+		}
+	}
+	return raw, nil
+}
+
+// ScrubFixture replaces known-sensitive substrings in body with
+// placeholders. It is intentionally a small, hard-coded list — the
+// goal is catching the obvious patterns (Authorization: Bearer ...,
+// project IDs in URLs) before a fixture is committed, not building
+// a general-purpose secret scanner. Adding to the list as new shapes
+// appear is expected.
+func ScrubFixture(body []byte) []byte {
+	for _, sub := range scrubbers {
+		body = sub.re.ReplaceAll(body, []byte(sub.replacement))
+	}
+	return body
+}
+
+type scrubber struct {
+	re          *regexp.Regexp
+	replacement string
+}
+
+// scrubbers list — extend when a new sensitive pattern appears. Each
+// entry is a (regex, replacement) pair; replacements are deliberately
+// human-readable so a reader skimming a fixture sees the redaction
+// rather than a random hex blob.
+var scrubbers = []scrubber{
+	// Authorization: Bearer sk-...
+	{
+		re:          regexp.MustCompile(`Bearer\s+sk-[A-Za-z0-9_\-]+`),
+		replacement: "Bearer REDACTED",
+	},
+	// api-key: sk-...
+	{
+		re:          regexp.MustCompile(`(?i)(api-key|x-api-key)\s*[:=]\s*sk-[A-Za-z0-9_\-]+`),
+		replacement: "${1}: REDACTED",
+	},
+	// Anthropic API keys (sk-ant-...)
+	{
+		re:          regexp.MustCompile(`sk-ant-[A-Za-z0-9_\-]+`),
+		replacement: "REDACTED-ANTHROPIC-KEY",
+	},
+	// GCP project IDs in vertex URLs: projects/<id>/locations/<loc>
+	{
+		re:          regexp.MustCompile(`projects/[A-Za-z0-9_\-]+/locations`),
+		replacement: "projects/test-project/locations",
+	},
+}
+
+// canonicalise normalises a JSON document so two semantically equal
+// bodies compare byte-equal. Returns an error if the input is not
+// valid JSON; callers should treat that as a fixture-format bug.
+func canonicalise(raw []byte) ([]byte, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty body")
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w (body: %s)", err, snippet(raw))
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	return out, nil
+}
+
+// snippet returns up to 200 bytes of raw so error messages don't
+// dump a multi-megabyte payload into the test output.
+func snippet(raw []byte) string {
+	const limit = 200
+	if len(raw) <= limit {
+		return string(raw)
+	}
+	return string(raw[:limit]) + "...(truncated)"
+}
+
+// Helpers below are exported for tests that need to introspect
+// fixture content directly (e.g. asserting the presence of a
+// specific extra body field without going through AssertWireEqual).
+
+// MustUnmarshal decodes raw into v, failing the test on any error.
+// Mirrors stdlib testify-style helpers without taking a dependency.
+func MustUnmarshal(t *testing.T, raw []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, v); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, snippet(raw))
+	}
+}
+
+// HasJSONKey reports whether raw, parsed as a JSON object, contains
+// the given top-level key. Useful for spot-checks of the wire body
+// shape in tests that don't want to assert the whole shape via
+// AssertWireEqual.
+func HasJSONKey(t *testing.T, raw []byte, key string) bool {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	_, ok := m[key]
+	return ok
+}
+
+// JSONString returns a compact JSON representation of v, failing the
+// test on any error. Used to construct the "actual" side of an
+// AssertWireEqual call from a Go struct.
+func JSONString(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// JoinPath is a tiny path-join helper that does not pull in
+// path/filepath at every call site. Test fixtures live under
+// testdata/quirks/<provider>/<model>/ so a three-arg join is the
+// common form.
+func JoinPath(parts ...string) string {
+	return strings.Join(parts, "/")
+}

--- a/harness/internal/provider/quirkstest/quirkstest_test.go
+++ b/harness/internal/provider/quirkstest/quirkstest_test.go
@@ -1,0 +1,110 @@
+package quirkstest_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirkstest"
+)
+
+// TestFixturesScrubbed is the CI gate that enforces design risk 4:
+// no fixture committed to the repository may carry an upstream
+// credential or other sensitive substring that ScrubFixture would
+// rewrite. The previous state shipped ScrubFixture with zero call
+// sites, so a real wire capture committed with a Bearer token in it
+// would have landed unnoticed.
+//
+// The test walks every file under
+// harness/internal/provider/testdata/quirks/ and asserts ScrubFixture
+// is a no-op against its content: scrub(bytes) == bytes. Any future
+// fixture that carries a sensitive substring fails the build with a
+// path-pinned message, naming the file the operator needs to revisit.
+//
+// Run from the quirkstest package (not the provider package) so the
+// helper imports do not pull a real provider symbol into a test-only
+// build. The fixture root is resolved relative to this test file,
+// which sits at harness/internal/provider/quirkstest/; the fixtures
+// live in a sibling subdirectory of the parent.
+func TestFixturesScrubbed(t *testing.T) {
+	fixtureRoot := filepath.Join("..", "testdata", "quirks")
+	if _, err := os.Stat(fixtureRoot); err != nil {
+		t.Skipf("fixture root %q unavailable: %v", fixtureRoot, err)
+	}
+	checked := 0
+	err := filepath.Walk(fixtureRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		scrubbed := quirkstest.ScrubFixture(raw)
+		if !bytes.Equal(raw, scrubbed) {
+			diff := firstDiff(raw, scrubbed)
+			t.Errorf("fixture %s contains a substring the scrubber would rewrite (first divergence at offset %d): "+
+				"raw=%q scrubbed=%q. Commit the scrubbed form instead, or extend the scrubber list if the substring is benign.",
+				path, diff.offset, diff.rawSnippet, diff.scrubbedSnippet)
+		}
+		checked++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixtures: %v", err)
+	}
+	if checked == 0 {
+		// A zero-fixture state means either the fixture directory was
+		// renamed (in which case the gate is dead) or the harness has
+		// no fixtures yet (unlikely after Step 2). Fail loudly either
+		// way so the CI gate cannot silently regress to a no-op.
+		t.Fatalf("walked %s and found zero fixtures; the gate is no longer enforcing anything", fixtureRoot)
+	}
+}
+
+// diff is a small helper for surfacing the first byte at which raw
+// and scrubbed diverge, so the test error message points an operator
+// at the substring rather than dumping a multi-line file.
+type diff struct {
+	offset          int
+	rawSnippet      string
+	scrubbedSnippet string
+}
+
+func firstDiff(a, b []byte) diff {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return diff{
+				offset:          i,
+				rawSnippet:      snippet(a, i),
+				scrubbedSnippet: snippet(b, i),
+			}
+		}
+	}
+	if len(a) != len(b) {
+		return diff{offset: n, rawSnippet: snippet(a, n), scrubbedSnippet: snippet(b, n)}
+	}
+	return diff{}
+}
+
+func snippet(s []byte, around int) string {
+	const window = 40
+	start := around - window
+	if start < 0 {
+		start = 0
+	}
+	end := around + window
+	if end > len(s) {
+		end = len(s)
+	}
+	return strings.ReplaceAll(string(s[start:end]), "\n", "\\n")
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/gpt-4o/request.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/gpt-4o/request.json
@@ -1,0 +1,13 @@
+# synthetic: derived from buildOpenAIRequest + DefaultRegistry().Resolve because the harness does not yet carry a live capture; gpt-4o is the no-quirks-apply baseline so this fixture pins the unmodified canonical request shape.
+{
+  "model": "gpt-4o",
+  "messages": [
+    {
+      "role": "user",
+      "content": "hello"
+    }
+  ],
+  "max_completion_tokens": 4096,
+  "temperature": 0.5,
+  "stream": true
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/gpt-5-chat-latest/request.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/gpt-5-chat-latest/request.json
@@ -1,0 +1,13 @@
+# synthetic: derived from buildOpenAIRequest + DefaultRegistry().Resolve because gpt-5-chat-latest is a moving alias; the canonical key set pins that the gpt-5-chat carve-out reverses the reasoning-class omission so temperature is transmitted.
+{
+  "model": "gpt-5-chat-latest",
+  "messages": [
+    {
+      "role": "user",
+      "content": "hello"
+    }
+  ],
+  "max_completion_tokens": 4096,
+  "temperature": 0.5,
+  "stream": true
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/gpt-5-nano/request.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/gpt-5-nano/request.json
@@ -1,0 +1,12 @@
+# synthetic: derived from buildOpenAIRequest + DefaultRegistry().Resolve because gpt-5-nano is not yet generally available; the canonical key set and the omission of sampling params are pinned by the gpt-5* reasoning-class rule in builtin.go.
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "hello"
+    }
+  ],
+  "max_completion_tokens": 4096,
+  "stream": true
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/gpt-5-nano/response.sse
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/gpt-5-nano/response.sse
@@ -1,0 +1,9 @@
+# synthetic: derived from a typical Chat Completions streaming response because gpt-5-nano is not yet generally available; the SSE shape mirrors gpt-4o because OpenAI uses the same wire format across Chat Completions models.
+data: {"id":"chatcmpl-gpt5nano-test","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-gpt5nano-test","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-gpt5nano-test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":1}}
+
+data: [DONE]
+

--- a/harness/internal/provider/testdata/quirks/openai-compatible/o1-mini/request.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/o1-mini/request.json
@@ -1,0 +1,12 @@
+# synthetic: derived from buildOpenAIRequest + DefaultRegistry().Resolve because the harness does not yet have a live o1-mini capture; the canonical key set and the omission of sampling params are pinned by the reasoning-class rule in builtin.go.
+{
+  "model": "o1-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "hello"
+    }
+  ],
+  "max_completion_tokens": 4096,
+  "stream": true
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/o1-mini/response.sse
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/o1-mini/response.sse
@@ -1,0 +1,9 @@
+# synthetic: derived from a typical Chat Completions streaming response because the harness does not yet have a live o1-mini capture; the SSE shape mirrors gpt-4o because OpenAI uses the same wire format across Chat Completions models.
+data: {"id":"chatcmpl-o1mini-test","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-o1mini-test","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-o1mini-test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":1}}
+
+data: [DONE]
+

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -758,6 +758,50 @@ func TestRunConfigFromProto_BatchProviderConfigPreserved(t *testing.T) {
 	})
 }
 
+// TestRunConfigFromProto_CompatProfileRoundTrip pins the wire-to-
+// internal copy of ProviderConfig.CompatProfile (issue #221 Wave 2).
+// The translate hop is forward-only — operators set CompatProfile on
+// the wire and the harness consumes it; there is no symmetric Go-to-
+// proto path for this field. The same silent-drop class of regression
+// that bit SessionName (gh-95), Anthropic WIF (gh-117), Azure WIF
+// (gh-118), and TraceEmitter (gh-100) is the failure mode this test
+// guards against: a future ProviderConfig field reshuffle could drop
+// CompatProfile from the translate block and a Z.ai-targeted run
+// would silently fall back to the openai-compatible defaults — a
+// HTTP 400 on the first turn rather than a clean validation error.
+//
+// Three sub-cases cover the wire→internal contract:
+//   - explicit "zai-glm" round-trips verbatim
+//   - empty string round-trips as empty (default profile)
+//   - unrecognised string round-trips verbatim; ValidateRunConfig is
+//     responsible for rejecting it — the translate layer must not
+//     silently coerce unknown values
+func TestRunConfigFromProto_CompatProfileRoundTrip(t *testing.T) {
+	cases := []struct {
+		name        string
+		profile     string
+		wantProfile string
+	}{
+		{name: "zai-glm", profile: "zai-glm", wantProfile: "zai-glm"},
+		{name: "empty default", profile: "", wantProfile: ""},
+		{name: "unrecognised value passes through", profile: "future-profile", wantProfile: "future-profile"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := &pb.RunConfig{
+				Provider: &pb.ProviderConfig{
+					Type:          "openai-compatible",
+					CompatProfile: tc.profile,
+				},
+			}
+			rc := runConfigFromProto(pc)
+			if rc.Provider.CompatProfile != tc.wantProfile {
+				t.Errorf("CompatProfile: got %q, want %q", rc.Provider.CompatProfile, tc.wantProfile)
+			}
+		})
+	}
+}
+
 // TestRunConfigFromProto_TemperatureRoundTrip pins the pointer-vs-nil
 // distinction across the wire boundary for RunConfig.Temperature
 // (issue #217). The control plane must be able to (a) leave the field


### PR DESCRIPTION
Second integration PR for #221 / Wave 2 of the tool-use debacle workstream. Builds on PR #315 (scaffold). Wires the quirks layer into the openai-compatible adapter, adds the first builtin rules, introduces the Z.ai compat profile, and plumbs the Responses adapter. **Behaviour change**: reasoning-class models (o-series, GPT-5 non-chat) now omit sampling params automatically; `CompatProfile = "zai-glm"` enables Z.ai's `max_tokens` + `tool_stream` extension.

Per the approved Wave 2 design at `stirrup-coord/scratch/wave-2-design.md`.

## What ships

### openai-compatible adapter (`provider/openai.go`)
- `Stream()` calls `Registry.ResolveWithRules(providerType, params.Model)` at the top; resolved `ProviderQuirks` and the matching rule list flow into `buildOpenAIRequest`.
- `openaiRequest` refactored to custom `MarshalJSON`/`UnmarshalJSON` — dynamic field inclusion/exclusion (`OmitSamplingParams`), token-field switching (`TokenFieldMaxCompletionTokens` ↔ `TokenFieldMaxTokens`), and `ExtraBodyFields` merge can't be expressed with static struct tags.
- `MarshalJSON` errors on `ExtraBodyFields` key collision with canonical fields; `UnmarshalJSON` errors if both `max_completion_tokens` and `max_tokens` keys appear in the same body (instead of silently overwriting).
- Per-`Stream` debug log lists applied rule descriptions; warn log on suppressed temperature references the rule. Suppressed value not logged (sidechannel concern).

### Builtin rules (`provider/quirks/builtin.go`)
- `o[1-9]*` for openai-compatible → `applyOpenAIReasoningClass` (covers bare `o3`, `o4`, dash-suffix `o1-mini`, and forward-compat two-digit `o10-mini`).
- `gpt-5*` → `applyOpenAIReasoningClass`.
- `gpt-5-chat*` → carve-out: clears `OmitSamplingParams` so chat models keep `temperature`/`top_p`/etc. Longest-glob-wins composition (D10) puts the carve-out last.

### Z.ai compat profile (`provider/compat/zai/`)
- `CompatRule()` exported: matches Z.ai GLM models; sets `TokenField = TokenFieldMaxTokens` and `ExtraBodyFields[\"tool_stream\"] = true`.
- Injected by `core/factory.go::resolveCompatProfile` when `Provider.CompatProfile == \"zai-glm\"`; `DefaultRegistry()` remains pristine.
- Parse-side semantics of `tool_stream` not yet verified against a live Z.ai endpoint (design §9 risk 5) — conservative interpretation: send-only flag. Documented in `zai.go` package comment.

### Responses adapter (`provider/openai_responses.go`)
- `Registry` field + `ResolveWithRules` call wired. No rules in v1; debug log fires regardless.

### Batch adapter (`provider/batch.go`)
- `Registry` field added to `BatchAdapter` (optional; nil → `DefaultRegistry()`). Factory plumbs the streaming inner adapter's registry through, so compat-profile rules apply consistently in batch when Z.ai is eventually allow-listed.

### Tests added (selection)
- `TestOpenAIQuirks_{O1MiniOmitsSamplingParams, GPT5NanoOmitsSamplingParams, GPT5ChatLatestKeepsSamplingParams, GPT4oNoQuirksApply}` — fixture-driven contract.
- `TestNoRegressionMaxCompletionTokensDefault` — pins design §9 risk 1; asserts temperature absent for reasoning models.
- `TestOpenAIRequest_MarshalJSON_ExtraBodyFieldCollision` — pins the collision guards.
- `TestOpenAIRequest_UnmarshalJSON` — legacy field decode + dual-key error + round-trip.
- `TestOpenAIAdapter_OmitSamplingParams_WarnsOnSuppressedTemperatureWithRuleDescription` — pins the traceability mitigation for §9 risk 2.
- `TestBuildProvider_OpenAICompatibleWithCompatProfile_ZAI` + `..._UnknownProfileErrors` — factory `resolveCompatProfile` injection path (was at 0% coverage pre-remediation).
- `TestCompatRuleExtraBodyFieldsNoSecrets` — per-compat-package no-secrets guard for §9 risk 4.
- `TestBatchAdapter_Marshal{UsesInjectedRegistry, FallsBackToDefaultRegistryWhenNil}` — pins both batch registry paths.
- `TestFixturesScrubbed` — CI gate that walks `testdata/quirks/` and asserts `ScrubFixture(contents) == contents` for every file.
- `TestRuleCarveOuts` — pins `gpt-5-chat-latest` clears, `gpt-5-nano` sets, two-digit `o10-mini` sets.
- `TestNoMetacharsInKnownModelIDs`, `TestBuiltinRulesValidate` extended with canonical-field-set check.
- `TestRunConfigFromProto_CompatProfileRoundTrip` — closes Step 1 deferral.

### Step 1 deferral tests landed in this PR
`TestRuleCarveOuts`, `TestNoMetacharsInKnownModelIDs`, `TestBuiltinRulesValidate` canonical-field-set check, `TestBuiltinRulesExtraBodyFieldsNoSecrets`, `TestCompatRuleExtraBodyFieldsNoSecrets`, gRPC `CompatProfile` round-trip.

## Pre-merge remediation

Reviewers caught 6 blockers; all resolved before push:
1. `o[1-9]-*` glob missed bare `o3`/`o4` (real prod breakage) → widened to `o[1-9]*`.
2. `resolveCompatProfile` factory path at 0% coverage → factory tests added.
3. `MarshalJSON` collision detection error paths at 0% coverage → tests added.
4. `TestBuiltinRulesExtraBodyFieldsNoSecrets` didn't reach `CompatRule()` → per-compat-package test added.
5. Per-`Stream` debug log + warn-log rule description missing → `ResolveWithRules` API added; both logs implemented.
6. `BatchAdapter` registry gap was prose-only → wired registry field structurally.

Plus 8 non-blocking polish items: dual-key UnmarshalJSON error, naming consistency (`OmitSampling` → `OmitSamplingParams`), removed temperature value from warn log (sidechannel), regression test asserts temperature absence for reasoning models, `removeFromOmit` test renamed to signal reserved-helper intent, `ScrubFixture` CI gate, `o10*` forward-compat coverage, misleading UnmarshalJSON comment fixed.

## Verification

- `just` exits 0; `just lint` (golangci-lint v2) reports `0 issues`.
- Quirks package coverage: ~95%.
- Z.ai compat package: 100%.
- All fixtures carry `# synthetic:` source comments per design §6.

## Deferred (Step 3, Step 5, follow-ups)

- Gemini quirks integration → Step 3.
- ReplayFields parse-side recognition → Step 5.
- `docs/provider-quirks.md` replacement → Step 6.
- `response.sse` fixture tests in `testdata/quirks/openai-compatible/` → Step 5 (ReplayFields).
- `_, _ := registry.ResolveWithRules(...)` in `openai_responses.go` doesn't yet thread `q` into `buildResponsesRequest` (no rules consume it in v1) — first Responses rule will thread it.
- Real-capture fixtures replacing the synthetic ones → tracked under #224.
- `resolveCompatProfile` error message hard-codes `\"supported: zai-glm\"` — fine until a second profile lands.
- `canonicalOpenAIFields` duplicated between `provider/openai.go` and `provider/quirks/quirks_test.go` — defer to third consumer per api-design suggestion.

Reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers; remediation brief in workstream scratch. Verdict: NEEDS REMEDIATION (applied).