### PR TITLE
tool/builtins: enrich descriptions with when-to-use guidance and worked examples (Wave 3 Step C)

### DIFF
--- a/harness/internal/edit/multi.go
+++ b/harness/internal/edit/multi.go
@@ -103,8 +103,14 @@ func NewMultiStrategy(fuzzyThreshold float64) *MultiStrategy {
 // ToolDefinition returns the unified tool definition for the multi-strategy.
 func (m *MultiStrategy) ToolDefinition() types.ToolDefinition {
 	return types.ToolDefinition{
-		Name:        "edit_file",
-		Description: "Edit a file using an explicit operation. Set operation to 'replace' (old_string + new_string), 'delete' (old_string only), 'rewrite' (content), or 'patch' (diff). The operation field is required.",
+		Name: "edit_file",
+		Description: "Modify an existing file in the workspace. Use this for targeted edits; use write_file when authoring a new file or replacing the entire contents wholesale. " +
+			"The operation field is required and selects the strategy:\n" +
+			"  - 'replace' substitutes new_string for old_string. Requires old_string + new_string. old_string must occur exactly once in the file.\n" +
+			"  - 'delete' removes old_string from the file. Requires old_string only; passing new_string is rejected — choose 'replace' for any non-empty substitution.\n" +
+			"  - 'rewrite' replaces the whole file with content. Requires content.\n" +
+			"  - 'patch' applies a unified diff. Requires diff. Useful for multi-hunk edits.\n" +
+			"Example (replace): {\"path\": \"main.go\", \"operation\": \"replace\", \"old_string\": \"return nil\", \"new_string\": \"return err\"}",
 		InputSchema: multiSchema,
 	}
 }

--- a/harness/internal/edit/multi.go
+++ b/harness/internal/edit/multi.go
@@ -104,11 +104,11 @@ func NewMultiStrategy(fuzzyThreshold float64) *MultiStrategy {
 func (m *MultiStrategy) ToolDefinition() types.ToolDefinition {
 	return types.ToolDefinition{
 		Name: "edit_file",
-		Description: "Modify an existing file in the workspace. Use this for targeted edits; use write_file when authoring a new file or replacing the entire contents wholesale. " +
+		Description: "Modify an existing file in the workspace. Use this for targeted edits on a file that already exists; use write_file to create a NEW file or when the file may not exist yet. " +
 			"The operation field is required and selects the strategy:\n" +
 			"  - 'replace' substitutes new_string for old_string. Requires old_string + new_string. old_string must occur exactly once in the file.\n" +
 			"  - 'delete' removes old_string from the file. Requires old_string only; passing new_string is rejected — choose 'replace' for any non-empty substitution.\n" +
-			"  - 'rewrite' replaces the whole file with content. Requires content.\n" +
+			"  - 'rewrite' replaces the entire content of an EXISTING file with content. Requires content. Prefer write_file when authoring a new file.\n" +
 			"  - 'patch' applies a unified diff. Requires diff. Useful for multi-hunk edits.\n" +
 			"Example (replace): {\"path\": \"main.go\", \"operation\": \"replace\", \"old_string\": \"return nil\", \"new_string\": \"return err\"}",
 		InputSchema: multiSchema,

--- a/harness/internal/edit/multi_test.go
+++ b/harness/internal/edit/multi_test.go
@@ -88,8 +88,12 @@ func TestMultiStrategy_DescriptionEnrichedShape(t *testing.T) {
 	if len(def.Description) > maxEditFileDescriptionLen {
 		t.Errorf("description length %d exceeds cap %d", len(def.Description), maxEditFileDescriptionLen)
 	}
-	if !strings.Contains(def.Description, "Use this") {
-		t.Errorf("description missing when-to-use guidance (expected substring %q)", "Use this")
+	// hasPositiveUseThis rejects negated matches (a description
+	// containing only "Do not use this..." would otherwise pass an
+	// unguarded strings.Contains check). Mirrors the helper in
+	// harness/internal/tool/builtins/builtins_test.go.
+	if !hasPositiveUseThis(def.Description) {
+		t.Errorf("description missing positive when-to-use guidance (expected non-negated \"Use this\" clause)")
 	}
 	example, ok := extractEditFileJSONExample(def.Description)
 	if !ok {
@@ -98,6 +102,31 @@ func TestMultiStrategy_DescriptionEnrichedShape(t *testing.T) {
 	var probe map[string]any
 	if err := json.Unmarshal([]byte(example), &probe); err != nil {
 		t.Errorf("example is not valid JSON: %v\nexample: %s", err, example)
+	}
+}
+
+// hasPositiveUseThis reports whether desc contains a "Use this" clause
+// that is NOT negated. Mirrors the helper in
+// harness/internal/tool/builtins/builtins_test.go; the two packages
+// keep independent copies so each test suite stays self-contained.
+func hasPositiveUseThis(desc string) bool {
+	lower := strings.ToLower(desc)
+	idx := 0
+	for {
+		hit := strings.Index(lower[idx:], "use this")
+		if hit < 0 {
+			return false
+		}
+		pos := idx + hit
+		start := pos - 8
+		if start < 0 {
+			start = 0
+		}
+		prefix := lower[start:pos]
+		if !strings.HasSuffix(prefix, "not ") && !strings.HasSuffix(prefix, "'t ") {
+			return true
+		}
+		idx = pos + len("use this")
 	}
 }
 

--- a/harness/internal/edit/multi_test.go
+++ b/harness/internal/edit/multi_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
@@ -66,6 +67,85 @@ func TestMultiStrategy_ToolDefinition(t *testing.T) {
 	if !hasOperation {
 		t.Error("operation should be listed in required")
 	}
+}
+
+// maxEditFileDescriptionLen mirrors the cap used for built-in tool
+// descriptions in harness/internal/tool/builtins. Kept local rather than
+// reaching across packages so the two test suites stay independently
+// runnable.
+const maxEditFileDescriptionLen = 2000
+
+// TestMultiStrategy_DescriptionEnrichedShape asserts that the edit_file
+// description carries the #227 contract — when-to-use guidance, an
+// example labelled "Example", and a bounded length. The example is
+// extracted by finding the rightmost "Example" marker and walking the
+// brace balance to capture the JSON object, matching the helper in
+// harness/internal/tool/builtins/builtins_test.go.
+func TestMultiStrategy_DescriptionEnrichedShape(t *testing.T) {
+	m := NewMultiStrategy(defaultFuzzyThreshold)
+	def := m.ToolDefinition()
+
+	if len(def.Description) > maxEditFileDescriptionLen {
+		t.Errorf("description length %d exceeds cap %d", len(def.Description), maxEditFileDescriptionLen)
+	}
+	if !strings.Contains(def.Description, "Use this") {
+		t.Errorf("description missing when-to-use guidance (expected substring %q)", "Use this")
+	}
+	example, ok := extractEditFileJSONExample(def.Description)
+	if !ok {
+		t.Fatalf("description missing JSON example after \"Example\" marker; got: %s", def.Description)
+	}
+	var probe map[string]any
+	if err := json.Unmarshal([]byte(example), &probe); err != nil {
+		t.Errorf("example is not valid JSON: %v\nexample: %s", err, example)
+	}
+}
+
+// extractEditFileJSONExample locates the rightmost "Example" marker in
+// desc, then walks brace balance from the first '{' that follows to find
+// the matching '}'. String literals are skipped so embedded braces in
+// quoted values cannot terminate the scan early.
+func extractEditFileJSONExample(desc string) (string, bool) {
+	marker := strings.LastIndex(desc, "Example")
+	if marker < 0 {
+		return "", false
+	}
+	rest := desc[marker:]
+	open := strings.Index(rest, "{")
+	if open < 0 {
+		return "", false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := open; i < len(rest); i++ {
+		c := rest[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch c {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return rest[open : i+1], true
+			}
+		}
+	}
+	return "", false
 }
 
 func TestMultiStrategy_RoutesPatchToUdiff(t *testing.T) {

--- a/harness/internal/edit/multi_test.go
+++ b/harness/internal/edit/multi_test.go
@@ -134,6 +134,14 @@ func hasPositiveUseThis(desc string) bool {
 // desc, then walks brace balance from the first '{' that follows to find
 // the matching '}'. String literals are skipped so embedded braces in
 // quoted values cannot terminate the scan early.
+//
+// Contract: descriptions must contain at least one capital-`E` "Example"
+// marker followed by a valid JSON object. The rightmost such marker is
+// the one parsed. A future #222 migration that extracts examples into a
+// structured InputExamples []any field on types.ToolDefinition relies on
+// this contract — the helper here is the seam it would replace. The
+// duplicate of this helper in harness/internal/tool/builtins/builtins_test.go
+// carries the same contract.
 func extractEditFileJSONExample(desc string) (string, bool) {
 	marker := strings.LastIndex(desc, "Example")
 	if marker < 0 {

--- a/harness/internal/edit/multi_test.go
+++ b/harness/internal/edit/multi_test.go
@@ -148,6 +148,59 @@ func extractEditFileJSONExample(desc string) (string, bool) {
 	return "", false
 }
 
+// TestExtractEditFileJSONExample locks the contract of the
+// extractEditFileJSONExample helper directly. The helper duplicates the
+// extractJSONExample helper in harness/internal/tool/builtins; the two
+// suites run independently so the duplication is intentional. A future
+// #222 migration to a structured InputExamples []any field on
+// types.ToolDefinition would replace both helpers — this test pins the
+// edge-case behaviour so the migration stays mechanical.
+func TestExtractEditFileJSONExample(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "no marker",
+			input:  "This description has no marker",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "two markers rightmost wins",
+			input:  "Example: {\"a\": 1}\n\nExample: {\"b\": 2}",
+			want:   "{\"b\": 2}",
+			wantOK: true,
+		},
+		{
+			name:   "malformed json after marker",
+			input:  "Example: {not valid",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "standard happy path",
+			input:  "Use this for targeted edits. Example: {\"path\": \"x\"}",
+			want:   "{\"path\": \"x\"}",
+			wantOK: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractEditFileJSONExample(tc.input)
+			if ok != tc.wantOK {
+				t.Errorf("ok mismatch: got %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("value mismatch: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMultiStrategy_RoutesPatchToUdiff(t *testing.T) {
 	dir := t.TempDir()
 	exec := newTestExecutor(t, dir)

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -728,6 +728,58 @@ func TestBuiltinDescriptions_EnrichedShape(t *testing.T) {
 	}
 }
 
+// TestExtractJSONExample locks the contract of the extractJSONExample
+// helper directly, independent of any real tool description. The helper
+// is the seam a future #222 migration to a structured InputExamples
+// []any field on types.ToolDefinition would replace; pinning the
+// edge-case behaviour here keeps that migration mechanical instead of
+// archaeological.
+func TestExtractJSONExample(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantOK  bool
+	}{
+		{
+			name:   "no marker",
+			input:  "This description has no marker",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "two markers rightmost wins",
+			input:  "Example: {\"a\": 1}\n\nExample: {\"b\": 2}",
+			want:   "{\"b\": 2}",
+			wantOK: true,
+		},
+		{
+			name:   "malformed json after marker",
+			input:  "Example: {not valid",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "standard happy path",
+			input:  "Use this when reading a known file. Example: {\"path\": \"x\"}",
+			want:   "{\"path\": \"x\"}",
+			wantOK: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractJSONExample(tc.input)
+			if ok != tc.wantOK {
+				t.Errorf("ok mismatch: got %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("value mismatch: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestSpawnAgentTool_EnrichedShape applies the same description contract
 // to spawn_agent, which is wired separately from RegisterBuiltins (the
 // factory injects a real spawner closure). A trivial spawner suffices

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -828,10 +828,10 @@ func TestHasPositiveUseThis(t *testing.T) {
 // archaeological.
 func TestExtractJSONExample(t *testing.T) {
 	cases := []struct {
-		name    string
-		input   string
-		want    string
-		wantOK  bool
+		name   string
+		input  string
+		want   string
+		wantOK bool
 	}{
 		{
 			name:   "no marker",

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -643,6 +643,37 @@ func TestRegisterBuiltins(t *testing.T) {
 // tool is generous — the longest description today is well under 1000.
 const maxToolDescriptionLen = 2000
 
+// hasPositiveUseThis reports whether desc contains a "Use this" clause
+// that is NOT negated. A description containing only "Do not use this..."
+// or "Don't use this..." would slip past a plain substring check on
+// "Use this"; this helper walks every occurrence and rejects those whose
+// immediately preceding text ends in "not " or "'t ", returning true
+// only if at least one *positive* when-to-use clause is present.
+// Case-insensitive: both "Use this" and "use this" count.
+func hasPositiveUseThis(desc string) bool {
+	lower := strings.ToLower(desc)
+	idx := 0
+	for {
+		hit := strings.Index(lower[idx:], "use this")
+		if hit < 0 {
+			return false
+		}
+		pos := idx + hit
+		// Inspect the immediately preceding context (up to 8 chars) for
+		// negative-guidance prefixes. "Do not " / "don't " / " not "
+		// all end in "not " or "'t " before "use this".
+		start := pos - 8
+		if start < 0 {
+			start = 0
+		}
+		prefix := lower[start:pos]
+		if !strings.HasSuffix(prefix, "not ") && !strings.HasSuffix(prefix, "'t ") {
+			return true
+		}
+		idx = pos + len("use this")
+	}
+}
+
 // extractJSONExample pulls the JSON object that follows the rightmost
 // "Example" marker in a tool description and returns the raw bytes.
 // Matching from the rightmost marker keeps tools with multiple worked
@@ -713,8 +744,11 @@ func TestBuiltinDescriptions_EnrichedShape(t *testing.T) {
 			// the enriched descriptions. Asserting on it (rather than a
 			// hand-curated per-tool phrase) keeps the contract uniform
 			// and forces future tools to adopt the same convention.
-			if !strings.Contains(def.Description, "Use this") {
-				t.Errorf("description missing when-to-use guidance (expected substring %q)", "Use this")
+			// hasPositiveUseThis rejects matches that are negated (a
+			// description containing only "Do not use this..." would
+			// otherwise pass an unguarded strings.Contains).
+			if !hasPositiveUseThis(def.Description) {
+				t.Errorf("description missing positive when-to-use guidance (expected non-negated \"Use this\" clause)")
 			}
 			example, ok := extractJSONExample(def.Description)
 			if !ok {
@@ -723,6 +757,58 @@ func TestBuiltinDescriptions_EnrichedShape(t *testing.T) {
 			var probe map[string]any
 			if err := json.Unmarshal([]byte(example), &probe); err != nil {
 				t.Errorf("example is not valid JSON: %v\nexample: %s", err, example)
+			}
+		})
+	}
+}
+
+// TestHasPositiveUseThis confirms the tightened when-to-use check
+// rejects descriptions whose only "Use this" appears inside a negation
+// (Do not / Don't / not) while still passing descriptions that carry
+// both a negation and a genuine positive clause. Locks the contract so
+// a future loosening of the helper trips a clear failure.
+func TestHasPositiveUseThis(t *testing.T) {
+	cases := []struct {
+		name string
+		desc string
+		want bool
+	}{
+		{
+			name: "only negated do not",
+			desc: "Do not use this for X.",
+			want: false,
+		},
+		{
+			name: "only negated don't",
+			desc: "Don't use this for X.",
+			want: false,
+		},
+		{
+			name: "only negated bare not",
+			desc: "We do not use this approach.",
+			want: false,
+		},
+		{
+			name: "positive only",
+			desc: "Use this when reading a known file.",
+			want: true,
+		},
+		{
+			name: "both negated and positive",
+			desc: "Use this for X. Do not use this for Y.",
+			want: true,
+		},
+		{
+			name: "no use this at all",
+			desc: "Some unrelated description.",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasPositiveUseThis(tc.desc); got != tc.want {
+				t.Errorf("hasPositiveUseThis(%q) = %v, want %v", tc.desc, got, tc.want)
 			}
 		})
 	}
@@ -792,8 +878,8 @@ func TestSpawnAgentTool_EnrichedShape(t *testing.T) {
 	if len(def.Description) > maxToolDescriptionLen {
 		t.Errorf("description length %d exceeds cap %d", len(def.Description), maxToolDescriptionLen)
 	}
-	if !strings.Contains(def.Description, "Use this") {
-		t.Errorf("description missing when-to-use guidance")
+	if !hasPositiveUseThis(def.Description) {
+		t.Errorf("description missing positive when-to-use guidance (expected non-negated \"Use this\" clause)")
 	}
 	example, ok := extractJSONExample(def.Description)
 	if !ok {

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -637,3 +637,118 @@ func TestRegisterBuiltins(t *testing.T) {
 		t.Error("search_files must not be registered (split into grep_files and find_files)")
 	}
 }
+
+// maxToolDescriptionLen caps each enriched description so a worst-case
+// system prompt with every tool registered stays bounded. 2000 chars per
+// tool is generous — the longest description today is well under 1000.
+const maxToolDescriptionLen = 2000
+
+// extractJSONExample pulls the JSON object that follows the rightmost
+// "Example" marker in a tool description and returns the raw bytes.
+// Matching from the rightmost marker keeps tools with multiple worked
+// examples (e.g. edit_file's "Example (replace): ...") working without
+// the test having to know each tool's example label. The boundary is the
+// matching '}' for the first '{' after the marker, walking the brace
+// balance so embedded objects do not terminate the scan early.
+func extractJSONExample(desc string) (string, bool) {
+	marker := strings.LastIndex(desc, "Example")
+	if marker < 0 {
+		return "", false
+	}
+	rest := desc[marker:]
+	open := strings.Index(rest, "{")
+	if open < 0 {
+		return "", false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := open; i < len(rest); i++ {
+		c := rest[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch c {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return rest[open : i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+// TestBuiltinDescriptions_EnrichedShape asserts that every registered
+// built-in tool description satisfies the #227 contract: when-to-use
+// guidance, a syntactically valid JSON example, and a length below the
+// system-prompt budget cap. Failures here mean a future contributor
+// pared a description back below the agreed shape — the test exists to
+// surface that regression before the change ships.
+func TestBuiltinDescriptions_EnrichedShape(t *testing.T) {
+	mock := &mockExecutor{}
+	registry := tool.NewRegistry()
+	RegisterBuiltins(registry, mock)
+
+	for _, def := range registry.List() {
+		t.Run(def.Name, func(t *testing.T) {
+			if len(def.Description) > maxToolDescriptionLen {
+				t.Errorf("description length %d exceeds cap %d", len(def.Description), maxToolDescriptionLen)
+			}
+			// "Use this" is the canonical when-to-use opener used across
+			// the enriched descriptions. Asserting on it (rather than a
+			// hand-curated per-tool phrase) keeps the contract uniform
+			// and forces future tools to adopt the same convention.
+			if !strings.Contains(def.Description, "Use this") {
+				t.Errorf("description missing when-to-use guidance (expected substring %q)", "Use this")
+			}
+			example, ok := extractJSONExample(def.Description)
+			if !ok {
+				t.Fatalf("description missing JSON example after \"Example\" marker; got: %s", def.Description)
+			}
+			var probe map[string]any
+			if err := json.Unmarshal([]byte(example), &probe); err != nil {
+				t.Errorf("example is not valid JSON: %v\nexample: %s", err, example)
+			}
+		})
+	}
+}
+
+// TestSpawnAgentTool_EnrichedShape applies the same description contract
+// to spawn_agent, which is wired separately from RegisterBuiltins (the
+// factory injects a real spawner closure). A trivial spawner suffices
+// because only the static tool definition is under test.
+func TestSpawnAgentTool_EnrichedShape(t *testing.T) {
+	noopSpawner := func(ctx context.Context, prompt, mode string, maxTurns int) (json.RawMessage, error) {
+		return json.RawMessage("{}"), nil
+	}
+	def := SpawnAgentTool(noopSpawner)
+	if len(def.Description) > maxToolDescriptionLen {
+		t.Errorf("description length %d exceeds cap %d", len(def.Description), maxToolDescriptionLen)
+	}
+	if !strings.Contains(def.Description, "Use this") {
+		t.Errorf("description missing when-to-use guidance")
+	}
+	example, ok := extractJSONExample(def.Description)
+	if !ok {
+		t.Fatalf("description missing JSON example after \"Example\" marker")
+	}
+	var probe map[string]any
+	if err := json.Unmarshal([]byte(example), &probe); err != nil {
+		t.Errorf("example is not valid JSON: %v\nexample: %s", err, example)
+	}
+}

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -681,6 +681,12 @@ func hasPositiveUseThis(desc string) bool {
 // the test having to know each tool's example label. The boundary is the
 // matching '}' for the first '{' after the marker, walking the brace
 // balance so embedded objects do not terminate the scan early.
+//
+// Contract: descriptions must contain at least one capital-`E` "Example"
+// marker followed by a valid JSON object. The rightmost such marker is
+// the one parsed. A future #222 migration that extracts examples into a
+// structured InputExamples []any field on types.ToolDefinition relies on
+// this contract — the helper here is the seam it would replace.
 func extractJSONExample(desc string) (string, bool) {
 	marker := strings.LastIndex(desc, "Example")
 	if marker < 0 {

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -108,9 +108,13 @@ const (
 // hard error here trains them to over-read whole files instead of probing.
 func ReadFileTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:              "read_file",
-		Description:       "Read the contents of a file from the workspace. Returns line-numbered output. Use start_line and limit to read a specific range; otherwise the first 2000 lines are returned.",
-		InputSchema:       readFileSchema,
+		Name: "read_file",
+		Description: "Read the contents of a file from the workspace. Returns line-numbered output (\"123\\tcontent\") so subsequent edits can refer to specific lines. " +
+			"Use this when the exact content of a known file is needed; prefer grep_files when searching for a string across many files. " +
+			"start_line is 1-indexed and limit caps the lines returned (default 2000, max 5000). " +
+			"When start_line is past end-of-file the tool returns a notice rather than an error, so probing with a guessed start_line is safe. " +
+			"Example: {\"path\": \"harness/internal/tool/builtins/filesystem.go\", \"start_line\": 100, \"limit\": 50}",
+		InputSchema: readFileSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
@@ -197,9 +201,12 @@ func formatReadFile(content string, startLine, limit int) string {
 // WriteFileTool returns a tool that writes content to a file in the workspace.
 func WriteFileTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:              "write_file",
-		Description:       "Write content to a file in the workspace. Creates parent directories as needed.",
-		InputSchema:       writeFileSchema,
+		Name: "write_file",
+		Description: "Create or overwrite a file in the workspace, writing content verbatim. Parent directories are created automatically. " +
+			"Use this when authoring a new file or when a wholesale rewrite is simpler than a targeted change. " +
+			"Do not use for small edits to existing files — prefer edit_file with operation 'replace' or 'patch' so unrelated lines stay untouched. " +
+			"Example: {\"path\": \"cmd/cli/main.go\", \"content\": \"package main\\n\\nfunc main() {}\\n\"}",
+		InputSchema: writeFileSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
@@ -227,9 +234,12 @@ func WriteFileTool(exec executor.Executor) *tool.Tool {
 // carry a trailing slash so models can spot them at a glance.
 func ListDirectoryTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:              "list_directory",
-		Description:       "List the contents of a directory in the workspace. Directories have a trailing slash. Set recursive=true to walk subdirectories up to max_depth (default 3, max 10). Results are capped at max_entries (default 1000, max 10000).",
-		InputSchema:       listDirectorySchema,
+		Name: "list_directory",
+		Description: "List the contents of a directory in the workspace. Directory entries carry a trailing slash so they are visually distinguishable from files. " +
+			"Use this to discover the shape of an unfamiliar tree; prefer find_files when the goal is to locate files by name across the workspace. " +
+			"Set recursive=true to walk subdirectories up to max_depth (default 3, max 10). Results are capped at max_entries (default 1000, max 10000) and a truncation sentinel is appended when the cap is hit. " +
+			"Example: {\"path\": \"harness/internal\", \"recursive\": true, \"max_depth\": 2}",
+		InputSchema: listDirectorySchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -114,7 +114,7 @@ func ReadFileTool(exec executor.Executor) *tool.Tool {
 			"start_line is 1-indexed and limit caps the lines returned (default 2000, max 5000). " +
 			"When start_line is past end-of-file the tool returns a notice rather than an error, so probing with a guessed start_line is safe. " +
 			"Example: {\"path\": \"harness/internal/tool/builtins/filesystem.go\", \"start_line\": 100, \"limit\": 50}",
-		InputSchema: readFileSchema,
+		InputSchema:       readFileSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
@@ -206,7 +206,7 @@ func WriteFileTool(exec executor.Executor) *tool.Tool {
 			"Use this when authoring a new file or when a wholesale rewrite is simpler than a targeted change. " +
 			"Do not use for small edits to existing files — prefer edit_file with operation 'replace' or 'patch' so unrelated lines stay untouched. " +
 			"Example: {\"path\": \"cmd/cli/main.go\", \"content\": \"package main\\n\\nfunc main() {}\\n\"}",
-		InputSchema: writeFileSchema,
+		InputSchema:       writeFileSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
@@ -239,7 +239,7 @@ func ListDirectoryTool(exec executor.Executor) *tool.Tool {
 			"Use this to discover the shape of an unfamiliar tree; prefer find_files when the goal is to locate files by name across the workspace. " +
 			"Set recursive=true to walk subdirectories up to max_depth (default 3, max 10). Results are capped at max_entries (default 1000, max 10000) and a truncation sentinel is appended when the cap is hit. " +
 			"Example: {\"path\": \"harness/internal\", \"recursive\": true, \"max_depth\": 2}",
-		InputSchema: listDirectorySchema,
+		InputSchema:       listDirectorySchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -113,7 +113,7 @@ func ReadFileTool(exec executor.Executor) *tool.Tool {
 			"Use this when the exact content of a known file is needed; prefer grep_files when searching for a string across many files. " +
 			"start_line is 1-indexed and limit caps the lines returned (default 2000, max 5000). " +
 			"When start_line is past end-of-file the tool returns a notice rather than an error, so probing with a guessed start_line is safe. " +
-			"Example: {\"path\": \"harness/internal/tool/builtins/filesystem.go\", \"start_line\": 100, \"limit\": 50}",
+			"Example: {\"path\": \"path/to/file.go\", \"start_line\": 100, \"limit\": 50}",
 		InputSchema:       readFileSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,

--- a/harness/internal/tool/builtins/register.go
+++ b/harness/internal/tool/builtins/register.go
@@ -10,6 +10,12 @@ import (
 // manages its own HTTP client independently. The legacy search_files tool
 // is deliberately absent: callers must use grep_files (regex content) or
 // find_files (glob filename) instead.
+//
+// Cross-references inside tool descriptions (e.g. grep_files mentioning
+// find_files, list_directory mentioning find_files, edit_file mentioning
+// write_file) use the canonical registry tool name. Wave 5 #234 aliases
+// must NOT rename these references — descriptions resolve via the
+// canonical name regardless of which alias the provider surface exposes.
 func RegisterBuiltins(registry *tool.Registry, exec executor.Executor) {
 	registry.Register(ReadFileTool(exec))
 	registry.Register(WriteFileTool(exec))

--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -158,6 +158,11 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 			"Use this when looking for a string, symbol, or pattern inside files; use find_files instead when searching by filename or extension. " +
 			"The pattern is a regex, not a glob — pass '\\bMyFunc\\b' to find the symbol MyFunc, not '*MyFunc*'. " +
 			"include and exclude take shell-style globs (e.g. '*.go') applied to candidate paths. Results are capped by max_results (default 100, max 1000); binary files are skipped. " +
+			// The `\\\\b` in the example renders as `\b` on the wire (a RE2
+			// word boundary). It is double-escaped because the Go string
+			// literal first consumes one layer of backslashes, leaving the
+			// JSON example with `\\b`, which JSON parsers then decode to
+			// `\b` for the regex engine.
 			"Example: {\"pattern\": \"func ReadFile\\\\b\", \"include\": [\"*.go\"], \"path\": \"harness/internal\"}",
 		InputSchema:       grepFilesSchema,
 		WorkspaceMutating: false,

--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -153,9 +153,13 @@ var lookPath = func(name string) (string, error) {
 // without re-running the search.
 func GrepFilesTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:              "grep_files",
-		Description:       "Search file contents in the workspace for a regular expression (RE2). Returns 'path:line:match' lines. Prefers ripgrep when available, falls back to a Go-native walker. Results are bounded by max_results.",
-		InputSchema:       grepFilesSchema,
+		Name: "grep_files",
+		Description: "Search file contents in the workspace for a regular expression (Go RE2 syntax). Returns one 'path:line:match' line per hit. " +
+			"Use this when looking for a string, symbol, or pattern inside files; use find_files instead when searching by filename or extension. " +
+			"The pattern is a regex, not a glob — pass '\\bMyFunc\\b' to find the symbol MyFunc, not '*MyFunc*'. " +
+			"include and exclude take shell-style globs (e.g. '*.go') applied to candidate paths. Results are capped by max_results (default 100, max 1000); binary files are skipped. " +
+			"Example: {\"pattern\": \"func ReadFile\\\\b\", \"include\": [\"*.go\"], \"path\": \"harness/internal\"}",
+		InputSchema: grepFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
@@ -231,9 +235,13 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 // executor regardless of CanExec.
 func FindFilesTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:              "find_files",
-		Description:       "Find files in the workspace whose names match a shell-style glob (e.g. '*.go', 'handler_*.ts'). Returns one path per line. Results are bounded by max_results.",
-		InputSchema:       findFilesSchema,
+		Name: "find_files",
+		Description: "Locate files in the workspace whose basenames match a shell-style glob. Returns one workspace-relative path per line. " +
+			"Use this when searching by filename or extension; use grep_files instead when searching for a pattern inside file contents. " +
+			"The name field is a glob (filepath.Match syntax) matched against each file's basename only — '*.go', 'handler_*.ts' — not a regex and not a path. The '**' segment is not supported in name; use the include filter to narrow by path. " +
+			"Results are capped by max_results (default 100, max 1000). " +
+			"Example: {\"name\": \"*_test.go\", \"path\": \"harness/internal\", \"exclude\": [\"*/testdata/*\"]}",
+		InputSchema: findFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {

--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -159,7 +159,7 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 			"The pattern is a regex, not a glob — pass '\\bMyFunc\\b' to find the symbol MyFunc, not '*MyFunc*'. " +
 			"include and exclude take shell-style globs (e.g. '*.go') applied to candidate paths. Results are capped by max_results (default 100, max 1000); binary files are skipped. " +
 			"Example: {\"pattern\": \"func ReadFile\\\\b\", \"include\": [\"*.go\"], \"path\": \"harness/internal\"}",
-		InputSchema: grepFilesSchema,
+		InputSchema:       grepFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
@@ -241,7 +241,7 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 			"The name field is a glob (filepath.Match syntax) matched against each file's basename only — '*.go', 'handler_*.ts' — not a regex and not a path. The '**' segment is not supported in name; use the include filter to narrow by path. " +
 			"Results are capped by max_results (default 100, max 1000). " +
 			"Example: {\"name\": \"*_test.go\", \"path\": \"harness/internal\", \"exclude\": [\"*/testdata/*\"]}",
-		InputSchema: findFilesSchema,
+		InputSchema:       findFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -31,9 +31,13 @@ var runCommandSchema = json.RawMessage(`{
 // RunCommandTool returns a tool that executes a shell command in the workspace.
 func RunCommandTool(exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:              "run_command",
-		Description:       "Execute a shell command in the workspace directory. Returns stdout and stderr. The command is killed if it exceeds the timeout.",
-		InputSchema:       runCommandSchema,
+		Name: "run_command",
+		Description: "Execute a shell command in the workspace directory. Returns stdout, then a 'STDERR:' block when stderr is non-empty, then '[exit code: N]' when the command exited non-zero. " +
+			"Use this for build, test, format, lint, and other tooling invocations that have to actually run. " +
+			"Do not use for filesystem inspection that a dedicated tool covers — prefer read_file, list_directory, grep_files, find_files because they return structured, bounded output and do not need a shell. " +
+			"timeout is in seconds (default 30, max 300); the command is killed when the timeout elapses. " +
+			"Example: {\"command\": \"go test ./harness/internal/tool/...\", \"timeout\": 120}",
+		InputSchema: runCommandSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -37,7 +37,7 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 			"Do not use for filesystem inspection that a dedicated tool covers — prefer read_file, list_directory, grep_files, find_files because they return structured, bounded output and do not need a shell. " +
 			"timeout is in seconds (default 30, max 300); the command is killed when the timeout elapses. " +
 			"Example: {\"command\": \"go test ./harness/internal/tool/...\", \"timeout\": 120}",
-		InputSchema: runCommandSchema,
+		InputSchema:       runCommandSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {

--- a/harness/internal/tool/builtins/subagent.go
+++ b/harness/internal/tool/builtins/subagent.go
@@ -43,8 +43,12 @@ type SubAgentSpawner func(ctx context.Context, prompt, mode string, maxTurns int
 // reference to the parent AgenticLoop and RunConfig.
 func SpawnAgentTool(spawner SubAgentSpawner) *tool.Tool {
 	return &tool.Tool{
-		Name:        "spawn_agent",
-		Description: "Spawn a sub-agent to handle a subtask. The sub-agent has access to the same workspace and tools but runs independently with its own conversation history. Use for tasks that benefit from a fresh context or that can be performed independently.",
+		Name: "spawn_agent",
+		Description: "Delegate a self-contained subtask to a fresh sub-agent. The sub-agent shares the workspace and tools but runs with its own conversation history and returns a single JSON-encoded result. " +
+			"Use this for work that benefits from a clean context (broad exploration, parallel-feel investigation, a bounded refactor) or that would otherwise pollute the parent conversation. " +
+			"Do not use for trivial one-tool-call tasks — the spawn overhead outweighs the benefit. The prompt must be specific and self-contained because the sub-agent cannot see the parent's history. " +
+			"mode defaults to the parent's mode; max_turns bounds the sub-agent at 1-20 turns (default 10). " +
+			"Example: {\"prompt\": \"Find every call site of harness.RunConfig.Redact and list them as path:line.\", \"mode\": \"research\", \"max_turns\": 8}",
 		InputSchema: spawnAgentSchema,
 		// The spawn_agent tool itself does not mutate the workspace —
 		// the sub-agent it launches is gated by its own permission

--- a/harness/internal/tool/builtins/subagent.go
+++ b/harness/internal/tool/builtins/subagent.go
@@ -45,6 +45,7 @@ func SpawnAgentTool(spawner SubAgentSpawner) *tool.Tool {
 	return &tool.Tool{
 		Name: "spawn_agent",
 		Description: "Delegate a self-contained subtask to a fresh sub-agent. The sub-agent shares the workspace and tools but runs with its own conversation history and returns a single JSON-encoded result. " +
+			"The sub-agent inherits the parent's permission policy, security GuardRail, and code scanner — spawning is a high-privilege delegation, not a sandbox. " +
 			"Use this for work that benefits from a clean context (broad exploration, parallel-feel investigation, a bounded refactor) or that would otherwise pollute the parent conversation. " +
 			"Do not use for trivial one-tool-call tasks — the spawn overhead outweighs the benefit. The prompt must be specific and self-contained because the sub-agent cannot see the parent's history. " +
 			"mode defaults to the parent's mode; max_turns bounds the sub-agent at 1-20 turns (default 10). " +

--- a/harness/internal/tool/builtins/webfetch.go
+++ b/harness/internal/tool/builtins/webfetch.go
@@ -57,8 +57,12 @@ func newWebFetchTool(opts webFetchOptions) *tool.Tool {
 	}
 
 	return &tool.Tool{
-		Name:        "web_fetch",
-		Description: "Fetch a URL via HTTP GET and return the response body as text. Response is truncated at 100KB.",
+		Name: "web_fetch",
+		Description: "Fetch a URL via HTTP GET and return the response body as text. The body is truncated at 100KB and a notice is appended when truncation occurred. " +
+			"Use this when external documentation, an issue body, a release note, or another public web resource is needed to complete the task. " +
+			"Do not use to read files from disk (use read_file) or to call internal services — only http:// and https:// schemes are accepted and private / loopback / link-local hosts are refused. " +
+			"Non-2xx responses are returned as errors. " +
+			"Example: {\"url\": \"https://pkg.go.dev/encoding/json\"}",
 		InputSchema: webFetchSchema,
 		// web_fetch does not mutate the workspace, but it makes outbound
 		// network requests on the user's behalf — gate it behind


### PR DESCRIPTION
Closes #227. **Final Wave 3 PR.** Stacked on [PR #320](https://github.com/rxbynerd/stirrup/pull/320) (Wave 3 Step B). The full stack: main → #315 (merged) → Wave 2 [#316, #317, #318] → Wave 3 [#319, #320, this PR].

When this stack merges, the tool-use debacle workstream's Waves 1–3 are complete; remaining waves cover loop recovery (#230/#231), eval suite (#233), aliases (#234), and lazy loading (#235).

---

## Wave 3 summary (across #319, #320, this PR)

Wave 3 reshapes the built-in tool surface so models can use it correctly without trial and error and providers can lint/enforce it server-side:

- **Step A (#319)** — schema redesign. `read_file` gets line ranges + numbered output. `search_files` splits into `grep_files` (regex content) + `find_files` (glob filename, basename-only) with no BC alias; legacy callers see an explicit migration error. `edit_file` requires an explicit `operation` enum (`replace`/`delete`/`rewrite`/`patch`) with per-op required-field validation. `list_directory` gets bounded recursion. Critical security fix during remediation: `grep_files` native walker no longer follows workspace-escaping symlinks (CWE-59), and glob include/exclude filters no longer fail open via unescaped regex metacharacters (CWE-185). 5 example RunConfigs + safety/security docs updated for the rename.

- **Step B (#320)** — provider-side schema lint + OpenAI strict-mode normalisation. New `quirks/strictschema.go` recursively rewrites tool schemas to OpenAI's strict-mode shape (all-required, nullable optionals, no additionalProperties); fails closed on unsupported keywords; cached per-adapter under singleflight semantics. New `gemini_schema_lint.go` rejects schemas containing keywords the resolved Gemini profile doesn't accept. Quirks rules opt in `gpt-4o-mini*` / `gpt-4.1*` / `gpt-5*` (with the `gpt-5-chat*` carve-out preserving strict mode) and Gemini-3 lint. Error messages identify tool + field path, never leak `description` or `enum` content.

- **This PR (Step C, #227)** — operator-facing description enrichment. All 9 built-in tools now carry a when-to-use sentence, an anti-pattern sentence (where applicable), bounds and failure-mode summary, and one parseable JSON example. Cross-references between `grep_files` ↔ `find_files`. `edit_file` lists required fields per operation, mirroring the runtime validation. Descriptions stay under a 2000-char per-tool cap; regression tests pin shape, parseable example, and the cap.

---

## What this PR (Step C) ships

### Enriched descriptions for 9 built-in tools
- **filesystem**: `read_file`, `write_file`, `list_directory`
- **search**: `grep_files`, `find_files` (cross-referenced for disambiguation)
- **edit**: `edit_file` (per-operation field requirements mirroring `validateOperationFields`)
- **shell**: `run_command`
- **fetch**: `web_fetch`
- **spawn**: `spawn_agent` (privilege-inheritance note added during polish)

### Worked JSON examples
- Each tool's description carries one syntactically-valid JSON snippet labelled `Example:`.
- `edit_file` uses `Example (replace):` to scope the example to one operation; the regression test extracts the rightmost `Example` marker.
- Examples use synthetic placeholders (e.g. `path/to/file.go`) — no self-referential project paths.

### Regression tests
- `TestBuiltinDescriptions_EnrichedShape` (table-driven, all 7 `RegisterBuiltins` tools): when-to-use, parseable JSON example, ≤ 2000 chars.
- `TestSpawnAgentTool_EnrichedShape`: spawn_agent specifically (wired via factory, not RegisterBuiltins).
- `TestMultiStrategy_DescriptionEnrichedShape`: edit_file's `Example (replace):` form.
- `TestExtractJSONExample` (new during polish): pins the rightmost-marker extraction contract.
- `TestHasPositiveUseThis`: the tightened "Use this" check that rejects negation-only descriptions.

## Pre-merge polish (no blockers)

Reviewers found 0 blocking items. 8 polish items applied:
- `spawn_agent` description now names the inherited capabilities (permission policy, GuardRail, scanner) — matters for prompt-injection resilience.
- `read_file` example switched from a real project path to a synthetic placeholder.
- `edit_file` description disambiguates `write_file` (new file or non-existent target) vs `rewrite` (replace contents of existing file).
- `grep_files` source-level `\\\\b` carries an inline comment explaining the wire form is `\b` (RE2 word boundary).
- `TestExtractJSONExample` covers no-marker / two-marker / malformed JSON edge cases.
- `TestBuiltinDescriptions_EnrichedShape` tightened: rejects descriptions whose "Use this" appears only in negations like "Do not use this...".
- Doc comments on `extractJSONExample` (both copies) lock the rightmost-marker uniqueness contract for the future #222 (`InputExamples`) migration.
- Cross-reference stability comment near `grep_files`/`find_files`: Wave 5 #234 aliases should not rename the references; descriptions resolve via canonical names.

## Verification

- `just` (build + full test suite) exits 0.
- `just lint` (golangci-lint v2) reports `0 issues`.
- Every enriched tool well under the 2000-char cap (longest is `spawn_agent` at ~784 chars, 39% of budget).
- All 9 enriched tools are pinned by structural tests (100% coverage on the structural target).
- Tightened "Use this" check confirmed to FAIL `"Do not use this for X."` and PASS the actual enriched descriptions.

## Deferred (#222 / Wave 4 / Wave 5 / future)

- **#222 (tool-contract extension)** — `InputExamples []any` field on `types.ToolDefinition`. When it lands, lift the JSON snippet from each description's `Example:` marker into the structured field and drop the suffix from `Description`. The `extractJSONExample` helper is the natural extraction starting point. Doc comments lock the contract.
- **Wave 4 #231 (structured tool results)** — when results gain structure, descriptions may also describe the result shape. Out of scope here.
- **Wave 5 #234 (toolset profiles + aliases)** — cross-references between `grep_files` and `find_files` use canonical registry names; aliases should not rename. Constraint commented.
- **`provider.quirkOverrides`** — design §5.1 sketch; operator-authored quirk surface remains deferred.
- **Provider-aware description size limits** — current 2000-char cap is a system-prompt budget heuristic, not a provider limit. Revisit if a provider's tool-description limit is observed to be lower.
- **Adversarial multi-`Example`-marker fuzz testing** — defer to when prose introduces real risk.
- **`extractJSONExample` duplication across packages** — implementer documented as intentional for test-binary independence; not worth a testutil extraction yet.

Reviewed by code, security, spec-compliance, test-coverage, and api-design reviewers; remediation brief in workstream scratch. Verdict: SHIP WITH POLISH (applied).