### PR TITLE
provider/quirks: ReplayFields parse-side recognition + docs replacement (Wave 2 Step 5+6)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -433,16 +433,21 @@ back as a user message. Three implementations ship:
 
 The provider-quirks layer (see
 [`provider-quirks.md`](provider-quirks.md)) surfaces resolution
-observability via slog rather than via span attributes. Each
-`ProviderAdapter.Stream` call emits a `provider quirks resolved`
-DEBUG record naming every contributing rule's description; when a
+observability through both slog records and OTel span attributes
+so log-only and trace-only consumers each see which rules fired.
+Each `ProviderAdapter.Stream` call emits an `openai quirks
+resolved` (or `gemini quirks resolved`) DEBUG record naming every
+contributing rule's description, and sets the matching
+`provider.quirk.applied` attribute on the active span. When a
 rule's `OmitSamplingParams` suppresses a caller-supplied non-nil
 `Temperature`, an `openai quirks suppressed caller temperature`
 WARN record fires naming the responsible rule. When a rule
 registers `ReplayFields` paths and any value is captured during
 the stream, a `quirks replay fields captured` DEBUG record fires
-on stream exit summarising `{count, total_len}` per path —
-length-only, never the captured values themselves.
+on stream exit summarising `{count, total_len}` per path — and
+the same totals are attached to the span as
+`replay_fields_captured.count` / `.total_len`. Length-only on
+both surfaces; never the captured values themselves.
 
 The `harness/internal/observability/` package emits OTel metrics
 alongside tracing: 13 counters (`stirrup.harness.runs`, `.turns`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,6 +321,22 @@ prefix stay distinguishable. A collision that cannot be resolved
 before any request is issued — silent aliasing would route a
 tool_call to the wrong handler.
 
+### Provider-quirks layer
+
+Beneath the tool-name normalization layer, each concrete adapter
+resolves a per-(provider, model) `ProviderQuirks` value at the top
+of every `Stream()` call. The layer handles wire-shape and
+behaviour divergences that the canonical `ProviderAdapter`
+interface cannot express: OpenAI reasoning-class sampling-param
+omissions, Z.ai GLM legacy field names, Gemini 3.x
+`thoughtSignature` capture, DeepSeek `reasoning_content` parse-side
+recognition. The `NormalizingAdapter` wraps the concrete adapter
+from the outside; the quirks resolution sits inside the adapter's
+`Stream()` body. Both layers compose without either knowing about
+the other.
+
+Full reference: [`provider-quirks.md`](provider-quirks.md).
+
 ### Sub-agent spawning
 
 The `spawn_agent` tool creates a fresh `AgenticLoop` with its own
@@ -414,6 +430,19 @@ back as a user message. Three implementations ship:
   verification, permission checks, and git operations. See
   [`observability-cloud.md`](observability-cloud.md) for cloud
   backend setup.
+
+The provider-quirks layer (see
+[`provider-quirks.md`](provider-quirks.md)) surfaces resolution
+observability via slog rather than via span attributes. Each
+`ProviderAdapter.Stream` call emits a `provider quirks resolved`
+DEBUG record naming every contributing rule's description; when a
+rule's `OmitSamplingParams` suppresses a caller-supplied non-nil
+`Temperature`, an `openai quirks suppressed caller temperature`
+WARN record fires naming the responsible rule. When a rule
+registers `ReplayFields` paths and any value is captured during
+the stream, a `quirks replay fields captured` DEBUG record fires
+on stream exit summarising `{count, total_len}` per path —
+length-only, never the captured values themselves.
 
 The `harness/internal/observability/` package emits OTel metrics
 alongside tracing: 13 counters (`stirrup.harness.runs`, `.turns`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,18 @@ the same flags grouped by concern.
 | `--base-url` | (none) | Provider base URL. Required for Azure / gateway scenarios. |
 | `--api-key-header` | (none) | Header name. Empty = `Authorization: Bearer`; set to `api-key` for Azure key auth. |
 | `--query-param key=value` | (none) | Repeatable. Adds query parameters to every provider request URL — e.g. `--query-param api-version=preview` for Azure. Keys here override duplicates already encoded in `--base-url`. |
+| `--provider-compat-profile` | (none) | Closed enum that loads a provider-quirks compatibility profile. Only legal value in v1: `"zai-glm"` (Z.ai GLM legacy `max_tokens` key + `tool_stream: true` extension). Unknown values fail at startup. JSON path: `provider.compatProfile`. |
+
+Wire-shape divergences between provider/model pairs (e.g. OpenAI
+reasoning-class sampling-param omissions, Z.ai GLM legacy field
+names, Gemini 3.x `thoughtSignature` preservation) are not exposed
+on `RunConfig`. They are first-party rules in the
+`harness/internal/provider/quirks` registry, applied per-stream by
+the adapter. The `--provider-compat-profile` flag is the only
+operator-facing surface that influences quirk resolution; all other
+rules apply automatically based on `provider.type` and `model`.
+Introspect with `stirrup providers quirks --provider X --model Y`;
+full reference at [`provider-quirks.md`](provider-quirks.md).
 
 For the full per-adapter wire-format reference, including Azure
 Foundry notes and intentional exclusions, see

--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -1,0 +1,441 @@
+# Provider quirks layer
+
+**Status:** implemented (Wave 2)
+
+The quirks layer encapsulates per-(provider, model) wire-shape and
+behaviour divergences that the canonical `ProviderAdapter` interface
+cannot express. Adapters resolve a `ProviderQuirks` value at the top
+of every `Stream()` call and apply it to request marshalling and
+response parsing. The registry is a first-party Go construct;
+operators do not author quirk rules, but can introspect resolution
+via `stirrup providers quirks --provider X --model Y`.
+
+This document is the canonical specification of the layer. The
+design history (the problem framing, the prior-art survey, the open
+risks) lives in §1 and §9 below.
+
+## 1. Problem
+
+A coding-agent harness has to talk to several model providers, and
+several model families within each provider. Each surface diverges
+in small ways that the canonical `ProviderAdapter` interface cannot
+absorb without either:
+
+- carrying a knob per divergence on the interface (bloat the surface),
+- branching on model substrings inside adapters (drift across adapters), or
+- letting the operator patch the request shape (RunConfig becomes
+  wire-shape).
+
+Concrete v1 divergences:
+
+- OpenAI's reasoning-class models (o-series, gpt-5 except `gpt-5-chat*`)
+  reject `temperature` / `top_p` / `presence_penalty` /
+  `frequency_penalty` / `logprobs` / `top_logprobs` / `logit_bias`
+  with HTTP 400. They require `max_completion_tokens` rather than
+  `max_tokens`.
+- Z.ai's GLM endpoint speaks the OpenAI Chat Completions wire format
+  but requires `max_tokens` (the legacy key) and accepts a
+  proprietary `tool_stream: true` extension.
+- Vertex AI's Gemini 3.x stream emits a `thoughtSignature` blob on
+  every `parts[]` entry that the harness must preserve verbatim for
+  multi-turn reasoning continuity. Issue #194 traced the symptom; the
+  fix is a registry-driven `ReplayFields` capture.
+- DeepSeek's reasoner and v4 families surface chain-of-thought
+  through a `reasoning_content` sibling field on the assistant
+  delta. Parse-side recognition lets the harness expose the field
+  in traces; outbound threading (round-tripping it on the next turn)
+  is a deferred follow-up.
+
+### 1.1 Prior art
+
+LiteLLM, LangChain, the Vercel AI SDK, OpenRouter, and vLLM all
+solve variants of the same problem with a registry of per-model
+rules. The cross-cutting findings their implementations share:
+
+- **One source of truth for send and parse.** Rules that govern
+  request shape and response parsing must be in the same data
+  structure; splitting them produces silent drift when one side is
+  updated and the other is not.
+- **Forward-compatible defaults.** A model id that matches no rule
+  must produce a working request — the zero-rule path is the
+  baseline, not an error.
+
+The quirks layer adopts both invariants. The Codec invariant (one
+resolved `ProviderQuirks` drives both send and parse paths) is the
+load-bearing structural property; the empty-registry path produces
+the same wire body as today's hand-rolled adapters.
+
+## 2. Naming and shape
+
+The layer lives at `harness/internal/provider/quirks/`:
+
+```
+harness/internal/provider/quirks/
+    quirks.go       — ProviderQuirks, Value, ProviderBehaviourFlags,
+                      OpenAIBehaviourFlags, GeminiBehaviourFlags,
+                      OpenAITokenField, GeminiStreamArgsShape types
+    registry.go     — Rule, Registry, Resolve, Date helper
+    builtin.go      — BuiltinRules() — the first-party rule set
+    helpers.go      — applyOpenAIReasoningClass, removeFromOmit,
+                      shared helper fns for rules
+    replay.go       — ReplayFields path parser + walker
+    quirks_test.go  — Resolve, TestBuiltinRulesValidate, TestRuleCarveOuts,
+                      TestNoMetacharsInKnownModelIDs, TestRuleStaleness
+    replay_test.go  — ReplayFields path parser + walker tests
+    testdata/
+        model-ids.txt — catalogue for TestNoMetacharsInKnownModelIDs
+```
+
+Compatibility profiles (operator-selected via
+`provider.compatProfile`) live in a parallel tree:
+
+```
+harness/internal/provider/compat/
+    zai/
+        zai.go      — CompatRule() returning the Z.ai GLM rule
+        zai_test.go — httptest contract test
+```
+
+Fixture trees for the wire-shape contract tests:
+
+```
+harness/internal/provider/testdata/quirks/
+    openai-compatible/<model>/{request.json, response.sse}
+    openai-compatible/<deepseek-model>/{response.sse, replay.json}
+    gemini/<model>/{request.json, response.sse[, replay.json]}
+```
+
+### 2.1 ProviderQuirks
+
+`ProviderQuirks` is the in-memory result of resolving the registry
+for a (providerType, model) pair. Adapters read it when building a
+request and (for paths that diverge) when interpreting a response.
+
+```go
+type ProviderQuirks struct {
+    // Wire-shape overrides.
+    FieldRenames    map[string]string         // canonical adapter field → wire JSON key
+    OmitFields      []string                  // canonical fields the adapter MUST NOT emit
+    ValueOverrides  map[string]Value          // forced serialised value, ignoring StreamParams
+    EnumCoercions   map[string]map[string]string // caller value → wire value
+    ReplayFields    []string                  // assistant-message paths to preserve (parse-side only in v1)
+
+    // Behaviour flags (per-adapter typed sub-structs).
+    BehaviourFlags  ProviderBehaviourFlags
+}
+
+type ProviderBehaviourFlags struct {
+    OpenAI OpenAIBehaviourFlags
+    Gemini GeminiBehaviourFlags
+}
+```
+
+`Registry.Resolve` always returns a `ProviderQuirks` with every map
+and slice pre-initialised so Apply closures can read-modify-write
+without nil guards.
+
+Behaviour-flag sub-structs:
+
+```go
+type OpenAIBehaviourFlags struct {
+    TokenField         OpenAITokenField  // max_completion_tokens (default) or max_tokens
+    OmitSamplingParams bool              // suppress temperature, top_p, penalties, log* fields
+    ExtraBodyFields    map[string]any    // gateway-specific top-level keys (Z.ai's tool_stream)
+}
+
+type GeminiBehaviourFlags struct {
+    StreamFunctionCallArgsShape GeminiStreamArgsShape // off (post-#191 default) / v2_snapshot / v3_deltas
+}
+```
+
+The typed per-adapter sub-struct is the design choice that replaces
+PR #196's original `StructuralFlags any`: it preserves compile-time
+type safety and removes the runtime type-assertion every adapter
+would otherwise need.
+
+### 2.2 Rule and Registry
+
+```go
+type Rule struct {
+    ProviderType string        // exact RunConfig provider.type
+    ModelMatch   string        // path.Match glob; "" matches all models
+    Description  string        // required; surfaces in traces and CLI introspection
+    LastVerified time.Time     // set via Date("YYYY-MM-DD"); staleness signal at 180 days
+    Apply        func(*ProviderQuirks)
+}
+
+type Registry struct { /* unexported */ }
+func NewRegistry(rules []Rule) *Registry
+func DefaultRegistry() *Registry
+func (r *Registry) Resolve(providerType, model string) ProviderQuirks
+func (r *Registry) ResolveWithRules(providerType, model string) (ProviderQuirks, []Rule)
+```
+
+Composition is **specificity-then-declaration-order**: rules with a
+longer `ModelMatch` glob run later so their writes override earlier
+rules. Ties (identical glob length) break on declaration order. An
+empty `ModelMatch` is treated as length 0 and matches every model,
+so a "default for this provider" rule can be declared once and
+overridden by a specific glob. The `gpt-5*` + `gpt-5-chat*` carve-out
+in `BuiltinRules()` is the worked example.
+
+`DefaultRegistry()` is constructed once via `sync.Once` and is
+read-only after construction. Tests inject custom registries via
+the adapter's `Registry *quirks.Registry` field (the field is
+exported on `OpenAICompatibleAdapter` and `GeminiAdapter`).
+
+### 2.3 ReplayFields path syntax
+
+`ReplayFields` lists assistant-message field paths to capture from a
+provider response. The path grammar is intentionally narrow:
+
+```
+path     := segment ( "." segment )*
+segment  := key ( "[]" )?
+key      := [A-Za-z_][A-Za-z0-9_]*
+```
+
+`[]` always means "iterate every element" of an array. A path that
+ends in `[]` is a syntax error (it would name a value rather than a
+field). Indexed access (`[0]`) is intentionally NOT supported in v1:
+a rule that pins a single index is almost certainly modelling
+provider behaviour wrong.
+
+The parser sits in `quirks/replay.go` so both adapters share one
+implementation. `BuiltinRulesValidate` and the
+`TestBuiltinRulesValidate_ReplayFieldsPathsAreSyntacticallyValid`
+test catch malformed paths at registry-build time.
+
+## 3. Wave 2 rules (`BuiltinRules`)
+
+| ProviderType        | ModelMatch         | Description                                                          |
+|---------------------|--------------------|----------------------------------------------------------------------|
+| `openai-compatible` | `o[1-9]*`          | OpenAI reasoning-class (o-series): omit sampling params              |
+| `openai-compatible` | `gpt-5*`           | OpenAI gpt-5 family: omit sampling params                            |
+| `openai-compatible` | `gpt-5-chat*`      | OpenAI gpt-5-chat carve-out: chat-class accepts sampling params      |
+| `openai-compatible` | `deepseek-reasoner*` | DeepSeek reasoner: preserve `reasoning_content` (parse-side only)  |
+| `openai-compatible` | `deepseek-v4*`     | DeepSeek v4: preserve `reasoning_content` (parse-side only)          |
+| `gemini`            | `*`                | Gemini: off `streamFunctionCallArguments` (post-#191 default)        |
+| `gemini`            | `gemini-3*`        | Gemini 3: preserve `thoughtSignature` on `functionCall` parts (parse-side only) |
+
+The compat profile rule for Z.ai GLM is registered separately via
+`harness/internal/provider/compat/zai/CompatRule()`; it is not in
+`BuiltinRules()` and only loads when `provider.compatProfile =
+"zai-glm"` is set.
+
+### 3.1 ReplayFields rules (parse-side only)
+
+The three `ReplayFields` rules added in Wave 2 land **parse-side
+recognition only**. Captured values surface in a per-stream debug
+log so operators can see the rule fired, but the values are not yet
+threaded back into outbound message history. Multi-turn runs against
+affected models continue to fail on turn 2 in the same way they did
+before the rule; the observable improvement is the debug attribute.
+
+Outbound threading is design §9 risk 7 and is tracked separately.
+The Description of every ReplayFields rule ends in `(parse-side
+only)` so trace consumers know the captured value is observable but
+not round-tripped. `TestBuiltinRulesParseSideOnlySuffix` enforces
+the convention.
+
+The captured-fields debug log line is `quirks replay fields
+captured` at slog DEBUG level. It records a per-path summary of
+`{count, total_len}` only — captured values themselves are
+provider-private (DeepSeek reasoning_content, Gemini
+thoughtSignature) and never appear in log sinks.
+`TestReplayFields_DeepSeekReasoner_LogIsLengthOnly` pins the
+side-channel guard.
+
+## 4. Composition with the NormalizingAdapter
+
+The `NormalizingAdapter` (PR #303, merged) wraps the concrete
+adapter and sits **outside** the quirks layer in the call stack. The
+quirks resolution is *inside* the concrete adapter's `Stream()`.
+The factory order is:
+
+```
+loop.Provider
+  └── NormalizingAdapter          ← outermost; tool-name normalization
+        └── OpenAICompatibleAdapter
+              └── quirks.Resolve  ← innermost; wire-shape/behaviour per model
+```
+
+Two separate responsibilities: tool-name normalization is a
+loop→adapter concern; quirk resolution is an adapter→wire concern.
+The factory composes both without either knowing about the other.
+
+## 5. Operator surface
+
+| Surface | How | Notes |
+|---|---|---|
+| `provider.compatProfile` on `ProviderConfig` | `RunConfig` string field | Closed enum. Only legal value in v1: `"zai-glm"`. Unknown values fail at startup via `ValidateRunConfig`. |
+| `stirrup providers quirks --provider X --model Y` | CLI subcommand | Prints resolved `ProviderQuirks` as JSON, plus `Description`, `LastVerified`, staleness flag of every contributing rule. Side-effect-free. |
+| `provider quirks resolved` / `gemini quirks resolved` slog DEBUG line | structured log | One line per Stream call, listing every contributing rule's Description in apply order. Last entry is the rule whose writes won on overlapping fields. Emitted even when no rule fired (rules:[]) so a missing line unambiguously means "the resolution did not run". |
+| `quirks replay fields captured` slog DEBUG line | structured log | Per-stream summary of `{count, total_len}` per captured ReplayFields path, emitted on stream exit. Length-only — captured values themselves are not logged. |
+| `openai quirks suppressed caller temperature` slog WARN line | structured log | Fires when `OmitSamplingParams` suppresses a caller-supplied non-nil `Temperature`. Names the rule that caused the suppression. The suppressed value itself is not logged. |
+
+### 5.1 Read-only registry
+
+Operators cannot author arbitrary quirk rules. Quirks are first-party
+Go code (`harness/internal/provider/quirks/builtin.go`), tested
+exhaustively, and shared across every operator targeting the same
+(provider, model) pair. The introspection subcommand makes the
+registry transparent enough for debugging without needing authoring
+capability.
+
+A future `provider.quirkOverrides` emergency-override field is
+sketched but remains deferred. If operational pressure justifies it,
+the surface must be narrow (only `OmitFields` and `FieldRenames`,
+not `BehaviourFlags`, `ValueOverrides`, or `ReplayFields`) and every
+applied override must fire a `SecurityLogger` event.
+
+## 6. Z.ai compat placement
+
+Z.ai/GLM is a compatibility-only target. The rule lives at
+`harness/internal/provider/compat/zai/zai.go` and exports a single
+`CompatRule()` function. The factory injects it into the registry
+when `provider.compatProfile = "zai-glm"` is set.
+
+`CompatProfile` does not violate the "no wire-shape on `RunConfig`"
+invariant: it is a named profile selector from a closed enum (only
+`""` and `"zai-glm"` are accepted; unknown values fail at startup),
+not a free-form wire-shape patch. The wire-shape knowledge stays in
+the `compat/` package; `RunConfig` carries only a string
+discriminator. This is the same pattern as `provider.type` itself.
+
+`RunConfig.Redact()` is unaffected — `CompatProfile` contains no
+credentials.
+
+Z.ai tests live entirely in
+`harness/internal/provider/compat/zai/zai_test.go` and use
+`httptest.Server` to capture the request body. No live Z.ai calls
+in CI.
+
+## 7. Wire-shape fixture format
+
+Contract tests for the wire-shape rules use real captures (or
+explicitly-marked synthetics) under:
+
+```
+harness/internal/provider/testdata/quirks/<provider-type>/<model>/
+    request.json   — canonical JSON body the adapter produces;
+                     stored in go-sorted-key form (unmarshal →
+                     re-marshal). Updated whenever the rule's Apply
+                     changes.
+    response.sse   — real SSE response body captured from the
+                     upstream, sanitised of auth headers and run
+                     IDs. Synthetic equivalents carry a top-of-file
+                     comment:
+                       "# synthetic: derived from <source> because <reason>"
+    replay.json    — present only for ReplayFields rules; the
+                     post-parse assistant-message snapshot showing
+                     the preserved field shape per captured path.
+```
+
+Capture discipline:
+
+- Secrets (API keys, session tokens, project IDs in URLs, GCP `ya29.*`
+  OAuth tokens) must be scrubbed before committing. The helper
+  `quirkstest.ScrubFixture` enforces the scrub pass; the CI gate
+  `TestFixturesScrubbed` fails the build if a fixture contains a
+  substring the scrubber would rewrite.
+- `quirkstest.AssertWireEqual(t, wantPath, got)` is the canonical
+  form check: unmarshal → re-marshal → byte-compare. Used by every
+  adapter's contract test.
+- Fixtures live in the `provider` module at
+  `harness/internal/provider/testdata/`. They are excluded from the
+  binary via the `_test` convention.
+
+## 8. Adjacent concerns (not part of this layer)
+
+The quirks layer is deliberately scoped to per-(provider, model)
+request-shape and response-parsing divergence. Several adjacent
+concerns are tracked separately:
+
+- **Tool-contract metadata (#222).** Provider-facing tool metadata
+  (strict mode, tool-choice policy, parallel-call policy, input
+  examples, annotations) is a property of `types.ToolDefinition`,
+  keyed by tool name — not by (provider, model). The two
+  cardinalities are different. When #222 lands, each adapter's
+  `translateTools()` will gain the mapping; whether a model supports
+  a given tool feature (e.g. `strict: true`) is a one-line check
+  against the resolved `ProviderQuirks` (likely a `SupportsStrictMode
+  bool` flag on `OpenAIBehaviourFlags`). This is a small extension to
+  the quirks shape, not a redesign.
+- **Toolset profiles and aliases (#234, Wave 5).** Operator-facing
+  toolset selection is a `RunConfig` concern, not a per-model
+  one.
+- **Tool error budgets (#230) and tool-call deduplication (#231,
+  Wave 4).** Loop-level concerns that observe tool-call behaviour
+  across turns, distinct from per-model wire shape.
+
+## 9. Open risks
+
+1. **`openai.go` `max_completion_tokens` is already unconditional on main.**
+   The quirks integration does not restore `max_tokens` for providers
+   that now work fine with `max_completion_tokens`. The Z.ai compat
+   rule deliberately sets `TokenFieldMaxTokens`; all other
+   `openai-compatible` providers default to the existing field.
+   `TestNoRegressionMaxCompletionTokensDefault` pins this.
+
+2. **`OmitSamplingParams` and a caller-supplied non-nil `Temperature`.**
+   When an operator sets `--temperature 0.5` and the model is
+   `o1-mini`, the quirks layer suppresses the temperature field.
+   Mitigation: the debug log line at the top of `Stream()` lists the
+   applied rules, and a warn-level log line fires when a non-nil
+   `Temperature` is suppressed, naming the rule responsible. The
+   suppressed value itself is not logged.
+
+3. **`CompatProfile` string enum vs long-term extensibility.**
+   Starting with a single value (`"zai-glm"`) is fine. The risk is
+   that this field becomes a dumping ground for provider-specific
+   workarounds that should instead be first-party rules. Any new
+   `CompatProfile` value requires both an entry in
+   `validCompatProfiles` and a matching `harness/internal/core/factory.go`
+   switch arm; undocumented strings are errors at startup.
+
+4. **`ExtraBodyFields` and the secrets invariant.** A compat rule
+   that accidentally stored a secret reference in `ExtraBodyFields`
+   would violate the `RunConfig.Redact()` invariant even though
+   `RunConfig` is not involved. Mitigated by
+   `TestBuiltinRulesExtraBodyFieldsNoSecrets`, which asserts no
+   value in any registered rule's `ExtraBodyFields` contains the
+   `secret://` prefix.
+
+5. **Z.ai `tool_stream` semantics ambiguity.** The Z.ai docs
+   describe `tool_stream: true` as enabling streaming tool call
+   results, but it is unclear whether this affects all tool calls or
+   only specific tool types, and whether it changes the SSE event
+   shape on the inbound side. If a live verification finds the
+   inbound shape differs, an `OpenAIBehaviourFlags.StreamToolCallShape`
+   flag will be needed alongside the send-side `ExtraBodyFields`
+   entry.
+
+6. **Glob carve-out fragility.** The `gpt-5-chat*` carve-out depends
+   on specificity ordering; `TestRuleCarveOuts` is the load-bearing
+   negative test.
+
+7. **ReplayFields threading gap.** Wave 2 lands parse-side
+   recognition only. Operators seeing `provider.quirk.applied:
+   ["Gemini 3: preserve thought_signature on functionCall parts
+   (parse-side only)"]` in their trace must not assume the threading
+   is complete. The `(parse-side only)` suffix on every ReplayFields
+   rule's `Description` is the load-bearing observability signal;
+   `TestBuiltinRulesParseSideOnlySuffix` enforces it. Outbound
+   threading is a follow-up.
+
+8. **`DefaultRegistry()` singleton and test isolation.** The
+   singleton is constructed once via `sync.Once` and is read-only
+   after construction. Tests that need a custom rule set use
+   `NewRegistry` and inject via the adapter's exported `Registry`
+   field. `TestDefaultRegistryConcurrentAccess` stresses the
+   singleton under `-race`.
+
+9. **DeepSeek field-path verification gap.** The `reasoning_content`
+   path used by the DeepSeek-reasoner and DeepSeek-v4 rules is
+   sourced from the DeepSeek API documentation, not from a live
+   capture. If a live capture surfaces a different shape (e.g. a
+   structured `thinking` object rather than a flat string), the
+   rule's path and the corresponding `replay.json` fixture need
+   to be adjusted in lockstep. The 180-day staleness window flags
+   the rule for re-verification.

--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -216,7 +216,7 @@ test catch malformed paths at registry-build time.
 | `openai-compatible` | `deepseek-reasoner*` | DeepSeek reasoner: preserve `reasoning_content` (parse-side only)  |
 | `openai-compatible` | `deepseek-v4*`     | DeepSeek v4: preserve `reasoning_content` (parse-side only)          |
 | `gemini`            | `*`                | Gemini: off `streamFunctionCallArguments` (post-#191 default)        |
-| `gemini`            | `gemini-3*`        | Gemini 3: preserve `thoughtSignature` on `functionCall` parts (parse-side only) |
+| `gemini`            | `gemini-3*`        | Gemini 3: preserve `thoughtSignature` as a sibling of `functionCall` on each `parts[]` element (parse-side only) |
 
 The compat profile rule for Z.ai GLM is registered separately via
 `harness/internal/provider/compat/zai/CompatRule()`; it is not in
@@ -227,10 +227,12 @@ The compat profile rule for Z.ai GLM is registered separately via
 
 The three `ReplayFields` rules added in Wave 2 land **parse-side
 recognition only**. Captured values surface in a per-stream debug
-log so operators can see the rule fired, but the values are not yet
-threaded back into outbound message history. Multi-turn runs against
-affected models continue to fail on turn 2 in the same way they did
-before the rule; the observable improvement is the debug attribute.
+log (and as totals on the active OTel span) so operators can see
+the rule fired, but the values are not yet threaded back into
+outbound message history. Multi-turn runs against affected models
+continue to fail on turn 2 in the same way they did before the
+rule; the observable improvement is the slog DEBUG record and the
+matching span attributes.
 
 Outbound threading is design §9 risk 7 and is tracked separately.
 The Description of every ReplayFields rule ends in `(parse-side
@@ -241,10 +243,15 @@ the convention.
 The captured-fields debug log line is `quirks replay fields
 captured` at slog DEBUG level. It records a per-path summary of
 `{count, total_len}` only — captured values themselves are
-provider-private (DeepSeek reasoning_content, Gemini
-thoughtSignature) and never appear in log sinks.
-`TestReplayFields_DeepSeekReasoner_LogIsLengthOnly` pins the
-side-channel guard.
+provider-private (DeepSeek `reasoning_content`, Gemini
+`thoughtSignature` — the latter is a sibling of `functionCall` on
+each `parts[]` element, not a child; see `geminiPart` in
+`harness/internal/provider/gemini_types.go`) and never appear in
+log sinks. The same totals are mirrored onto the OTel span as
+`replay_fields_captured.count` and `replay_fields_captured.total_len`,
+so trace-only consumers see the rule fired without correlating
+back to slog. `TestReplayFields_DeepSeekReasoner_LogIsLengthOnly`
+pins the side-channel guard on the slog side.
 
 ## 4. Composition with the NormalizingAdapter
 
@@ -270,8 +277,10 @@ The factory composes both without either knowing about the other.
 |---|---|---|
 | `provider.compatProfile` on `ProviderConfig` | `RunConfig` string field | Closed enum. Only legal value in v1: `"zai-glm"`. Unknown values fail at startup via `ValidateRunConfig`. |
 | `stirrup providers quirks --provider X --model Y` | CLI subcommand | Prints resolved `ProviderQuirks` as JSON, plus `Description`, `LastVerified`, staleness flag of every contributing rule. Side-effect-free. |
-| `provider quirks resolved` / `gemini quirks resolved` slog DEBUG line | structured log | One line per Stream call, listing every contributing rule's Description in apply order. Last entry is the rule whose writes won on overlapping fields. Emitted even when no rule fired (rules:[]) so a missing line unambiguously means "the resolution did not run". |
+| `openai quirks resolved` / `gemini quirks resolved` slog DEBUG line (per-adapter prefix, identical body shape) | structured log | One line per Stream call, listing every contributing rule's Description in apply order. Last entry is the rule whose writes won on overlapping fields. Emitted even when no rule fired (rules:[]) so a missing line unambiguously means "the resolution did not run". Operators writing log filters should match the exact per-adapter prefix; a generic `"quirks resolved"` substring will not find either record. |
+| `provider.quirk.applied` OTel span attribute | trace attribute | Set on the active `provider.stream` span at the same point the slog DEBUG line is emitted. Carries the same `[]string` of rule Descriptions. Lets a trace-only consumer (Datadog, Honeycomb, Jaeger) see which rules fired without needing to correlate with a separate log sink. |
 | `quirks replay fields captured` slog DEBUG line | structured log | Per-stream summary of `{count, total_len}` per captured ReplayFields path, emitted on stream exit. Length-only — captured values themselves are not logged. |
+| `replay_fields_captured.count` / `replay_fields_captured.total_len` OTel span attributes | trace attributes | Set on the active `provider.stream` span on stream exit, in parallel with the slog DEBUG record above. Totals across every captured path; length-only invariant matches the slog surface. |
 | `openai quirks suppressed caller temperature` slog WARN line | structured log | Fires when `OmitSamplingParams` suppresses a caller-supplied non-nil `Temperature`. Names the rule that caused the suppression. The suppressed value itself is not logged. |
 
 ### 5.1 Read-only registry

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -124,6 +124,30 @@ AI Studio direct support.
 See `examples/runconfig/vertex-gemini.json` and
 `examples/runconfig/vertex-gemini-wif.json`.
 
+## Per-model wire-shape quirks
+
+Provider/model pairs sometimes diverge from the adapter's canonical
+wire shape: OpenAI's reasoning-class models reject sampling
+parameters, Z.ai GLM requires the legacy `max_tokens` key, Gemini
+3.x emits a `thoughtSignature` blob that must survive turn
+boundaries. Rather than encoding these as adapter-internal model
+substring checks, the harness routes them through a registry-driven
+quirks layer at `harness/internal/provider/quirks/`.
+
+Operators do not author quirk rules. Two surfaces are available:
+
+- `provider.compatProfile` on `ProviderConfig` — a closed enum that
+  selects from a small set of compatibility profiles. Only legal
+  value in v1: `"zai-glm"`, which loads the Z.ai GLM compat rule
+  (legacy `max_tokens` key and the `tool_stream: true` extension).
+  Unknown values fail at startup via `ValidateRunConfig`.
+- `stirrup providers quirks --provider X --model Y` — introspection
+  subcommand that prints the resolved `ProviderQuirks` value plus
+  every contributing rule's description, last-verified date, and
+  staleness flag as JSON. Side-effect-free.
+
+Full reference: [`provider-quirks.md`](provider-quirks.md).
+
 ## Credential federation
 
 All five providers consume credentials through `credential.Source.Resolve()`,

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -259,7 +259,7 @@ func (g *GeminiAdapter) Stream(ctx context.Context, params types.StreamParams) (
 
 	ch := make(chan types.StreamEvent, 64)
 	go func() {
-		g.consumeSSE(ctx, resp, ch, start, metricAttrs, streamN, q)
+		g.consumeSSE(ctx, resp, ch, start, metricAttrs, streamN, q, params.Model)
 		g.recordLatency(ctx, start, metricAttrs)
 	}()
 	return ch, nil
@@ -369,10 +369,29 @@ func (g *GeminiAdapter) consumeSSE(
 	metricAttrs metric.MeasurementOption,
 	streamN int64,
 	q quirks.ProviderQuirks,
+	model string,
 ) {
-	_ = q // reserved for Step 5 (ReplayFields parse-side recognition).
 	defer close(ch)
 	defer func() { _ = resp.Body.Close() }()
+
+	// ReplayFields capture (design D12, Wave 2 parse-side recognition).
+	// The accumulator collects every path matched across every chunk
+	// in this stream; the summary is emitted on any exit path via the
+	// deferred log so a stream that ends in an error still surfaces
+	// what was captured before the error. Length-only reporting per
+	// design §5 — captured values are provider-private (Gemini 3.x's
+	// thoughtSignature) and must not land in log sinks.
+	logger := g.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	replayFieldsCapture := map[string][]any{}
+	defer func() {
+		if len(replayFieldsCapture) == 0 {
+			return
+		}
+		logReplayFieldsCapture(ctx, logger, "gemini", model, replayFieldsCapture)
+	}()
 
 	ttfbRecorded := false
 	emitEvent := func(ev types.StreamEvent) {
@@ -475,6 +494,20 @@ func (g *GeminiAdapter) consumeSSE(
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 			emitEvent(types.StreamEvent{Type: "error", Error: fmt.Errorf("parse generateContent chunk: %w", err)})
 			return
+		}
+
+		// ReplayFields capture (design D12, Wave 2 parse-side
+		// recognition). Decode the same chunk bytes a second time as
+		// a generic map so the path walker can descend through fields
+		// the typed chunk struct does not know about. The double
+		// decode is per-chunk only when at least one rule is active —
+		// zero overhead for non-Gemini-3 streams.
+		if len(q.ReplayFields) > 0 {
+			if captured := quirks.CaptureFromJSON([]byte(data), q.ReplayFields); len(captured) > 0 {
+				for k, v := range captured {
+					replayFieldsCapture[k] = append(replayFieldsCapture[k], v...)
+				}
+			}
 		}
 
 		// Walk the first candidate's parts. Vertex always returns at most

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -187,6 +187,18 @@ func (g *GeminiAdapter) Stream(ctx context.Context, params types.StreamParams) (
 		slog.Any("rules", ruleDescriptions(appliedRules)),
 	)
 
+	// Mirror the applied-rules list onto the OTel span as a
+	// `provider.quirk.applied` attribute (design §5). Emitted in
+	// parallel with the slog DEBUG line above so log-only and
+	// trace-only consumers both observe which rules fired. The
+	// IsValid guard tolerates the no-tracer case: when no exporter
+	// is configured, SpanFromContext returns a non-recording span
+	// whose SetAttributes is a no-op anyway, but checking IsValid
+	// keeps the attribute slice allocation off the hot path.
+	if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		span.SetAttributes(attribute.StringSlice("provider.quirk.applied", ruleDescriptions(appliedRules)))
+	}
+
 	body, _, err := BuildGenerateContentRequest(params, g.safety, q)
 	if err != nil {
 		g.recordLatency(ctx, start, metricAttrs)
@@ -389,6 +401,18 @@ func (g *GeminiAdapter) consumeSSE(
 	defer func() {
 		if len(replayFieldsCapture) == 0 {
 			return
+		}
+		// Mirror the per-stream capture summary onto the OTel span
+		// (design §5): emit `replay_fields_captured.count` and
+		// `.total_len` so trace consumers see the rule fired without
+		// having to correlate with slog. Length-only — values stay
+		// off the trace just as they stay off the log.
+		if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+			totalCount, totalLen := summarizeReplayCaptures(replayFieldsCapture)
+			span.SetAttributes(
+				attribute.Int("replay_fields_captured.count", totalCount),
+				attribute.Int("replay_fields_captured.total_len", totalLen),
+			)
 		}
 		logReplayFieldsCapture(ctx, logger, "gemini", model, replayFieldsCapture)
 	}()

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -526,6 +526,15 @@ func (g *GeminiAdapter) consumeSSE(
 		// the typed chunk struct does not know about. The double
 		// decode is per-chunk only when at least one rule is active —
 		// zero overhead for non-Gemini-3 streams.
+		//
+		// Cost note: the typed decode into `generateContentChunk`
+		// above is the load-bearing one; CaptureFromJSON below
+		// re-decodes the same bytes into `any` for untyped path
+		// walking. The cost is one extra json.Unmarshal per chunk,
+		// bounded by the SSE scanner's per-line cap
+		// (geminiMaxScannerBuffer = 16 MiB, set above). Acceptable
+		// because the path is gated by len(q.ReplayFields) > 0 and
+		// only the gemini-3* rule registers ReplayFields today.
 		if len(q.ReplayFields) > 0 {
 			if captured := quirks.CaptureFromJSON([]byte(data), q.ReplayFields); len(captured) > 0 {
 				for k, v := range captured {

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -503,6 +503,15 @@ func (c *openaiChunkChoice) UnmarshalJSON(data []byte) error {
 	if len(helper.Delta) > 0 {
 		c.RawDelta = append(c.RawDelta[:0], helper.Delta...)
 		if err := json.Unmarshal(helper.Delta, &c.Delta); err != nil {
+			// No security.Scrub on the wrapped error: stdlib json
+			// decode errors (UnmarshalTypeError, SyntaxError) carry
+			// only the Go type name and field path — never the
+			// offending value. The gemini adapter does scrub its
+			// HTTP error-body branch (gemini.go around the
+			// resp.StatusCode != 200 path) because that branch
+			// holds the provider's diagnostic prose, which can
+			// contain quota identifiers and trace IDs; the per-
+			// chunk JSON decode here has no such payload.
 			return fmt.Errorf("openaiChunkChoice.delta: %w", err)
 		}
 	}

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -313,6 +314,63 @@ func ruleDescriptions(rules []quirks.Rule) []string {
 	return out
 }
 
+// logReplayFieldsCapture emits a debug-level summary of the per-stream
+// ReplayFields capture (design §5, design D12). Length-only reporting:
+// the captured values themselves are provider-private blobs (DeepSeek's
+// reasoning_content, Gemini's thoughtSignature) that the harness must
+// not echo into any log sink. Operators get presence + size; the rule
+// fired observably without leaking the content.
+//
+// Shared by both adapters so the log shape stays uniform; the
+// helper lives in openai.go because that is where ruleDescriptions
+// already sits.
+func logReplayFieldsCapture(ctx context.Context, logger *slog.Logger, providerType, model string, capture map[string][]any) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	// Sort the path keys so the log output is deterministic across
+	// runs even though Go map iteration order is not. Stable ordering
+	// makes the line greppable across runs and easier to test against.
+	paths := make([]string, 0, len(capture))
+	for k := range capture {
+		paths = append(paths, k)
+	}
+	sort.Strings(paths)
+	// Per-path summary: count of captured pieces and sum of stringified
+	// lengths. The string length is a proxy for "size of what was
+	// captured" that does not require knowing the underlying type; for
+	// non-string values, the JSON encoding's length is the natural
+	// proxy. Errors marshalling a value back to JSON degrade to a
+	// zero length rather than failing the log line.
+	summaries := make([]any, 0, len(paths))
+	for _, p := range paths {
+		values := capture[p]
+		totalLen := 0
+		for _, v := range values {
+			switch s := v.(type) {
+			case string:
+				totalLen += len(s)
+			default:
+				b, err := json.Marshal(v)
+				if err == nil {
+					totalLen += len(b)
+				}
+			}
+		}
+		summaries = append(summaries,
+			slog.Group(p,
+				slog.Int("count", len(values)),
+				slog.Int("total_len", totalLen),
+			),
+		)
+	}
+	logger.DebugContext(ctx, "quirks replay fields captured",
+		slog.String("provider.type", providerType),
+		slog.String("provider.model", model),
+		slog.Group("replay_fields_captured", summaries...),
+	)
+}
+
 // canonicalOpenAIFields enumerates the top-level Chat Completions
 // request fields the adapter knows how to emit. ExtraBodyFields rules
 // must not collide with any of these — the registry self-test guards
@@ -386,10 +444,43 @@ type openaiChunk struct {
 }
 
 // openaiChunkChoice is a single choice within a streaming chunk.
+//
+// RawDelta is the un-decoded JSON bytes of the same delta object that
+// Delta carries — captured so ReplayFields rules (design D12) can walk
+// non-canonical assistant-message fields (e.g. DeepSeek's
+// `reasoning_content`) without the adapter declaring them as typed
+// fields on openaiDelta. Populated by openaiChunkChoice.UnmarshalJSON;
+// the field is on the struct rather than computed lazily so the SSE
+// parse loop accesses it at zero cost when no rule is active.
 type openaiChunkChoice struct {
-	Index        int         `json:"index"`
-	Delta        openaiDelta `json:"delta"`
-	FinishReason *string     `json:"finish_reason"`
+	Index        int             `json:"index"`
+	Delta        openaiDelta     `json:"delta"`
+	FinishReason *string         `json:"finish_reason"`
+	RawDelta     json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON captures the raw bytes of the `delta` field alongside
+// the typed decode. The two-pass shape mirrors openaiRequest's
+// MarshalJSON / UnmarshalJSON: the typed fields drive the normal SSE
+// loop; the RawMessage gives the ReplayFields path walker a document
+// to descend without coupling the walker to the typed struct.
+func (c *openaiChunkChoice) UnmarshalJSON(data []byte) error {
+	type alias openaiChunkChoice
+	var helper struct {
+		alias
+		Delta json.RawMessage `json:"delta"`
+	}
+	if err := json.Unmarshal(data, &helper); err != nil {
+		return err
+	}
+	*c = openaiChunkChoice(helper.alias)
+	if len(helper.Delta) > 0 {
+		c.RawDelta = append(c.RawDelta[:0], helper.Delta...)
+		if err := json.Unmarshal(helper.Delta, &c.Delta); err != nil {
+			return fmt.Errorf("openaiChunkChoice.delta: %w", err)
+		}
+	}
+	return nil
 }
 
 // openaiDelta is the incremental content in a streaming chunk.
@@ -709,7 +800,7 @@ func (o *OpenAICompatibleAdapter) Stream(ctx context.Context, params types.Strea
 
 	ch := make(chan types.StreamEvent, 64)
 	go func() {
-		o.consumeSSE(ctx, resp, ch, start, metricAttrs)
+		o.consumeSSE(ctx, resp, ch, start, metricAttrs, q, logger, params.Model)
 		o.recordLatency(ctx, start, metricAttrs)
 	}()
 	return ch, nil
@@ -730,7 +821,18 @@ func (o *OpenAICompatibleAdapter) recordLatency(ctx context.Context, start time.
 // streamStart and metricAttrs are forwarded for ProviderTTFB measurement: the
 // first non-empty stream event observed marks "time to first byte" for this
 // request. TTFB is recorded at most once per stream.
-func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Response, ch chan<- types.StreamEvent, streamStart time.Time, metricAttrs metric.MeasurementOption) {
+//
+// q carries the resolved per-(provider, model) quirks for this stream
+// (design D5). The parser reads q.ReplayFields and captures the named
+// paths from each chunk's delta object — design D12. The captured set
+// surfaces in a per-stream debug log emitted at the end of the stream
+// (Wave 2 lands parse-side recognition only — outbound threading is
+// deferred per §9 risk 7).
+//
+// logger and model are threaded purely so the per-stream replay-fields
+// debug summary names the model and stays on the same logger the
+// caller-side debug/warn logs use.
+func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Response, ch chan<- types.StreamEvent, streamStart time.Time, metricAttrs metric.MeasurementOption, q quirks.ProviderQuirks, logger *slog.Logger, model string) {
 	defer close(ch)
 	defer func() { _ = resp.Body.Close() }()
 
@@ -748,6 +850,25 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 
 	// Track in-flight tool calls by index for argument accumulation.
 	toolCalls := make(map[int]*openaiToolCallState)
+
+	// replayFieldsCapture is the per-stream accumulator for the
+	// ReplayFields-captured values across every chunk's delta. Keyed by
+	// the rule's path string (verbatim from q.ReplayFields). Stored as
+	// a slice per path so a multi-chunk delta (e.g. DeepSeek's
+	// reasoning_content streamed across multiple chunks) records each
+	// piece in arrival order rather than only the last value. The
+	// terminal log line summarises lengths, not values.
+	replayFieldsCapture := map[string][]any{}
+	// Emit the per-stream ReplayFields summary on any exit path
+	// (normal end, early return on error, ctx cancel). Length-only
+	// reporting per design §5: avoid leaking captured content into
+	// any log sink that consumes DEBUG records.
+	defer func() {
+		if len(replayFieldsCapture) == 0 {
+			return
+		}
+		logReplayFieldsCapture(ctx, logger, "openai-compatible", model, replayFieldsCapture)
+	}()
 
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
@@ -785,6 +906,20 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 		}
 
 		for _, choice := range chunk.Choices {
+			// ReplayFields capture (design D12, Wave 2 parse-side
+			// recognition). Walk the raw delta object once per chunk
+			// and merge any matching paths into the per-stream
+			// accumulator. The path walker is a no-op when
+			// q.ReplayFields is empty so the cost in the zero-rules
+			// case is one slice-length check.
+			if len(q.ReplayFields) > 0 && len(choice.RawDelta) > 0 {
+				if captured := quirks.CaptureFromJSON(choice.RawDelta, q.ReplayFields); len(captured) > 0 {
+					for k, v := range captured {
+						replayFieldsCapture[k] = append(replayFieldsCapture[k], v...)
+					}
+				}
+			}
+
 			// Text content delta.
 			if choice.Delta.Content != nil && *choice.Delta.Content != "" {
 				emitEvent(types.StreamEvent{

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -314,6 +314,32 @@ func ruleDescriptions(rules []quirks.Rule) []string {
 	return out
 }
 
+// summarizeReplayCaptures sums per-path piece counts and the string-or-
+// JSON-encoded length of every captured value across the whole map. The
+// same length proxy logReplayFieldsCapture uses (raw string length for
+// string values, json.Marshal length otherwise) so the span attribute
+// and the slog summary agree. Returned as totals only — never per-path,
+// never per-value — so callers can attach the summary to an OTel span
+// without enumerating field names that would balloon attribute count
+// on a multi-rule stream.
+func summarizeReplayCaptures(capture map[string][]any) (totalCount, totalLen int) {
+	for _, values := range capture {
+		totalCount += len(values)
+		for _, v := range values {
+			switch s := v.(type) {
+			case string:
+				totalLen += len(s)
+			default:
+				b, err := json.Marshal(v)
+				if err == nil {
+					totalLen += len(b)
+				}
+			}
+		}
+	}
+	return totalCount, totalLen
+}
+
 // logReplayFieldsCapture emits a debug-level summary of the per-stream
 // ReplayFields capture (design §5, design D12). Length-only reporting:
 // the captured values themselves are provider-private blobs (DeepSeek's
@@ -711,6 +737,20 @@ func (o *OpenAICompatibleAdapter) Stream(ctx context.Context, params types.Strea
 		slog.Any("rules", ruleDescriptions(appliedRules)),
 	)
 
+	// Mirror the applied-rules list onto the OTel span as a
+	// `provider.quirk.applied` attribute (design §5). The slog DEBUG
+	// line and the span attribute are emitted together so log-only
+	// (Cloud Logging) and trace-only (Jaeger, Honeycomb, Datadog)
+	// consumers both observe which rules fired. The IsValid guard
+	// tolerates the no-tracer case: when no exporter is configured,
+	// SpanFromContext returns a non-recording span whose
+	// SetAttributes is a no-op anyway, but checking IsValid keeps the
+	// attribute slice allocation off the hot path when no tracer is
+	// attached.
+	if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		span.SetAttributes(attribute.StringSlice("provider.quirk.applied", ruleDescriptions(appliedRules)))
+	}
+
 	// Warn-level log when a caller-supplied non-nil Temperature is
 	// suppressed by a quirk rule (design risk 2, §9). The reasoning-
 	// class rules omit temperature outright; without this signal an
@@ -866,6 +906,19 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 	defer func() {
 		if len(replayFieldsCapture) == 0 {
 			return
+		}
+		// Mirror the per-stream capture summary onto the OTel span
+		// (design §5): emit `replay_fields_captured.count` and
+		// `.total_len` so trace consumers see the rule fired without
+		// having to correlate with slog. Length-only — values stay
+		// off the trace just as they stay off the log. The IsValid
+		// guard keeps the marshal cost off the no-tracer path.
+		if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+			totalCount, totalLen := summarizeReplayCaptures(replayFieldsCapture)
+			span.SetAttributes(
+				attribute.Int("replay_fields_captured.count", totalCount),
+				attribute.Int("replay_fields_captured.total_len", totalLen),
+			)
 		}
 		logReplayFieldsCapture(ctx, logger, "openai-compatible", model, replayFieldsCapture)
 	}()

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -371,6 +371,58 @@ func TestOpenAIAdapter_OmitSamplingParams_WarnsOnSuppressedTemperatureWithRuleDe
 	}
 }
 
+// TestLogReplayFieldsCapture_NonStringValue exercises the
+// non-string fallback branch in logReplayFieldsCapture's per-value
+// switch. The default arm runs json.Marshal on the value to compute
+// its length contribution; without this test, the side-channel
+// safety invariant (length only, never the value) was unverified
+// for any captured value type other than string.
+//
+// Current ReplayFields rules only register string-typed fields
+// (reasoning_content, thoughtSignature), but CaptureReplayFields
+// can return any JSON value type, and the helper is the safety
+// gate for future rules. The test pins three properties: the log
+// line is emitted, it contains the field name and length metadata,
+// and it does NOT contain the literal value (the leakage we
+// guard against).
+func TestLogReplayFieldsCapture_NonStringValue(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Use a float64 value that, when JSON-marshalled, yields a
+	// distinctive substring ("123.45"). The default branch in the
+	// type switch is the one that fires here — strings short-circuit
+	// on the typed case before reaching the marshal path.
+	capture := map[string][]any{
+		"reasoning_content": {float64(123.45)},
+	}
+	logReplayFieldsCapture(context.Background(), logger, "openai-compatible", "deepseek-reasoner", capture)
+
+	out := buf.String()
+	if !strings.Contains(out, "quirks replay fields captured") {
+		t.Fatalf("log line missing; got: %s", out)
+	}
+	if !strings.Contains(out, "reasoning_content") {
+		t.Errorf("log line missing field name 'reasoning_content'; got: %s", out)
+	}
+	if !strings.Contains(out, `"count":1`) {
+		t.Errorf("log line missing count=1; got: %s", out)
+	}
+	// json.Marshal(float64(123.45)) = "123.45" (6 bytes). The
+	// total_len must equal 6. Pin it exactly to catch any future
+	// regression that decides to skip the default branch.
+	if !strings.Contains(out, `"total_len":6`) {
+		t.Errorf("log line missing total_len=6; got: %s", out)
+	}
+	// The value itself must NOT appear in the log under any
+	// representation. "123.45" is the canonical JSON form and the
+	// one the marshal path would emit if a future refactor swapped
+	// length-reporting for value-reporting.
+	if strings.Contains(out, "123.45") {
+		t.Errorf("log leaked non-string value 123.45 (length-only invariant violated); got: %s", out)
+	}
+}
+
 // TestOpenAIChunkChoice_UnmarshalJSON covers the custom decoder's
 // three observable states: a chunk with no delta key (the false-
 // branch of the len(helper.Delta) > 0 guard), a chunk with a

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -371,6 +371,75 @@ func TestOpenAIAdapter_OmitSamplingParams_WarnsOnSuppressedTemperatureWithRuleDe
 	}
 }
 
+// TestOpenAIChunkChoice_UnmarshalJSON covers the custom decoder's
+// three observable states: a chunk with no delta key (the false-
+// branch of the len(helper.Delta) > 0 guard), a chunk with a
+// malformed delta value (the json.Unmarshal error return), and a
+// chunk with a valid delta (the happy path that populates both
+// RawDelta and the typed Delta). Coverage on the decoder was 80%
+// before this test — the no-delta branch and the error-return
+// branch were both uncovered, leaving production-critical per-
+// chunk paths unverified.
+func TestOpenAIChunkChoice_UnmarshalJSON(t *testing.T) {
+	t.Run("no_delta", func(t *testing.T) {
+		raw := []byte(`{"index":0,"finish_reason":"stop"}`)
+		var c openaiChunkChoice
+		if err := json.Unmarshal(raw, &c); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if c.RawDelta != nil {
+			t.Errorf("RawDelta = %q, want nil (no delta key present)", c.RawDelta)
+		}
+		// Delta must remain the zero value: no Role, no Content, no
+		// ToolCalls.
+		if c.Delta.Role != "" || c.Delta.Content != nil || len(c.Delta.ToolCalls) > 0 {
+			t.Errorf("Delta = %+v, want zero value", c.Delta)
+		}
+		if c.Index != 0 {
+			t.Errorf("Index = %d, want 0", c.Index)
+		}
+		if c.FinishReason == nil || *c.FinishReason != "stop" {
+			t.Errorf("FinishReason = %v, want \"stop\"", c.FinishReason)
+		}
+	})
+	t.Run("malformed_delta", func(t *testing.T) {
+		// A non-object delta cannot decode into openaiDelta (which is
+		// a struct); the typed Unmarshal returns a UnmarshalTypeError
+		// that the custom UnmarshalJSON wraps under
+		// "openaiChunkChoice.delta:". The error must surface.
+		raw := []byte(`{"index":0,"delta":"not-an-object"}`)
+		var c openaiChunkChoice
+		err := json.Unmarshal(raw, &c)
+		if err == nil {
+			t.Fatalf("Unmarshal returned no error; expected delta decode failure")
+		}
+		if !strings.Contains(err.Error(), "openaiChunkChoice.delta") {
+			t.Errorf("error = %q, want substring \"openaiChunkChoice.delta\"", err.Error())
+		}
+	})
+	t.Run("valid_delta", func(t *testing.T) {
+		raw := []byte(`{"index":0,"delta":{"role":"assistant","content":"hello"}}`)
+		var c openaiChunkChoice
+		if err := json.Unmarshal(raw, &c); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if c.Delta.Role != "assistant" {
+			t.Errorf("Delta.Role = %q, want \"assistant\"", c.Delta.Role)
+		}
+		if c.Delta.Content == nil || *c.Delta.Content != "hello" {
+			t.Errorf("Delta.Content = %v, want \"hello\"", c.Delta.Content)
+		}
+		// RawDelta must hold the raw bytes of the delta object so a
+		// ReplayFields walker can descend without coupling to the
+		// typed struct. The bytes are not whitespace-normalised; an
+		// exact match is the strongest assertion.
+		const wantRaw = `{"role":"assistant","content":"hello"}`
+		if string(c.RawDelta) != wantRaw {
+			t.Errorf("RawDelta = %q, want %q", string(c.RawDelta), wantRaw)
+		}
+	})
+}
+
 // TestOpenAIAdapter_DebugLogListsAppliedRules pins the per-Stream
 // debug line from design §5: the line fires at the top of every
 // Stream call and lists the descriptions of the rules that

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -85,5 +85,80 @@ func BuiltinRules() []Rule {
 				q.BehaviourFlags.Gemini.StreamFunctionCallArgsShape = StreamArgsOff
 			},
 		},
+		// --- ReplayFields rules (design §6.5, D12) ---
+		//
+		// Wave 2 lands parse-side recognition only. Each rule's
+		// Description ends in "(parse-side only)" so trace consumers
+		// know the captured value is observable but not yet threaded
+		// back into outbound history. Outbound threading is design
+		// §9 risk 7, deferred to a follow-up.
+		//
+		// The Description suffix is enforced by
+		// TestBuiltinRulesParseSideOnlySuffix in replay_test.go.
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "deepseek-reasoner*",
+			Description:  "DeepSeek reasoner: preserve reasoning_content (parse-side only)",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// DeepSeek's reasoner family surfaces its chain-of-
+				// thought as a `reasoning_content` field on each
+				// assistant delta, alongside the canonical `content`
+				// field. The DeepSeek API docs describe the field as
+				// part of the model's response, and the openai-
+				// compatible streaming layout places it at the same
+				// nesting level as `content` (a direct child of
+				// `delta`). The single-segment path captures it
+				// directly when the adapter walks the choice's raw
+				// delta object.
+				//
+				// Field-path verification status: unverified against a
+				// live DeepSeek-reasoner capture as of LastVerified.
+				// Mark the rule stale if not re-verified within the
+				// 180-day window; the staleness test will surface it.
+				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+			},
+		},
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "deepseek-v4*",
+			Description:  "DeepSeek v4: preserve reasoning_content (parse-side only)",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// DeepSeek's v4 series uses the same reasoning_content
+				// field on the assistant delta as the reasoner family
+				// per the DeepSeek API documentation. If a future v4
+				// release diverges (e.g. adopts a structured
+				// `thinking` field instead) the rule needs a
+				// LastVerified bump and the path adjusted; the
+				// staleness test will surface the prompt.
+				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+			},
+		},
+		{
+			ProviderType: "gemini",
+			ModelMatch:   "gemini-3*",
+			Description:  "Gemini 3: preserve thoughtSignature on functionCall parts (parse-side only)",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// Gemini 3.x emits `thoughtSignature` as a sibling
+				// field on every `parts[]` entry alongside the
+				// `functionCall` or `text` discriminator (see
+				// gemini_types.go::geminiPart). The signature is
+				// part-level state, not a child of the functionCall
+				// itself — a path that descends through functionCall
+				// captures nothing (pinned by
+				// TestCaptureReplayFields_GeminiToolCall in
+				// replay_test.go).
+				//
+				// The path uses [] array iteration twice because the
+				// response shape nests candidates (a list, even when
+				// only one is requested) of content with parts (also
+				// a list, one per textual/functionCall chunk).
+				q.ReplayFields = append(q.ReplayFields,
+					"candidates[].content.parts[].thoughtSignature",
+				)
+			},
+		},
 	}
 }

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -368,6 +368,98 @@ func TestGeminiRule_NoMatchOnOpenAICompatProvider(t *testing.T) {
 	}
 }
 
+// TestReplayFieldsRules_DeepSeekReasoner pins the DeepSeek-reasoner
+// rule fires and populates ReplayFields with the documented path.
+// The defensive isolation cases assert the rule does NOT fire for
+// other DeepSeek-family models (e.g. deepseek-v3) and does NOT fire
+// when the same model name is routed through a non-openai-compatible
+// provider.
+func TestReplayFieldsRules_DeepSeekReasoner(t *testing.T) {
+	t.Run("fires on deepseek-reasoner", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "deepseek-reasoner")
+		if len(q.ReplayFields) != 1 || q.ReplayFields[0] != "reasoning_content" {
+			t.Errorf("ReplayFields = %v, want [reasoning_content]", q.ReplayFields)
+		}
+	})
+	t.Run("fires on deepseek-reasoner-lite (suffix variant)", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "deepseek-reasoner-lite")
+		if len(q.ReplayFields) != 1 || q.ReplayFields[0] != "reasoning_content" {
+			t.Errorf("ReplayFields = %v, want [reasoning_content]", q.ReplayFields)
+		}
+	})
+	t.Run("does not fire on unrelated openai-compatible models", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "deepseek-chat")
+		if len(q.ReplayFields) != 0 {
+			t.Errorf("deepseek-chat must not fire deepseek-reasoner rule; got ReplayFields=%v", q.ReplayFields)
+		}
+	})
+	t.Run("does not fire when routed through a different provider", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("gemini", "deepseek-reasoner")
+		for _, p := range q.ReplayFields {
+			if p == "reasoning_content" {
+				t.Errorf("DeepSeek rule leaked into Gemini provider resolution: %v", q.ReplayFields)
+			}
+		}
+	})
+}
+
+// TestReplayFieldsRules_DeepSeekV4 mirrors DeepSeekReasoner for the
+// v4 family rule. Same shape, different glob.
+func TestReplayFieldsRules_DeepSeekV4(t *testing.T) {
+	t.Run("fires on deepseek-v4", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "deepseek-v4")
+		if len(q.ReplayFields) != 1 || q.ReplayFields[0] != "reasoning_content" {
+			t.Errorf("ReplayFields = %v, want [reasoning_content]", q.ReplayFields)
+		}
+	})
+	t.Run("fires on deepseek-v4-chat", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "deepseek-v4-chat")
+		if len(q.ReplayFields) != 1 || q.ReplayFields[0] != "reasoning_content" {
+			t.Errorf("ReplayFields = %v, want [reasoning_content]", q.ReplayFields)
+		}
+	})
+	t.Run("does not fire on deepseek-v3 (no rule)", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "deepseek-v3")
+		if len(q.ReplayFields) != 0 {
+			t.Errorf("deepseek-v3 must not fire deepseek-v4 rule; got ReplayFields=%v", q.ReplayFields)
+		}
+	})
+}
+
+// TestReplayFieldsRules_Gemini3 pins the gemini-3* ReplayFields rule:
+// fires on gemini-3* model ids, captures the sibling-of-functionCall
+// thoughtSignature path, and does not fire on 2.x or on
+// openai-compatible resolutions that happen to use a Gemini-like model
+// name.
+func TestReplayFieldsRules_Gemini3(t *testing.T) {
+	t.Run("fires on gemini-3.1-pro-preview", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("gemini", "gemini-3.1-pro-preview")
+		wantPath := "candidates[].content.parts[].thoughtSignature"
+		found := false
+		for _, p := range q.ReplayFields {
+			if p == wantPath {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Gemini 3 rule did not register %q; got ReplayFields=%v", wantPath, q.ReplayFields)
+		}
+	})
+	t.Run("does not fire on gemini-2.5-pro", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("gemini", "gemini-2.5-pro")
+		if len(q.ReplayFields) != 0 {
+			t.Errorf("gemini-2.5-pro must not fire gemini-3* rule; got ReplayFields=%v", q.ReplayFields)
+		}
+	})
+	t.Run("does not fire when routed through openai-compatible", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "gemini-3.1-pro-preview")
+		if len(q.ReplayFields) != 0 {
+			t.Errorf("Gemini 3 rule leaked into openai-compatible resolution: %v", q.ReplayFields)
+		}
+	})
+}
+
 // TestRuleStaleness logs (does not fail) any rule whose LastVerified
 // is more than 180 days behind today. Per design §2.3 staleness is a
 // signal, not an error — re-verification is the response, not breaking

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -102,14 +102,12 @@ func TestBuiltinRulesValidate(t *testing.T) {
 		}
 		if rule.Apply == nil {
 			t.Errorf("BuiltinRules()[%d] (%q): Apply is required", i, rule.Description)
+			continue
 		}
 		// Canonical-field check: materialise the rule's effect on a
 		// fresh ProviderQuirks and assert every FieldRenames key
 		// (the source side of the rename) is in the canonical set.
 		// Rules that don't touch FieldRenames are no-ops here.
-		if rule.Apply == nil {
-			continue
-		}
 		if rule.ProviderType != "openai-compatible" {
 			// The canonical-field check applies only to openai-compatible
 			// rules today. The Gemini base rule (added in Step 3) sets a

--- a/harness/internal/provider/quirks/replay.go
+++ b/harness/internal/provider/quirks/replay.go
@@ -60,6 +60,13 @@ type ReplayPathSegment struct {
 // The parser is intentionally small and table-driven so the surface
 // stays auditable. Callers should treat the returned segments as
 // immutable — the walker reads them many times per response.
+//
+// Precondition: paths come from first-party BuiltinRules() only.
+// There is no operator-injectable path surface in v1, so no
+// segment-count or key-length cap is enforced here. If a future
+// provider.quirkOverrides surface (design §5.1) ever lets operators
+// author paths, enforce caps (e.g. 16 segments, 64-byte keys) at
+// that injection point before the path reaches ParseReplayPath.
 func ParseReplayPath(path string) ([]ReplayPathSegment, error) {
 	if path == "" {
 		return nil, fmt.Errorf("quirks: empty replay path")

--- a/harness/internal/provider/quirks/replay.go
+++ b/harness/internal/provider/quirks/replay.go
@@ -1,0 +1,227 @@
+package quirks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// This file implements the shared ReplayFields path parser and walker.
+// ReplayFields is the design D12 surface: a rule lists assistant-message
+// field paths that should be captured from a provider response so the
+// agentic loop can echo them back on the next turn. Wave 2 lands
+// parse-side recognition only (design §9 risk 7) — the captured values
+// surface in trace attributes so an operator can see the rule fired,
+// but they are not yet threaded back into outbound message history.
+//
+// The parser is cross-adapter: both openai.go and gemini.go call it
+// against their decoded SSE payloads, so the path syntax is the only
+// place that needs to stay coherent across providers. A rule author
+// who writes "candidates[].content.parts[].functionCall.thoughtSignature"
+// for Gemini and "reasoning_content" for DeepSeek can rely on the same
+// semantics: dot-separated keys descend objects, `[]` iterates arrays
+// of objects.
+//
+// Path grammar (informal):
+//
+//   path     := segment ( "." segment )*
+//   segment  := key ( "[]" )?
+//   key      := [A-Za-z_][A-Za-z0-9_]*
+//
+// `[]` always means "iterate every element". A path that ends in `[]`
+// would name a value rather than a key, which is meaningless for
+// ReplayFields (the surface is keyed on field names), so a trailing
+// `[]` is a syntax error. Indexed access (`[0]`) is intentionally NOT
+// supported in v1: a rule that wants to pin a single index is almost
+// certainly modelling provider behaviour wrong (e.g. assuming Gemini
+// only ever returns one candidate).
+//
+// The parser is strict: bad paths return an error from
+// ValidateReplayPath, called from BuiltinRulesValidate, so a typo in a
+// rule fails the test rather than silently capturing nothing at parse
+// time. A bad path that somehow reaches the walker logs at debug and
+// captures nothing, matching the "loudly elsewhere, safe at runtime"
+// pattern used by RuleMatches.
+
+// ReplayPathSegment is one decoded segment of a ReplayFields path.
+// Key is the JSON field name; IsArray reports whether the segment is
+// followed by `[]`, meaning the walker should iterate the value as an
+// array of objects rather than treating it as the terminal value.
+type ReplayPathSegment struct {
+	Key     string
+	IsArray bool
+}
+
+// ParseReplayPath decodes one path string into its ordered segments.
+// Returns an error when the input is empty, contains an empty segment
+// ("a..b"), uses an unsupported character in a key, or ends with `[]`
+// (which would name a value, not a field).
+//
+// The parser is intentionally small and table-driven so the surface
+// stays auditable. Callers should treat the returned segments as
+// immutable — the walker reads them many times per response.
+func ParseReplayPath(path string) ([]ReplayPathSegment, error) {
+	if path == "" {
+		return nil, fmt.Errorf("quirks: empty replay path")
+	}
+	rawSegments := strings.Split(path, ".")
+	out := make([]ReplayPathSegment, 0, len(rawSegments))
+	for i, raw := range rawSegments {
+		if raw == "" {
+			return nil, fmt.Errorf("quirks: empty segment at position %d in replay path %q", i, path)
+		}
+		seg := ReplayPathSegment{Key: raw}
+		if strings.HasSuffix(raw, "[]") {
+			seg.IsArray = true
+			seg.Key = strings.TrimSuffix(raw, "[]")
+			if seg.Key == "" {
+				return nil, fmt.Errorf("quirks: bare [] without a key at position %d in replay path %q", i, path)
+			}
+		}
+		if !isValidReplayKey(seg.Key) {
+			return nil, fmt.Errorf("quirks: invalid key %q at position %d in replay path %q", seg.Key, i, path)
+		}
+		out = append(out, seg)
+	}
+	// A trailing `[]` would mean "iterate the values at the terminal
+	// position" — meaningless for a field-capture surface. Forbid it so
+	// rule authors notice the typo at registry-build time rather than
+	// at runtime when nothing is captured.
+	if out[len(out)-1].IsArray {
+		return nil, fmt.Errorf("quirks: replay path %q ends in [] — paths must terminate on a field name, not an array iteration", path)
+	}
+	return out, nil
+}
+
+// ValidateReplayPath reports whether the supplied path is syntactically
+// valid. Used by BuiltinRulesValidate to fail the build on a rule that
+// names a malformed path; the walker does not need to re-validate
+// because parsed paths are cached at adapter startup.
+func ValidateReplayPath(path string) error {
+	_, err := ParseReplayPath(path)
+	return err
+}
+
+// isValidReplayKey reports whether s is a syntactically valid JSON
+// field-name segment under the ReplayFields grammar. Restricted to
+// `[A-Za-z_][A-Za-z0-9_]*` so the path syntax has no overlap with the
+// reserved `.` separator or the `[]` array marker. Provider field names
+// that violate this set (e.g. a literal dot in a key) cannot be
+// expressed; if a real upstream emits such a key, the grammar needs a
+// quoting form before the rule can reference it.
+func isValidReplayKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r == '_':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// CaptureReplayFields walks a decoded JSON document (a map or slice
+// produced by encoding/json into `any`) and returns the value at each
+// supplied path. Paths that do not resolve are silently skipped —
+// missing fields are the common case (a v3 thoughtSignature on a v2.5
+// response, for instance), not an error.
+//
+// The returned map is keyed by the original path string (verbatim from
+// ReplayFields), so consumers can render trace attributes without
+// re-deriving the source key. Map iteration order is non-deterministic
+// in Go; callers that need stable ordering should sort the keys
+// themselves.
+//
+// Each captured value is the raw decoded JSON value (`string`,
+// `float64`, `map[string]any`, etc.). Trace consumers stringify
+// downstream as appropriate. For paths with `[]` segments, multiple
+// values may exist; the returned slice holds them in walk order.
+//
+// CaptureReplayFields is intentionally tolerant of malformed paths at
+// runtime: a path that fails ParseReplayPath is silently dropped
+// rather than panicking. The rule registry's build-time validator
+// catches the malformed path; if it slips through, runtime stays safe.
+func CaptureReplayFields(doc any, paths []string) map[string][]any {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := map[string][]any{}
+	for _, raw := range paths {
+		segments, err := ParseReplayPath(raw)
+		if err != nil {
+			continue
+		}
+		values := walkReplayPath(doc, segments)
+		if len(values) > 0 {
+			out[raw] = values
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// walkReplayPath recursively descends doc according to segments.
+// At each step, an array-marked segment iterates every element of the
+// value at the key; a non-array segment descends into a single value.
+// Returns the collected leaf values in walk order; a path that fails
+// to resolve returns nil.
+func walkReplayPath(doc any, segments []ReplayPathSegment) []any {
+	if len(segments) == 0 {
+		// Terminal: return the document itself. The non-empty path
+		// invariant on ParseReplayPath means this branch is only
+		// reached after at least one segment has been consumed.
+		if doc == nil {
+			return nil
+		}
+		return []any{doc}
+	}
+	seg := segments[0]
+	rest := segments[1:]
+
+	obj, ok := doc.(map[string]any)
+	if !ok {
+		return nil
+	}
+	val, ok := obj[seg.Key]
+	if !ok || val == nil {
+		return nil
+	}
+
+	if !seg.IsArray {
+		return walkReplayPath(val, rest)
+	}
+	arr, ok := val.([]any)
+	if !ok {
+		return nil
+	}
+	var collected []any
+	for _, el := range arr {
+		collected = append(collected, walkReplayPath(el, rest)...)
+	}
+	return collected
+}
+
+// CaptureFromJSON is a convenience wrapper around CaptureReplayFields
+// that takes raw JSON bytes. Used by the openai adapter's parse hook,
+// which has a json.RawMessage in hand rather than a decoded map.
+// Returns nil on a decode error — the SSE parser is the authoritative
+// reporter for chunk-level decode failures; this wrapper does not
+// duplicate that error path.
+func CaptureFromJSON(raw json.RawMessage, paths []string) map[string][]any {
+	if len(raw) == 0 || len(paths) == 0 {
+		return nil
+	}
+	var doc any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil
+	}
+	return CaptureReplayFields(doc, paths)
+}

--- a/harness/internal/provider/quirks/replay_test.go
+++ b/harness/internal/provider/quirks/replay_test.go
@@ -1,0 +1,403 @@
+package quirks
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestParseReplayPath_Valid covers the four legal segment shapes:
+// a single key, a dotted chain, a key followed by `[]` to iterate an
+// array of objects, and a chain that mixes both. The expected segments
+// list is checked by reflect.DeepEqual so a future widening of the
+// segment struct (e.g. an explicit index for the unsupported [N]
+// form) fails this test rather than silently passing.
+func TestParseReplayPath_Valid(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want []ReplayPathSegment
+	}{
+		{
+			name: "single key",
+			path: "reasoning_content",
+			want: []ReplayPathSegment{{Key: "reasoning_content"}},
+		},
+		{
+			name: "dotted chain",
+			path: "delta.reasoning_content",
+			want: []ReplayPathSegment{{Key: "delta"}, {Key: "reasoning_content"}},
+		},
+		{
+			name: "array iteration in the middle",
+			path: "candidates[].content.parts[].functionCall.thoughtSignature",
+			want: []ReplayPathSegment{
+				{Key: "candidates", IsArray: true},
+				{Key: "content"},
+				{Key: "parts", IsArray: true},
+				{Key: "functionCall"},
+				{Key: "thoughtSignature"},
+			},
+		},
+		{
+			name: "underscore-only key",
+			path: "_internal_field",
+			want: []ReplayPathSegment{{Key: "_internal_field"}},
+		},
+		{
+			name: "digits allowed after first char",
+			path: "field1.subfield2",
+			want: []ReplayPathSegment{{Key: "field1"}, {Key: "subfield2"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseReplayPath(tc.path)
+			if err != nil {
+				t.Fatalf("ParseReplayPath(%q): %v", tc.path, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseReplayPath(%q) = %+v, want %+v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseReplayPath_Invalid pins every error arm. Each case fails
+// because a typo or unsupported construct would otherwise silently
+// capture nothing at runtime — better to fail at registry build time.
+func TestParseReplayPath_Invalid(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"empty path", ""},
+		{"empty segment in the middle", "a..b"},
+		{"empty leading segment", ".a"},
+		{"empty trailing segment", "a."},
+		{"trailing array iteration", "candidates[]"},
+		{"leading digit in key", "1field"},
+		{"hyphen in key", "field-name"},
+		{"space in key", "field name"},
+		{"dot in key (would need quoting)", ""},
+		{"bare brackets", "[]"},
+		{"key with just brackets after a dot", "a.[]"},
+	}
+	for _, tc := range cases {
+		if tc.path == "" && tc.name != "empty path" {
+			// "dot in key (would need quoting)" — empty placeholder
+			// to document the absent feature; skip the actual assertion.
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseReplayPath(tc.path)
+			if err == nil {
+				t.Errorf("ParseReplayPath(%q): expected error, got nil", tc.path)
+			}
+		})
+	}
+}
+
+// TestValidateReplayPath_DelegatesToParse confirms ValidateReplayPath
+// is a thin wrapper. The build-time validator relies on this
+// equivalence — a rule that survives ValidateReplayPath must also
+// parse cleanly at runtime.
+func TestValidateReplayPath_DelegatesToParse(t *testing.T) {
+	if err := ValidateReplayPath("a.b.c"); err != nil {
+		t.Errorf("expected nil error for valid path: %v", err)
+	}
+	if err := ValidateReplayPath("a..b"); err == nil {
+		t.Error("expected error for invalid path")
+	}
+}
+
+// TestCaptureReplayFields_GeminiToolCall is the load-bearing fixture
+// for the Gemini 3.x ReplayFields rule. The shape mirrors the
+// gemini-3.1-pro-preview/response.sse fixture: one candidate, one
+// part, a functionCall with a thoughtSignature. The path that the
+// rule registers must surface the captured value here so a rule
+// regression fails this test rather than only being caught at
+// fixture-comparison time.
+func TestCaptureReplayFields_GeminiToolCall(t *testing.T) {
+	doc := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"role": "model",
+					"parts": []any{
+						map[string]any{
+							"functionCall": map[string]any{
+								"name": "read_file",
+								"args": map[string]any{"path": "main.go"},
+							},
+							"thoughtSignature": "AY89a18t+D98lADcFYKgjMgoHS7rOPAQUE==",
+						},
+					},
+				},
+				"finishReason": "STOP",
+				"index":        float64(0),
+			},
+		},
+	}
+	// thoughtSignature lives ON the part, alongside functionCall — it
+	// is NOT a child of functionCall. A rule that drills through
+	// functionCall.thoughtSignature would silently capture nothing.
+	// This negative assertion guards against a rule author writing
+	// such a path and assuming it works without running the test.
+	out := CaptureReplayFields(doc, []string{
+		"candidates[].content.parts[].functionCall.thoughtSignature",
+	})
+	if len(out) != 0 {
+		t.Errorf("path through functionCall must NOT capture sibling thoughtSignature; got %v", out)
+	}
+
+	// The correct path for Gemini 3.x's wire shape descends to the
+	// part, then reads the sibling field.
+	out = CaptureReplayFields(doc, []string{
+		"candidates[].content.parts[].thoughtSignature",
+	})
+	values, ok := out["candidates[].content.parts[].thoughtSignature"]
+	if !ok {
+		t.Fatalf("expected captured thoughtSignature; got map %v", out)
+	}
+	if len(values) != 1 {
+		t.Fatalf("expected exactly 1 captured value, got %d: %v", len(values), values)
+	}
+	if got, ok := values[0].(string); !ok || got != "AY89a18t+D98lADcFYKgjMgoHS7rOPAQUE==" {
+		t.Errorf("captured value = %v (%T), want the thoughtSignature string", values[0], values[0])
+	}
+}
+
+// TestCaptureReplayFields_DeepSeekReasoningContent pins the path the
+// DeepSeek rules use. DeepSeek (and OpenAI's prior reasoning preview
+// builds) carry reasoning_content as a sibling of content on the
+// assistant delta — a single-segment path against the decoded delta
+// object captures it directly.
+func TestCaptureReplayFields_DeepSeekReasoningContent(t *testing.T) {
+	delta := map[string]any{
+		"role":              "assistant",
+		"content":           "The answer is 42.",
+		"reasoning_content": "Step 1: identified the question. Step 2: computed the answer.",
+	}
+	out := CaptureReplayFields(delta, []string{"reasoning_content"})
+	values, ok := out["reasoning_content"]
+	if !ok {
+		t.Fatalf("expected reasoning_content captured; got %v", out)
+	}
+	if len(values) != 1 {
+		t.Fatalf("expected exactly 1 value, got %d", len(values))
+	}
+	if got, ok := values[0].(string); !ok || got == "" {
+		t.Errorf("captured value = %v, want non-empty string", values[0])
+	}
+}
+
+// TestCaptureReplayFields_MissingPathIsNoOp confirms a path that does
+// not resolve returns nothing rather than an error. This is the
+// expected behaviour for forward-compatible rules: a path that names
+// a field the response did not emit must not surface as a captured
+// empty value, because that would be indistinguishable from a real
+// empty-string field.
+func TestCaptureReplayFields_MissingPathIsNoOp(t *testing.T) {
+	doc := map[string]any{"a": map[string]any{"b": "value"}}
+	out := CaptureReplayFields(doc, []string{"missing.path"})
+	if len(out) != 0 {
+		t.Errorf("expected empty map for missing path, got %v", out)
+	}
+}
+
+// TestCaptureReplayFields_PartialResolveCapturesWhatItCan asserts the
+// walker captures from paths that resolve and silently skips those
+// that don't, in a multi-path call. This is the production case: a
+// rule may register several alternative paths, and only one will be
+// present for any given response shape.
+func TestCaptureReplayFields_PartialResolveCapturesWhatItCan(t *testing.T) {
+	doc := map[string]any{"reasoning_content": "thinking..."}
+	out := CaptureReplayFields(doc, []string{
+		"reasoning_content",
+		"candidates[].content.parts[].thoughtSignature",
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected exactly one path captured, got %d: %v", len(out), out)
+	}
+	if _, ok := out["reasoning_content"]; !ok {
+		t.Errorf("expected reasoning_content captured; got %v", out)
+	}
+}
+
+// TestCaptureReplayFields_MalformedPathSilentlyDropped pins the
+// runtime safety property: a malformed path that somehow reaches the
+// walker (e.g. through a non-builtin Rule injected at test time)
+// returns nothing rather than panicking. The build-time validator
+// (BuiltinRulesValidate) is the authoritative gate; this is defence
+// in depth.
+func TestCaptureReplayFields_MalformedPathSilentlyDropped(t *testing.T) {
+	doc := map[string]any{"reasoning_content": "thinking..."}
+	out := CaptureReplayFields(doc, []string{"a..b", "reasoning_content"})
+	if len(out) != 1 {
+		t.Errorf("expected only the valid path to capture, got %v", out)
+	}
+}
+
+// TestCaptureReplayFields_EmptyDocOrPaths handles the two no-op
+// inputs. Both must return nil so callers can branch cleanly on
+// `len(captured) == 0` without inspecting the map shape.
+func TestCaptureReplayFields_EmptyDocOrPaths(t *testing.T) {
+	if got := CaptureReplayFields(nil, []string{"a"}); got != nil {
+		t.Errorf("nil doc: got %v, want nil", got)
+	}
+	if got := CaptureReplayFields(map[string]any{"a": "b"}, nil); got != nil {
+		t.Errorf("empty paths: got %v, want nil", got)
+	}
+}
+
+// TestCaptureFromJSON_HappyPath pins the JSON-bytes convenience
+// wrapper. The openai adapter holds a json.RawMessage for the delta
+// object inside an SSE chunk; the wrapper decodes it once and delegates
+// to CaptureReplayFields.
+func TestCaptureFromJSON_HappyPath(t *testing.T) {
+	raw := json.RawMessage(`{"role":"assistant","reasoning_content":"thinking"}`)
+	out := CaptureFromJSON(raw, []string{"reasoning_content"})
+	if len(out) != 1 {
+		t.Fatalf("expected one captured path, got %v", out)
+	}
+	values := out["reasoning_content"]
+	if len(values) != 1 || values[0] != "thinking" {
+		t.Errorf("captured = %v, want [thinking]", values)
+	}
+}
+
+// TestCaptureFromJSON_MalformedJSONIsNoOp confirms a decode failure
+// is silent. The SSE parser is the authoritative reporter for chunk
+// decode failures (it already returns an error event); this wrapper
+// must not double-report.
+func TestCaptureFromJSON_MalformedJSONIsNoOp(t *testing.T) {
+	if got := CaptureFromJSON(json.RawMessage(`{not json`), []string{"a"}); got != nil {
+		t.Errorf("expected nil for malformed JSON, got %v", got)
+	}
+}
+
+// TestBuiltinRulesValidate_ReplayFieldsPathsAreSyntacticallyValid is
+// the gate that catches a typo in a rule's ReplayFields entry at
+// registry-build time. Walks every builtin rule, materialises its
+// effect on a fresh ProviderQuirks, and asserts every entry in the
+// resulting ReplayFields slice parses cleanly.
+//
+// This extends the existing TestBuiltinRulesValidate; the path-parse
+// check sits in this file so the path parser and its validator are
+// tested together, against the same shared catalogue.
+func TestBuiltinRulesValidate_ReplayFieldsPathsAreSyntacticallyValid(t *testing.T) {
+	for i, rule := range BuiltinRules() {
+		if rule.Apply == nil {
+			continue
+		}
+		q := ProviderQuirks{
+			FieldRenames:   map[string]string{},
+			OmitFields:     []string{},
+			ValueOverrides: map[string]Value{},
+			EnumCoercions:  map[string]map[string]string{},
+			ReplayFields:   []string{},
+			BehaviourFlags: ProviderBehaviourFlags{OpenAI: OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}}},
+		}
+		rule.Apply(&q)
+		for _, path := range q.ReplayFields {
+			if err := ValidateReplayPath(path); err != nil {
+				t.Errorf("BuiltinRules()[%d] (%q): ReplayFields path %q is invalid: %v", i, rule.Description, path, err)
+			}
+		}
+	}
+}
+
+// TestBuiltinRulesParseSideOnlySuffix pins design §9 risk 7: a rule
+// that registers a ReplayFields path MUST end its Description with
+// "(parse-side only)" so trace consumers know the captured value is
+// observable but not yet threaded back into outbound history. Without
+// this convention an operator reading the trace might assume the
+// preserved field is being round-tripped on the next turn — it is
+// not, by design, in v1.
+//
+// The check applies only to rules that write to ReplayFields, so
+// existing wire-shape rules are unaffected.
+func TestBuiltinRulesParseSideOnlySuffix(t *testing.T) {
+	const suffix = "(parse-side only)"
+	for i, rule := range BuiltinRules() {
+		if rule.Apply == nil {
+			continue
+		}
+		q := ProviderQuirks{
+			FieldRenames:   map[string]string{},
+			OmitFields:     []string{},
+			ValueOverrides: map[string]Value{},
+			EnumCoercions:  map[string]map[string]string{},
+			ReplayFields:   []string{},
+			BehaviourFlags: ProviderBehaviourFlags{OpenAI: OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}}},
+		}
+		rule.Apply(&q)
+		if len(q.ReplayFields) == 0 {
+			continue
+		}
+		// The convention is a substring (not strict suffix) so a rule
+		// that adds a clarifying parenthetical after the marker stays
+		// valid; the marker presence is the load-bearing signal.
+		if !containsCaseInsensitive(rule.Description, suffix) {
+			t.Errorf("BuiltinRules()[%d] (%q): ReplayFields rule description must contain %q so trace consumers know the value is parse-side only", i, rule.Description, suffix)
+		}
+	}
+}
+
+// containsCaseInsensitive avoids importing strings for a one-shot
+// helper; the test runs once per build and ASCII case-folding is
+// sufficient for the rule descriptions in this repo.
+func containsCaseInsensitive(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	if len(haystack) < len(needle) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			a := haystack[i+j]
+			b := needle[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSortedReplayPathKeys is a small utility test for the trace-attribute
+// rendering layer: when an operator looks at a captured replay-fields
+// map in a trace, the keys should be presented in sorted order for
+// deterministic comparison. The walker does not sort (Go maps are
+// unordered), so consumers are expected to call sort.Strings on the
+// key set themselves; this test pins that contract via a real
+// invocation.
+func TestSortedReplayPathKeys(t *testing.T) {
+	doc := map[string]any{
+		"reasoning_content": "thinking",
+		"other_field":       "value",
+	}
+	out := CaptureReplayFields(doc, []string{"reasoning_content", "other_field"})
+	keys := make([]string, 0, len(out))
+	for k := range out {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) != 2 || keys[0] != "other_field" || keys[1] != "reasoning_content" {
+		t.Errorf("sorted keys = %v, want [other_field reasoning_content]", keys)
+	}
+}

--- a/harness/internal/provider/quirks/testdata/model-ids.txt
+++ b/harness/internal/provider/quirks/testdata/model-ids.txt
@@ -14,3 +14,6 @@ gemini-2.5-pro
 gemini-3.1-pro-preview
 glm-4-plus
 glm-4-air
+deepseek-reasoner
+deepseek-v4
+deepseek-v4-chat

--- a/harness/internal/provider/replay_quirks_test.go
+++ b/harness/internal/provider/replay_quirks_test.go
@@ -330,6 +330,12 @@ func TestReplayFields_Gemini3_PreservesThoughtSignature(t *testing.T) {
 // grepping for "quirks replay fields captured" must see an absent
 // line on a vanilla model.
 func TestReplayFields_GPT4o_NoCaptureWhenNoRuleFires(t *testing.T) {
+	// Reuses the o1-mini fixture because gpt-4o has no dedicated SSE
+	// fixture under testdata/. The test asserts the *absence* of the
+	// replay-fields debug line — fixture content doesn't matter, only
+	// that the adapter doesn't synthesise a capture when no rule
+	// fires. Routing the o1-mini SSE through a gpt-4o stream call
+	// drives that path with valid SSE bytes the parser can decode.
 	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/o1-mini/response.sse"))
 	defer srv.Close()
 

--- a/harness/internal/provider/replay_quirks_test.go
+++ b/harness/internal/provider/replay_quirks_test.go
@@ -1,0 +1,503 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirkstest"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// loadReplayFixture reads a replay.json fixture and returns its
+// parsed shape: a map of path → list of captured values, projecting
+// non-array values (rendered as strings for readability) to a single-
+// element slice. The fixture's keys are the rule's path strings (or
+// adjacent fields that the fixture-author wants to record for human
+// context); each value is either an array (multiple captured pieces)
+// or a scalar (one piece, written without the surrounding [] for
+// readability when the field is captured exactly once).
+//
+// The fixture is the source of truth for the post-parse assertion; a
+// divergence between the SSE parser's capture and the fixture is the
+// load-bearing signal that either the parser drifted or the rule's
+// path is wrong.
+//
+// Strips the # synthetic comment line so JSON.Unmarshal succeeds on
+// synthetic fixtures — the production fixtures (when available) carry
+// no comment line.
+func loadReplayFixture(t *testing.T, path string) map[string][]any {
+	t.Helper()
+	raw, err := quirkstest.LoadFixture(path)
+	if err != nil {
+		t.Fatalf("load replay fixture %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse replay fixture %s: %v\nbody: %s", path, err, raw)
+	}
+	out := map[string][]any{}
+	for k, v := range doc {
+		if arr, ok := v.([]any); ok {
+			out[k] = arr
+		} else {
+			out[k] = []any{v}
+		}
+	}
+	return out
+}
+
+// streamFixtureSSE reads an SSE fixture file (synthetic comment
+// stripped) and returns the bytes the test httptest server should
+// write to its response body. The SSE wire format expects each event
+// terminated by a blank line; the fixture stores the wire-equivalent
+// bytes verbatim, so the server can write them unchanged.
+func streamFixtureSSE(t *testing.T, path string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read sse fixture %s: %v", path, err)
+	}
+	// Strip a leading "# synthetic: ..." line; the same convention
+	// used by quirkstest.LoadFixture, but applied without the JSON
+	// decode that LoadFixture would attempt.
+	if bytes.HasPrefix(raw, []byte("# synthetic:")) {
+		if idx := bytes.IndexByte(raw, '\n'); idx >= 0 {
+			raw = raw[idx+1:]
+		} else {
+			raw = nil
+		}
+	}
+	return raw
+}
+
+// sseStubServer returns an httptest server that responds with the
+// given SSE bytes verbatim. Used by the ReplayFields integration
+// tests so the same adapter Stream path that runs in production
+// drives the fixture, exercising the SSE parser's RawDelta capture
+// and the per-stream debug summary together.
+func sseStubServer(t *testing.T, sse []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(sse); err != nil {
+			t.Errorf("write sse: %v", err)
+		}
+	}))
+}
+
+// drainStream pulls every event off the channel and returns the slice
+// of events for inspection. The ReplayFields integration tests do not
+// branch on the events themselves — the assertion target is the debug
+// log produced by the per-stream summary helper — but a parser error
+// would surface as a "type=error" event, so drainStream returns the
+// slice for the caller to spot-check.
+func drainStream(t *testing.T, ch <-chan types.StreamEvent) []types.StreamEvent {
+	t.Helper()
+	var events []types.StreamEvent
+	for ev := range ch {
+		if ev.Type == "error" {
+			t.Errorf("stream emitted error event: %v", ev.Error)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// extractReplayFieldsLog parses the slog JSON output and returns the
+// replay_fields_captured group from the "quirks replay fields
+// captured" record, projected into the same shape replay.json uses
+// (path → ordered length values reconstructed as one-string-per-piece
+// — the log records counts only, so the test reconstructs piece-count
+// equivalence rather than per-value equivalence).
+//
+// Returns nil if the log line was not emitted (which is itself a
+// failure case for any test that expects the rule to fire).
+func extractReplayFieldsLog(t *testing.T, logOutput string) map[string]int {
+	t.Helper()
+	// The log emitter prints one JSON record per line. Walk the lines
+	// and find the first "quirks replay fields captured" record.
+	for _, line := range strings.Split(logOutput, "\n") {
+		if !strings.Contains(line, "quirks replay fields captured") {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("parse log line: %v\nline: %s", err, line)
+		}
+		raw, ok := record["replay_fields_captured"].(map[string]any)
+		if !ok {
+			t.Fatalf("replay_fields_captured missing or not a map in: %s", line)
+		}
+		out := map[string]int{}
+		for path, summary := range raw {
+			s, ok := summary.(map[string]any)
+			if !ok {
+				continue
+			}
+			count, _ := s["count"].(float64)
+			out[path] = int(count)
+		}
+		return out
+	}
+	return nil
+}
+
+// TestReplayFields_DeepSeekReasoner_PreservesReasoningContent is the
+// load-bearing assertion that the parse-side hook on the OpenAI
+// adapter captures reasoning_content from every chunk's delta and
+// surfaces the per-stream summary on the debug logger. The
+// replay.json fixture is the source of truth for the expected
+// captured shape; the SSE parser must agree with it.
+func TestReplayFields_DeepSeekReasoner_PreservesReasoningContent(t *testing.T) {
+	const ssePath = "testdata/quirks/openai-compatible/deepseek-reasoner/response.sse"
+	const replayPath = "testdata/quirks/openai-compatible/deepseek-reasoner/replay.json"
+
+	srv := sseStubServer(t, streamFixtureSSE(t, ssePath))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-reasoner",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+
+	// The per-stream summary records the count of captured pieces per
+	// path. The replay.json fixture lists the expected pieces; the
+	// equality on lengths verifies the parser observed all of them.
+	want := loadReplayFixture(t, replayPath)
+	got := extractReplayFieldsLog(t, buf.String())
+	if got == nil {
+		t.Fatalf("debug log missing 'quirks replay fields captured' record; log:\n%s", buf.String())
+	}
+	for path, wantPieces := range want {
+		if path == "content" {
+			// content is part of the fixture for human-readability but
+			// is not a captured path — the rule only registers
+			// reasoning_content. Skip the assertion on the content
+			// key.
+			continue
+		}
+		gotCount, ok := got[path]
+		if !ok {
+			t.Errorf("path %q not captured; got summary %v", path, got)
+			continue
+		}
+		if gotCount != len(wantPieces) {
+			t.Errorf("path %q: captured %d pieces, want %d (from fixture)", path, gotCount, len(wantPieces))
+		}
+	}
+}
+
+// TestReplayFields_DeepSeekV4_PreservesReasoningContent mirrors the
+// reasoner test for the v4 family. Same rule shape, different
+// glob and fixture.
+func TestReplayFields_DeepSeekV4_PreservesReasoningContent(t *testing.T) {
+	const ssePath = "testdata/quirks/openai-compatible/deepseek-v4/response.sse"
+	const replayPath = "testdata/quirks/openai-compatible/deepseek-v4/replay.json"
+
+	srv := sseStubServer(t, streamFixtureSSE(t, ssePath))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-v4",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+
+	want := loadReplayFixture(t, replayPath)
+	got := extractReplayFieldsLog(t, buf.String())
+	if got == nil {
+		t.Fatalf("debug log missing 'quirks replay fields captured' record; log:\n%s", buf.String())
+	}
+	for path, wantPieces := range want {
+		if path == "content" {
+			continue
+		}
+		gotCount, ok := got[path]
+		if !ok {
+			t.Errorf("path %q not captured; got summary %v", path, got)
+			continue
+		}
+		if gotCount != len(wantPieces) {
+			t.Errorf("path %q: captured %d pieces, want %d", path, gotCount, len(wantPieces))
+		}
+	}
+}
+
+// TestReplayFields_Gemini3_PreservesThoughtSignature drives the
+// gemini-3.1-pro-preview/response.sse fixture through the Gemini
+// adapter and asserts the per-stream summary names the
+// thoughtSignature path. The fixture's synthetic signature is the
+// value the walker captures.
+func TestReplayFields_Gemini3_PreservesThoughtSignature(t *testing.T) {
+	const ssePath = "testdata/quirks/gemini/gemini-3.1-pro-preview/response.sse"
+	const replayPath = "testdata/quirks/gemini/gemini-3.1-pro-preview/replay.json"
+
+	srv := sseStubServer(t, streamFixtureSSE(t, ssePath))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewGeminiAdapter(staticBearer("test-token"), "test-project", "us-central1", nil)
+	adapter.baseURLOverride = srv.URL
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gemini-3.1-pro-preview",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+		Tools: []types.ToolDefinition{
+			{
+				Name:        "read_file",
+				Description: "read a file",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+
+	want := loadReplayFixture(t, replayPath)
+	got := extractReplayFieldsLog(t, buf.String())
+	if got == nil {
+		t.Fatalf("debug log missing 'quirks replay fields captured' record; log:\n%s", buf.String())
+	}
+	wantPaths := make([]string, 0, len(want))
+	for k := range want {
+		wantPaths = append(wantPaths, k)
+	}
+	sort.Strings(wantPaths)
+	for _, path := range wantPaths {
+		wantCount := len(want[path])
+		gotCount, ok := got[path]
+		if !ok {
+			t.Errorf("path %q not captured; got summary %v", path, got)
+			continue
+		}
+		if gotCount != wantCount {
+			t.Errorf("path %q: captured %d pieces, want %d", path, gotCount, wantCount)
+		}
+	}
+}
+
+// TestReplayFields_GPT4o_NoCaptureWhenNoRuleFires pins the negative
+// case: a model with no ReplayFields rule produces no debug summary
+// line because the per-stream accumulator is empty. Operators
+// grepping for "quirks replay fields captured" must see an absent
+// line on a vanilla model.
+func TestReplayFields_GPT4o_NoCaptureWhenNoRuleFires(t *testing.T) {
+	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/o1-mini/response.sse"))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gpt-4o",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+
+	if strings.Contains(buf.String(), "quirks replay fields captured") {
+		t.Errorf("gpt-4o: replay-fields debug line surfaced when no rule fired; log:\n%s", buf.String())
+	}
+}
+
+// TestReplayFields_Gemini25_NoCaptureWhenNoRuleFires mirrors the
+// gpt-4o negative test for Gemini. A 2.5 stream must not produce a
+// replay-fields summary line because the gemini-3* rule does not
+// fire.
+func TestReplayFields_Gemini25_NoCaptureWhenNoRuleFires(t *testing.T) {
+	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/gemini/gemini-2.5-pro/response.sse"))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewGeminiAdapter(staticBearer("test-token"), "test-project", "us-central1", nil)
+	adapter.baseURLOverride = srv.URL
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gemini-2.5-pro",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+
+	if strings.Contains(buf.String(), "quirks replay fields captured") {
+		t.Errorf("gemini-2.5-pro: replay-fields debug line surfaced when no rule fired; log:\n%s", buf.String())
+	}
+}
+
+// TestReplayFields_DeepSeekReasoner_LogIsLengthOnly is the side-
+// channel guard pinning design risk 7 / §5: the debug log must NOT
+// contain the verbatim reasoning_content value, only its length. The
+// captured strings in the fixture include the substring "step by
+// step" — assert it does not appear in the log output. If a future
+// refactor switches the summariser to value-logging the test
+// surfaces the leak before it ships.
+func TestReplayFields_DeepSeekReasoner_LogIsLengthOnly(t *testing.T) {
+	const ssePath = "testdata/quirks/openai-compatible/deepseek-reasoner/response.sse"
+
+	srv := sseStubServer(t, streamFixtureSSE(t, ssePath))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-reasoner",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "quirks replay fields captured") {
+		t.Fatalf("debug log missing 'quirks replay fields captured' record; log:\n%s", logOutput)
+	}
+	// The fixture's reasoning_content substrings.
+	for _, leaked := range []string{
+		"Let me think step by step",
+		"The user asked for 2+2",
+	} {
+		if strings.Contains(logOutput, leaked) {
+			t.Errorf("debug log leaked reasoning_content substring %q: %s", leaked, logOutput)
+		}
+	}
+}
+
+// TestReplayFieldsCapture_AcrossCallChunks_AccumulatesInOrder is the
+// behavioural sanity check for the openai parse hook's per-stream
+// accumulator: a value that arrives across multiple chunks must
+// accumulate in the order received, not be overwritten by the last
+// chunk's piece. The replay.json fixture for deepseek-reasoner lists
+// two pieces; the per-stream summary's `count` must equal 2, not 1.
+func TestReplayFieldsCapture_AcrossCallChunks_AccumulatesInOrder(t *testing.T) {
+	const ssePath = "testdata/quirks/openai-compatible/deepseek-reasoner/response.sse"
+
+	srv := sseStubServer(t, streamFixtureSSE(t, ssePath))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-reasoner",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+
+	got := extractReplayFieldsLog(t, buf.String())
+	// Fixture has three chunks containing reasoning_content: an empty
+	// initial role chunk ("reasoning_content":""), then two real
+	// pieces. The walker captures every non-nil value including the
+	// empty string, so the expected count is 3.
+	wantCount := 3
+	if got["reasoning_content"] != wantCount {
+		t.Errorf("reasoning_content captured %d pieces, want %d; got %v", got["reasoning_content"], wantCount, got)
+	}
+}
+
+// TestQuirksRegistry_ReplayFieldsArePassedThroughToCaptured is the
+// minimum-effort link between the registry-resolved value and the
+// adapter's parse-side capture: a rule that writes to ReplayFields
+// must be visible in the parse path as well. The check is structural
+// (no SSE involved) so a registry-resolution test failure stays
+// distinguishable from a parser-side failure.
+func TestQuirksRegistry_ReplayFieldsArePassedThroughToCaptured(t *testing.T) {
+	cases := []struct {
+		name         string
+		providerType string
+		model        string
+		wantPaths    []string
+	}{
+		{"deepseek-reasoner", "openai-compatible", "deepseek-reasoner", []string{"reasoning_content"}},
+		{"deepseek-v4", "openai-compatible", "deepseek-v4", []string{"reasoning_content"}},
+		{"gemini-3", "gemini", "gemini-3.1-pro-preview", []string{"candidates[].content.parts[].thoughtSignature"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := quirks.DefaultRegistry().Resolve(tc.providerType, tc.model)
+			if !reflect.DeepEqual(q.ReplayFields, tc.wantPaths) {
+				t.Errorf("ReplayFields = %v, want %v", q.ReplayFields, tc.wantPaths)
+			}
+		})
+	}
+}

--- a/harness/internal/provider/testdata/quirks/gemini/gemini-3.1-pro-preview/replay.json
+++ b/harness/internal/provider/testdata/quirks/gemini/gemini-3.1-pro-preview/replay.json
@@ -1,0 +1,5 @@
+{
+  "candidates[].content.parts[].thoughtSignature": [
+    "AY89a18t+D98lADcFYKgjMgoHS7rOPAQUE=="
+  ]
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-reasoner/replay.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-reasoner/replay.json
@@ -1,0 +1,8 @@
+{
+  "reasoning_content": [
+    "",
+    "Let me think step by step.",
+    " The user asked for 2+2."
+  ],
+  "content": "The answer is 4."
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-reasoner/response.sse
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-reasoner/response.sse
@@ -1,0 +1,13 @@
+# synthetic: derived from the DeepSeek API documentation for the chat-completions streaming endpoint because the harness does not yet have a live deepseek-reasoner capture. The reasoning_content field is documented as a sibling of content on each assistant delta; the value here is fabricated text demonstrating the field's presence so the Step 5 ReplayFields parse-side test has a fixture to assert against. Replace with a real DeepSeek-reasoner capture before relying on the rule against live traffic.
+data: {"id":"chatcmpl-ds-reasoner-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-reasoner-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"Let me think step by step."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-reasoner-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":" The user asked for 2+2."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-reasoner-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"The answer is 4."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-reasoner-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":12}}
+
+data: [DONE]
+

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4/replay.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4/replay.json
@@ -1,0 +1,7 @@
+{
+  "reasoning_content": [
+    "",
+    "Considering the request carefully."
+  ],
+  "content": "Done."
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4/response.sse
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4/response.sse
@@ -1,0 +1,11 @@
+# synthetic: derived from the DeepSeek API documentation for the chat-completions streaming endpoint because the harness does not yet have a live deepseek-v4 capture. The v4 family uses the same reasoning_content sibling-of-content shape as the reasoner family per the DeepSeek API docs; this fixture mirrors that wire shape with v4-appropriate strings so the Step 5 ReplayFields parse-side test has independent fixtures for each rule. Replace with a real DeepSeek-v4 capture before relying on the rule against live traffic.
+data: {"id":"chatcmpl-ds-v4-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"Considering the request carefully."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":6}}
+
+data: [DONE]
+


### PR DESCRIPTION
**Closes #221. Final PR for Wave 2 of the tool-use debacle workstream.** Stacked on [PR #317](https://github.com/rxbynerd/stirrup/pull/317). The full Wave 2 stack is: main → #315 (merged) → #316 → #317 → this PR.

**Supersedes [PR #196](https://github.com/rxbynerd/stirrup/pull/196).** This PR replaces `docs/provider-quirks.md` with the as-merged Wave 2 design — the user previously authorised clobbering #196 where the implementation revealed issues. Sections kept verbatim: §1 (problem), §1.1 (prior art — LiteLLM, LangChain, Vercel, OpenRouter, vLLM), the Codec invariant. Sections amended: `StructuralFlags any` → typed `ProviderBehaviourFlags` sub-structs; reasoning-class `OmitFields` → `OmitSamplingParams bool`; added `CompatProfile` operator surface; sub-package placement. Sections replaced: implementation order (coordinator artefact), clobbering notes (coordinator artefact). New §9 risk 9 documents the DeepSeek `reasoning_content` field-path verification gap.

## Wave 2 summary (cumulative across #315, #316, #317, this PR)

Closes #221. Introduces the per-(provider, model) capability/quirks layer reconciling PR #196 and #221:

- **Scaffold** (#315): `ProviderQuirks` struct, `Registry` with specificity-then-declaration-order composition, `DefaultRegistry()` `sync.Once` singleton, `RuleMatches` predicate, `Value` tagged union, typed `OpenAIBehaviourFlags`/`GeminiBehaviourFlags`, `CompatProfile` operator surface (closed enum: `\"\"`, `\"zai-glm\"`), `stirrup providers quirks --provider X --model Y` introspection subcommand.
- **openai-compatible + Responses + Z.ai compat** (#316): adapter `Stream` resolves at top via `ResolveWithRules`, custom `MarshalJSON`/`UnmarshalJSON` on `openaiRequest` for dynamic field exclusion/token-field switching, reasoning-class rules (`o[1-9]*`, `gpt-5*` with `gpt-5-chat*` carve-out), `compat/zai/` package, factory `resolveCompatProfile` wiring, `BatchAdapter.Registry` plumbing, `quirkstest` test helpers (`AssertWireEqual`, `ScrubFixture`, `TestFixturesScrubbed` CI gate).
- **Gemini** (#317): mirrors openai-compatible integration pattern; Gemini base rule (`gemini`/`*` → `StreamArgsOff`, post-#191 default); `streamFunctionCallArgsFromQuirks` helper routes V2/V3 enum to wire bool; `gemini-3.1-pro-preview/response.sse` carries a synthetic `thoughtSignature` as Step 5 forward-stub; `ya29.*` GCP OAuth scrubber added.
- **This PR (Step 5+6)**: ReplayFields parse-side recognition in openai+gemini adapters; three rules (`deepseek-reasoner*`, `deepseek-v4*`, `gemini-3*`); cross-adapter path parser at `quirks/replay.go`; OTel `provider.quirk.applied` + `replay_fields_captured.{count,total_len}` span attributes (parallel to slog DEBUG); replaces `docs/provider-quirks.md` with as-merged design + cross-references in providers.md/configuration.md/architecture.md.

## What this PR (Step 5+6) ships

### ReplayFields parse-side recognition

- New `harness/internal/provider/quirks/replay.go`: `ParseReplayPath`, `ValidateReplayPath`, `CaptureReplayFields`, `CaptureFromJSON`. Path syntax: dot-separated keys + `[]` for array-of-objects. Validated at registry build time via `TestBuiltinRulesValidate_ReplayFieldsPathsAreSyntacticallyValid` — malformed paths fail at registry-load, not at parse time.
- `provider/openai.go::consumeSSE` now accepts `q`, `logger`, `model`. `openaiChunkChoice` gains `RawDelta json.RawMessage` via custom `UnmarshalJSON` (two-pass: capture raw bytes, then typed decode). `CaptureFromJSON` runs on each chunk's `RawDelta` when `len(q.ReplayFields) > 0`. Captures accumulate per-stream; deferred `logReplayFieldsCapture` emits the summary at stream exit.
- `provider/gemini.go::consumeSSE`: Step 3's `_ = q` placeholder replaced; second untyped `json.Unmarshal` runs per chunk when ReplayFields are active. Per-stream summary emitted on exit.
- **Length-only side-channel invariant**: `logReplayFieldsCapture` emits `count` and `total_len` per captured field name — NEVER values. `TestReplayFields_DeepSeekReasoner_LogIsLengthOnly` pins the contract. `TestLogReplayFieldsCapture_NonStringValue` covers the non-string fallback path (`float64`, etc.) so the invariant holds for any JSON value type.
- **OTel parity** (the design §5 promise): `provider.quirk.applied` (string-slice of contributing rule descriptions) and `replay_fields_captured.{count,total_len}` (int) span attributes are emitted alongside the slog DEBUG lines. `summarizeReplayCaptures` helper keeps both surfaces using identical length-proxy logic so they don't drift.

### Three ReplayFields rules

- `deepseek-reasoner*` → preserves `reasoning_content` (parse-side only).
- `deepseek-v4*` → preserves `reasoning_content` (parse-side only).
- `gemini-3*` → preserves `candidates[].content.parts[].thoughtSignature` (parse-side only). **Path corrected from the original design**: `thoughtSignature` is a sibling of `functionCall` on the part, not a child. Verified vs `geminiPart` struct.

`TestBuiltinRulesParseSideOnlySuffix` enforces every ReplayFields rule's `Description` ends with `(parse-side only)` so operators reading traces understand the scope (outbound threading is deferred per design §9 risk 7).

### Docs

- `docs/provider-quirks.md` replaced with the as-merged design.
- `docs/providers.md`: cross-reference + `compatProfile` mention + `stirrup providers quirks` subcommand pointer.
- `docs/configuration.md`: `provider.compatProfile` schema (closed enum).
- `docs/architecture.md`: Provider-quirks layer subsection; OTel + slog trace-schema paragraph.

## Pre-merge remediation

Reviewers caught 3 blockers; all resolved:
1. `provider.quirk.applied` OTel span attribute was missing — added in both adapters with parallel `replay_fields_captured.{count,total_len}` attributes. Docs updated to reflect dual slog+OTel surface.
2. `openaiChunkChoice.UnmarshalJSON` at 80% coverage (zero-delta + decode-error branches uncovered) — `TestOpenAIChunkChoice_UnmarshalJSON` added with 3 sub-cases.
3. `logReplayFieldsCapture` at 77.8% coverage (non-string fallback branch was part of the side-channel safety invariant) — `TestLogReplayFieldsCapture_NonStringValue` added.

Plus 5 non-blocking polish items: Gemini-3 sibling-path doc clarification, slog/OTel acknowledgement in docs, dead nil-Apply guard collapsed, `replay_quirks_test.go` fixture-reuse comment, code comments on first-party path precondition + JSON-error scrub + Gemini double-decode cost.

## Verification

- `just` (build + full test suite) exits 0.
- `just lint` (golangci-lint v2) reports `0 issues`.
- Quirks package coverage ≥94.6%; replay.go ≥90% per-function; new tests run under `-race`.
- `TestFixturesScrubbed` enforces secret-scrub on every `testdata/quirks/` file (now covers Bearer sk-*, x-api-key sk-*, sk-ant-*, projects/*/locations, ya29.*).
- `TestBuiltinRulesValidate_ReplayFieldsPathsAreSyntacticallyValid` catches malformed paths at registry-load.
- `TestBuiltinRulesParseSideOnlySuffix` enforces ReplayFields rule discipline.

## Deferred (post-Wave-2 follow-ups)

These were considered but explicitly out of scope; file follow-up issues post-merge:

- **Real-capture DeepSeek fixtures** — current `reasoning_content` path is sourced from DeepSeek's published API docs, not a live capture. `docs/provider-quirks.md` §9 risk 9 documents this. The 180-day staleness window will surface a re-verification prompt.
- **Outbound ReplayFields threading** — design §9 risk 7. Parse-side recognition lands now; threading captured fields back into subsequent turns' message history is a separate change.
- **`provider.quirkOverrides` operator surface** — design §5.1 sketch. Operator-authored quirk rules with the narrow override surface. Not in v1.
- **`canonicalGeminiFieldNames` validation table** — wait for first Gemini rule that touches `FieldRenames`.
- **`AdapterDeps` consolidation** of shared `Logger`/`Registry` fields — premature at 3 adapters; revisit at the 4th.
- **`ruleDescriptions` move to a shared `provider_util.go`** — defer to when Anthropic gains quirks resolution.
- **Real-capture Gemini 3 `thoughtSignature` fixture** — currently synthetic per `# synthetic:` comment.
- **`consumeSSE` `streamOptions` struct refactor** — defer to next feature that adds a parameter.

Reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers (twice across the stack); remediation briefs in workstream scratch. Verdict: NEEDS REMEDIATION (applied).