### PR TITLE
core: tool-choice escalation for missed-tool answers (Wave 4 A2, closes #230 + #313)

### DIFF
--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -241,6 +241,16 @@ type harnessCLIOptions struct {
 	// EffectiveToolDispatchMaxParallel.
 	ToolDispatchMaxParallel int
 
+	// EscalateToolChoice opts the run into the missed-tool recovery
+	// (issue #230). When false (the default) no
+	// ToolChoiceEscalation sub-config is persisted, so the loop's
+	// escalation path stays inert. EscalateToolChoiceMaxRetries tunes the
+	// per-inner-loop retry cap; zero defers to the library default
+	// (DefaultToolChoiceEscalationMaxRetries) and is ignored entirely
+	// unless EscalateToolChoice is set.
+	EscalateToolChoice           bool
+	EscalateToolChoiceMaxRetries int
+
 	// Batch opts the run into async batch submission (issue #136).
 	// The flag carries only the Enabled bit; operators wanting any of
 	// the other BatchProviderConfig fields (MaxWaitSeconds,
@@ -489,6 +499,19 @@ func buildHarnessRunConfigCore(opts harnessCLIOptions) (*types.RunConfig, error)
 	// that the operator did not voice.
 	if opts.ToolDispatchMaxParallel > 0 {
 		config.ToolDispatch = &types.ToolDispatchConfig{MaxParallel: opts.ToolDispatchMaxParallel}
+	}
+
+	// Tool-choice escalation (issue #230). Only persist the sub-config
+	// when the operator opted in via --escalate-tool-choice; leaving it
+	// nil keeps the loop's escalation path inert so a bare run is
+	// unchanged. The retry-cap flag is carried through verbatim — zero is
+	// legal and resolves to DefaultToolChoiceEscalationMaxRetries via
+	// EffectiveToolChoiceEscalationMaxRetries.
+	if opts.EscalateToolChoice {
+		config.ToolChoiceEscalation = &types.ToolChoiceEscalationConfig{
+			Enabled:    true,
+			MaxRetries: opts.EscalateToolChoiceMaxRetries,
+		}
 	}
 
 	// Batch (issue #136). --batch carries only the Enabled bit; every
@@ -1119,6 +1142,32 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 			// the mode-toggle workflow the flag is built for.
 			cfg.Provider.Batch.Enabled = false
 		}
+	}
+
+	// Tool-choice escalation (issue #230). --escalate-tool-choice flips
+	// the Enabled bit, preserving any file-supplied MaxRetries so a
+	// follow-up toggle does not require re-supplying --config (same
+	// mode-toggle rationale as --batch). --escalate-tool-choice-max-retries
+	// pins the cap independently; like --max-tool-parallel an explicit
+	// override only takes effect when set, and the loop resolves an unset
+	// cap to DefaultToolChoiceEscalationMaxRetries.
+	if changed("escalate-tool-choice") {
+		enabled, _ := f.GetBool("escalate-tool-choice")
+		if enabled {
+			if cfg.ToolChoiceEscalation == nil {
+				cfg.ToolChoiceEscalation = &types.ToolChoiceEscalationConfig{}
+			}
+			cfg.ToolChoiceEscalation.Enabled = true
+		} else if cfg.ToolChoiceEscalation != nil {
+			cfg.ToolChoiceEscalation.Enabled = false
+		}
+	}
+	if changed("escalate-tool-choice-max-retries") {
+		mr, _ := f.GetInt("escalate-tool-choice-max-retries")
+		if cfg.ToolChoiceEscalation == nil {
+			cfg.ToolChoiceEscalation = &types.ToolChoiceEscalationConfig{}
+		}
+		cfg.ToolChoiceEscalation.MaxRetries = mr
 	}
 	return nil
 }

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -4207,6 +4207,66 @@ func TestApplyOverrides_ToolDispatchMaxParallelDefaultDoesNotOverride(t *testing
 	}
 }
 
+// TestApplyOverrides_EscalateToolChoiceEnables pins that
+// --escalate-tool-choice flips Enabled on cfg.ToolChoiceEscalation (issue
+// #230), allocating the sub-config when the file omitted it.
+func TestApplyOverrides_EscalateToolChoiceEnables(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	if err := cmd.Flags().Set("escalate-tool-choice", "true"); err != nil {
+		t.Fatalf("set escalate-tool-choice: %v", err)
+	}
+
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+
+	if cfg.ToolChoiceEscalation == nil || !cfg.ToolChoiceEscalation.Enabled {
+		t.Fatalf("--escalate-tool-choice should enable escalation, got %+v", cfg.ToolChoiceEscalation)
+	}
+}
+
+// TestApplyOverrides_EscalateToolChoiceDefaultDoesNotEnable pins the
+// OFF-by-default safety: without the flag, no escalation sub-config is
+// synthesised so a bare run stays inert.
+func TestApplyOverrides_EscalateToolChoiceDefaultDoesNotEnable(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+
+	if cfg.ToolChoiceEscalation != nil {
+		t.Errorf("escalation must stay nil without the flag, got %+v", cfg.ToolChoiceEscalation)
+	}
+}
+
+// TestApplyOverrides_EscalateToolChoiceMaxRetries pins that the retry-cap
+// flag lands on cfg.ToolChoiceEscalation.MaxRetries, allocating the
+// sub-config when needed.
+func TestApplyOverrides_EscalateToolChoiceMaxRetries(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	cfg := baseFileConfig()
+	if err := cmd.Flags().Set("escalate-tool-choice", "true"); err != nil {
+		t.Fatalf("set escalate-tool-choice: %v", err)
+	}
+	if err := cmd.Flags().Set("escalate-tool-choice-max-retries", "2"); err != nil {
+		t.Fatalf("set escalate-tool-choice-max-retries: %v", err)
+	}
+
+	if err := applyOverrides(cmd, cfg, nil); err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+
+	if cfg.ToolChoiceEscalation == nil {
+		t.Fatal("escalation sub-config should be populated")
+	}
+	if cfg.ToolChoiceEscalation.MaxRetries != 2 {
+		t.Errorf("MaxRetries = %d, want 2", cfg.ToolChoiceEscalation.MaxRetries)
+	}
+}
+
 // TestRunHarness_OutputRunConfigWritesFile pins the dry-run capture
 // surface from issue #240: --output-runconfig writes the resolved
 // RunConfig to disk, the loop is not invoked, and the process exits

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -388,7 +388,16 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 	workspaceExportTo, _ := f.GetString("export-workspace-to")
 	toolDispatchMaxParallel, _ := f.GetInt("max-tool-parallel")
 	escalateToolChoice, _ := f.GetBool("escalate-tool-choice")
-	escalateToolChoiceMaxRetries, _ := f.GetInt("escalate-tool-choice-max-retries")
+	// Read the retry cap only when the operator set it explicitly. Mirrors
+	// the applyOverrides Changed() discipline: forwarding the flag's
+	// default (0) unconditionally would clobber a base-config MaxRetries
+	// with 0. The clobber is benign today (0 resolves to the library
+	// default) but a future non-zero-default knob would silently override
+	// a file value otherwise.
+	escalateToolChoiceMaxRetries := 0
+	if f.Changed("escalate-tool-choice-max-retries") {
+		escalateToolChoiceMaxRetries, _ = f.GetInt("escalate-tool-choice-max-retries")
+	}
 	batch, _ := f.GetBool("batch")
 
 	var queryParams map[string]string

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -387,6 +387,8 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 	providerRetryWallClockBudget, _ := f.GetDuration("provider-retry-wall-clock")
 	workspaceExportTo, _ := f.GetString("export-workspace-to")
 	toolDispatchMaxParallel, _ := f.GetInt("max-tool-parallel")
+	escalateToolChoice, _ := f.GetBool("escalate-tool-choice")
+	escalateToolChoiceMaxRetries, _ := f.GetInt("escalate-tool-choice-max-retries")
 	batch, _ := f.GetBool("batch")
 
 	var queryParams map[string]string
@@ -465,6 +467,8 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 		ProviderRetryWallClockBudget: providerRetryWallClockBudget,
 		WorkspaceExportTo:            workspaceExportTo,
 		ToolDispatchMaxParallel:      toolDispatchMaxParallel,
+		EscalateToolChoice:           escalateToolChoice,
+		EscalateToolChoiceMaxRetries: escalateToolChoiceMaxRetries,
 		Batch:                        batch,
 	})
 }

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -140,6 +140,46 @@ func TestBuildRunConfig_StdinBaseWithFlagOverride(t *testing.T) {
 	}
 }
 
+// TestBuildRunConfig_EscalationMaxRetriesBasePreserved pins the R3
+// Changed() guard: a base config that sets toolChoiceEscalation.maxRetries
+// must survive when the operator passes no --escalate-tool-choice-max-retries
+// flag. Before the guard the flag's default (0) was forwarded
+// unconditionally and would clobber the base value.
+func TestBuildRunConfig_EscalationMaxRetriesBasePreserved(t *testing.T) {
+	var base types.RunConfig
+	if err := json.Unmarshal([]byte(minimalRunConfigJSON(t)), &base); err != nil {
+		t.Fatalf("unmarshal base: %v", err)
+	}
+	base.ToolChoiceEscalation = &types.ToolChoiceEscalationConfig{Enabled: true, MaxRetries: 3}
+	raw, err := json.Marshal(base)
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{"--max-turns", "5"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin:   strings.NewReader(string(raw)),
+		Cmd:     cmd,
+		Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.ToolChoiceEscalation == nil {
+		t.Fatal("base ToolChoiceEscalation must survive, got nil")
+	}
+	if !cfg.ToolChoiceEscalation.Enabled {
+		t.Error("base Enabled=true must survive")
+	}
+	if cfg.ToolChoiceEscalation.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3 (base preserved, no flag passed)", cfg.ToolChoiceEscalation.MaxRetries)
+	}
+}
+
 // TestBuildRunConfig_FilePath verifies the file-loading branch. The
 // path coverage matters because loadRunConfigFile already had a code
 // path for file reads pre-refactor — the test confirms BuildRunConfig

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -84,6 +84,9 @@ func addRunConfigFlags(cmd *cobra.Command) {
 
 	f.Int("max-tool-parallel", 0, "Maximum number of async tool calls dispatched concurrently in a single turn. Range: 1-16. 0 uses the library default (4).")
 
+	f.Bool("escalate-tool-choice", false, "Recover from a first-turn no-tool answer on a workspace-dependent task by retrying with provider-native required tool choice (or a stronger prompt where unsupported). OFF by default. See issue #230.")
+	f.Int("escalate-tool-choice-max-retries", 0, "Maximum forced retries per inner-loop run when --escalate-tool-choice is set. Range: 1-3. 0 uses the default (1). No effect unless --escalate-tool-choice is set.")
+
 	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/sandbox.md.")
 
 	addRunConfigFlagCompletions(cmd)

--- a/harness/internal/core/escalation.go
+++ b/harness/internal/core/escalation.go
@@ -1,0 +1,143 @@
+package core
+
+// Tool-choice escalation (#230). This file defines the seam between the
+// agentic loop and the missed-tool recovery policy. The loop never decides
+// *whether* a no-tool answer is suspicious or *how* to recover — that
+// judgement lives behind the EscalationPolicy interface, injected by the
+// factory. Keeping the decision out of the loop preserves the
+// loop-as-pure-interfaces invariant (CLAUDE.md): the loop reads no
+// environment, touches no filesystem, and imports no concrete component
+// here. It hands the policy a value-typed EscalationInput and acts on the
+// returned EscalationDecision.
+
+// EscalationKind enumerates the recovery action the policy selected for a
+// suspected missed-tool turn. The zero value (EscalationNone) means "do
+// not escalate" so a nil-safe / disabled policy is a no-op by construction.
+type EscalationKind int
+
+const (
+	// EscalationNone — the turn is not a missed-tool failure (or the
+	// feature is off / the cap is exhausted). The loop accepts the
+	// model's answer unchanged.
+	EscalationNone EscalationKind = iota
+
+	// EscalationNative — retry the turn with provider-native required
+	// tool choice (StreamParams.ToolChoice = ToolChoiceRequired). Chosen
+	// only when the resolved provider capability advertises
+	// Supported && Required.
+	EscalationNative
+
+	// EscalationPrompt — retry the turn after injecting a stronger-prompt
+	// user message stating the missing requirement. The fallback when the
+	// provider cannot force tool use natively.
+	EscalationPrompt
+)
+
+// String returns the wire/label form of the escalation kind, used on the
+// trace span attribute so operators can audit which recovery ran.
+func (k EscalationKind) String() string {
+	switch k {
+	case EscalationNative:
+		return "native"
+	case EscalationPrompt:
+		return "prompt"
+	default:
+		return "none"
+	}
+}
+
+// EscalationInput is the value-typed view of a completed turn the loop
+// hands the policy. It carries only data the loop already has in scope, so
+// the policy needs no access to loop internals: the run mode, the resolved
+// provider/model (for capability lookup), the model's stop reason, whether
+// any tool was available this turn, whether the model emitted any tool call
+// this turn, the turn index, and how many escalations have already fired in
+// this inner-loop run.
+type EscalationInput struct {
+	// Mode is the run mode ("planning"/"review"/"research"/"execution"/
+	// "toil"). The policy uses it to pick the mode-specific requirement
+	// and to stay silent for modes where no tool is required.
+	Mode string
+
+	// Provider and Model identify the resolved (provider, model) pair so
+	// the policy can resolve the native tool-choice capability and decide
+	// native-vs-prompt fallback. Empty strings resolve to no native
+	// capability, so the policy falls back to the prompt path.
+	Provider string
+	Model    string
+
+	// StopReason is the turn's provider stop reason. A missed-tool answer
+	// is a final/text stop reason (e.g. "end_turn"); a "tool_use" turn is
+	// never a missed-tool failure.
+	StopReason string
+
+	// ToolsAvailable reports whether the loop attached any tool
+	// definitions to the turn. The trigger never fires when false — a run
+	// with no tools cannot be expected to call one.
+	ToolsAvailable bool
+
+	// PriorToolCalls is the number of tool calls dispatched so far in this
+	// inner-loop run. The conservative trigger fires only on the *first*
+	// assistant turn (PriorToolCalls == 0): a model that has already used
+	// tools and then answers is making a legitimate judgement.
+	PriorToolCalls int
+
+	// Turn is the zero-based turn index within the inner-loop run.
+	Turn int
+
+	// EscalationsSoFar is the number of escalations already performed in
+	// this inner-loop run. The policy compares it against its cap so a
+	// retry that itself ends in a no-tool answer cannot loop unboundedly.
+	EscalationsSoFar int
+}
+
+// EscalationDecision is the policy's verdict for one turn.
+//
+// The zero value (Kind == EscalationNone) is the safe default: a disabled
+// or nil policy returns it and the loop accepts the model's answer
+// unchanged.
+type EscalationDecision struct {
+	// Kind selects the recovery action. EscalationNone means no retry.
+	Kind EscalationKind
+
+	// PromptMessage is the user-message text the loop appends before the
+	// retry when Kind == EscalationPrompt. Empty for the native path
+	// (the provider field forces the call, so no extra prompt is added).
+	PromptMessage string
+
+	// Reason is a short, bounded, non-model-derived explanation of why the
+	// escalation fired (e.g. the mode requirement that was unmet). It is
+	// attached to the trace span so operators can audit the trigger
+	// without the raw model output. It is NOT a metric label.
+	Reason string
+}
+
+// EscalationPolicy decides whether a completed no-tool turn is a likely
+// missed-tool failure and, if so, how to recover. It is injected into the
+// AgenticLoop by the factory so the loop stays free of the detection
+// heuristic, the mode-requirement table, and the provider-capability
+// lookup.
+//
+// Implementations MUST be safe to call on every turn: the loop calls
+// Decide unconditionally and relies on the EscalationNone zero value to
+// mean "do nothing". A nil EscalationPolicy on the loop is treated as a
+// disabled policy (see (*AgenticLoop).escalationDecision).
+type EscalationPolicy interface {
+	// Decide returns the recovery action for the given turn. It must never
+	// return EscalationNative/EscalationPrompt when in.ToolsAvailable is
+	// false, when in.StopReason is "tool_use", when in.PriorToolCalls > 0,
+	// or when in.EscalationsSoFar has reached the cap.
+	Decide(in EscalationInput) EscalationDecision
+}
+
+// escalationDecision resolves the loop's EscalationPolicy, treating a nil
+// policy as disabled (returns the EscalationNone zero value). Centralising
+// the nil check keeps the call site in runInnerLoop free of a guard and
+// guarantees the loop is a no-op whenever the factory left the policy
+// unset (the OFF-by-default path).
+func (l *AgenticLoop) escalationDecision(in EscalationInput) EscalationDecision {
+	if l.Escalation == nil {
+		return EscalationDecision{Kind: EscalationNone}
+	}
+	return l.Escalation.Decide(in)
+}

--- a/harness/internal/core/escalation_default.go
+++ b/harness/internal/core/escalation_default.go
@@ -100,9 +100,17 @@ func (p *defaultEscalationPolicy) Decide(in EscalationInput) EscalationDecision 
 	if !in.ToolsAvailable {
 		return none
 	}
-	// Only the first assistant turn. A model that already used tools and
-	// then answers is making a legitimate judgement, not skipping context.
-	if in.PriorToolCalls > 0 || in.Turn > 0 {
+	// The model must not have called any tool yet. This is the
+	// load-bearing gate: it distinguishes a model skipping workspace
+	// context from one that answered after using tools (which is a
+	// legitimate judgement). It is NOT keyed on Turn — a forced retry
+	// advances the turn counter, so gating on Turn would make the
+	// EscalationsSoFar cap unreachable for maxRetries > 1, and Turn is a
+	// weaker proxy that breaks when a compacted context resets it. With
+	// PriorToolCalls == 0 as the gate, escalation repeats (up to the cap
+	// checked above) only while the model still has not called any tool,
+	// and stops naturally the moment one is called.
+	if in.PriorToolCalls > 0 {
 		return none
 	}
 	// Mode-aware requirement. Modes absent from the table require no tool,
@@ -117,13 +125,13 @@ func (p *defaultEscalationPolicy) Decide(in EscalationInput) EscalationDecision 
 	if p.supportsNativeRequired(in.Provider, in.Model) {
 		return EscalationDecision{
 			Kind:   EscalationNative,
-			Reason: fmt.Sprintf("mode %q expects a tool call on the first turn; retrying with provider-native required tool choice", in.Mode),
+			Reason: fmt.Sprintf("mode %q expects a tool call before answering and none was made; retrying with provider-native required tool choice", in.Mode),
 		}
 	}
 	return EscalationDecision{
 		Kind:          EscalationPrompt,
 		PromptMessage: fmt.Sprintf("You answered without calling any tool, but this task requires it: %s. Call an appropriate tool now rather than answering from assumption.", req.description),
-		Reason:        fmt.Sprintf("mode %q expects a tool call on the first turn; provider lacks native required tool choice, retrying with a stronger prompt", in.Mode),
+		Reason:        fmt.Sprintf("mode %q expects a tool call before answering and none was made; provider lacks native required tool choice, retrying with a stronger prompt", in.Mode),
 	}
 }
 

--- a/harness/internal/core/escalation_default.go
+++ b/harness/internal/core/escalation_default.go
@@ -135,6 +135,6 @@ func (p *defaultEscalationPolicy) supportsNativeRequired(providerType, model str
 	if p.caps == nil || providerType == "" {
 		return false
 	}
-	cap := p.caps.Resolve(providerType, model).ToolChoice
-	return cap.Supported && cap.Required
+	tc := p.caps.Resolve(providerType, model).ToolChoice
+	return tc.Supported && tc.Required
 }

--- a/harness/internal/core/escalation_default.go
+++ b/harness/internal/core/escalation_default.go
@@ -1,0 +1,140 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+)
+
+// capabilityResolver is the minimal view of the quirks registry the
+// default escalation policy needs: resolve a (provider, model) pair to its
+// tool-choice capability. Declared as an interface so tests can inject a
+// fake capability without a real registry, and so the policy depends on a
+// behaviour rather than the concrete *quirks.Registry.
+type capabilityResolver interface {
+	Resolve(providerType, model string) quirks.ProviderQuirks
+}
+
+// modeRequirement describes the first-turn tool expectation for a run mode.
+// A mode absent from the table (or one whose requirement is the zero value)
+// is treated as "no tool required" and never escalates — this is what keeps
+// modes where a no-tool answer is legitimate safe from spurious retries.
+type modeRequirement struct {
+	// description is the human-readable requirement injected into the
+	// prompt-fallback message and surfaced on the trace span. It names
+	// what the model was expected to do (e.g. "inspect the workspace with
+	// a read or search tool"). Empty means the mode requires no tool.
+	description string
+}
+
+// modeRequirements is the conservative, mode-aware policy table (#230).
+//
+//   - planning / review: expect at least one read/search tool call before
+//     a final answer — both modes reason about existing code.
+//   - research: a fetch is an acceptable first tool, so the requirement is
+//     phrased around gathering context rather than reading the workspace.
+//   - execution: the agent edits code, so it must read before it answers.
+//   - toil: a read-only mode for routine maintenance; like planning/review
+//     it should inspect before concluding.
+//
+// A mode not present here requires no tool and is never escalated. The
+// table is intentionally small and explicit; widening it is a deliberate
+// policy change, not an accident of defaulting.
+var modeRequirements = map[string]modeRequirement{
+	"planning":  {description: "inspect the relevant files with a read or search tool before answering"},
+	"review":    {description: "inspect the code under review with a read or search tool before answering"},
+	"research":  {description: "gather the needed context with a read, search, or fetch tool before answering"},
+	"execution": {description: "read the relevant files with a read or search tool before making changes or answering"},
+	"toil":      {description: "inspect the relevant files with a read or search tool before answering"},
+}
+
+// defaultEscalationPolicy is the production EscalationPolicy. It is OFF
+// unless maxRetries > 0 (the factory passes 0 when the operator did not
+// opt in via RunConfig.ToolChoiceEscalation), so a bare run never escalates.
+//
+// The detection heuristic is deliberately conservative: it fires only on
+// the first assistant turn of an inner-loop run, only when tools were
+// available and none was called, only for modes with a tool requirement,
+// and never beyond the configured cap. Native vs prompt fallback is chosen
+// from the resolved provider tool-choice capability.
+type defaultEscalationPolicy struct {
+	maxRetries int
+	caps       capabilityResolver
+}
+
+var _ EscalationPolicy = (*defaultEscalationPolicy)(nil)
+
+// newDefaultEscalationPolicy builds the production policy. maxRetries <= 0
+// yields a policy that never escalates (the disabled / OFF-by-default
+// case); the factory only passes a positive cap when the operator opted
+// in. caps resolves provider tool-choice capability; a nil caps degrades
+// every decision to the prompt fallback (no native capability is ever
+// detected) rather than panicking.
+func newDefaultEscalationPolicy(maxRetries int, caps capabilityResolver) *defaultEscalationPolicy {
+	return &defaultEscalationPolicy{maxRetries: maxRetries, caps: caps}
+}
+
+// Decide implements EscalationPolicy. See the conservative-trigger
+// description on defaultEscalationPolicy. The guard ordering mirrors the
+// interface contract so each early return documents one reason a no-tool
+// answer is NOT a missed-tool failure.
+func (p *defaultEscalationPolicy) Decide(in EscalationInput) EscalationDecision {
+	none := EscalationDecision{Kind: EscalationNone}
+
+	// Feature off / cap not configured.
+	if p.maxRetries <= 0 {
+		return none
+	}
+	// Never exceed the cap — bounds the recovery so a model that keeps
+	// refusing to call a tool cannot drive an unbounded retry loop.
+	if in.EscalationsSoFar >= p.maxRetries {
+		return none
+	}
+	// A tool_use turn is the model doing exactly what we wanted; only a
+	// final/text answer is a candidate.
+	if in.StopReason == "tool_use" {
+		return none
+	}
+	// No tools available → the model cannot be expected to call one. This
+	// also covers purely conceptual questions on a tool-less run.
+	if !in.ToolsAvailable {
+		return none
+	}
+	// Only the first assistant turn. A model that already used tools and
+	// then answers is making a legitimate judgement, not skipping context.
+	if in.PriorToolCalls > 0 || in.Turn > 0 {
+		return none
+	}
+	// Mode-aware requirement. Modes absent from the table require no tool,
+	// so a no-tool answer there is legitimate and must not be escalated.
+	req, ok := modeRequirements[in.Mode]
+	if !ok || req.description == "" {
+		return none
+	}
+
+	// The turn is a likely missed-tool failure. Choose native required
+	// tool choice when the provider supports it, else the prompt fallback.
+	if p.supportsNativeRequired(in.Provider, in.Model) {
+		return EscalationDecision{
+			Kind:   EscalationNative,
+			Reason: fmt.Sprintf("mode %q expects a tool call on the first turn; retrying with provider-native required tool choice", in.Mode),
+		}
+	}
+	return EscalationDecision{
+		Kind:          EscalationPrompt,
+		PromptMessage: fmt.Sprintf("You answered without calling any tool, but this task requires it: %s. Call an appropriate tool now rather than answering from assumption.", req.description),
+		Reason:        fmt.Sprintf("mode %q expects a tool call on the first turn; provider lacks native required tool choice, retrying with a stronger prompt", in.Mode),
+	}
+}
+
+// supportsNativeRequired reports whether the resolved (provider, model)
+// pair can force at least one tool call natively. A nil resolver or an
+// empty provider means "no native capability", so the policy falls back to
+// the prompt path.
+func (p *defaultEscalationPolicy) supportsNativeRequired(providerType, model string) bool {
+	if p.caps == nil || providerType == "" {
+		return false
+	}
+	cap := p.caps.Resolve(providerType, model).ToolChoice
+	return cap.Supported && cap.Required
+}

--- a/harness/internal/core/escalation_test.go
+++ b/harness/internal/core/escalation_test.go
@@ -260,16 +260,38 @@ func TestEscalationPolicy_Decide(t *testing.T) {
 			wantKind: EscalationNone,
 		},
 		{
-			name:     "no_escalation_on_later_turn",
+			// Post-B1: Turn is no longer a guard. A later turn with no
+			// prior tool calls (e.g. after a compacted context reset the
+			// counter) is still a missed-tool failure and must escalate;
+			// only PriorToolCalls > 0 stops it.
+			name:     "escalates_on_later_turn_when_no_prior_tool_calls",
 			policy:   newDefaultEscalationPolicy(1, nativeCaps),
 			mutate:   func(in *EscalationInput) { in.Turn = 2 },
-			wantKind: EscalationNone,
+			wantKind: EscalationNative,
 		},
 		{
 			name:     "no_escalation_for_mode_without_requirement",
 			policy:   newDefaultEscalationPolicy(1, nativeCaps),
 			mutate:   func(in *EscalationInput) { in.Mode = "no-such-mode" },
 			wantKind: EscalationNone,
+		},
+		{
+			name:     "planning_mode_escalates",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.Mode = "planning" },
+			wantKind: EscalationNative,
+		},
+		{
+			name:     "review_mode_escalates",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.Mode = "review" },
+			wantKind: EscalationNative,
+		},
+		{
+			name:     "toil_mode_escalates",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.Mode = "toil" },
+			wantKind: EscalationNative,
 		},
 		{
 			name:     "prompt_when_resolver_nil",
@@ -294,6 +316,28 @@ func TestEscalationPolicy_Decide(t *testing.T) {
 				t.Error("native escalation must not carry a PromptMessage")
 			}
 		})
+	}
+}
+
+// TestEscalationKindString pins the wire form of each EscalationKind.
+// These strings are written verbatim into the escalation.kind OTel span
+// attribute, so a rename of an iota constant that forgot to update
+// String() would silently produce a wrong span label. EscalationNone's
+// "none" reaches String() only via the default fall-through, so the value
+// is asserted explicitly here rather than relying on indirect coverage.
+func TestEscalationKindString(t *testing.T) {
+	cases := []struct {
+		kind EscalationKind
+		want string
+	}{
+		{EscalationNone, "none"},
+		{EscalationNative, "native"},
+		{EscalationPrompt, "prompt"},
+	}
+	for _, tc := range cases {
+		if got := tc.kind.String(); got != tc.want {
+			t.Errorf("EscalationKind(%d).String() = %q, want %q", tc.kind, got, tc.want)
+		}
 	}
 }
 
@@ -413,11 +457,13 @@ func TestEscalation_ResearchAllowsFetchTool(t *testing.T) {
 	}
 }
 
-// TestEscalation_MaxRetryCapEnforced is the unbounded-loop guard: a model
-// that keeps answering without a tool must be escalated at most once (the
-// default cap) and the run must terminate rather than spin. The scripted
-// provider returns a no-tool answer on every call; the loop must stop
-// escalating after the cap and accept the answer.
+// TestEscalation_MaxRetryCapEnforced is the unbounded-loop guard at the
+// default cap: a model that keeps answering without a tool must be
+// escalated at most once and the run must terminate rather than spin. The
+// scripted provider returns a no-tool answer on every call. With the
+// first-turn guard removed (B1), the EscalationsSoFar >= maxRetries cap is
+// the sole bound: after one escalation EscalationsSoFar == 1 == maxRetries,
+// so Decide returns none and the answer is accepted.
 func TestEscalation_MaxRetryCapEnforced(t *testing.T) {
 	prov := &sequencedProvider{scripts: [][]types.StreamEvent{noToolAnswer()}}
 	loop, reader := buildEscalationLoop(prov, newDefaultEscalationPolicy(1, nativeCaps))
@@ -426,13 +472,62 @@ func TestEscalation_MaxRetryCapEnforced(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	// One escalation (cap=1): the original answer + exactly one forced
-	// retry. The retry also answers with no tool, but the cap (and the
-	// first-turn guard) prevent any further escalation, so the run
-	// terminates at 2 provider calls.
+	// retry. The retry also answers with no tool, but the cap prevents any
+	// further escalation, so the run terminates at 2 provider calls.
 	if prov.calls() != 2 {
 		t.Errorf("cap=1 must yield exactly 2 provider calls (answer + 1 retry), got %d", prov.calls())
 	}
 	if n := countNoToolWhenRequired(t, reader); n != 1 {
 		t.Errorf("no_tool_when_required count = %d, want exactly 1 (cap enforced)", n)
+	}
+}
+
+// TestEscalation_MaxRetryCapEnforcedAtTwo proves the cap ceiling is now
+// reachable (B1): with maxRetries=2 and a model that never calls a tool,
+// escalation fires exactly twice — original answer + two forced retries =
+// 3 provider calls and 2 no_tool_when_required emissions — then the cap
+// stops it and the run terminates. Before B1 this behaved identically to
+// maxRetries=1 because the turn guard short-circuited the second retry.
+func TestEscalation_MaxRetryCapEnforcedAtTwo(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{noToolAnswer()}}
+	loop, reader := buildEscalationLoop(prov, newDefaultEscalationPolicy(2, nativeCaps))
+
+	if _, err := loop.Run(context.Background(), escalationConfig("execution")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.calls() != 3 {
+		t.Errorf("cap=2 must yield exactly 3 provider calls (answer + 2 retries), got %d", prov.calls())
+	}
+	if n := countNoToolWhenRequired(t, reader); n != 2 {
+		t.Errorf("no_tool_when_required count = %d, want exactly 2 (cap=2 enforced)", n)
+	}
+	// Every forced retry must carry ToolChoiceRequired (native-capable).
+	for i := 1; i < prov.calls(); i++ {
+		if prov.choiceAt(i) != types.ToolChoiceRequired {
+			t.Errorf("retry call %d ToolChoice = %v, want required", i, prov.choiceAt(i))
+		}
+	}
+}
+
+// TestEscalation_RecoveryStopsAfterToolCall pins the natural stop now that
+// PriorToolCalls — not Turn — is the gate: a model that answers with no
+// tool, is escalated, and then calls a tool on the retry must NOT be
+// escalated again even when the cap (2) would otherwise allow it. The
+// PriorToolCalls > 0 guard ends recovery the moment a tool is used.
+func TestEscalation_RecoveryStopsAfterToolCall(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{
+		noToolAnswer(),
+		toolCallTurn(),
+		{{Type: "text_delta", Text: "done"}, {Type: "message_complete", StopReason: "end_turn"}},
+	}}
+	loop, reader := buildEscalationLoop(prov, newDefaultEscalationPolicy(2, nativeCaps))
+
+	if _, err := loop.Run(context.Background(), escalationConfig("execution")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// answer (escalate) -> tool call (PriorToolCalls becomes 1) ->
+	// final no-tool answer accepted (PriorToolCalls > 0 blocks escalation).
+	if n := countNoToolWhenRequired(t, reader); n != 1 {
+		t.Errorf("no_tool_when_required count = %d, want 1 (recovery stops once a tool is called)", n)
 	}
 }

--- a/harness/internal/core/escalation_test.go
+++ b/harness/internal/core/escalation_test.go
@@ -1,0 +1,438 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
+	"github.com/rxbynerd/stirrup/harness/internal/edit"
+	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/permission"
+	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/harness/internal/router"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/harness/internal/verifier"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeCapabilityResolver returns a fixed ToolChoiceCapability for every
+// (provider, model) so the native-vs-prompt fallback can be exercised
+// without a real quirks registry.
+type fakeCapabilityResolver struct {
+	cap quirks.ToolChoiceCapability
+}
+
+func (f fakeCapabilityResolver) Resolve(_, _ string) quirks.ProviderQuirks {
+	return quirks.ProviderQuirks{ToolChoice: f.cap}
+}
+
+// sequencedProvider returns a different slice of stream events on each
+// successive Stream call and captures the ToolChoice of every call. It
+// lets a single loop run see "no-tool answer, then a tool call" without
+// any live provider.
+type sequencedProvider struct {
+	mu          sync.Mutex
+	scripts     [][]types.StreamEvent
+	call        int
+	toolChoices []types.ToolChoiceMode
+}
+
+func (p *sequencedProvider) Stream(_ context.Context, params types.StreamParams) (<-chan types.StreamEvent, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.toolChoices = append(p.toolChoices, params.ToolChoice)
+	idx := p.call
+	if idx >= len(p.scripts) {
+		idx = len(p.scripts) - 1
+	}
+	events := p.scripts[idx]
+	p.call++
+	ch := make(chan types.StreamEvent, len(events))
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (p *sequencedProvider) calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.call
+}
+
+func (p *sequencedProvider) choiceAt(i int) types.ToolChoiceMode {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if i >= len(p.toolChoices) {
+		return types.ToolChoiceAuto
+	}
+	return p.toolChoices[i]
+}
+
+// noToolAnswer is the first-turn missed-tool stream: a final text answer
+// with no tool call.
+func noToolAnswer() []types.StreamEvent {
+	return []types.StreamEvent{
+		{Type: "text_delta", Text: "Here is the answer without looking."},
+		{Type: "message_complete", StopReason: "end_turn"},
+	}
+}
+
+// toolCallThenDone is the recovered turn: the model calls a tool.
+func toolCallTurn() []types.StreamEvent {
+	return []types.StreamEvent{
+		{Type: "tool_call", ID: "tc1", Name: "test_tool", Input: map[string]any{}},
+		{Type: "message_complete", StopReason: "tool_use"},
+	}
+}
+
+// buildEscalationLoop wires a loop with a scripted provider, an escalation
+// policy, and a manual-reader metric provider so tests can assert both the
+// retry behaviour and the no_tool_when_required emission. A nil policy
+// leaves escalation disabled.
+func buildEscalationLoop(prov *sequencedProvider, policy EscalationPolicy) (*AgenticLoop, *sdkmetric.ManualReader) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, _ := observability.NewMetricsForTesting(mp)
+
+	registry := tool.NewRegistry()
+	registry.Register(&tool.Tool{
+		Name:              "test_tool",
+		Description:       "A test tool",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: false,
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "tool result", nil
+		},
+	})
+
+	return &AgenticLoop{
+		Provider:    prov,
+		Router:      router.NewStaticRouter("anthropic", "claude-sonnet-4-6"),
+		Prompt:      prompt.NewDefaultPromptBuilder(),
+		Context:     contextpkg.NewSlidingWindowStrategy(),
+		Tools:       registry,
+		Edit:        edit.NewWholeFileStrategy(),
+		Verifier:    verifier.NewNoneVerifier(),
+		Permissions: permission.NewAllowAll(),
+		Git:         git.NewNoneGitStrategy(),
+		Escalation:  policy,
+		Transport:   transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{}),
+		Trace:       trace.NewJSONLTraceEmitter(&bytes.Buffer{}),
+		Tracer:      noop.NewTracerProvider().Tracer(""),
+		Metrics:     metrics,
+		Logger:      slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)),
+	}, reader
+}
+
+// buildEscalationLoopNoTools is buildEscalationLoop with an empty tool
+// registry so the "no tools available" branch can be exercised.
+func buildEscalationLoopNoTools(prov *sequencedProvider, policy EscalationPolicy) *AgenticLoop {
+	loop, _ := buildEscalationLoop(prov, policy)
+	loop.Tools = tool.NewRegistry()
+	return loop
+}
+
+func escalationConfig(mode string) *types.RunConfig {
+	timeout := 60
+	return &types.RunConfig{
+		RunID:            "test-escalation",
+		Mode:             mode,
+		Prompt:           "Fix the bug in the workspace.",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://TEST"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: "/tmp"},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		MaxTurns:         20,
+		Timeout:          &timeout,
+	}
+}
+
+func countNoToolWhenRequired(t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "stirrup.harness.tool_failures" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				for _, kv := range dp.Attributes.ToSlice() {
+					if string(kv.Key) == "category" &&
+						kv.Value.Emit() == observability.ToolFailureNoToolWhenRequired.String() {
+						total += dp.Value
+					}
+				}
+			}
+		}
+	}
+	return total
+}
+
+// --- defaultEscalationPolicy.Decide unit tests ---
+
+// nativeCaps advertises native required tool choice; promptCaps does not.
+var (
+	nativeCaps = fakeCapabilityResolver{cap: quirks.ToolChoiceCapability{Supported: true, Required: true}}
+	promptCaps = fakeCapabilityResolver{cap: quirks.ToolChoiceCapability{Supported: true, Required: false}}
+)
+
+func TestEscalationPolicy_Decide(t *testing.T) {
+	base := EscalationInput{
+		Mode:           "execution",
+		Provider:       "anthropic",
+		Model:          "claude-sonnet-4-6",
+		StopReason:     "end_turn",
+		ToolsAvailable: true,
+		PriorToolCalls: 0,
+		Turn:           0,
+	}
+	cases := []struct {
+		name     string
+		policy   *defaultEscalationPolicy
+		mutate   func(*EscalationInput)
+		wantKind EscalationKind
+	}{
+		{
+			name:     "native_when_supported",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			wantKind: EscalationNative,
+		},
+		{
+			name:     "prompt_when_native_unsupported",
+			policy:   newDefaultEscalationPolicy(1, promptCaps),
+			wantKind: EscalationPrompt,
+		},
+		{
+			name:     "no_escalation_when_disabled",
+			policy:   newDefaultEscalationPolicy(0, nativeCaps),
+			wantKind: EscalationNone,
+		},
+		{
+			name:     "no_escalation_when_cap_reached",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.EscalationsSoFar = 1 },
+			wantKind: EscalationNone,
+		},
+		{
+			name:     "no_escalation_on_tool_use",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.StopReason = "tool_use" },
+			wantKind: EscalationNone,
+		},
+		{
+			name:     "no_escalation_when_no_tools",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.ToolsAvailable = false },
+			wantKind: EscalationNone,
+		},
+		{
+			name:     "no_escalation_after_prior_tool_calls",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.PriorToolCalls = 1 },
+			wantKind: EscalationNone,
+		},
+		{
+			name:     "no_escalation_on_later_turn",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.Turn = 2 },
+			wantKind: EscalationNone,
+		},
+		{
+			name:     "no_escalation_for_mode_without_requirement",
+			policy:   newDefaultEscalationPolicy(1, nativeCaps),
+			mutate:   func(in *EscalationInput) { in.Mode = "no-such-mode" },
+			wantKind: EscalationNone,
+		},
+		{
+			name:     "prompt_when_resolver_nil",
+			policy:   newDefaultEscalationPolicy(1, nil),
+			wantKind: EscalationPrompt,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := base
+			if tc.mutate != nil {
+				tc.mutate(&in)
+			}
+			got := tc.policy.Decide(in)
+			if got.Kind != tc.wantKind {
+				t.Errorf("Decide kind = %v, want %v", got.Kind, tc.wantKind)
+			}
+			if got.Kind == EscalationPrompt && got.PromptMessage == "" {
+				t.Error("prompt escalation must carry a non-empty PromptMessage")
+			}
+			if got.Kind == EscalationNative && got.PromptMessage != "" {
+				t.Error("native escalation must not carry a PromptMessage")
+			}
+		})
+	}
+}
+
+// --- loop integration tests ---
+
+// TestEscalation_NativeRetryOnMissedTool covers the acceptance criterion:
+// a first-turn no-tool answer on a workspace-dependent task with a
+// native-capable provider triggers a retry that forces ToolChoiceRequired.
+func TestEscalation_NativeRetryOnMissedTool(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{
+		noToolAnswer(),
+		toolCallTurn(),
+		{{Type: "text_delta", Text: "done"}, {Type: "message_complete", StopReason: "end_turn"}},
+	}}
+	loop, reader := buildEscalationLoop(prov, newDefaultEscalationPolicy(1, nativeCaps))
+
+	if _, err := loop.Run(context.Background(), escalationConfig("execution")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.calls() < 2 {
+		t.Fatalf("expected at least 2 provider calls (answer + forced retry), got %d", prov.calls())
+	}
+	// The first call is auto; the retry must force required tool choice.
+	if got := prov.choiceAt(0); got != types.ToolChoiceAuto {
+		t.Errorf("first call ToolChoice = %v, want auto", got)
+	}
+	if got := prov.choiceAt(1); got != types.ToolChoiceRequired {
+		t.Errorf("retry call ToolChoice = %v, want required", got)
+	}
+	if n := countNoToolWhenRequired(t, reader); n != 1 {
+		t.Errorf("no_tool_when_required count = %d, want 1", n)
+	}
+}
+
+// TestEscalation_PromptFallback covers the prompt-fallback path: a
+// provider that cannot force tool choice natively gets a stronger-prompt
+// retry instead, and ToolChoiceRequired is never set on the wire.
+func TestEscalation_PromptFallback(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{
+		noToolAnswer(),
+		toolCallTurn(),
+		{{Type: "text_delta", Text: "done"}, {Type: "message_complete", StopReason: "end_turn"}},
+	}}
+	loop, reader := buildEscalationLoop(prov, newDefaultEscalationPolicy(1, promptCaps))
+
+	if _, err := loop.Run(context.Background(), escalationConfig("execution")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.calls() < 2 {
+		t.Fatalf("expected a retry, got %d provider calls", prov.calls())
+	}
+	for i := 0; i < prov.calls(); i++ {
+		if prov.choiceAt(i) == types.ToolChoiceRequired {
+			t.Errorf("prompt fallback must not force required tool choice; call %d did", i)
+		}
+	}
+	if n := countNoToolWhenRequired(t, reader); n != 1 {
+		t.Errorf("no_tool_when_required count = %d, want 1", n)
+	}
+}
+
+// TestEscalation_DisabledNoRetry pins the OFF-by-default safety: with no
+// escalation policy a first-turn no-tool answer is accepted as the final
+// answer — no retry, no emission. This is the "legitimate no-tool answer"
+// / "bare run unchanged" acceptance case.
+func TestEscalation_DisabledNoRetry(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{noToolAnswer()}}
+	loop, reader := buildEscalationLoop(prov, nil)
+
+	if _, err := loop.Run(context.Background(), escalationConfig("execution")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.calls() != 1 {
+		t.Errorf("disabled escalation must not retry; got %d provider calls", prov.calls())
+	}
+	if n := countNoToolWhenRequired(t, reader); n != 0 {
+		t.Errorf("no_tool_when_required count = %d, want 0 when disabled", n)
+	}
+}
+
+// TestEscalation_NoToolsNoRetry pins that escalation never fires when no
+// tools are available, even when the policy is enabled — a conceptual
+// question on a tool-less run is a legitimate no-tool answer.
+func TestEscalation_NoToolsNoRetry(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{noToolAnswer()}}
+	loop := buildEscalationLoopNoTools(prov, newDefaultEscalationPolicy(1, nativeCaps))
+
+	if _, err := loop.Run(context.Background(), escalationConfig("execution")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.calls() != 1 {
+		t.Errorf("no-tools run must not escalate; got %d provider calls", prov.calls())
+	}
+}
+
+// TestEscalation_ResearchAllowsFetchTool pins the mode-aware policy for
+// research: a no-tool first-turn answer is escalated (research expects a
+// read/search/fetch first), and a recovered turn that calls a tool is
+// accepted. This exercises a read-only mode end-to-end so the recovery is
+// proven not to depend on write tools.
+func TestEscalation_ResearchAllowsFetchTool(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{
+		noToolAnswer(),
+		toolCallTurn(),
+		{{Type: "text_delta", Text: "done"}, {Type: "message_complete", StopReason: "end_turn"}},
+	}}
+	loop, reader := buildEscalationLoop(prov, newDefaultEscalationPolicy(1, promptCaps))
+
+	if _, err := loop.Run(context.Background(), escalationConfig("research")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.calls() < 2 {
+		t.Errorf("research mode must escalate a first-turn no-tool answer; got %d calls", prov.calls())
+	}
+	if n := countNoToolWhenRequired(t, reader); n != 1 {
+		t.Errorf("no_tool_when_required count = %d, want 1", n)
+	}
+}
+
+// TestEscalation_MaxRetryCapEnforced is the unbounded-loop guard: a model
+// that keeps answering without a tool must be escalated at most once (the
+// default cap) and the run must terminate rather than spin. The scripted
+// provider returns a no-tool answer on every call; the loop must stop
+// escalating after the cap and accept the answer.
+func TestEscalation_MaxRetryCapEnforced(t *testing.T) {
+	prov := &sequencedProvider{scripts: [][]types.StreamEvent{noToolAnswer()}}
+	loop, reader := buildEscalationLoop(prov, newDefaultEscalationPolicy(1, nativeCaps))
+
+	if _, err := loop.Run(context.Background(), escalationConfig("execution")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// One escalation (cap=1): the original answer + exactly one forced
+	// retry. The retry also answers with no tool, but the cap (and the
+	// first-turn guard) prevent any further escalation, so the run
+	// terminates at 2 provider calls.
+	if prov.calls() != 2 {
+		t.Errorf("cap=1 must yield exactly 2 provider calls (answer + 1 retry), got %d", prov.calls())
+	}
+	if n := countNoToolWhenRequired(t, reader); n != 1 {
+		t.Errorf("no_tool_when_required count = %d, want exactly 1 (cap enforced)", n)
+	}
+}

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -487,6 +487,16 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	}
 	providers = wrappedProviders
 
+	// Tool-choice escalation policy (#230). OFF by default: when the
+	// operator did not opt in via RunConfig.ToolChoiceEscalation,
+	// EffectiveToolChoiceEscalationMaxRetries returns 0 and
+	// buildEscalationPolicy returns nil, so the loop's escalation path is
+	// inert and a bare run is unchanged. The capability resolver is the
+	// quirks registry the default provider adapter resolves against, so
+	// the native-vs-prompt choice matches the wire shape the adapter would
+	// actually serialise (including a compat profile's registry).
+	escalation := buildEscalationPolicy(config.EffectiveToolChoiceEscalationMaxRetries(), prov)
+
 	loop := &AgenticLoop{
 		Provider:     prov,
 		Providers:    providers,
@@ -500,6 +510,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		Permissions:  pp,
 		Git:          gs,
 		GuardRail:    gr,
+		Escalation:   escalation,
 		Transport:    tp,
 		Trace:        te,
 		Tracer:       tracer,
@@ -541,6 +552,28 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	}
 
 	return loop, nil
+}
+
+// buildEscalationPolicy constructs the tool-choice escalation policy
+// (#230) injected into the loop. A maxRetries <= 0 returns nil — the
+// OFF-by-default case where the loop's escalation path is a no-op — so the
+// only way to enable escalation is an explicit RunConfig.ToolChoiceEscalation
+// with Enabled:true (which makes EffectiveToolChoiceEscalationMaxRetries
+// positive).
+//
+// The capability resolver is quirks.DefaultRegistry(): tool-choice support
+// is a cross-provider capability declared by each provider type's base
+// rule, and no compat profile overrides it, so the default registry is the
+// authoritative source for the native-vs-prompt fallback decision and
+// matches what every adapter resolves against. The _ provider argument is
+// reserved so a future per-provider registry (e.g. a compat profile that
+// disables required tool choice for a specific gateway) can be threaded in
+// without changing the call site.
+func buildEscalationPolicy(maxRetries int, _ provider.ProviderAdapter) EscalationPolicy {
+	if maxRetries <= 0 {
+		return nil
+	}
+	return newDefaultEscalationPolicy(maxRetries, quirks.DefaultRegistry())
 }
 
 func buildProviders(ctx context.Context, config *types.RunConfig, secrets security.SecretStore) (provider.ProviderAdapter, map[string]provider.ProviderAdapter, error) {

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -417,6 +417,17 @@ func (l *AgenticLoop) runInnerLoop(
 	var lastStopReason string
 	stall := &stallDetector{}
 
+	// Tool-choice escalation state (#230). priorToolCalls tracks whether
+	// the model has dispatched any tool yet this inner-loop run;
+	// escalationsSoFar bounds the missed-tool recovery; pendingToolChoice
+	// carries a forced tool-choice mode onto the next turn's Stream call
+	// (set by the native escalation path, consumed once). All three stay
+	// at their zero values — and the escalation path is never taken — when
+	// the loop's EscalationPolicy is nil (the OFF-by-default case).
+	priorToolCalls := 0
+	escalationsSoFar := 0
+	pendingToolChoice := types.ToolChoiceAuto
+
 	for turn := 0; turn < config.MaxTurns; turn++ {
 		l.Logger.Info("turn started", "turn", turn)
 
@@ -612,6 +623,15 @@ func (l *AgenticLoop) runInnerLoop(
 		if temperature == nil {
 			temperature = types.Float64Ptr(defaultTemperature)
 		}
+		// Consume any forced tool choice the escalation path set on the
+		// previous iteration. Reset to auto immediately so the override
+		// applies to exactly one turn — a single bounded nudge, not a
+		// sticky mode. The zero value (ToolChoiceAuto) leaves the request
+		// byte-for-byte unchanged, so a run that never escalates is
+		// unaffected.
+		turnToolChoice := pendingToolChoice
+		pendingToolChoice = types.ToolChoiceAuto
+
 		ch, err := selectedProvider.Stream(spanCtx, types.StreamParams{
 			Model:       selection.Model,
 			System:      systemPrompt,
@@ -619,6 +639,7 @@ func (l *AgenticLoop) runInnerLoop(
 			Tools:       l.Tools.List(),
 			MaxTokens:   defaultReserveForResponse,
 			Temperature: temperature,
+			ToolChoice:  turnToolChoice,
 		})
 		if err != nil {
 			// Scrub the status string before it lands on the OTel span.
@@ -811,6 +832,38 @@ func (l *AgenticLoop) runInnerLoop(
 		// Extract tool calls.
 		toolCalls := collectToolCalls(sr.Blocks)
 
+		// Tool-choice escalation (#230). When the model returns a
+		// final/text answer (no tool calls) on a turn where the harness
+		// expected tool use, the injected EscalationPolicy decides whether
+		// this is a likely missed-tool failure and how to recover. The
+		// loop itself makes no judgement — it forwards the turn facts and
+		// acts on the decision. A nil policy (OFF by default) makes
+		// escalationDecision a no-op, so this block is inert on a bare run.
+		// The check runs before the terminal end_turn / non-tool-use
+		// returns so a recovered turn continues the loop instead of being
+		// accepted as the final answer.
+		if len(toolCalls) == 0 && sr.StopReason != "tool_use" {
+			decision := l.escalationDecision(EscalationInput{
+				Mode:             config.Mode,
+				Provider:         selection.Provider,
+				Model:            selection.Model,
+				StopReason:       sr.StopReason,
+				ToolsAvailable:   len(toolDefs) > 0,
+				PriorToolCalls:   priorToolCalls,
+				Turn:             turn,
+				EscalationsSoFar: escalationsSoFar,
+			})
+			if decision.Kind != EscalationNone {
+				// Persist the no-tool turn transcript before the retry so
+				// replay/mining still sees the rejected answer. The retry
+				// turn is recorded separately on its own iteration.
+				l.Trace.RecordTurnRecord(turnRecord)
+				messages = l.applyEscalation(ctx, config, decision, selection.Provider, selection.Model, messages, &pendingToolChoice)
+				escalationsSoFar++
+				continue
+			}
+		}
+
 		if sr.StopReason == "end_turn" {
 			// Record the turn transcript with no tool calls before the
 			// success return. Even an end_turn carries a transcript
@@ -880,6 +933,11 @@ func (l *AgenticLoop) runInnerLoop(
 		turnRecord.ToolCalls = toolRecords
 		l.Trace.RecordTurnRecord(turnRecord)
 		messages = appendToolResults(messages, toolResults)
+		// Record that the model has now used tools this run. The
+		// escalation trigger (#230) fires only on the first assistant
+		// turn with no prior tool calls; once this is non-zero a later
+		// no-tool answer is a legitimate judgement and is left alone.
+		priorToolCalls += len(toolCalls)
 		if stallOutcome != "" {
 			return messages, stallOutcome
 		}
@@ -906,6 +964,74 @@ func (l *AgenticLoop) runInnerLoop(
 
 	// Reached max turns.
 	return messages, "max_turns"
+}
+
+// applyEscalation performs the recovery the EscalationPolicy chose for a
+// suspected missed-tool turn (#230) and records its observability. It
+// returns the (possibly extended) message history.
+//
+//   - EscalationNative sets *pendingToolChoice to ToolChoiceRequired so
+//     the next turn's Stream call forces a tool. The provider adapter only
+//     honours this when the resolved capability supports it; the policy has
+//     already confirmed support, but the prompt path is the safe fallback
+//     either way.
+//   - EscalationPrompt appends a user message stating the unmet
+//     requirement so the model is nudged to call a tool on the next turn.
+//
+// Both paths emit a stirrup.harness.tool_failures observation under the
+// no_tool_when_required category (bounded labels only — no model strings)
+// and an escalation OTel span tagged with the run mode, the chosen kind,
+// and the policy's reason, so operators can audit why a retry happened.
+func (l *AgenticLoop) applyEscalation(
+	ctx context.Context,
+	config *types.RunConfig,
+	decision EscalationDecision,
+	providerType, model string,
+	messages []types.Message,
+	pendingToolChoice *types.ToolChoiceMode,
+) []types.Message {
+	switch decision.Kind {
+	case EscalationNative:
+		*pendingToolChoice = types.ToolChoiceRequired
+	case EscalationPrompt:
+		if decision.PromptMessage != "" {
+			messages = append(messages, types.Message{
+				Role: "user",
+				Content: []types.ContentBlock{
+					{Type: "text", Text: decision.PromptMessage},
+				},
+			})
+		}
+	}
+
+	// Co-emit into the tool-failure series so dashboards keyed on
+	// stirrup.harness.tool_failures see missed-tool recovery alongside the
+	// dispatch-site categories. tool.name is the empty bounded sentinel —
+	// no tool was involved — matching the provider_request/stream paths.
+	l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
+		attribute.String("tool.name", ""),
+		attribute.String("category", observability.ToolFailureNoToolWhenRequired.String()),
+		attribute.String("provider.type", providerType),
+		attribute.String("provider.model", model),
+		attribute.String("run.mode", config.Mode),
+	))
+
+	_, span := l.Tracer.Start(l.traceCtx(ctx), "tool_choice.escalation",
+		oteltrace.WithAttributes(
+			attribute.String("run.mode", config.Mode),
+			attribute.String("escalation.kind", decision.Kind.String()),
+			attribute.String("escalation.reason", decision.Reason),
+		),
+	)
+	span.End()
+
+	l.Logger.Info("tool-choice escalation",
+		"mode", config.Mode,
+		"kind", decision.Kind.String(),
+		"reason", decision.Reason,
+	)
+
+	return messages
 }
 
 // RunFollowUpLoop waits for follow-up user_response control events on the

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -1008,19 +1008,34 @@ func (l *AgenticLoop) applyEscalation(
 	// stirrup.harness.tool_failures see missed-tool recovery alongside the
 	// dispatch-site categories. tool.name is the empty bounded sentinel —
 	// no tool was involved — matching the provider_request/stream paths.
-	l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
-		attribute.String("tool.name", ""),
-		attribute.String("category", observability.ToolFailureNoToolWhenRequired.String()),
-		attribute.String("provider.type", providerType),
-		attribute.String("provider.model", model),
-		attribute.String("run.mode", config.Mode),
-	))
+	// Gate on IsValid() like every dispatch.go emit site so a future
+	// dynamic category can never widen label cardinality past the enum.
+	if observability.ToolFailureNoToolWhenRequired.IsValid() {
+		l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
+			attribute.String("tool.name", ""),
+			attribute.String("category", observability.ToolFailureNoToolWhenRequired.String()),
+			attribute.String("provider.type", providerType),
+			attribute.String("provider.model", model),
+			attribute.String("run.mode", config.Mode),
+		))
+	}
+
+	// Scrub the policy reason before it lands on the OTel span and the
+	// slog line. The only built-in policy builds Reason from the validated
+	// mode enum (no secret can reach it), but EscalationPolicy is a public
+	// interface: a future policy interpolating in.StopReason or workspace
+	// content would otherwise leak past ScrubHandler, which covers neither
+	// span attributes nor this log path. Mirrors the scrubbedErr pattern at
+	// the provider.Stream call sites.
+	scrubbedReason := security.Scrub(decision.Reason)
 
 	_, span := l.Tracer.Start(l.traceCtx(ctx), "tool_choice.escalation",
 		oteltrace.WithAttributes(
 			attribute.String("run.mode", config.Mode),
 			attribute.String("escalation.kind", decision.Kind.String()),
-			attribute.String("escalation.reason", decision.Reason),
+			// Reason is a short static string; see EscalationDecision.Reason
+			// godoc — NOT a metric label.
+			attribute.String("escalation.reason", scrubbedReason),
 		),
 	)
 	span.End()
@@ -1028,7 +1043,7 @@ func (l *AgenticLoop) applyEscalation(
 	l.Logger.Info("tool-choice escalation",
 		"mode", config.Mode,
 		"kind", decision.Kind.String(),
-		"reason", decision.Reason,
+		"reason", scrubbedReason,
 	)
 
 	return messages

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -564,6 +564,7 @@ func TestToolFailureCategory_EnumIsValid(t *testing.T) {
 		observability.ToolFailureProviderStream,
 		observability.ToolFailureStallRepeated,
 		observability.ToolFailureStallConsecutiveFailures,
+		observability.ToolFailureNoToolWhenRequired,
 	}
 	for _, c := range known {
 		if !c.IsValid() {

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -68,6 +68,7 @@ type AgenticLoop struct {
 	Permissions  permission.PermissionPolicy
 	Git          git.GitStrategy
 	GuardRail    guard.GuardRail
+	Escalation   EscalationPolicy // tool-choice missed-tool recovery (#230); nil = disabled
 	Transport    transport.Transport
 	Trace        trace.TraceEmitter
 	Tracer       oteltrace.Tracer         // OTel tracer for loop-level spans (noop when not using OTel)

--- a/harness/internal/observability/toolfailure.go
+++ b/harness/internal/observability/toolfailure.go
@@ -110,6 +110,12 @@ const (
 	// maxConsecutiveFailures consecutive failed calls. Fires from
 	// planAndDispatch when stall.recordToolCall returns "tool_failures".
 	ToolFailureStallConsecutiveFailures ToolFailureCategory = "stall_consecutive_failures"
+
+	// ToolFailureNoToolWhenRequired — model returned without calling any
+	// tool when the harness required tool use (Wave 4 / #230). Fires from
+	// the loop's tool-choice escalation path when a first-turn no-tool
+	// answer is detected on a workspace-dependent task.
+	ToolFailureNoToolWhenRequired ToolFailureCategory = "no_tool_when_required"
 )
 
 // allToolFailureCategories is the closed set of valid category values.
@@ -135,6 +141,7 @@ var allToolFailureCategories = map[ToolFailureCategory]struct{}{
 	ToolFailureProviderStream:           {},
 	ToolFailureStallRepeated:            {},
 	ToolFailureStallConsecutiveFailures: {},
+	ToolFailureNoToolWhenRequired:       {},
 }
 
 // IsValid reports whether c is a recognised tool failure category. Used by

--- a/harness/internal/observability/toolfailure_test.go
+++ b/harness/internal/observability/toolfailure_test.go
@@ -32,6 +32,7 @@ func TestToolFailureCategory_KnownValuesAreValid(t *testing.T) {
 		ToolFailureProviderStream,
 		ToolFailureStallRepeated,
 		ToolFailureStallConsecutiveFailures,
+		ToolFailureNoToolWhenRequired,
 	}
 	for _, c := range known {
 		if !c.IsValid() {

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -208,6 +208,15 @@ type RunConfig struct {
 	// fields (per-tool overrides, semaphore strategy) land without a
 	// breaking change.
 	ToolDispatch *ToolDispatchConfig `json:"toolDispatch,omitempty"`
+
+	// ToolChoiceEscalation configures the bounded recovery the loop runs
+	// when the model returns a final answer without calling any tool on a
+	// turn the harness expected tool use (#230). Nil — the default — means
+	// the feature is OFF: a bare run takes no extra turns and is byte-for-
+	// byte unchanged. Set Enabled=true to opt in; see
+	// ToolChoiceEscalationConfig for the per-knob semantics and the
+	// mode-aware policy that decides when a no-tool answer is suspicious.
+	ToolChoiceEscalation *ToolChoiceEscalationConfig `json:"toolChoiceEscalation,omitempty"`
 }
 
 // ObservabilityConfig carries operator-supplied labels that are promoted to
@@ -900,6 +909,65 @@ type ResourceLimits struct {
 // ValidateRunConfig.
 type ToolDispatchConfig struct {
 	MaxParallel int `json:"maxParallel,omitempty"`
+}
+
+// ToolChoiceEscalationConfig configures the missed-tool recovery (#230).
+//
+// The feature is OFF by default: a nil *ToolChoiceEscalationConfig on the
+// RunConfig disables it entirely, and an explicit Enabled:false does the
+// same. When enabled, the loop watches the first assistant turn of an
+// inner-loop run: if tools are available, no tool call has happened yet,
+// and the model returns a final/text answer, the loop treats it as a
+// likely missed-tool failure and retries the turn — forcing native
+// required tool choice when the resolved provider supports it, or
+// injecting a stronger-prompt message otherwise.
+//
+// The trigger is intentionally conservative (see the loop's escalation
+// policy). It never fires when no tools are available, and it never
+// exceeds MaxRetries.
+type ToolChoiceEscalationConfig struct {
+	// Enabled turns the recovery on. Default false (safe): a bare run
+	// must not change behaviour, so the loop only escalates when an
+	// operator explicitly opts in.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxRetries caps the number of forced retries per inner-loop run.
+	// Zero (or a nil config) resolves to DefaultToolChoiceEscalationMaxRetries
+	// via EffectiveToolChoiceEscalationMaxRetries; values outside
+	// [1, MaxToolChoiceEscalationMaxRetries] are rejected by
+	// ValidateRunConfig. The cap bounds the recovery so a model that
+	// keeps refusing to call a tool cannot drive an unbounded retry loop.
+	MaxRetries int `json:"maxRetries,omitempty"`
+}
+
+const (
+	// DefaultToolChoiceEscalationMaxRetries is the per-inner-loop forced
+	// retry cap applied when escalation is enabled but MaxRetries is unset.
+	// One matches the issue #230 default: a single recovery attempt is the
+	// conservative starting point.
+	DefaultToolChoiceEscalationMaxRetries = 1
+
+	// MaxToolChoiceEscalationMaxRetries is the hard ceiling on
+	// ToolChoiceEscalationConfig.MaxRetries enforced by ValidateRunConfig.
+	// Bounds the additional provider calls a single run can spend on
+	// missed-tool recovery.
+	MaxToolChoiceEscalationMaxRetries = 3
+)
+
+// EffectiveToolChoiceEscalationMaxRetries returns the forced-retry cap the
+// loop should apply. Returns 0 when escalation is disabled (nil config or
+// Enabled:false) so the loop's escalation path is a no-op; otherwise
+// returns DefaultToolChoiceEscalationMaxRetries when MaxRetries is unset,
+// or the configured value verbatim (ValidateRunConfig has already bounded
+// it to [1, MaxToolChoiceEscalationMaxRetries]).
+func (rc *RunConfig) EffectiveToolChoiceEscalationMaxRetries() int {
+	if rc == nil || rc.ToolChoiceEscalation == nil || !rc.ToolChoiceEscalation.Enabled {
+		return 0
+	}
+	if rc.ToolChoiceEscalation.MaxRetries == 0 {
+		return DefaultToolChoiceEscalationMaxRetries
+	}
+	return rc.ToolChoiceEscalation.MaxRetries
 }
 
 // EditStrategyConfig selects the edit strategy implementation.
@@ -1720,6 +1788,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateGuardRailConfig(config.GuardRail, "guardRail", false, &errs)
 	validateObservabilityConfig(config.Observability, &errs)
 	validateToolDispatchConfig(config.ToolDispatch, &errs)
+	validateToolChoiceEscalationConfig(config.ToolChoiceEscalation, &errs)
 	validateBatchConfig(config, &errs)
 
 	if len(errs) > 0 {
@@ -2098,6 +2167,24 @@ func validateToolDispatchConfig(cfg *ToolDispatchConfig, errs *[]string) {
 		// have to infer from "between 1 and 16" whether 0 is also
 		// rejected. Zero IS legal and resolves to the library default.
 		*errs = append(*errs, fmt.Sprintf("toolDispatch.maxParallel must be 0 (use default) or between 1 and %d", MaxToolDispatchMaxParallel))
+	}
+}
+
+// validateToolChoiceEscalationConfig bounds
+// ToolChoiceEscalation.MaxRetries to MaxToolChoiceEscalationMaxRetries. A
+// nil config is legal (feature OFF) and so is an explicit zero — both
+// resolve via EffectiveToolChoiceEscalationMaxRetries (to "disabled" and
+// DefaultToolChoiceEscalationMaxRetries respectively), so an unmarshalled
+// empty sub-message survives validation. MaxRetries only matters when
+// Enabled is true, but the bound is enforced regardless so a disabled
+// config carrying a nonsensical value still fails loudly rather than
+// silently surviving until a later enable.
+func validateToolChoiceEscalationConfig(cfg *ToolChoiceEscalationConfig, errs *[]string) {
+	if cfg == nil {
+		return
+	}
+	if cfg.MaxRetries < 0 || cfg.MaxRetries > MaxToolChoiceEscalationMaxRetries {
+		*errs = append(*errs, fmt.Sprintf("toolChoiceEscalation.maxRetries must be 0 (use default) or between 1 and %d", MaxToolChoiceEscalationMaxRetries))
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -4800,6 +4800,19 @@ func TestValidateRunConfig_ToolChoiceEscalationAcceptsValid(t *testing.T) {
 			t.Errorf("disabled effective retries = %d, want 0", got)
 		}
 	})
+	t.Run("explicit_cap_2", func(t *testing.T) {
+		// Exercises the third return branch of
+		// EffectiveToolChoiceEscalationMaxRetries (Enabled && MaxRetries > 0
+		// → return the configured value verbatim).
+		c := validConfig()
+		c.ToolChoiceEscalation = &ToolChoiceEscalationConfig{Enabled: true, MaxRetries: 2}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("enabled escalation with explicit cap must validate: %v", err)
+		}
+		if got := c.EffectiveToolChoiceEscalationMaxRetries(); got != 2 {
+			t.Errorf("explicit cap effective retries = %d, want 2", got)
+		}
+	})
 }
 
 // --- BatchProviderConfig ---

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -4741,6 +4741,67 @@ func TestValidateRunConfig_ToolDispatchRejectsOutOfRange(t *testing.T) {
 	}
 }
 
+// TestValidateRunConfig_ToolChoiceEscalationRejectsOutOfRange pins the
+// MaxRetries bound (#230): values outside [1, MaxToolChoiceEscalationMaxRetries]
+// are rejected with the "0 (use default)" sentinel called out, mirroring
+// the ToolDispatch bound. The check fires regardless of Enabled so a
+// disabled config carrying a bad value still fails loudly.
+func TestValidateRunConfig_ToolChoiceEscalationRejectsOutOfRange(t *testing.T) {
+	for _, n := range []int{-1, MaxToolChoiceEscalationMaxRetries + 1, 9_000} {
+		t.Run(fmt.Sprintf("max_retries=%d", n), func(t *testing.T) {
+			c := validConfig()
+			c.ToolChoiceEscalation = &ToolChoiceEscalationConfig{Enabled: true, MaxRetries: n}
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("expected error for toolChoiceEscalation.maxRetries=%d", n)
+			}
+			if !strings.Contains(err.Error(), "toolChoiceEscalation.maxRetries") {
+				t.Errorf("expected error to mention toolChoiceEscalation.maxRetries, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "0 (use default)") {
+				t.Errorf("expected error to call out the accepted zero sentinel, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_ToolChoiceEscalationAcceptsValid pins the accepted
+// shapes: nil (feature off), an explicit zero (defaults), and a bounded
+// positive cap all pass validation, and the Effective accessor resolves
+// each to the documented value.
+func TestValidateRunConfig_ToolChoiceEscalationAcceptsValid(t *testing.T) {
+	t.Run("nil_disabled", func(t *testing.T) {
+		c := validConfig()
+		c.ToolChoiceEscalation = nil
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("nil escalation must validate: %v", err)
+		}
+		if got := c.EffectiveToolChoiceEscalationMaxRetries(); got != 0 {
+			t.Errorf("nil config effective retries = %d, want 0 (disabled)", got)
+		}
+	})
+	t.Run("enabled_default", func(t *testing.T) {
+		c := validConfig()
+		c.ToolChoiceEscalation = &ToolChoiceEscalationConfig{Enabled: true}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("enabled escalation with zero retries must validate: %v", err)
+		}
+		if got := c.EffectiveToolChoiceEscalationMaxRetries(); got != DefaultToolChoiceEscalationMaxRetries {
+			t.Errorf("enabled+zero effective retries = %d, want %d", got, DefaultToolChoiceEscalationMaxRetries)
+		}
+	})
+	t.Run("disabled_with_retries_stays_disabled", func(t *testing.T) {
+		c := validConfig()
+		c.ToolChoiceEscalation = &ToolChoiceEscalationConfig{Enabled: false, MaxRetries: 2}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("disabled escalation must validate: %v", err)
+		}
+		if got := c.EffectiveToolChoiceEscalationMaxRetries(); got != 0 {
+			t.Errorf("disabled effective retries = %d, want 0", got)
+		}
+	})
+}
+
 // --- BatchProviderConfig ---
 
 // batchValidConfig is the baseline for the batch suite: a non-execution


### PR DESCRIPTION
## Summary

Second chunk of **Wave 4 / #230**. Builds on the A1 plumbing (PR #322) to add the **loop-side recovery**: when a model returns a no-tool final answer on a workspace-dependent task without ever calling a tool, the loop escalates — retrying with provider-native required tool-choice where supported, or a stronger-prompt fallback otherwise — bounded by a configurable cap.

Together with #322, this **closes #230**. Also **closes #313** (reserves + registers the `no_tool_when_required` failure category).

Stacked: `#321` ← `#322` (A1) ← **A2**. Auto-retargets as lower PRs merge.

## What lands

- **Escalation behind an injected interface.** `EscalationPolicy.Decide(EscalationInput) EscalationDecision` lives in `core/escalation.go`; the default impl (`escalation_default.go`) is the only thing importing `quirks`. The factory injects it exactly like `GuardRail`/`Verifier`. **The agentic loop stays a pure function of its interfaces** — no concrete-impl import, no env, no FS.
- **Conservative trigger:** fires only when `PriorToolCalls == 0 && ToolsAvailable && the mode has a tool requirement`. Conceptual questions and no-tools runs never escalate.
- **Native vs prompt:** resolves the `(provider, model)` `ToolChoiceCapability`; `Supported && Required` → retry with `StreamParams.ToolChoice = ToolChoiceRequired` (one turn), else inject a stronger-prompt message naming the unmet requirement.
- **Bounded:** the cap is solely `EscalationsSoFar >= MaxRetries`, gated on `PriorToolCalls == 0`, so a configured cap of 2/3 actually escalates that many times then accepts — and stops the instant a tool is called.
- **Observability:** `stirrup.harness.tool_failures{category=no_tool_when_required}` (bounded labels, `.IsValid()`-guarded) + a `tool_choice.escalation` OTel span (`escalation.kind`/`reason`/`run.mode`, reason `security.Scrub()`-ed).
- **Config:** `RunConfig.ToolChoiceEscalation{Enabled, MaxRetries}` + `--escalate-tool-choice` / `--escalate-tool-choice-max-retries`. **OFF by default**, ceiling enforced in `ValidateRunConfig`.

## Review hardening (post-review remediation)

- Fixed a dead-config bug: the retry cap above 1 was previously unreachable (trigger short-circuited on `Turn > 0` before the cap was consulted). Now keyed on `PriorToolCalls == 0`, cap binds correctly — proven by `TestEscalation_MaxRetryCapEnforcedAtTwo` + `TestEscalation_RecoveryStopsAfterToolCall`.
- `.IsValid()` guard on the metric emit; `security.Scrub()` on the trace reason (defense-in-depth for future policies); `Changed()` guard on the flag-only config path; added `Decide` coverage for planning/review/toil modes.

## Test plan

- [x] `just` (build + test) + `just lint` green
- [x] no-tool answer on workspace task → retry; conceptual / no-tools answer → NO retry
- [x] native-required path and prompt-fallback path both covered
- [x] cap enforced (1 and 2); recovery stops after a tool call
- [x] `no_tool_when_required` accepted by `TestToolFailureCategory_EnumIsValid`
- [x] disabled-by-default leaves loop behaviour unchanged

## Deferred (follow-ups filed post-merge)

- `buildEscalationPolicy` resolves capability from `quirks.DefaultRegistry()` rather than the adapter's actual registry (safe today — no compat profile touches tool-choice; fix needs factory reordering).
- Synthetic stronger-prompt message visibility in the verifier's message view.
- Minor `EscalationInput.ToolsAvailable` modelling debt.

Closes #230. Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)