### PR TITLE
core: tool-choice plumbing — StreamParams control + cross-provider quirks capability (Wave 4 A1)

### DIFF
--- a/harness/cmd/stirrup/cmd/providers_quirks_test.go
+++ b/harness/cmd/stirrup/cmd/providers_quirks_test.go
@@ -24,13 +24,17 @@ func newTestProvidersQuirksCommand() *cobra.Command {
 }
 
 // TestProvidersQuirks_EmptyRegistryEmitsValidJSON exercises the
-// Step-1 BuiltinRules() empty state: the subcommand must still
-// produce a structurally valid JSON document with an empty
-// appliedRules slice (not null) and a ProviderQuirks value at the
-// post-Resolve zero shape (non-nil empty maps/slices).
+// no-rules-matched state: the subcommand must still produce a
+// structurally valid JSON document with an empty appliedRules slice
+// (not null) and a ProviderQuirks value at the post-Resolve zero shape
+// (non-nil empty maps/slices). It resolves an unknown provider type so
+// no builtin rule fires — the first-party providers now all carry a
+// cross-provider tool-choice base rule (#230) that matches every model,
+// so this assertion needs a provider with no rules at all to still
+// observe the empty-appliedRules path.
 func TestProvidersQuirks_EmptyRegistryEmitsValidJSON(t *testing.T) {
 	cmd := newTestProvidersQuirksCommand()
-	if err := cmd.ParseFlags([]string{"--provider", "openai-compatible", "--model", "gpt-4o"}); err != nil {
+	if err := cmd.ParseFlags([]string{"--provider", "no-such-provider", "--model", "gpt-4o"}); err != nil {
 		t.Fatalf("ParseFlags: %v", err)
 	}
 	var buf bytes.Buffer
@@ -43,8 +47,8 @@ func TestProvidersQuirks_EmptyRegistryEmitsValidJSON(t *testing.T) {
 		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
 	}
 
-	if got.Provider != "openai-compatible" {
-		t.Errorf("Provider = %q, want openai-compatible", got.Provider)
+	if got.Provider != "no-such-provider" {
+		t.Errorf("Provider = %q, want no-such-provider", got.Provider)
 	}
 	if got.Model != "gpt-4o" {
 		t.Errorf("Model = %q, want gpt-4o", got.Model)

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -180,6 +180,13 @@ func anthropicToolChoiceFromParams(params types.StreamParams, cap quirks.ToolCho
 		if !cap.NamedTool || params.ToolChoiceName == "" {
 			return nil
 		}
+		// Defense-in-depth at the wire boundary (#230 B3): A2 will feed
+		// model-influenced names through ToolChoiceName, so reject any
+		// name outside the providers' shared grammar and degrade to auto.
+		if err := types.ValidateToolChoiceName(params.ToolChoiceName); err != nil {
+			warnInvalidToolChoiceName("anthropic", params.Model, len(params.ToolChoiceName))
+			return nil
+		}
 		return &anthropicToolChoice{Type: "tool", Name: params.ToolChoiceName}
 	default:
 		// ToolChoiceAuto (zero value) and ToolChoiceNone both emit no

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -59,6 +60,17 @@ type AnthropicAdapter struct {
 	baseURL    string                 // overridable for testing
 	Tracer     oteltrace.Tracer       // optional, set by factory for span instrumentation
 	Metrics    *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
+
+	// Registry resolves per-(provider, model) quirks at the top of every
+	// Stream call. The constructor seeds it with quirks.DefaultRegistry()
+	// so callers that ignore the field still get the built-in rule set;
+	// the nil-Registry guard in Stream tolerates direct construction. The
+	// Anthropic adapter only reads the cross-provider ToolChoice
+	// capability today (Anthropic has no wire-shape or sampling-param
+	// divergences StreamParams cannot already express), but resolving
+	// through the registry keeps the tool-choice gating consistent with
+	// the OpenAI and Gemini adapters.
+	Registry *quirks.Registry
 }
 
 // NewAnthropicAdapter creates an adapter for the Anthropic Messages API.
@@ -88,7 +100,8 @@ func NewAnthropicAdapter(bearer credential.BearerTokenFunc, authMode AuthMode) *
 				IdleConnTimeout:       90 * time.Second,
 			},
 		},
-		baseURL: anthropicAPIURL,
+		baseURL:  anthropicAPIURL,
+		Registry: quirks.DefaultRegistry(),
 	}
 }
 
@@ -127,7 +140,53 @@ type anthropicRequest struct {
 	Tools       []types.ToolDefinition `json:"tools,omitempty"`
 	MaxTokens   int                    `json:"max_tokens"`
 	Temperature *float64               `json:"temperature,omitempty"`
-	Stream      bool                   `json:"stream"`
+	// ToolChoice is the Anthropic tool_choice object. A nil pointer omits
+	// the field entirely so a request that does not pin tool choice is
+	// byte-identical to the pre-#230 shape; this is the zero-value
+	// ToolChoiceAuto path. Populated only when the resolved quirks
+	// advertise native support for the requested mode.
+	ToolChoice *anthropicToolChoice `json:"tool_choice,omitempty"`
+	Stream     bool                 `json:"stream"`
+}
+
+// anthropicToolChoice is the Anthropic Messages API tool_choice object.
+// Type is one of "auto", "any", or "tool"; Name is set only for "tool".
+// Anthropic has no native "none" — a no-tools turn is expressed by
+// omitting the tools array — so ToolChoiceNone never produces this
+// struct.
+type anthropicToolChoice struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+}
+
+// anthropicToolChoiceFromParams projects the provider-neutral
+// StreamParams.ToolChoice onto the Anthropic tool_choice object, gated on
+// the resolved capability. Returns nil — meaning "emit no field" — for the
+// auto mode, for an unsupported mode, and for the structural "none" case
+// (Anthropic expresses none by omitting tools, not via tool_choice).
+func anthropicToolChoiceFromParams(params types.StreamParams, cap quirks.ToolChoiceCapability) *anthropicToolChoice {
+	if !cap.Supported {
+		return nil
+	}
+	switch params.ToolChoice {
+	case types.ToolChoiceRequired:
+		if !cap.Required {
+			return nil
+		}
+		return &anthropicToolChoice{Type: "any"}
+	case types.ToolChoiceTool:
+		// A named-tool choice with no name is not expressible; treat it
+		// as auto (emit nothing) rather than send an invalid object.
+		if !cap.NamedTool || params.ToolChoiceName == "" {
+			return nil
+		}
+		return &anthropicToolChoice{Type: "tool", Name: params.ToolChoiceName}
+	default:
+		// ToolChoiceAuto (zero value) and ToolChoiceNone both emit no
+		// tool_choice field: auto is the wire default, and Anthropic has
+		// no native none.
+		return nil
+	}
 }
 
 // anthropicMessage is the Anthropic-side wire shape for a single message.
@@ -232,10 +291,17 @@ type sseMessageDelta struct {
 // non-streaming caller (batch submission, phase 2 of issue #133) can reuse
 // the same projection without duplicating field-by-field copying.
 //
+// q carries the resolved per-(provider, model) quirks. Today the only
+// load-bearing field for the Anthropic build path is the cross-provider
+// ToolChoice capability, which gates whether StreamParams.ToolChoice is
+// projected onto the tool_choice object. A zero-value q (Supported=false)
+// emits no tool_choice field, so callers that do not route through the
+// registry produce the pre-#230 wire shape.
+//
 // TODO(batch): if the batch endpoint rejects fields the streaming endpoint
 // accepts (e.g. thinking_config), change the return type to
 // (json.RawMessage, error) and apply a batch-specific projection here.
-func buildAnthropicRequest(params types.StreamParams, stream bool) anthropicRequest {
+func buildAnthropicRequest(params types.StreamParams, stream bool, q quirks.ProviderQuirks) anthropicRequest {
 	return anthropicRequest{
 		Model:    params.Model,
 		System:   params.System,
@@ -250,6 +316,7 @@ func buildAnthropicRequest(params types.StreamParams, stream bool) anthropicRequ
 		Tools:       slices.Clone(params.Tools),
 		MaxTokens:   params.MaxTokens,
 		Temperature: params.Temperature,
+		ToolChoice:  anthropicToolChoiceFromParams(params, q.ToolChoice),
 		Stream:      stream,
 	}
 }
@@ -264,7 +331,17 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, params types.StreamParams
 		attribute.String("provider.model", params.Model),
 	)
 
-	reqBody := buildAnthropicRequest(params, true)
+	// Resolve quirks for this (provider, model) pair. Per design D4 the
+	// resolution is per-stream. The nil-Registry guard tolerates callers
+	// that build the adapter outside the factory without going through
+	// NewAnthropicAdapter.
+	registry := a.Registry
+	if registry == nil {
+		registry = quirks.DefaultRegistry()
+	}
+	q := registry.Resolve("anthropic", params.Model)
+
+	reqBody := buildAnthropicRequest(params, true, q)
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {

--- a/harness/internal/provider/anthropic_builder_test.go
+++ b/harness/internal/provider/anthropic_builder_test.go
@@ -175,7 +175,8 @@ func TestBuildAnthropicRequest_StreamFlag(t *testing.T) {
 //   - ToolChoiceAuto (zero) and ToolChoiceNone emit no tool_choice field;
 //   - ToolChoiceRequired emits {"type":"any"};
 //   - ToolChoiceTool with a name emits {"type":"tool","name":...};
-//   - ToolChoiceTool with no name degrades to auto (no field).
+//   - ToolChoiceTool with no name, an invalid name, or an over-length
+//     name degrades to auto (no field).
 func TestBuildAnthropicRequest_ToolChoice(t *testing.T) {
 	base := types.StreamParams{
 		Model:     "claude-sonnet-4-6",
@@ -198,6 +199,8 @@ func TestBuildAnthropicRequest_ToolChoice(t *testing.T) {
 		{"required emits any", types.ToolChoiceRequired, "", `"tool_choice":{"type":"any"}`},
 		{"tool emits named", types.ToolChoiceTool, "read_file", `"tool_choice":{"type":"tool","name":"read_file"}`},
 		{"tool without name degrades to auto", types.ToolChoiceTool, "", ""},
+		{"tool with invalid name degrades to auto", types.ToolChoiceTool, "bad name!", ""},
+		{"tool with over-length name degrades to auto", types.ToolChoiceTool, strings.Repeat("a", 65), ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -239,6 +242,27 @@ func TestBuildAnthropicRequest_ToolChoiceUnsupportedCapability(t *testing.T) {
 	}
 	if strings.Contains(string(body), "tool_choice") {
 		t.Errorf("zero-value capability must emit no tool_choice field, got: %s", body)
+	}
+}
+
+// TestBuildAnthropicRequest_ToolChoice_PartialCapability exercises the
+// per-mode guard branch (B2) that the full-support builtin rule never
+// reaches: a capability with Supported=true but Required=false must omit
+// the field rather than fail open and emit {"type":"any"}.
+func TestBuildAnthropicRequest_ToolChoice_PartialCapability(t *testing.T) {
+	params := types.StreamParams{
+		Model:      "claude-sonnet-4-6",
+		MaxTokens:  256,
+		ToolChoice: types.ToolChoiceRequired,
+		Messages:   []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+	}
+	q := quirks.ProviderQuirks{ToolChoice: quirks.ToolChoiceCapability{Supported: true, Required: false, NamedTool: true}}
+	body, err := json.Marshal(buildAnthropicRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "tool_choice") {
+		t.Errorf("Required=false capability must emit no tool_choice field, got: %s", body)
 	}
 }
 

--- a/harness/internal/provider/anthropic_builder_test.go
+++ b/harness/internal/provider/anthropic_builder_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -115,7 +116,8 @@ func TestBuildAnthropicRequest_MatchesStream(t *testing.T) {
 			}
 			captured := <-capturedCh
 
-			built := buildAnthropicRequest(tc.params, true)
+			q := quirks.DefaultRegistry().Resolve("anthropic", tc.params.Model)
+			built := buildAnthropicRequest(tc.params, true, q)
 			builtBytes, err := json.Marshal(built)
 			if err != nil {
 				t.Fatalf("marshal builder output: %v", err)
@@ -144,25 +146,99 @@ func TestBuildAnthropicRequest_StreamFlag(t *testing.T) {
 		MaxTokens: 1024,
 		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
 	}
-	if got := buildAnthropicRequest(params, true).Stream; got != true {
+	q := quirks.DefaultRegistry().Resolve("anthropic", params.Model)
+	if got := buildAnthropicRequest(params, true, q).Stream; got != true {
 		t.Errorf("stream=true argument: got Stream=%v, want true", got)
 	}
-	if got := buildAnthropicRequest(params, false).Stream; got != false {
+	if got := buildAnthropicRequest(params, false, q).Stream; got != false {
 		t.Errorf("stream=false argument: got Stream=%v, want false", got)
 	}
-	trueBody, err := json.Marshal(buildAnthropicRequest(params, true))
+	trueBody, err := json.Marshal(buildAnthropicRequest(params, true, q))
 	if err != nil {
 		t.Fatalf("marshal stream=true body: %v", err)
 	}
 	if !strings.Contains(string(trueBody), `"stream":true`) {
 		t.Errorf(`expected "stream":true in stream=true body: %s`, trueBody)
 	}
-	falseBody, err := json.Marshal(buildAnthropicRequest(params, false))
+	falseBody, err := json.Marshal(buildAnthropicRequest(params, false, q))
 	if err != nil {
 		t.Fatalf("marshal stream=false body: %v", err)
 	}
 	if !strings.Contains(string(falseBody), `"stream":false`) {
 		t.Errorf(`expected "stream":false in stream=false body: %s`, falseBody)
+	}
+}
+
+// TestBuildAnthropicRequest_ToolChoice pins the tool_choice projection
+// gated on the resolved capability. Anthropic's base rule advertises
+// auto/any/tool (no native none), so:
+//   - ToolChoiceAuto (zero) and ToolChoiceNone emit no tool_choice field;
+//   - ToolChoiceRequired emits {"type":"any"};
+//   - ToolChoiceTool with a name emits {"type":"tool","name":...};
+//   - ToolChoiceTool with no name degrades to auto (no field).
+func TestBuildAnthropicRequest_ToolChoice(t *testing.T) {
+	base := types.StreamParams{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: 256,
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+		Tools: []types.ToolDefinition{
+			{Name: "read_file", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	}
+	q := quirks.DefaultRegistry().Resolve("anthropic", base.Model)
+
+	cases := []struct {
+		name       string
+		choice     types.ToolChoiceMode
+		toolName   string
+		wantSubstr string // empty means "no tool_choice field"
+	}{
+		{"auto omits field", types.ToolChoiceAuto, "", ""},
+		{"none omits field (no native none)", types.ToolChoiceNone, "", ""},
+		{"required emits any", types.ToolChoiceRequired, "", `"tool_choice":{"type":"any"}`},
+		{"tool emits named", types.ToolChoiceTool, "read_file", `"tool_choice":{"type":"tool","name":"read_file"}`},
+		{"tool without name degrades to auto", types.ToolChoiceTool, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := base
+			params.ToolChoice = tc.choice
+			params.ToolChoiceName = tc.toolName
+			body, err := json.Marshal(buildAnthropicRequest(params, true, q))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if tc.wantSubstr == "" {
+				if strings.Contains(string(body), "tool_choice") {
+					t.Errorf("expected no tool_choice field, got body: %s", body)
+				}
+				return
+			}
+			if !strings.Contains(string(body), tc.wantSubstr) {
+				t.Errorf("expected %s in body, got: %s", tc.wantSubstr, body)
+			}
+		})
+	}
+}
+
+// TestBuildAnthropicRequest_ToolChoiceUnsupportedCapability pins the
+// graceful no-op: when the resolved capability advertises no support
+// (zero-value quirks), no tool_choice field is emitted even for a
+// ToolChoiceRequired request. The escalation chunk's prompt fallback
+// covers this case, not the adapter.
+func TestBuildAnthropicRequest_ToolChoiceUnsupportedCapability(t *testing.T) {
+	params := types.StreamParams{
+		Model:      "claude-sonnet-4-6",
+		MaxTokens:  256,
+		ToolChoice: types.ToolChoiceRequired,
+		Messages:   []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+	}
+	body, err := json.Marshal(buildAnthropicRequest(params, true, quirks.ProviderQuirks{}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "tool_choice") {
+		t.Errorf("zero-value capability must emit no tool_choice field, got: %s", body)
 	}
 }
 
@@ -198,7 +274,8 @@ func TestBuildAnthropicRequest_ThoughtSignatureDropped(t *testing.T) {
 			},
 		},
 	}
-	body, err := json.Marshal(buildAnthropicRequest(params, false))
+	q := quirks.DefaultRegistry().Resolve("anthropic", params.Model)
+	body, err := json.Marshal(buildAnthropicRequest(params, false, q))
 	if err != nil {
 		t.Fatalf("marshal builder output: %v", err)
 	}

--- a/harness/internal/provider/batch.go
+++ b/harness/internal/provider/batch.go
@@ -258,7 +258,12 @@ func (a *BatchAdapter) LastBatchID() string {
 func (a *BatchAdapter) marshalRequestBody(params types.StreamParams) (json.RawMessage, error) {
 	switch a.provType {
 	case "anthropic":
-		return json.Marshal(buildAnthropicRequest(params, false))
+		registry := a.Registry
+		if registry == nil {
+			registry = quirks.DefaultRegistry()
+		}
+		q := registry.Resolve("anthropic", params.Model)
+		return json.Marshal(buildAnthropicRequest(params, false, q))
 	case "openai-compatible":
 		registry := a.Registry
 		if registry == nil {

--- a/harness/internal/provider/gemini_request.go
+++ b/harness/internal/provider/gemini_request.go
@@ -36,14 +36,19 @@ var defaultGeminiSafetyThresholds = []geminiSafetySetting{
 // defaultGeminiSafetyThresholds for the full list.
 //
 // q carries the resolved per-(provider, model) quirks for this stream.
-// Today its only load-bearing field for the request-build path is
-// BehaviourFlags.Gemini.StreamFunctionCallArgsShape, which selects the
-// value emitted at functionCallingConfig.streamFunctionCallArguments.
+// The request-build path reads two fields from it:
+//   - BehaviourFlags.Gemini.StreamFunctionCallArgsShape selects the value
+//     emitted at functionCallingConfig.streamFunctionCallArguments.
+//   - ToolChoice (the cross-provider capability) gates whether
+//     StreamParams.ToolChoice is projected onto
+//     functionCallingConfig.mode / allowedFunctionNames.
+//
 // A zero-value q reproduces today's post-#191 behaviour (StreamArgsOff
-// → false on the wire), so callers that do not yet route through the
-// registry continue to work. Future Gemini quirks (3.x V3Deltas pilot,
-// model-specific tool-config flags) are added by extending the switch
-// rather than threading new parameters.
+// → false on the wire, and mode AUTO with no allow-list because the
+// capability advertises no support), so callers that do not yet route
+// through the registry continue to work. Future Gemini quirks (3.x
+// V3Deltas pilot, model-specific tool-config flags) are added by
+// extending the switch rather than threading new parameters.
 //
 // Errors fall into three categories:
 //
@@ -353,6 +358,12 @@ func geminiToolChoiceFromParams(params types.StreamParams, capability quirks.Too
 		// a single allowed function name. A choice with no name is not
 		// expressible, so fall back to AUTO.
 		if !capability.NamedTool || params.ToolChoiceName == "" {
+			return "AUTO", nil
+		}
+		// Defense-in-depth at the wire boundary (#230 B3): reject any name
+		// outside the providers' shared grammar and degrade to AUTO.
+		if err := types.ValidateToolChoiceName(params.ToolChoiceName); err != nil {
+			warnInvalidToolChoiceName("gemini", params.Model, len(params.ToolChoiceName))
 			return "AUTO", nil
 		}
 		return "ANY", []string{params.ToolChoiceName}

--- a/harness/internal/provider/gemini_request.go
+++ b/harness/internal/provider/gemini_request.go
@@ -104,10 +104,12 @@ func BuildGenerateContentRequest(
 				Parameters:  converted,
 			})
 		}
+		mode, allowed := geminiToolChoiceFromParams(params, q.ToolChoice)
 		req.Tools = []geminiTools{{FunctionDeclarations: decls}}
 		req.ToolConfig = &geminiToolConfig{
 			FunctionCallingConfig: geminiFunctionCallingConfig{
-				Mode:                        "AUTO",
+				Mode:                        mode,
+				AllowedFunctionNames:        allowed,
 				StreamFunctionCallArguments: streamFunctionCallArgsFromQuirks(q),
 			},
 		}
@@ -321,6 +323,42 @@ func normaliseToolArgs(in json.RawMessage) json.RawMessage {
 		return json.RawMessage("{}")
 	}
 	return in
+}
+
+// geminiToolChoiceFromParams projects the provider-neutral
+// StreamParams.ToolChoice onto Gemini's functionCallingConfig.mode and,
+// for the named-tool form, allowedFunctionNames. It is gated on the
+// resolved capability and falls back to "AUTO" (the historical default
+// emitted whenever tools were present) for the auto mode, for any
+// unsupported mode, and for a named-tool choice with no name. Returning
+// "AUTO" with a nil allow-list keeps the wire body byte-identical to the
+// pre-#230 shape in every non-escalated turn.
+func geminiToolChoiceFromParams(params types.StreamParams, capability quirks.ToolChoiceCapability) (mode string, allowedFunctionNames []string) {
+	if !capability.Supported {
+		return "AUTO", nil
+	}
+	switch params.ToolChoice {
+	case types.ToolChoiceRequired:
+		if !capability.Required {
+			return "AUTO", nil
+		}
+		return "ANY", nil
+	case types.ToolChoiceNone:
+		if !capability.None {
+			return "AUTO", nil
+		}
+		return "NONE", nil
+	case types.ToolChoiceTool:
+		// Gemini expresses "force this one tool" as ANY mode restricted to
+		// a single allowed function name. A choice with no name is not
+		// expressible, so fall back to AUTO.
+		if !capability.NamedTool || params.ToolChoiceName == "" {
+			return "AUTO", nil
+		}
+		return "ANY", []string{params.ToolChoiceName}
+	default:
+		return "AUTO", nil
+	}
 }
 
 // streamFunctionCallArgsFromQuirks projects the resolved

--- a/harness/internal/provider/gemini_request_test.go
+++ b/harness/internal/provider/gemini_request_test.go
@@ -55,8 +55,9 @@ type decodedFuncDecl struct {
 
 type decodedToolConfig struct {
 	FunctionCallingConfig struct {
-		Mode                        string `json:"mode"`
-		StreamFunctionCallArguments bool   `json:"streamFunctionCallArguments"`
+		Mode                        string   `json:"mode"`
+		AllowedFunctionNames        []string `json:"allowedFunctionNames"`
+		StreamFunctionCallArguments bool     `json:"streamFunctionCallArguments"`
 	} `json:"functionCallingConfig"`
 }
 
@@ -376,6 +377,90 @@ func TestBuildGenerateContentRequest_StreamFunctionCallArgumentsFalseWhenToolsPr
 	}
 	if params["type"] != "OBJECT" {
 		t.Errorf("parameters.type = %v, want OBJECT", params["type"])
+	}
+}
+
+// TestBuildGenerateContentRequest_ToolChoice pins the
+// functionCallingConfig.mode projection gated on the resolved
+// capability. Gemini's base rule advertises every mode, so:
+//   - ToolChoiceAuto (zero) keeps mode AUTO with no allowedFunctionNames;
+//   - ToolChoiceRequired emits mode ANY;
+//   - ToolChoiceNone emits mode NONE;
+//   - ToolChoiceTool emits mode ANY restricted to the named tool;
+//   - ToolChoiceTool with no name degrades to AUTO.
+func TestBuildGenerateContentRequest_ToolChoice(t *testing.T) {
+	q := quirks.DefaultRegistry().Resolve("gemini", "gemini-2.5-pro")
+	baseTools := []types.ToolDefinition{
+		{Name: "read_file", Description: "read a file", InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+	}
+
+	cases := []struct {
+		name        string
+		choice      types.ToolChoiceMode
+		toolName    string
+		wantMode    string
+		wantAllowed []string
+	}{
+		{"auto", types.ToolChoiceAuto, "", "AUTO", nil},
+		{"required", types.ToolChoiceRequired, "", "ANY", nil},
+		{"none", types.ToolChoiceNone, "", "NONE", nil},
+		{"named tool", types.ToolChoiceTool, "read_file", "ANY", []string{"read_file"}},
+		{"named tool without name degrades to auto", types.ToolChoiceTool, "", "AUTO", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _, err := BuildGenerateContentRequest(types.StreamParams{
+				Model:          "gemini-2.5-pro",
+				ToolChoice:     tc.choice,
+				ToolChoiceName: tc.toolName,
+				Messages:       []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}}},
+				Tools:          baseTools,
+			}, nil, q)
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			dr := decodeGeminiRequest(t, body)
+			if dr.ToolConfig == nil {
+				t.Fatalf("expected toolConfig to be set")
+			}
+			if got := dr.ToolConfig.FunctionCallingConfig.Mode; got != tc.wantMode {
+				t.Errorf("mode = %q, want %q", got, tc.wantMode)
+			}
+			got := dr.ToolConfig.FunctionCallingConfig.AllowedFunctionNames
+			if len(got) != len(tc.wantAllowed) {
+				t.Fatalf("allowedFunctionNames = %v, want %v", got, tc.wantAllowed)
+			}
+			for i := range got {
+				if got[i] != tc.wantAllowed[i] {
+					t.Errorf("allowedFunctionNames[%d] = %q, want %q", i, got[i], tc.wantAllowed[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBuildGenerateContentRequest_ToolChoiceUnsupportedCapability pins
+// the graceful no-op: a zero-value capability leaves the mode at AUTO
+// even for a ToolChoiceRequired request (the historical default emitted
+// whenever tools are present).
+func TestBuildGenerateContentRequest_ToolChoiceUnsupportedCapability(t *testing.T) {
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model:      "gemini-2.5-pro",
+		ToolChoice: types.ToolChoiceRequired,
+		Messages:   []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}}},
+		Tools: []types.ToolDefinition{
+			{Name: "read_file", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	}, nil, quirks.ProviderQuirks{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	dr := decodeGeminiRequest(t, body)
+	if dr.ToolConfig == nil {
+		t.Fatalf("expected toolConfig to be set")
+	}
+	if got := dr.ToolConfig.FunctionCallingConfig.Mode; got != "AUTO" {
+		t.Errorf("zero-value capability: mode = %q, want AUTO", got)
 	}
 }
 

--- a/harness/internal/provider/gemini_request_test.go
+++ b/harness/internal/provider/gemini_request_test.go
@@ -406,6 +406,8 @@ func TestBuildGenerateContentRequest_ToolChoice(t *testing.T) {
 		{"none", types.ToolChoiceNone, "", "NONE", nil},
 		{"named tool", types.ToolChoiceTool, "read_file", "ANY", []string{"read_file"}},
 		{"named tool without name degrades to auto", types.ToolChoiceTool, "", "AUTO", nil},
+		{"named tool with invalid name degrades to auto", types.ToolChoiceTool, "bad name!", "AUTO", nil},
+		{"named tool with over-length name degrades to auto", types.ToolChoiceTool, strings.Repeat("a", 65), "AUTO", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -461,6 +463,44 @@ func TestBuildGenerateContentRequest_ToolChoiceUnsupportedCapability(t *testing.
 	}
 	if got := dr.ToolConfig.FunctionCallingConfig.Mode; got != "AUTO" {
 		t.Errorf("zero-value capability: mode = %q, want AUTO", got)
+	}
+}
+
+// TestBuildGenerateContentRequest_ToolChoice_PartialCapability exercises
+// the per-mode guard branches (B2) that today's full-support builtin
+// rule never reaches: Supported=true with a specific mode disabled must
+// fall back to mode AUTO rather than emit the disallowed mode.
+func TestBuildGenerateContentRequest_ToolChoice_PartialCapability(t *testing.T) {
+	tools := []types.ToolDefinition{
+		{Name: "read_file", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	cases := []struct {
+		name   string
+		choice types.ToolChoiceMode
+		cap    quirks.ToolChoiceCapability
+	}{
+		{"required disabled", types.ToolChoiceRequired, quirks.ToolChoiceCapability{Supported: true, Required: false}},
+		{"none disabled", types.ToolChoiceNone, quirks.ToolChoiceCapability{Supported: true, None: false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _, err := BuildGenerateContentRequest(types.StreamParams{
+				Model:      "gemini-2.5-pro",
+				ToolChoice: tc.choice,
+				Messages:   []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}}},
+				Tools:      tools,
+			}, nil, quirks.ProviderQuirks{ToolChoice: tc.cap})
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			dr := decodeGeminiRequest(t, body)
+			if dr.ToolConfig == nil {
+				t.Fatalf("expected toolConfig to be set")
+			}
+			if got := dr.ToolConfig.FunctionCallingConfig.Mode; got != "AUTO" {
+				t.Errorf("partial capability: mode = %q, want AUTO", got)
+			}
+		})
 	}
 }
 

--- a/harness/internal/provider/gemini_types.go
+++ b/harness/internal/provider/gemini_types.go
@@ -127,11 +127,14 @@ type geminiToolConfig struct {
 
 // geminiFunctionCallingConfig selects the tool-calling mode and streaming
 // behaviour. Mode "AUTO" lets the model choose whether to call a tool;
-// "ANY" / "NONE" exist on the API but the harness does not currently
-// expose them.
+// "ANY" forces a tool call, "NONE" forbids one. AllowedFunctionNames
+// restricts an ANY-mode turn to a specific subset — the harness uses it
+// to express a single-named-tool choice (StreamParams.ToolChoiceTool).
+// It is omitempty so AUTO/NONE and an unrestricted ANY emit no array.
 type geminiFunctionCallingConfig struct {
-	Mode                        string `json:"mode"`
-	StreamFunctionCallArguments bool   `json:"streamFunctionCallArguments,omitempty"`
+	Mode                        string   `json:"mode"`
+	AllowedFunctionNames        []string `json:"allowedFunctionNames,omitempty"`
+	StreamFunctionCallArguments bool     `json:"streamFunctionCallArguments,omitempty"`
 }
 
 // geminiSafetySetting is the wire-format struct (HARM_CATEGORY_*,

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -482,6 +482,23 @@ type openaiTool struct {
 	Function openaiToolDefinition `json:"function"`
 }
 
+// openAINamedToolChoice is the object form of OpenAI's tool_choice that
+// forces a specific function. Typed (rather than a map[string]any) so the
+// marshalled key order is deterministic — "type" before "function" — and
+// to honour the project's anti-`any` rule (wave-2 design D13). The string
+// forms ("required"/"none") are emitted directly as a string value, so
+// only the named form needs a struct.
+type openAINamedToolChoice struct {
+	Type     string                    `json:"type"` // "function"
+	Function openAINamedToolChoiceFunc `json:"function"`
+}
+
+// openAINamedToolChoiceFunc is the function payload inside an
+// openAINamedToolChoice.
+type openAINamedToolChoiceFunc struct {
+	Name string `json:"name"`
+}
+
 // openaiToolDefinition is the function definition inside an openaiTool.
 //
 // Strict is a *bool so the zero-value request body omits the field
@@ -724,7 +741,12 @@ func translateTools(tools []types.ToolDefinition, strict bool, model string, cac
 //
 // OpenAI accepts a string ("auto"/"required"/"none") or an object naming
 // a specific function. The named-tool form degrades to nil when the tool
-// name is empty (not expressible) rather than emitting an invalid object.
+// name is empty or fails ValidateToolChoiceName (not expressible / unsafe)
+// rather than emitting an invalid object.
+//
+// The return type is `any` because OpenAI's tool_choice is a sum type
+// (string OR object); the named-tool object is the typed
+// openAINamedToolChoice so its key order is deterministic on the wire.
 func openAIToolChoiceFromParams(params types.StreamParams, capability quirks.ToolChoiceCapability) any {
 	if !capability.Supported {
 		return nil
@@ -744,15 +766,42 @@ func openAIToolChoiceFromParams(params types.StreamParams, capability quirks.Too
 		if !capability.NamedTool || params.ToolChoiceName == "" {
 			return nil
 		}
-		return map[string]any{
-			"type":     "function",
-			"function": map[string]any{"name": params.ToolChoiceName},
+		if err := types.ValidateToolChoiceName(params.ToolChoiceName); err != nil {
+			warnInvalidToolChoiceName("openai-compatible", params.Model, len(params.ToolChoiceName))
+			return nil
+		}
+		return openAINamedToolChoice{
+			Type:     "function",
+			Function: openAINamedToolChoiceFunc{Name: params.ToolChoiceName},
 		}
 	default:
 		// ToolChoiceAuto (zero value): auto is the wire default, so emit
 		// nothing rather than an explicit "auto" string.
 		return nil
 	}
+}
+
+// warnInvalidToolChoiceName logs a single warn when a ToolChoiceTool
+// request carried a name that failed ValidateToolChoiceName, so the
+// degradation to auto is observable. Shared by all three adapters'
+// projection helpers. Uses slog.Default() rather than threading the
+// per-adapter logger: this is a should-never-happen defensive path (A1
+// has no caller that feeds model-influenced names through ToolChoiceName),
+// so the value of trace correlation does not justify widening every
+// builder signature.
+//
+// The offending name is NOT logged. It is caller/model-influenced input
+// that could carry log-injection bytes (newlines, control chars), and the
+// fixed grammar in the message is enough for an operator to understand
+// the rejection. The name's length is the only quantitative signal, which
+// is safe to surface.
+func warnInvalidToolChoiceName(providerType, model string, nameLen int) {
+	slog.Default().Warn("tool choice name failed validation; degrading to auto",
+		slog.String("provider.type", providerType),
+		slog.String("provider.model", model),
+		slog.String("grammar", "^[a-zA-Z0-9_-]{1,64}$"),
+		slog.Int("name_len", nameLen),
+	)
 }
 
 // mapFinishReason converts OpenAI's finish_reason to stirrup's stop reason.

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -158,6 +158,14 @@ type openaiRequest struct {
 	TokenField         quirks.OpenAITokenField
 	OmitSamplingParams bool
 	ExtraBodyFields    map[string]any
+	// ToolChoice is the wire value for the OpenAI "tool_choice" field:
+	// a string ("auto"/"required"/"none") or an object naming a function.
+	// A nil interface omits the field entirely so the zero-value
+	// ToolChoiceAuto request is byte-identical to the pre-#230 shape.
+	// Populated by buildOpenAIRequest only when the resolved capability
+	// advertises support for the requested mode; steers MarshalJSON, it
+	// has no JSON struct tag of its own.
+	ToolChoice any
 }
 
 // MarshalJSON projects the canonical openaiRequest into the wire body
@@ -195,6 +203,9 @@ func (r openaiRequest) MarshalJSON() ([]byte, error) {
 	}
 	if len(r.Tools) > 0 {
 		out["tools"] = r.Tools
+	}
+	if r.ToolChoice != nil {
+		out["tool_choice"] = r.ToolChoice
 	}
 	if !r.OmitSamplingParams && r.Temperature != nil {
 		out["temperature"] = *r.Temperature
@@ -258,6 +269,14 @@ func (r *openaiRequest) UnmarshalJSON(data []byte) error {
 		}
 		r.Temperature = &t
 		delete(raw, "temperature")
+	}
+	if v, ok := raw["tool_choice"]; ok {
+		var tc any
+		if err := json.Unmarshal(v, &tc); err != nil {
+			return fmt.Errorf("openaiRequest.tool_choice: %w", err)
+		}
+		r.ToolChoice = tc
+		delete(raw, "tool_choice")
 	}
 	// Token budget: accept either canonical key. MarshalJSON emits
 	// exactly one key, so a valid request body should not contain
@@ -414,6 +433,7 @@ var canonicalOpenAIFields = map[string]struct{}{
 	"model":                 {},
 	"messages":              {},
 	"tools":                 {},
+	"tool_choice":           {},
 	"max_completion_tokens": {},
 	"max_tokens":            {},
 	"temperature":           {},
@@ -696,6 +716,45 @@ func translateTools(tools []types.ToolDefinition, strict bool, model string, cac
 	return out, nil
 }
 
+// openAIToolChoiceFromParams projects the provider-neutral
+// StreamParams.ToolChoice onto the OpenAI tool_choice wire value, gated
+// on the resolved capability. Returns nil — meaning "emit no field" — for
+// the auto mode and for any unsupported mode, leaving the request
+// byte-identical to the pre-#230 shape.
+//
+// OpenAI accepts a string ("auto"/"required"/"none") or an object naming
+// a specific function. The named-tool form degrades to nil when the tool
+// name is empty (not expressible) rather than emitting an invalid object.
+func openAIToolChoiceFromParams(params types.StreamParams, capability quirks.ToolChoiceCapability) any {
+	if !capability.Supported {
+		return nil
+	}
+	switch params.ToolChoice {
+	case types.ToolChoiceRequired:
+		if !capability.Required {
+			return nil
+		}
+		return "required"
+	case types.ToolChoiceNone:
+		if !capability.None {
+			return nil
+		}
+		return "none"
+	case types.ToolChoiceTool:
+		if !capability.NamedTool || params.ToolChoiceName == "" {
+			return nil
+		}
+		return map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": params.ToolChoiceName},
+		}
+	default:
+		// ToolChoiceAuto (zero value): auto is the wire default, so emit
+		// nothing rather than an explicit "auto" string.
+		return nil
+	}
+}
+
 // mapFinishReason converts OpenAI's finish_reason to stirrup's stop reason.
 func mapFinishReason(reason string) string {
 	switch reason {
@@ -745,6 +804,7 @@ func buildOpenAIRequest(params types.StreamParams, stream bool, q quirks.Provide
 		TokenField:         q.BehaviourFlags.OpenAI.TokenField,
 		OmitSamplingParams: q.BehaviourFlags.OpenAI.OmitSamplingParams,
 		ExtraBodyFields:    q.BehaviourFlags.OpenAI.ExtraBodyFields,
+		ToolChoice:         openAIToolChoiceFromParams(params, q.ToolChoice),
 	}, nil
 }
 

--- a/harness/internal/provider/openai_builder_test.go
+++ b/harness/internal/provider/openai_builder_test.go
@@ -1,10 +1,12 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -281,6 +283,54 @@ func TestBuildOpenAIRequest_ToolChoice_PartialCapability(t *testing.T) {
 		q := quirks.ProviderQuirks{ToolChoice: quirks.ToolChoiceCapability{Supported: true, None: false}}
 		assertNoToolChoice(t, params, q)
 	})
+}
+
+// TestToolChoiceName_InvalidEmitsWarn pins B3's observability half: an
+// invalid named-tool name degrades to auto AND emits a slog.Warn that
+// carries the grammar but NOT the offending name (which could carry
+// log-injection bytes). The shared warnInvalidToolChoiceName helper is
+// exercised through the openai projection; a single test covers the
+// helper for all three adapters since they call the same function.
+func TestToolChoiceName_InvalidEmitsWarn(t *testing.T) {
+	prevDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	const badName = "bad name!\ninjected"
+	params := types.StreamParams{
+		Model:          "gpt-4o",
+		MaxTokens:      256,
+		ToolChoice:     types.ToolChoiceTool,
+		ToolChoiceName: badName,
+		Messages:       []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+		Tools:          []types.ToolDefinition{{Name: "read_file", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	req, err := buildOpenAIRequest(params, true, q, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "tool_choice") {
+		t.Errorf("invalid name must degrade to auto, got: %s", body)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "failed validation") {
+		t.Errorf("expected a validation warn, got log: %s", logged)
+	}
+	// The raw name must NOT appear in the log line — only its length and
+	// the grammar are safe to surface.
+	if strings.Contains(logged, "bad name!") || strings.Contains(logged, "injected") {
+		t.Errorf("warn leaked the offending name into the log: %s", logged)
+	}
+	if !strings.Contains(logged, `"grammar"`) {
+		t.Errorf("warn missing the grammar attribute: %s", logged)
+	}
 }
 
 // assertNoToolChoice builds the request and fails if the marshalled body

--- a/harness/internal/provider/openai_builder_test.go
+++ b/harness/internal/provider/openai_builder_test.go
@@ -155,6 +155,86 @@ func TestBuildOpenAIRequest_MatchesStream(t *testing.T) {
 	}
 }
 
+// TestBuildOpenAIRequest_ToolChoice pins the tool_choice projection gated
+// on the resolved capability. OpenAI's base rule advertises every mode,
+// so:
+//   - ToolChoiceAuto (zero) emits no tool_choice field;
+//   - ToolChoiceRequired emits "tool_choice":"required";
+//   - ToolChoiceNone emits "tool_choice":"none";
+//   - ToolChoiceTool emits the function object;
+//   - ToolChoiceTool with no name degrades to auto (no field).
+func TestBuildOpenAIRequest_ToolChoice(t *testing.T) {
+	base := types.StreamParams{
+		Model:     "gpt-4o",
+		MaxTokens: 256,
+		Messages:  []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+		Tools: []types.ToolDefinition{
+			{Name: "read_file", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", base.Model)
+
+	cases := []struct {
+		name       string
+		choice     types.ToolChoiceMode
+		toolName   string
+		wantSubstr string // empty means "no tool_choice field"
+	}{
+		{"auto omits field", types.ToolChoiceAuto, "", ""},
+		{"required emits required", types.ToolChoiceRequired, "", `"tool_choice":"required"`},
+		{"none emits none", types.ToolChoiceNone, "", `"tool_choice":"none"`},
+		{"tool emits function object", types.ToolChoiceTool, "read_file", `"tool_choice":{"function":{"name":"read_file"},"type":"function"}`},
+		{"tool without name degrades to auto", types.ToolChoiceTool, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := base
+			params.ToolChoice = tc.choice
+			params.ToolChoiceName = tc.toolName
+			req, err := buildOpenAIRequest(params, true, q, nil)
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			body, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if tc.wantSubstr == "" {
+				if strings.Contains(string(body), "tool_choice") {
+					t.Errorf("expected no tool_choice field, got body: %s", body)
+				}
+				return
+			}
+			if !strings.Contains(string(body), tc.wantSubstr) {
+				t.Errorf("expected %s in body, got: %s", tc.wantSubstr, body)
+			}
+		})
+	}
+}
+
+// TestBuildOpenAIRequest_ToolChoiceUnsupportedCapability pins the
+// graceful no-op: a zero-value capability emits no tool_choice field
+// even for a ToolChoiceRequired request.
+func TestBuildOpenAIRequest_ToolChoiceUnsupportedCapability(t *testing.T) {
+	params := types.StreamParams{
+		Model:      "gpt-4o",
+		MaxTokens:  256,
+		ToolChoice: types.ToolChoiceRequired,
+		Messages:   []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+	}
+	req, err := buildOpenAIRequest(params, true, quirks.ProviderQuirks{}, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "tool_choice") {
+		t.Errorf("zero-value capability must emit no tool_choice field, got: %s", body)
+	}
+}
+
 // TestBuildOpenAIRequest_StreamFlag verifies the stream argument drives
 // the wire field, so a future batch caller passing false produces a body
 // with "stream":false. Pinning this here prevents the helper from

--- a/harness/internal/provider/openai_builder_test.go
+++ b/harness/internal/provider/openai_builder_test.go
@@ -161,8 +161,10 @@ func TestBuildOpenAIRequest_MatchesStream(t *testing.T) {
 //   - ToolChoiceAuto (zero) emits no tool_choice field;
 //   - ToolChoiceRequired emits "tool_choice":"required";
 //   - ToolChoiceNone emits "tool_choice":"none";
-//   - ToolChoiceTool emits the function object;
-//   - ToolChoiceTool with no name degrades to auto (no field).
+//   - ToolChoiceTool emits the typed function object (deterministic key
+//     order: "type" before "function");
+//   - ToolChoiceTool with no name, an invalid name, or an over-length
+//     name degrades to auto (no field).
 func TestBuildOpenAIRequest_ToolChoice(t *testing.T) {
 	base := types.StreamParams{
 		Model:     "gpt-4o",
@@ -183,8 +185,12 @@ func TestBuildOpenAIRequest_ToolChoice(t *testing.T) {
 		{"auto omits field", types.ToolChoiceAuto, "", ""},
 		{"required emits required", types.ToolChoiceRequired, "", `"tool_choice":"required"`},
 		{"none emits none", types.ToolChoiceNone, "", `"tool_choice":"none"`},
-		{"tool emits function object", types.ToolChoiceTool, "read_file", `"tool_choice":{"function":{"name":"read_file"},"type":"function"}`},
+		// The typed openAINamedToolChoice fixes key order: "type" before
+		// "function", deterministic across processes (B1).
+		{"tool emits typed function object", types.ToolChoiceTool, "read_file", `"tool_choice":{"type":"function","function":{"name":"read_file"}}`},
 		{"tool without name degrades to auto", types.ToolChoiceTool, "", ""},
+		{"tool with invalid name degrades to auto", types.ToolChoiceTool, "bad name!", ""},
+		{"tool with over-length name degrades to auto", types.ToolChoiceTool, strings.Repeat("a", 65), ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -209,6 +215,88 @@ func TestBuildOpenAIRequest_ToolChoice(t *testing.T) {
 				t.Errorf("expected %s in body, got: %s", tc.wantSubstr, body)
 			}
 		})
+	}
+}
+
+// TestBuildOpenAIRequest_ToolChoice_DeterministicKeyOrder pins B1: the
+// named-tool object is a typed struct, not a map[string]any, so its JSON
+// key order is identical on every run. The map form produced
+// process-dependent ordering (Go's randomised map hash seed), which made
+// the fixture pin flaky. Marshalling the same request many times must
+// yield byte-identical output.
+func TestBuildOpenAIRequest_ToolChoice_DeterministicKeyOrder(t *testing.T) {
+	params := types.StreamParams{
+		Model:          "gpt-4o",
+		MaxTokens:      256,
+		ToolChoice:     types.ToolChoiceTool,
+		ToolChoiceName: "read_file",
+		Messages:       []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+		Tools:          []types.ToolDefinition{{Name: "read_file", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+
+	var first string
+	for i := 0; i < 20; i++ {
+		req, err := buildOpenAIRequest(params, true, q, nil)
+		if err != nil {
+			t.Fatalf("build (iter %d): %v", i, err)
+		}
+		body, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal (iter %d): %v", i, err)
+		}
+		if i == 0 {
+			first = string(body)
+			continue
+		}
+		if string(body) != first {
+			t.Fatalf("non-deterministic body on iter %d:\n first: %s\n now:   %s", i, first, body)
+		}
+	}
+}
+
+// TestBuildOpenAIRequest_ToolChoice_PartialCapability exercises the
+// per-mode guard branches (B2) that today's full-support builtin rules
+// never reach: a capability with Supported=true but a specific mode
+// disabled must omit the field rather than fail open and emit the
+// disallowed mode on the wire.
+func TestBuildOpenAIRequest_ToolChoice_PartialCapability(t *testing.T) {
+	t.Run("required disabled", func(t *testing.T) {
+		params := types.StreamParams{
+			Model:      "gpt-4o",
+			MaxTokens:  256,
+			ToolChoice: types.ToolChoiceRequired,
+			Messages:   []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+		}
+		q := quirks.ProviderQuirks{ToolChoice: quirks.ToolChoiceCapability{Supported: true, Required: false}}
+		assertNoToolChoice(t, params, q)
+	})
+	t.Run("none disabled", func(t *testing.T) {
+		params := types.StreamParams{
+			Model:      "gpt-4o",
+			MaxTokens:  256,
+			ToolChoice: types.ToolChoiceNone,
+			Messages:   []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "x"}}}},
+		}
+		q := quirks.ProviderQuirks{ToolChoice: quirks.ToolChoiceCapability{Supported: true, None: false}}
+		assertNoToolChoice(t, params, q)
+	})
+}
+
+// assertNoToolChoice builds the request and fails if the marshalled body
+// carries a tool_choice field.
+func assertNoToolChoice(t *testing.T, params types.StreamParams, q quirks.ProviderQuirks) {
+	t.Helper()
+	req, err := buildOpenAIRequest(params, true, q, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "tool_choice") {
+		t.Errorf("expected no tool_choice field, got body: %s", body)
 	}
 }
 

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -322,6 +322,73 @@ func TestOpenAIRequest_UnmarshalJSON(t *testing.T) {
 			t.Errorf("ExtraBodyFields[tool_stream] = %v (ok=%v), want true", v, ok)
 		}
 	})
+
+	t.Run("tool_choice string round-trips out of ExtraBodyFields", func(t *testing.T) {
+		// A string tool_choice must decode into r.ToolChoice, not leak
+		// into ExtraBodyFields (which would trip the marshal-side
+		// canonical-field collision guard on the next encode).
+		original := openaiRequest{
+			Model:      "gpt-4o",
+			Messages:   []openaiMessage{{Role: "user", Content: "hi"}},
+			MaxTokens:  256,
+			Stream:     true,
+			ToolChoice: "required",
+		}
+		out, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		var round openaiRequest
+		if err := json.Unmarshal(out, &round); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if _, leaked := round.ExtraBodyFields["tool_choice"]; leaked {
+			t.Errorf("tool_choice leaked into ExtraBodyFields: %+v", round.ExtraBodyFields)
+		}
+		if round.ToolChoice != "required" {
+			t.Errorf("ToolChoice = %v, want \"required\"", round.ToolChoice)
+		}
+		// Re-marshalling the decoded request must reproduce the field
+		// stably (the canonical guard must not reject it).
+		out2, err := json.Marshal(round)
+		if err != nil {
+			t.Fatalf("re-Marshal: %v", err)
+		}
+		if !strings.Contains(string(out2), `"tool_choice":"required"`) {
+			t.Errorf("re-marshalled body missing tool_choice: %s", out2)
+		}
+	})
+
+	t.Run("tool_choice typed named object round-trips with deterministic order", func(t *testing.T) {
+		original := openaiRequest{
+			Model:     "gpt-4o",
+			Messages:  []openaiMessage{{Role: "user", Content: "hi"}},
+			MaxTokens: 256,
+			Stream:    true,
+			ToolChoice: openAINamedToolChoice{
+				Type:     "function",
+				Function: openAINamedToolChoiceFunc{Name: "read_file"},
+			},
+		}
+		out, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		// The typed struct pins key order: "type" before "function".
+		if !strings.Contains(string(out), `"tool_choice":{"type":"function","function":{"name":"read_file"}}`) {
+			t.Errorf("marshalled body has unexpected tool_choice shape: %s", out)
+		}
+		var round openaiRequest
+		if err := json.Unmarshal(out, &round); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if _, leaked := round.ExtraBodyFields["tool_choice"]; leaked {
+			t.Errorf("tool_choice leaked into ExtraBodyFields: %+v", round.ExtraBodyFields)
+		}
+		if round.ToolChoice == nil {
+			t.Error("decoded ToolChoice is nil, want the function object")
+		}
+	})
 }
 
 // quirksLogStubServer returns an httptest server that drains the

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -238,6 +238,73 @@ func BuiltinRules() []Rule {
 				)
 			},
 		},
+		// --- Tool-choice capability rules (#230, Wave 4 A1) ---
+		//
+		// tool_choice is a cross-provider capability, so the resolved
+		// flag lives on the top-level ProviderQuirks.ToolChoice field
+		// rather than under a provider sub-struct. Each first-party
+		// provider declares a base "*" rule advertising the modes its
+		// API supports; adapters gate serialisation on the resolved
+		// flag and emit nothing when Supported is false. The escalation
+		// chunk (A2) consumes the StreamParams.ToolChoice control these
+		// rules make safe to serialise.
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "*",
+			Description:  "Anthropic: native tool_choice (auto/any/tool); no native none",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// Anthropic's Messages API accepts a tool_choice object
+				// with type "auto", "any", or "tool". There is no native
+				// "none" — a no-tools turn is expressed by omitting the
+				// tools array — so None stays false and the adapter
+				// handles ToolChoiceNone structurally.
+				q.ToolChoice = ToolChoiceCapability{
+					Supported: true,
+					Auto:      true,
+					Required:  true,
+					None:      false,
+					NamedTool: true,
+				}
+			},
+		},
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "*",
+			Description:  "OpenAI-compatible: native tool_choice (auto/required/none/function)",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// OpenAI Chat Completions accepts tool_choice as a string
+				// ("auto"/"required"/"none") or an object naming a
+				// specific function. The full surface is supported.
+				q.ToolChoice = ToolChoiceCapability{
+					Supported: true,
+					Auto:      true,
+					Required:  true,
+					None:      true,
+					NamedTool: true,
+				}
+			},
+		},
+		{
+			ProviderType: "gemini",
+			ModelMatch:   "*",
+			Description:  "Gemini: native functionCallingConfig.mode (AUTO/ANY/NONE)",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// Gemini expresses tool choice via
+				// toolConfig.functionCallingConfig.mode (AUTO/ANY/NONE)
+				// and a specific tool via ANY + allowedFunctionNames, so
+				// every mode maps onto a native shape.
+				q.ToolChoice = ToolChoiceCapability{
+					Supported: true,
+					Auto:      true,
+					Required:  true,
+					None:      true,
+					NamedTool: true,
+				}
+			},
+		},
 		{
 			ProviderType: "gemini",
 			ModelMatch:   "gemini-3*",

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -43,6 +43,20 @@ type ProviderQuirks struct {
 	// a follow-up. Paths use dot-separated keys with [] for array-of-objects.
 	ReplayFields []string `json:"replayFields"`
 
+	// --- Capabilities ---
+
+	// ToolChoice declares whether and how the resolved (provider, model)
+	// supports a native tool-choice control. It is a TOP-LEVEL capability
+	// rather than a per-provider behaviour flag because tool_choice is a
+	// cross-provider concept: Anthropic, OpenAI-compatible, and Gemini all
+	// expose some form (tool_choice / functionCallingConfig). Modelling it
+	// under one provider's sub-struct would force the other adapters to
+	// reach across family boundaries to read it, which the BehaviourFlags
+	// ownership rule forbids. The zero value advertises no support, so an
+	// adapter for a provider with no rule emits no tool-choice field — the
+	// graceful no-op the StreamParams.ToolChoice contract requires.
+	ToolChoice ToolChoiceCapability `json:"toolChoice"`
+
 	// --- Behaviour flags ---
 
 	// BehaviourFlags carries adapter-internal behaviour flags that cannot be

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -536,6 +536,88 @@ func TestGeminiRule_NoMatchOnOpenAICompatProvider(t *testing.T) {
 	}
 }
 
+// TestToolChoiceCapabilityRules pins that each first-party provider's
+// base rule advertises the tool-choice modes its API supports, that the
+// capability lands on the top-level ProviderQuirks.ToolChoice field, and
+// that a provider with no rule resolves the zero value (no support). The
+// Anthropic-specific assertion guards the one asymmetry: Anthropic has no
+// native "none", so None must stay false while the cross-provider modes
+// are true.
+func TestToolChoiceCapabilityRules(t *testing.T) {
+	t.Run("anthropic advertises auto/required/named but not none", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("anthropic", "claude-sonnet-4-5")
+		if !q.ToolChoice.Supported {
+			t.Fatalf("anthropic: ToolChoice.Supported = false, want true")
+		}
+		if !q.ToolChoice.Auto || !q.ToolChoice.Required || !q.ToolChoice.NamedTool {
+			t.Errorf("anthropic: ToolChoice = %+v, want Auto/Required/NamedTool all true", q.ToolChoice)
+		}
+		if q.ToolChoice.None {
+			t.Errorf("anthropic: ToolChoice.None = true, want false (no native none mode)")
+		}
+	})
+
+	t.Run("openai-compatible advertises every mode", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "gpt-4o")
+		want := ToolChoiceCapability{Supported: true, Auto: true, Required: true, None: true, NamedTool: true}
+		if q.ToolChoice != want {
+			t.Errorf("openai-compatible: ToolChoice = %+v, want %+v", q.ToolChoice, want)
+		}
+	})
+
+	t.Run("gemini advertises every mode", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("gemini", "gemini-2.5-pro")
+		want := ToolChoiceCapability{Supported: true, Auto: true, Required: true, None: true, NamedTool: true}
+		if q.ToolChoice != want {
+			t.Errorf("gemini: ToolChoice = %+v, want %+v", q.ToolChoice, want)
+		}
+	})
+
+	t.Run("unknown provider resolves zero (no support)", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("mystery-provider", "some-model")
+		if q.ToolChoice != (ToolChoiceCapability{}) {
+			t.Errorf("unknown provider: ToolChoice = %+v, want zero value (no native support)", q.ToolChoice)
+		}
+	})
+}
+
+// TestToolChoiceRulesSetSupportedWhenAnyMode pins the structural
+// relationship the adapters depend on: any first-party rule that turns on
+// a per-mode tool-choice bool must also set Supported. An adapter checks
+// Supported as the master gate, so a rule that set Required without
+// Supported would silently disable the feature it intended to enable.
+func TestToolChoiceRulesSetSupportedWhenAnyMode(t *testing.T) {
+	for i, rule := range BuiltinRules() {
+		if rule.Apply == nil {
+			continue
+		}
+		q := freshQuirks()
+		rule.Apply(&q)
+		tc := q.ToolChoice
+		anyMode := tc.Auto || tc.Required || tc.None || tc.NamedTool
+		if anyMode && !tc.Supported {
+			t.Errorf("BuiltinRules()[%d] (%q): a tool-choice mode is set but Supported is false", i, rule.Description)
+		}
+	}
+}
+
+// freshQuirks returns a ProviderQuirks with the same map/slice
+// pre-initialisation Resolve performs, for rule-materialisation tests
+// that call Apply directly.
+func freshQuirks() ProviderQuirks {
+	return ProviderQuirks{
+		FieldRenames:   map[string]string{},
+		OmitFields:     []string{},
+		ValueOverrides: map[string]Value{},
+		EnumCoercions:  map[string]map[string]string{},
+		ReplayFields:   []string{},
+		BehaviourFlags: ProviderBehaviourFlags{
+			OpenAI: OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}},
+			Gemini: GeminiBehaviourFlags{SchemaUnsupportedFeatures: []string{}},
+		},
+	}
+}
+
 // TestReplayFieldsRules_DeepSeekReasoner pins the DeepSeek-reasoner
 // rule fires and populates ReplayFields with the documented path.
 // The defensive isolation cases assert the rule does NOT fire for

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -77,6 +77,7 @@ var canonicalOpenAIFieldNames = map[string]bool{
 	"model":                 true,
 	"messages":              true,
 	"tools":                 true,
+	"tool_choice":           true,
 	"max_completion_tokens": true,
 	"max_tokens":            true,
 	"temperature":           true,

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -493,7 +493,7 @@ func TestKnownModelIDsResolutionSmoke(t *testing.T) {
 		}
 		for _, prov := range provs {
 			q := DefaultRegistry().Resolve(prov, line)
-			if q.BehaviourFlags.OpenAI.OmitSamplingParams || q.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxCompletionTokens || q.BehaviourFlags.Gemini.StreamFunctionCallArgsShape != StreamArgsOff {
+			if q.BehaviourFlags.OpenAI.OmitSamplingParams || q.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxCompletionTokens || q.BehaviourFlags.Gemini.StreamFunctionCallArgsShape != StreamArgsOff || q.ToolChoice.Supported {
 				resolved++
 			}
 		}

--- a/harness/internal/provider/quirks/toolchoice.go
+++ b/harness/internal/provider/quirks/toolchoice.go
@@ -1,0 +1,56 @@
+package quirks
+
+// ToolChoiceCapability declares the native tool-choice support of a
+// resolved (provider, model) pair. It is the cross-provider capability
+// the adapters consult before serialising a types.StreamParams.ToolChoice
+// onto the wire.
+//
+// The zero value advertises NO support: Supported is false and every mode
+// bool is false. An adapter resolving a provider with no tool-choice rule
+// therefore emits no tool-choice field, leaving the request byte-identical
+// to the pre-#230 shape. This is the graceful no-op the StreamParams
+// contract requires — the prompt-based fallback for unsupported providers
+// is handled by the loop escalation chunk, not here.
+//
+// The mode bools are independent rather than a single "max level" because
+// providers do not support the modes as a strict superset: a hypothetical
+// gateway might accept "required" but not a specific-named-tool form, and
+// the adapter must be able to fall back per-mode rather than assume that
+// supporting one mode implies supporting all of them.
+type ToolChoiceCapability struct {
+	// Supported is the master switch. When false, the adapter MUST NOT
+	// emit any tool-choice field regardless of the per-mode bools below.
+	// A rule that sets any per-mode bool is expected to also set
+	// Supported; the registry self-test pins that relationship.
+	Supported bool `json:"supported"`
+
+	// Auto reports whether the provider accepts an explicit "let the
+	// model decide" tool-choice value. This is distinct from the
+	// zero-value StreamParams.ToolChoiceAuto, which is always satisfied
+	// by emitting nothing: Auto here matters only for a future caller
+	// that wants to pin auto explicitly. Every provider with a native
+	// control supports it, so first-party rules set it alongside
+	// Supported.
+	Auto bool `json:"auto"`
+
+	// Required reports whether the provider can force at least one tool
+	// call on the turn (Anthropic "any", OpenAI "required", Gemini
+	// "ANY"). This is the load-bearing mode for issue #230's escalation:
+	// an adapter that resolves Required == false must not emit the field
+	// for a ToolChoiceRequired request, deferring to the prompt fallback.
+	Required bool `json:"required"`
+
+	// None reports whether the provider can forbid tool calls on the turn
+	// via a native value (OpenAI "none", Gemini "NONE"). Anthropic has no
+	// native "none" — a ToolChoiceNone request is expressed by omitting
+	// the tool list — so the Anthropic rule leaves this false and the
+	// adapter handles the mode structurally rather than via the field.
+	None bool `json:"none"`
+
+	// NamedTool reports whether the provider can force one specific tool
+	// (Anthropic {"type":"tool"}, OpenAI {"type":"function"}, Gemini ANY
+	// with allowedFunctionNames). Set independently of Required because a
+	// gateway may accept the coarse "required" form without the named
+	// form.
+	NamedTool bool `json:"namedTool"`
+}

--- a/types/events.go
+++ b/types/events.go
@@ -1,6 +1,10 @@
 package types
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
 
 // StreamEvent represents a single event from the model's streaming response.
 //
@@ -91,6 +95,37 @@ const (
 	// (defensive: a named-tool choice with no name is not expressible).
 	ToolChoiceTool
 )
+
+// ToolChoiceAuto must remain the zero value: StreamParams.ToolChoice is
+// tagged omitempty, which suppresses the field only when the value is the
+// integer zero. If a future edit reorders the iota (e.g. promoting
+// ToolChoiceNone to 0 as a "safer" default), omitempty would silently
+// start suppressing the wrong mode and break every JSON round-trip
+// without a compilation error. Indexing a one-element array at
+// ToolChoiceAuto fails to compile the moment ToolChoiceAuto is non-zero.
+var _ = [1]struct{}{}[ToolChoiceAuto]
+
+// toolChoiceNamePattern is the character-set and length bound enforced on
+// StreamParams.ToolChoiceName before it is serialised onto any provider
+// wire. It is the intersection of the three providers' documented
+// function-name grammars (Anthropic's `^[a-zA-Z0-9_-]{1,64}$` is the
+// tightest, so it governs). See ValidateToolChoiceName.
+var toolChoiceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+// ValidateToolChoiceName reports whether a named-tool choice's tool name
+// is safe to emit onto a provider request body. It enforces
+// `^[a-zA-Z0-9_-]{1,64}$` — the intersection of the Anthropic, OpenAI,
+// and Gemini function-name grammars. A1 owns the tool-choice wire format,
+// so validation lives at the serialization boundary: the loop escalation
+// path (A2) will be the first caller to feed model-influenced names
+// through ToolChoiceName, and adapters call this to fail closed (degrade
+// the named-tool form to auto) rather than emit an unvalidated value.
+func ValidateToolChoiceName(name string) error {
+	if !toolChoiceNamePattern.MatchString(name) {
+		return fmt.Errorf("tool choice name %q must match %s", name, toolChoiceNamePattern.String())
+	}
+	return nil
+}
 
 // StreamParams holds the parameters for a model streaming request.
 type StreamParams struct {

--- a/types/events.go
+++ b/types/events.go
@@ -56,6 +56,42 @@ type StreamEvent struct {
 	ThoughtSignature string `json:"thought_signature,omitempty"`
 }
 
+// ToolChoiceMode is a closed enum selecting how the model is steered
+// toward (or away from) tool use on a single turn. It is a
+// provider-neutral control: each adapter projects it onto the provider's
+// native tool_choice / functionCallingConfig shape, gated on the resolved
+// provider capability. The zero value (ToolChoiceAuto) reproduces the
+// historical behaviour — the model decides whether to call a tool — so
+// every existing caller that never sets ToolChoice is unaffected.
+type ToolChoiceMode int
+
+const (
+	// ToolChoiceAuto lets the model decide whether to call a tool. Zero
+	// value: an adapter MUST treat it as "emit nothing on the wire" so
+	// the request is byte-identical to the pre-tool-choice shape.
+	ToolChoiceAuto ToolChoiceMode = iota
+
+	// ToolChoiceRequired forces the model to call at least one tool on
+	// this turn (Anthropic "any", OpenAI "required", Gemini "ANY"). The
+	// loop escalation chunk (A2) drives this when a turn ended without a
+	// tool call but one was expected.
+	ToolChoiceRequired
+
+	// ToolChoiceNone forbids tool calls on this turn (Anthropic "none"
+	// has no native form and is handled by omitting tools; OpenAI
+	// "none"; Gemini "NONE"). Reserved for callers that want a
+	// text-only turn while leaving the tool definitions in place.
+	ToolChoiceNone
+
+	// ToolChoiceTool forces the model to call one specific tool, named by
+	// StreamParams.ToolChoiceName. Anthropic {"type":"tool","name":...},
+	// OpenAI {"type":"function","function":{"name":...}}, Gemini ANY mode
+	// with allowedFunctionNames. A ToolChoice of ToolChoiceTool with an
+	// empty ToolChoiceName is treated by adapters as ToolChoiceAuto
+	// (defensive: a named-tool choice with no name is not expressible).
+	ToolChoiceTool
+)
+
 // StreamParams holds the parameters for a model streaming request.
 type StreamParams struct {
 	Model     string           `json:"model"`
@@ -71,6 +107,21 @@ type StreamParams struct {
 	// verbatim, including an explicit 0.0 to request greedy decoding.
 	// Use Float64Ptr to construct a pointer from a literal.
 	Temperature *float64 `json:"temperature,omitempty"`
+
+	// ToolChoice steers tool use for this turn. The zero value
+	// (ToolChoiceAuto) preserves the historical behaviour and is omitted
+	// from the wire by every adapter, so existing callers are byte-for-
+	// byte unchanged. An adapter emits a native tool_choice field only
+	// when the resolved provider capability advertises support for the
+	// requested mode; otherwise it is a graceful no-op (the prompt-based
+	// fallback is the escalation chunk's responsibility, not the
+	// adapter's).
+	ToolChoice ToolChoiceMode `json:"toolChoice,omitempty"`
+
+	// ToolChoiceName names the specific tool to force when ToolChoice is
+	// ToolChoiceTool. Ignored for every other mode. An empty value with
+	// ToolChoiceTool degrades to ToolChoiceAuto at the adapter.
+	ToolChoiceName string `json:"toolChoiceName,omitempty"`
 }
 
 // Float64Ptr returns a pointer to the given float64 value. It is a

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestValidateToolChoiceName exercises the character-set and length bound
+// the adapters enforce before emitting a named-tool choice. The grammar
+// is `^[a-zA-Z0-9_-]{1,64}$` — the intersection of the three providers'
+// documented function-name grammars.
+func TestValidateToolChoiceName(t *testing.T) {
+	valid := []string{
+		"read_file",
+		"a",
+		"Tool-Name_1",
+		"ABCDEFGHIJ0123456789",
+		strings.Repeat("a", 64), // boundary: exactly 64
+	}
+	for _, name := range valid {
+		if err := ValidateToolChoiceName(name); err != nil {
+			t.Errorf("ValidateToolChoiceName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := []string{
+		"",                      // empty
+		"bad name!",             // space + punctuation
+		"with.dot",              // dot is not in the intersection grammar
+		"slash/name",            // path separator
+		"emoji😀",                // non-ASCII
+		strings.Repeat("a", 65), // boundary: one over the limit
+	}
+	for _, name := range invalid {
+		if err := ValidateToolChoiceName(name); err == nil {
+			t.Errorf("ValidateToolChoiceName(%q) = nil, want error", name)
+		}
+	}
+}
+
+// TestStreamParamsToolChoiceOmitempty pins the zero-value/omitempty
+// coupling the R1 compile-time guard protects at runtime: a StreamParams
+// with ToolChoice unset (ToolChoiceAuto) must marshal without a
+// toolChoice key, while a non-auto value emits it. This is the JSON
+// round-trip half of the invariant the array-index guard enforces at
+// compile time.
+func TestStreamParamsToolChoiceOmitempty(t *testing.T) {
+	auto := StreamParams{Model: "m"}
+	b, err := json.Marshal(auto)
+	if err != nil {
+		t.Fatalf("marshal auto: %v", err)
+	}
+	if strings.Contains(string(b), "toolChoice") {
+		t.Errorf("ToolChoiceAuto must be omitted from JSON, got: %s", b)
+	}
+
+	required := StreamParams{Model: "m", ToolChoice: ToolChoiceRequired}
+	b, err = json.Marshal(required)
+	if err != nil {
+		t.Fatalf("marshal required: %v", err)
+	}
+	if !strings.Contains(string(b), "toolChoice") {
+		t.Errorf("non-auto ToolChoice must appear in JSON, got: %s", b)
+	}
+}


### PR DESCRIPTION
## Summary

First chunk of **Wave 4 / #230** (tool-choice escalation). This PR is the **plumbing layer only** — it makes provider-native tool-choice *expressible and serializable*, gated on a provider capability. The loop-side escalation logic (no-tool-turn detection, bounded retry, mode-aware policy) is the next chunk (A2) and is deliberately not here.

Stacked on the Wave 3 stack: `#321` ← **A1**. Auto-retargets to `main` as lower PRs merge.

## What lands

- **`types.StreamParams`** gains a closed `ToolChoiceMode` enum (`auto`/`required`/`none`/`tool`) + `ToolChoiceName`. Zero value = `auto` = no wire field, so every existing caller is byte-identical.
- **`ProviderQuirks.ToolChoice`** — a new top-level cross-provider `ToolChoiceCapability` (per-mode bools), not buried under an adapter sub-struct, because tool-choice spans Anthropic/OpenAI/Gemini and the BehaviourFlags ownership rule forbids cross-family reads. Three builtin `*`-glob rules (anthropic / openai-compatible / gemini).
- **Serialization** in all three adapters, gated on the resolved capability (emit nothing when unsupported — graceful no-op; the prompt fallback is A2's job):
  - Anthropic `tool_choice` object (`any`/`tool`),
  - OpenAI `tool_choice` (`required`/`none`/typed function object),
  - Gemini `functionCallingConfig.mode` (`ANY`/`NONE`) + `allowedFunctionNames`.

## Review hardening (post-review remediation)

- Typed `openAINamedToolChoice` replaces a `map[string]any` (deterministic JSON key order + project no-`any` rule); pinned by a 20× marshal-determinism test.
- `ValidateToolChoiceName` (`^[a-zA-Z0-9_-]{1,64}$`) at the wire boundary — invalid names **degrade** to the auto/no-field result with a `slog.Warn` that logs grammar + **length only**, never the raw name (avoids log-injection once A2 feeds model-influenced names through).
- Partial-capability tests bring all three `*ToolChoiceFromParams` projections to 100% function coverage.

## Test plan

- [x] `just` (build + test) green
- [x] `just lint` (golangci-lint v2) — 0 issues
- [x] Zero-value (auto) emits no `tool_choice` on any adapter — byte-identical to pre-#230
- [x] Per-adapter, per-mode serialization asserted against marshalled request bodies (no live provider calls)
- [x] Capability-gating + partial-capability omission covered
- [ ] Consumed end-to-end by A2 (next chunk)

Closes part of #230 (plumbing). Loop escalation + `no_tool_when_required` (incl. #313) follow in A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)