### PR TITLE
tools: structured tool-result envelope + built-in population (Wave 4 B1)

### DIFF
--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -38,7 +37,7 @@ type pendingCall struct {
 	spanCtx     context.Context //nolint:containedctx // span parent ctx threaded into dispatch
 	startedAt   time.Time
 	output      string
-	structured  json.RawMessage // optional typed result payload (issue #231); nil for text-only tools and every failure path
+	structured  structuredOutput // optional typed result payload + kind (issue #231); zero value for text-only tools and every failure path
 	success     bool
 	errorReason string // guard-deny reason; written to trace (apply security.Scrub before setting)
 	denied      bool   // PhasePreTool deny path; takes priority over (output, success)
@@ -329,7 +328,8 @@ func (l *AgenticLoop) planAndDispatch(
 			ToolUseID:  p.call.ID,
 			Content:    p.output,
 			IsError:    !p.success,
-			Structured: p.structured,
+			Structured: p.structured.payload,
+			Kind:       p.structured.kind,
 		}
 		// Full record carries raw input/output for the turn transcript.
 		// The dispatch site is the only place with both fields in scope:
@@ -345,7 +345,8 @@ func (l *AgenticLoop) planAndDispatch(
 			Output:     p.output,
 			DurationMs: callDuration.Milliseconds(),
 			Success:    p.success,
-			Structured: p.structured,
+			Structured: p.structured.payload,
+			Kind:       p.structured.kind,
 		}
 
 		if err := l.Transport.Emit(types.HarnessEvent{

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -37,6 +38,7 @@ type pendingCall struct {
 	spanCtx     context.Context //nolint:containedctx // span parent ctx threaded into dispatch
 	startedAt   time.Time
 	output      string
+	structured  json.RawMessage // optional typed result payload (issue #231); nil for text-only tools and every failure path
 	success     bool
 	errorReason string // guard-deny reason; written to trace (apply security.Scrub before setting)
 	denied      bool   // PhasePreTool deny path; takes priority over (output, success)
@@ -164,8 +166,9 @@ func (l *AgenticLoop) planAndDispatch(
 
 		// Sync path: dispatch inline, preserving the sequential code's
 		// behaviour for sync tools (including Unknown).
-		output, success, category := l.dispatchToolCallCategorized(toolSpanCtx, call)
+		output, success, category, structured := l.dispatchToolCallCategorized(toolSpanCtx, call)
 		plan[i].output = output
+		plan[i].structured = structured
 		plan[i].success = success
 		plan[i].failureCategory = category
 	}
@@ -212,8 +215,9 @@ func (l *AgenticLoop) planAndDispatch(
 						)
 					}
 				}()
-				output, success, category := l.dispatchToolCallCategorized(plan[idx].spanCtx, plan[idx].call)
+				output, success, category, structured := l.dispatchToolCallCategorized(plan[idx].spanCtx, plan[idx].call)
 				plan[idx].output = output
+				plan[idx].structured = structured
 				plan[idx].success = success
 				plan[idx].failureCategory = category
 			}()
@@ -322,9 +326,10 @@ func (l *AgenticLoop) planAndDispatch(
 		}
 
 		toolResults[i] = types.ToolResult{
-			ToolUseID: p.call.ID,
-			Content:   p.output,
-			IsError:   !p.success,
+			ToolUseID:  p.call.ID,
+			Content:    p.output,
+			IsError:    !p.success,
+			Structured: p.structured,
 		}
 		// Full record carries raw input/output for the turn transcript.
 		// The dispatch site is the only place with both fields in scope:
@@ -340,6 +345,7 @@ func (l *AgenticLoop) planAndDispatch(
 			Output:     p.output,
 			DurationMs: callDuration.Milliseconds(),
 			Success:    p.success,
+			Structured: p.structured,
 		}
 
 		if err := l.Transport.Emit(types.HarnessEvent{

--- a/harness/internal/core/dispatch_structured_test.go
+++ b/harness/internal/core/dispatch_structured_test.go
@@ -9,22 +9,26 @@ import (
 	"github.com/rxbynerd/stirrup/types"
 )
 
-// structuredEchoTool is a sync tool exposing a StructuredHandler that returns
-// both a text fallback and a typed structured payload, exercising the issue
-// #231 dispatch seam.
+// structuredEchoTool is a sync tool exposing a StructuredHandler that returns a
+// text fallback, a typed structured payload, and a kind discriminator,
+// exercising the issue #231 dispatch seam.
 func structuredEchoTool() *tool.Tool {
 	return &tool.Tool{
 		Name:        "structured_echo",
 		Description: "test structured tool",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
-		StructuredHandler: func(_ context.Context, _ json.RawMessage) (string, json.RawMessage, error) {
-			return "text fallback", json.RawMessage(`{"field":"value"}`), nil
+		StructuredHandler: func(_ context.Context, _ json.RawMessage) (tool.StructuredResult, error) {
+			return tool.StructuredResult{
+				Text:       "text fallback",
+				Structured: json.RawMessage(`{"field":"value"}`),
+				Kind:       "command_result",
+			}, nil
 		},
 	}
 }
 
-// plainEchoTool exposes only a plain Handler — it must produce a nil
-// structured payload so a text-only tool stays text-only.
+// plainEchoTool exposes only a plain Handler — it must produce a zero
+// structuredOutput so a text-only tool stays text-only.
 func plainEchoTool() *tool.Tool {
 	return &tool.Tool{
 		Name:        "plain_echo",
@@ -50,8 +54,11 @@ func TestDispatch_StructuredHandlerCarriesPayload(t *testing.T) {
 	if out != "text fallback" {
 		t.Errorf("text fallback mismatch: %q", out)
 	}
-	if string(structured) != `{"field":"value"}` {
-		t.Errorf("structured payload mismatch: %s", structured)
+	if string(structured.payload) != `{"field":"value"}` {
+		t.Errorf("structured payload mismatch: %s", structured.payload)
+	}
+	if structured.kind != "command_result" {
+		t.Errorf("structured kind mismatch: %q", structured.kind)
 	}
 }
 
@@ -66,13 +73,17 @@ func TestDispatch_PlainHandlerHasNilStructured(t *testing.T) {
 	if !success || out != "plain text" {
 		t.Fatalf("unexpected result: success=%v out=%q", success, out)
 	}
-	if structured != nil {
-		t.Errorf("plain-Handler tool must yield nil structured, got: %s", structured)
+	if structured.payload != nil {
+		t.Errorf("plain-Handler tool must yield nil structured payload, got: %s", structured.payload)
+	}
+	if structured.kind != "" {
+		t.Errorf("plain-Handler tool must yield empty kind, got: %q", structured.kind)
 	}
 }
 
 // TestPlanAndDispatch_StructuredFlowsToResult pins that the structured payload
-// reaches both the ToolResult (model-facing) and the ToolCallRecord (trace).
+// and kind reach both the ToolResult (model-facing) and the ToolCallRecord
+// (trace).
 func TestPlanAndDispatch_StructuredFlowsToResult(t *testing.T) {
 	tr := newAsyncTestTransport()
 	loop := buildAsyncTestLoop(t, tr, structuredEchoTool())
@@ -97,7 +108,13 @@ func TestPlanAndDispatch_StructuredFlowsToResult(t *testing.T) {
 	if string(results[0].Structured) != `{"field":"value"}` {
 		t.Errorf("ToolResult.Structured mismatch: %s", results[0].Structured)
 	}
+	if results[0].Kind != "command_result" {
+		t.Errorf("ToolResult.Kind mismatch: %q", results[0].Kind)
+	}
 	if string(records[0].Structured) != `{"field":"value"}` {
 		t.Errorf("ToolCallRecord.Structured mismatch: %s", records[0].Structured)
+	}
+	if records[0].Kind != "command_result" {
+		t.Errorf("ToolCallRecord.Kind mismatch: %q", records[0].Kind)
 	}
 }

--- a/harness/internal/core/dispatch_structured_test.go
+++ b/harness/internal/core/dispatch_structured_test.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// structuredEchoTool is a sync tool exposing a StructuredHandler that returns
+// both a text fallback and a typed structured payload, exercising the issue
+// #231 dispatch seam.
+func structuredEchoTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "structured_echo",
+		Description: "test structured tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		StructuredHandler: func(_ context.Context, _ json.RawMessage) (string, json.RawMessage, error) {
+			return "text fallback", json.RawMessage(`{"field":"value"}`), nil
+		},
+	}
+}
+
+// plainEchoTool exposes only a plain Handler — it must produce a nil
+// structured payload so a text-only tool stays text-only.
+func plainEchoTool() *tool.Tool {
+	return &tool.Tool{
+		Name:        "plain_echo",
+		Description: "test plain tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "plain text", nil
+		},
+	}
+}
+
+func TestDispatch_StructuredHandlerCarriesPayload(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, structuredEchoTool())
+
+	out, success, _, structured := loop.dispatchToolCallCategorized(
+		context.Background(),
+		types.ToolCall{ID: "tc1", Name: "structured_echo", Input: json.RawMessage(`{}`)},
+	)
+	if !success {
+		t.Fatalf("expected success, got failure: %q", out)
+	}
+	if out != "text fallback" {
+		t.Errorf("text fallback mismatch: %q", out)
+	}
+	if string(structured) != `{"field":"value"}` {
+		t.Errorf("structured payload mismatch: %s", structured)
+	}
+}
+
+func TestDispatch_PlainHandlerHasNilStructured(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, plainEchoTool())
+
+	out, success, _, structured := loop.dispatchToolCallCategorized(
+		context.Background(),
+		types.ToolCall{ID: "tc1", Name: "plain_echo", Input: json.RawMessage(`{}`)},
+	)
+	if !success || out != "plain text" {
+		t.Fatalf("unexpected result: success=%v out=%q", success, out)
+	}
+	if structured != nil {
+		t.Errorf("plain-Handler tool must yield nil structured, got: %s", structured)
+	}
+}
+
+// TestPlanAndDispatch_StructuredFlowsToResult pins that the structured payload
+// reaches both the ToolResult (model-facing) and the ToolCallRecord (trace).
+func TestPlanAndDispatch_StructuredFlowsToResult(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, structuredEchoTool())
+
+	results, records, stall := loop.planAndDispatch(
+		context.Background(),
+		&types.RunConfig{Mode: "execution"},
+		[]types.ToolCall{{ID: "tc1", Name: "structured_echo", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic",
+		"claude-sonnet-4-6",
+	)
+	if stall != "" {
+		t.Fatalf("unexpected stall outcome: %q", stall)
+	}
+	if len(results) != 1 || len(records) != 1 {
+		t.Fatalf("expected 1 result/record, got %d/%d", len(results), len(records))
+	}
+	if results[0].Content != "text fallback" {
+		t.Errorf("result text fallback mismatch: %q", results[0].Content)
+	}
+	if string(results[0].Structured) != `{"field":"value"}` {
+		t.Errorf("ToolResult.Structured mismatch: %s", results[0].Structured)
+	}
+	if string(records[0].Structured) != `{"field":"value"}` {
+		t.Errorf("ToolCallRecord.Structured mismatch: %s", records[0].Structured)
+	}
+}

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -230,7 +230,7 @@ func (l *AgenticLoop) metricAttrs(extra ...attribute.KeyValue) metric.Measuremen
 // stirrup.harness.tool_failures metric and the ToolCallTrace ErrorCategory
 // field.
 func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall) (string, bool) {
-	out, ok, _ := l.dispatchToolCallCategorized(ctx, call)
+	out, ok, _, _ := l.dispatchToolCallCategorized(ctx, call)
 	return out, ok
 }
 
@@ -239,7 +239,12 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 // success the category is empty. Every failure path in this function and
 // its async helper must assign a ToolFailureCategory drawn from the enum
 // in harness/internal/observability/toolfailure.go.
-func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call types.ToolCall) (string, bool, observability.ToolFailureCategory) {
+//
+// The fourth return value is the optional structured result payload (issue
+// #231). It is non-nil only on the success path of a tool that supplies a
+// StructuredHandler; every failure path, and any tool that exposes only a
+// plain Handler, returns nil so a text-only result stays text-only.
+func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call types.ToolCall) (string, bool, observability.ToolFailureCategory, json.RawMessage) {
 	t := l.Tools.Resolve(call.Name)
 	if t == nil {
 		// Issue #225 split the legacy search_files tool into two strictly-
@@ -249,9 +254,9 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 		// migration hint the model can act on in-loop, while still
 		// preserving the unknown-tool failure category for telemetry.
 		if msg, ok := renamedToolHint(call.Name); ok {
-			return msg, false, observability.ToolFailureUnknownTool
+			return msg, false, observability.ToolFailureUnknownTool, nil
 		}
-		return "Unknown tool: " + call.Name, false, observability.ToolFailureUnknownTool
+		return "Unknown tool: " + call.Name, false, observability.ToolFailureUnknownTool, nil
 	}
 
 	// Strip prototype-pollution keys before validation so we can both notify
@@ -273,14 +278,14 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 		if l.Security != nil {
 			l.Security.ToolInputRejected(call.Name, []string{err.Error()})
 		}
-		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false, observability.ToolFailureSchemaValidation
+		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false, observability.ToolFailureSchemaValidation, nil
 	}
 
 	if findings := security.GuardToolCall(call.Name, t.WorkspaceMutating, call.Input); len(findings) > 0 {
 		if l.Security != nil {
 			l.Security.ToolCallGuardTriggered(call.Name, findings)
 		}
-		return fmt.Sprintf("Tool call rejected by security guard for %s", call.Name), false, observability.ToolFailureSecurityGuard
+		return fmt.Sprintf("Tool call rejected by security guard for %s", call.Name), false, observability.ToolFailureSecurityGuard, nil
 	}
 
 	// Check permissions for tools that mutate the workspace or that
@@ -298,7 +303,7 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 			permSpan.RecordError(err)
 			permSpan.SetStatus(codes.Error, err.Error())
 			permSpan.End()
-			return "Permission check error: " + err.Error(), false, observability.ToolFailurePermissionError
+			return "Permission check error: " + err.Error(), false, observability.ToolFailurePermissionError, nil
 		}
 		permSpan.SetAttributes(attribute.Bool("permission.allowed", result.Allowed))
 		permSpan.End()
@@ -309,7 +314,7 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 			if l.Trace != nil {
 				l.Trace.RecordPermissionDenial()
 			}
-			return "Permission denied: " + result.Reason, false, observability.ToolFailurePermissionDenied
+			return "Permission denied: " + result.Reason, false, observability.ToolFailurePermissionDenied, nil
 		}
 	}
 
@@ -320,19 +325,31 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 	// / the timeout fires). Permission and security checks above already
 	// ran and gated dispatch identically to the sync path.
 	if t.AsyncHandler != nil {
-		return l.dispatchAsyncToolCall(ctx, t, call, inputForCall)
+		output, success, category := l.dispatchAsyncToolCall(ctx, t, call, inputForCall)
+		return output, success, category, nil
 	}
 
 	// Execute the tool handler with the cleaned input so the handler does not
-	// see prototype-pollution keys either.
-	if t.Handler == nil {
-		return fmt.Sprintf("Tool %s has no handler registered", call.Name), false, observability.ToolFailureHandlerMissing
+	// see prototype-pollution keys either. A StructuredHandler is preferred
+	// over the plain Handler: it yields the identical text plus an optional
+	// typed structured payload (issue #231). Either form is acceptable; a
+	// tool that sets only Handler simply returns a nil structured payload.
+	switch {
+	case t.StructuredHandler != nil:
+		output, structured, err := t.StructuredHandler(ctx, inputForCall)
+		if err != nil {
+			return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError, nil
+		}
+		return output, true, "", structured
+	case t.Handler != nil:
+		output, err := t.Handler(ctx, inputForCall)
+		if err != nil {
+			return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError, nil
+		}
+		return output, true, "", nil
+	default:
+		return fmt.Sprintf("Tool %s has no handler registered", call.Name), false, observability.ToolFailureHandlerMissing, nil
 	}
-	output, err := t.Handler(ctx, inputForCall)
-	if err != nil {
-		return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError
-	}
-	return output, true, ""
 }
 
 // dispatchAsyncToolCall runs the async tool path:

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -229,9 +229,23 @@ func (l *AgenticLoop) metricAttrs(extra ...attribute.KeyValue) metric.Measuremen
 // directly so the per-failure category flows into the
 // stirrup.harness.tool_failures metric and the ToolCallTrace ErrorCategory
 // field.
+//
+// NOTE: this shim drops the structured payload. New tests that need to assert
+// structured output must call dispatchToolCallCategorized directly.
 func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall) (string, bool) {
 	out, ok, _, _ := l.dispatchToolCallCategorized(ctx, call)
 	return out, ok
+}
+
+// structuredOutput carries the optional typed result payload (issue #231)
+// from a StructuredHandler back through dispatch. The zero value (nil payload,
+// empty kind) means "no structured data": every failure path and every plain-
+// Handler tool returns it, so a text-only result stays text-only. Kind names
+// the payload's shape so it can be routed without unmarshalling (see
+// types.ToolResult.Kind).
+type structuredOutput struct {
+	payload json.RawMessage
+	kind    string
 }
 
 // dispatchToolCallCategorized is the production entry point. The third
@@ -241,10 +255,10 @@ func (l *AgenticLoop) dispatchToolCall(ctx context.Context, call types.ToolCall)
 // in harness/internal/observability/toolfailure.go.
 //
 // The fourth return value is the optional structured result payload (issue
-// #231). It is non-nil only on the success path of a tool that supplies a
-// StructuredHandler; every failure path, and any tool that exposes only a
-// plain Handler, returns nil so a text-only result stays text-only.
-func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call types.ToolCall) (string, bool, observability.ToolFailureCategory, json.RawMessage) {
+// #231). It is the zero structuredOutput on every failure path and for any
+// tool that exposes only a plain Handler, so a text-only result stays
+// text-only; it is populated only on the success path of a StructuredHandler.
+func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call types.ToolCall) (string, bool, observability.ToolFailureCategory, structuredOutput) {
 	t := l.Tools.Resolve(call.Name)
 	if t == nil {
 		// Issue #225 split the legacy search_files tool into two strictly-
@@ -254,9 +268,9 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 		// migration hint the model can act on in-loop, while still
 		// preserving the unknown-tool failure category for telemetry.
 		if msg, ok := renamedToolHint(call.Name); ok {
-			return msg, false, observability.ToolFailureUnknownTool, nil
+			return msg, false, observability.ToolFailureUnknownTool, structuredOutput{}
 		}
-		return "Unknown tool: " + call.Name, false, observability.ToolFailureUnknownTool, nil
+		return "Unknown tool: " + call.Name, false, observability.ToolFailureUnknownTool, structuredOutput{}
 	}
 
 	// Strip prototype-pollution keys before validation so we can both notify
@@ -278,14 +292,14 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 		if l.Security != nil {
 			l.Security.ToolInputRejected(call.Name, []string{err.Error()})
 		}
-		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false, observability.ToolFailureSchemaValidation, nil
+		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false, observability.ToolFailureSchemaValidation, structuredOutput{}
 	}
 
 	if findings := security.GuardToolCall(call.Name, t.WorkspaceMutating, call.Input); len(findings) > 0 {
 		if l.Security != nil {
 			l.Security.ToolCallGuardTriggered(call.Name, findings)
 		}
-		return fmt.Sprintf("Tool call rejected by security guard for %s", call.Name), false, observability.ToolFailureSecurityGuard, nil
+		return fmt.Sprintf("Tool call rejected by security guard for %s", call.Name), false, observability.ToolFailureSecurityGuard, structuredOutput{}
 	}
 
 	// Check permissions for tools that mutate the workspace or that
@@ -303,7 +317,7 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 			permSpan.RecordError(err)
 			permSpan.SetStatus(codes.Error, err.Error())
 			permSpan.End()
-			return "Permission check error: " + err.Error(), false, observability.ToolFailurePermissionError, nil
+			return "Permission check error: " + err.Error(), false, observability.ToolFailurePermissionError, structuredOutput{}
 		}
 		permSpan.SetAttributes(attribute.Bool("permission.allowed", result.Allowed))
 		permSpan.End()
@@ -314,7 +328,7 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 			if l.Trace != nil {
 				l.Trace.RecordPermissionDenial()
 			}
-			return "Permission denied: " + result.Reason, false, observability.ToolFailurePermissionDenied, nil
+			return "Permission denied: " + result.Reason, false, observability.ToolFailurePermissionDenied, structuredOutput{}
 		}
 	}
 
@@ -326,29 +340,29 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 	// ran and gated dispatch identically to the sync path.
 	if t.AsyncHandler != nil {
 		output, success, category := l.dispatchAsyncToolCall(ctx, t, call, inputForCall)
-		return output, success, category, nil
+		return output, success, category, structuredOutput{}
 	}
 
 	// Execute the tool handler with the cleaned input so the handler does not
 	// see prototype-pollution keys either. A StructuredHandler is preferred
 	// over the plain Handler: it yields the identical text plus an optional
 	// typed structured payload (issue #231). Either form is acceptable; a
-	// tool that sets only Handler simply returns a nil structured payload.
+	// tool that sets only Handler simply returns no structured payload.
 	switch {
 	case t.StructuredHandler != nil:
-		output, structured, err := t.StructuredHandler(ctx, inputForCall)
+		res, err := t.StructuredHandler(ctx, inputForCall)
 		if err != nil {
-			return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError, nil
+			return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError, structuredOutput{}
 		}
-		return output, true, "", structured
+		return res.Text, true, "", structuredOutput{payload: res.Structured, kind: res.Kind}
 	case t.Handler != nil:
 		output, err := t.Handler(ctx, inputForCall)
 		if err != nil {
-			return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError, nil
+			return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError, structuredOutput{}
 		}
-		return output, true, "", nil
+		return output, true, "", structuredOutput{}
 	default:
-		return fmt.Sprintf("Tool %s has no handler registered", call.Name), false, observability.ToolFailureHandlerMissing, nil
+		return fmt.Sprintf("Tool %s has no handler registered", call.Name), false, observability.ToolFailureHandlerMissing, structuredOutput{}
 	}
 }
 

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -69,6 +69,19 @@ func (m *mockExecutor) Capabilities() executor.ExecutorCapabilities {
 	}
 }
 
+// invokeText dispatches a tool the way the agentic loop does — preferring a
+// StructuredHandler over a plain Handler (issue #231) — and returns just the
+// canonical text output and error. Tests that only assert the text fallback
+// use this so they remain agnostic to which handler form a tool exposes;
+// tests that assert the structured payload call StructuredHandler directly.
+func invokeText(ctx context.Context, tl *tool.Tool, input json.RawMessage) (string, error) {
+	if tl.StructuredHandler != nil {
+		text, _, err := tl.StructuredHandler(ctx, input)
+		return text, err
+	}
+	return tl.Handler(ctx, input)
+}
+
 // --- shellQuote tests ---
 
 func TestShellQuote_EmbeddedSingleQuote(t *testing.T) {
@@ -182,7 +195,7 @@ func TestReadFileTool_EmptyPath(t *testing.T) {
 	readTool := ReadFileTool(mock)
 
 	input, _ := json.Marshal(map[string]string{"path": ""})
-	_, err := readTool.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), readTool, input)
 	if err == nil {
 		t.Fatal("expected error for empty path")
 	}
@@ -200,7 +213,7 @@ func TestReadFileTool_LineNumberedOutput(t *testing.T) {
 	readTool := ReadFileTool(mock)
 
 	input, _ := json.Marshal(map[string]any{"path": "file.txt"})
-	result, err := readTool.Handler(context.Background(), input)
+	result, err := invokeText(context.Background(), readTool, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -223,7 +236,7 @@ func TestReadFileTool_LineRange(t *testing.T) {
 		"start_line": 2,
 		"limit":      2,
 	})
-	result, err := readTool.Handler(context.Background(), input)
+	result, err := invokeText(context.Background(), readTool, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -245,7 +258,7 @@ func TestReadFileTool_StartLinePastEOF(t *testing.T) {
 		"path":       "file.txt",
 		"start_line": 500,
 	})
-	result, err := readTool.Handler(context.Background(), input)
+	result, err := invokeText(context.Background(), readTool, input)
 	if err != nil {
 		t.Fatalf("expected non-error for start_line past EOF, got %v", err)
 	}
@@ -262,7 +275,7 @@ func TestReadFileTool_LimitOverMax(t *testing.T) {
 		"path":  "file.txt",
 		"limit": 100000,
 	})
-	_, err := readTool.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), readTool, input)
 	if err == nil {
 		t.Fatal("expected error for limit over maximum")
 	}
@@ -286,7 +299,7 @@ func TestReadFileTool_PaddingAlignsColumns(t *testing.T) {
 	readTool := ReadFileTool(mock)
 
 	input, _ := json.Marshal(map[string]any{"path": "file.txt"})
-	result, err := readTool.Handler(context.Background(), input)
+	result, err := invokeText(context.Background(), readTool, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -460,7 +473,7 @@ func TestReadFileTool_StartLineBelowOne(t *testing.T) {
 		"path":       "file.txt",
 		"start_line": 0,
 	})
-	_, err := readTool.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), readTool, input)
 	if err == nil || !strings.Contains(err.Error(), "start_line must be >=") {
 		t.Errorf("expected start_line lower-bound error, got %v", err)
 	}
@@ -474,7 +487,7 @@ func TestReadFileTool_LimitBelowOne(t *testing.T) {
 		"path":  "file.txt",
 		"limit": 0,
 	})
-	_, err := readTool.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), readTool, input)
 	if err == nil || !strings.Contains(err.Error(), "limit must be >=") {
 		t.Errorf("expected limit lower-bound error, got %v", err)
 	}
@@ -489,7 +502,7 @@ func TestReadFileTool_ExecError(t *testing.T) {
 	readTool := ReadFileTool(mock)
 
 	input, _ := json.Marshal(map[string]any{"path": "missing.txt"})
-	_, err := readTool.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), readTool, input)
 	if err == nil || !strings.Contains(err.Error(), "file not found") {
 		t.Errorf("expected file-not-found error, got %v", err)
 	}
@@ -566,7 +579,7 @@ func TestRunCommandTool_NonZeroExitCode(t *testing.T) {
 	runTool := RunCommandTool(mock)
 	input, _ := json.Marshal(map[string]string{"command": "false"})
 
-	result, err := runTool.Handler(context.Background(), input)
+	result, err := invokeText(context.Background(), runTool, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -586,7 +599,7 @@ func TestRunCommandTool_EmptyCommand(t *testing.T) {
 	runTool := RunCommandTool(mock)
 
 	input, _ := json.Marshal(map[string]string{"command": ""})
-	_, err := runTool.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), runTool, input)
 	if err == nil {
 		t.Fatal("expected error for empty command")
 	}

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -76,8 +76,8 @@ func (m *mockExecutor) Capabilities() executor.ExecutorCapabilities {
 // tests that assert the structured payload call StructuredHandler directly.
 func invokeText(ctx context.Context, tl *tool.Tool, input json.RawMessage) (string, error) {
 	if tl.StructuredHandler != nil {
-		text, _, err := tl.StructuredHandler(ctx, input)
-		return text, err
+		res, err := tl.StructuredHandler(ctx, input)
+		return res.Text, err
 	}
 	return tl.Handler(ctx, input)
 }

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -117,42 +117,89 @@ func ReadFileTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       readFileSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
-		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
 			var params struct {
 				Path      string `json:"path"`
 				StartLine *int   `json:"start_line,omitempty"`
 				Limit     *int   `json:"limit,omitempty"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", fmt.Errorf("parse input: %w", err)
+				return "", nil, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Path == "" {
-				return "", fmt.Errorf("path is required")
+				return "", nil, fmt.Errorf("path is required")
 			}
 			startLine := 1
 			if params.StartLine != nil {
 				if *params.StartLine < 1 {
-					return "", fmt.Errorf("start_line must be >= 1, got %d", *params.StartLine)
+					return "", nil, fmt.Errorf("start_line must be >= 1, got %d", *params.StartLine)
 				}
 				startLine = *params.StartLine
 			}
 			limit := readFileDefaultLimit
 			if params.Limit != nil {
 				if *params.Limit < 1 {
-					return "", fmt.Errorf("limit must be >= 1, got %d", *params.Limit)
+					return "", nil, fmt.Errorf("limit must be >= 1, got %d", *params.Limit)
 				}
 				if *params.Limit > readFileMaxLimit {
-					return "", fmt.Errorf("limit must be <= %d, got %d", readFileMaxLimit, *params.Limit)
+					return "", nil, fmt.Errorf("limit must be <= %d, got %d", readFileMaxLimit, *params.Limit)
 				}
 				limit = *params.Limit
 			}
 
 			content, err := exec.ReadFile(ctx, params.Path)
 			if err != nil {
-				return "", err
+				return "", nil, err
 			}
-			return formatReadFile(content, startLine, limit), nil
+			text := formatReadFile(content, startLine, limit)
+			excerpt := readFileExcerpt(params.Path, content, startLine, limit)
+			structured, marshalErr := json.Marshal(excerpt)
+			if marshalErr != nil {
+				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
+			}
+			return text, structured, nil
 		},
+	}
+}
+
+// readFileExcerpt computes the typed structured payload for read_file from the
+// same inputs formatReadFile uses, mirroring its line-window arithmetic so the
+// structured fields agree with the text rendering exactly (issue #231). Lines
+// holds the excerpt content without the line-number prefixes the text adds.
+// PastEOF is set when start_line is beyond the file, matching the past-EOF
+// notice the text returns; Lines is empty in that case. Truncated reports that
+// the window stopped short of the end of the file.
+func readFileExcerpt(path, content string, startLine, limit int) fileExcerpt {
+	// Mirror formatReadFile's trailing-newline handling so the line count and
+	// the EOF boundary match the text rendering byte-for-byte.
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	totalLines := len(lines)
+	if startLine > totalLines {
+		return fileExcerpt{
+			Path:      path,
+			StartLine: startLine,
+			EndLine:   totalLines,
+			PastEOF:   true,
+			Lines:     []string{},
+		}
+	}
+	endLine := startLine + limit - 1
+	if endLine > totalLines {
+		endLine = totalLines
+	}
+	excerptLines := make([]string, 0, endLine-startLine+1)
+	for i := startLine; i <= endLine; i++ {
+		excerptLines = append(excerptLines, lines[i-1])
+	}
+	return fileExcerpt{
+		Path:      path,
+		StartLine: startLine,
+		EndLine:   endLine,
+		Truncated: endLine < totalLines,
+		Lines:     excerptLines,
 	}
 }
 

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -117,47 +117,47 @@ func ReadFileTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       readFileSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
-		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
 			var params struct {
 				Path      string `json:"path"`
 				StartLine *int   `json:"start_line,omitempty"`
 				Limit     *int   `json:"limit,omitempty"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", nil, fmt.Errorf("parse input: %w", err)
+				return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Path == "" {
-				return "", nil, fmt.Errorf("path is required")
+				return tool.StructuredResult{}, fmt.Errorf("path is required")
 			}
 			startLine := 1
 			if params.StartLine != nil {
 				if *params.StartLine < 1 {
-					return "", nil, fmt.Errorf("start_line must be >= 1, got %d", *params.StartLine)
+					return tool.StructuredResult{}, fmt.Errorf("start_line must be >= 1, got %d", *params.StartLine)
 				}
 				startLine = *params.StartLine
 			}
 			limit := readFileDefaultLimit
 			if params.Limit != nil {
 				if *params.Limit < 1 {
-					return "", nil, fmt.Errorf("limit must be >= 1, got %d", *params.Limit)
+					return tool.StructuredResult{}, fmt.Errorf("limit must be >= 1, got %d", *params.Limit)
 				}
 				if *params.Limit > readFileMaxLimit {
-					return "", nil, fmt.Errorf("limit must be <= %d, got %d", readFileMaxLimit, *params.Limit)
+					return tool.StructuredResult{}, fmt.Errorf("limit must be <= %d, got %d", readFileMaxLimit, *params.Limit)
 				}
 				limit = *params.Limit
 			}
 
 			content, err := exec.ReadFile(ctx, params.Path)
 			if err != nil {
-				return "", nil, err
+				return tool.StructuredResult{}, err
 			}
 			text := formatReadFile(content, startLine, limit)
 			excerpt := readFileExcerpt(params.Path, content, startLine, limit)
 			structured, marshalErr := json.Marshal(excerpt)
 			if marshalErr != nil {
-				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
+				return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
 			}
-			return text, structured, nil
+			return tool.StructuredResult{Text: text, Structured: structured, Kind: kindFileExcerpt}, nil
 		},
 	}
 }

--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -168,7 +168,7 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       grepFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
-		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
 			var params struct {
 				Pattern    string   `json:"pattern"`
 				Path       string   `json:"path,omitempty"`
@@ -177,10 +177,10 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 				MaxResults *int     `json:"max_results,omitempty"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", nil, fmt.Errorf("parse input: %w", err)
+				return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Pattern == "" {
-				return "", nil, fmt.Errorf("pattern is required")
+				return tool.StructuredResult{}, fmt.Errorf("pattern is required")
 			}
 			// Compile the pattern early so a bad regex returns a clean
 			// error before the executor is even touched. Models often
@@ -188,15 +188,15 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 			// message is the clearest signal we can give them.
 			re, err := regexp.Compile(params.Pattern)
 			if err != nil {
-				return "", nil, fmt.Errorf("invalid regex pattern: %w", err)
+				return tool.StructuredResult{}, fmt.Errorf("invalid regex pattern: %w", err)
 			}
 			maxResults := grepDefaultMaxResults
 			if params.MaxResults != nil {
 				if *params.MaxResults < 1 {
-					return "", nil, fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
+					return tool.StructuredResult{}, fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
 				}
 				if *params.MaxResults > grepAbsoluteMax {
-					return "", nil, fmt.Errorf("max_results must be <= %d, got %d", grepAbsoluteMax, *params.MaxResults)
+					return tool.StructuredResult{}, fmt.Errorf("max_results must be <= %d, got %d", grepAbsoluteMax, *params.MaxResults)
 				}
 				maxResults = *params.MaxResults
 			}
@@ -206,17 +206,24 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 			}
 			resolvedDir, err := exec.ResolvePath(searchDir)
 			if err != nil {
-				return "", nil, fmt.Errorf("resolve search path: %w", err)
+				return tool.StructuredResult{}, fmt.Errorf("resolve search path: %w", err)
 			}
 
-			text := ""
+			// matches is built directly from source data by whichever search
+			// path runs — never re-parsed from rendered text — so a colon in a
+			// path or a matched line can never corrupt or silently drop a
+			// structured match (issue #231). The text rendering is derived from
+			// the same matches afterwards and stays byte-identical to the
+			// historical "path:line:text" format.
+			var matches []searchMatch
+			gotResult := false
 			if defaultRipgrepDetector.detect() && exec.Capabilities().CanExec {
-				out, ok, rgErr := grepViaRipgrep(ctx, exec, resolvedDir, params.Pattern, params.Include, params.Exclude, maxResults)
+				rgMatches, ok, rgErr := grepViaRipgrep(ctx, exec, resolvedDir, params.Pattern, params.Include, params.Exclude, maxResults)
 				switch {
 				case rgErr != nil && (errors.Is(rgErr, context.Canceled) || errors.Is(rgErr, context.DeadlineExceeded)):
 					// Context-cancellation must propagate — the caller asked
 					// to stop. Don't paper over it by re-walking natively.
-					return "", nil, rgErr
+					return tool.StructuredResult{}, rgErr
 				case rgErr != nil:
 					// Executor transport failure (Docker socket timeout,
 					// container restart, etc.) — treat the same as an rg
@@ -225,81 +232,63 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 					// than a real rg error.
 					slog.WarnContext(ctx, "rg invocation failed, falling back to native grep", "err", rgErr)
 				case ok:
-					text = out
+					matches = rgMatches
+					gotResult = true
 				}
 				// rg exited with an unexpected error code, or its transport
 				// failed; fall through to the Go-native walker so the
 				// caller still gets an answer.
 			}
-			if text == "" {
-				native, nativeErr := grepNative(resolvedDir, re, params.Include, params.Exclude, maxResults)
+			if !gotResult {
+				nativeMatches, nativeErr := grepNative(resolvedDir, re, params.Include, params.Exclude, maxResults)
 				if nativeErr != nil {
-					return "", nil, nativeErr
+					return tool.StructuredResult{}, nativeErr
 				}
-				text = native
+				matches = nativeMatches
 			}
 
-			// Parse the canonical "path:line:text" rendering back into typed
-			// matches for the structured payload (issue #231). Both the rg
-			// and native paths emit this shape, so parsing keeps the text
-			// rendering byte-identical while still surfacing stable fields.
-			matches := parseGrepMatches(text)
 			structured, marshalErr := json.Marshal(searchResult{
-				Matches:   matches,
+				Matches:   matchesOrEmpty(matches),
 				Truncated: len(matches) >= maxResults,
 			})
 			if marshalErr != nil {
-				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
+				return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
 			}
-			return text, structured, nil
+			return tool.StructuredResult{
+				Text:       renderGrepText(matches),
+				Structured: structured,
+				Kind:       kindSearchResult,
+			}, nil
 		},
 	}
 }
 
-// noMatchesText is the sentinel both search paths return when nothing matched.
+// noMatchesText is the sentinel both search tools render when nothing matched.
 const noMatchesText = "No matches found."
 
-// parseGrepMatches converts the canonical "path:line:text" grep rendering into
-// typed matches. It is the inverse of the text both grepNative and
-// grepViaRipgrep emit, so the structured payload can be derived without
-// re-running the search and without perturbing the text. The "No matches
-// found." sentinel and blank lines parse to an empty (non-nil) slice.
-//
-// A line is split on its first two colons: anything after the second colon is
-// the match text verbatim (so a match containing colons is preserved). A line
-// that does not parse into path/line/text — e.g. a path containing a colon
-// that confuses the split, which neither path produces in practice — is
-// skipped rather than guessed at; the verbatim text rendering still carries it
-// for the model.
-func parseGrepMatches(text string) []searchMatch {
-	matches := make([]searchMatch, 0)
-	if text == "" || text == noMatchesText {
-		return matches
+// matchesOrEmpty guarantees a non-nil slice so the marshalled searchResult
+// always carries a "matches" array rather than null.
+func matchesOrEmpty(m []searchMatch) []searchMatch {
+	if m == nil {
+		return []searchMatch{}
 	}
-	for _, line := range strings.Split(text, "\n") {
-		if line == "" {
-			continue
-		}
-		firstColon := strings.IndexByte(line, ':')
-		if firstColon < 0 {
-			continue
-		}
-		rest := line[firstColon+1:]
-		secondColon := strings.IndexByte(rest, ':')
-		if secondColon < 0 {
-			continue
-		}
-		lineNum, err := strconv.Atoi(rest[:secondColon])
-		if err != nil {
-			continue
-		}
-		matches = append(matches, searchMatch{
-			Path: line[:firstColon],
-			Line: lineNum,
-			Text: rest[secondColon+1:],
-		})
+	return m
+}
+
+// renderGrepText produces the canonical "path:line:text" grep rendering from
+// typed matches. It is the inverse of how grepNative/grepViaRipgrep build their
+// matches and reproduces the historical text byte-for-byte: one
+// "path:line:text" line per match joined by newlines, or the no-matches
+// sentinel when empty.
+func renderGrepText(matches []searchMatch) string {
+	if len(matches) == 0 {
+		return noMatchesText
 	}
-	return matches
+	lines := make([]string, len(matches))
+	for i, m := range matches {
+		lines[i] = fmt.Sprintf("%s:%d:%s", m.Path, m.Line, m.Text)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // FindFilesTool returns a tool that searches for file names matching a
@@ -317,7 +306,7 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       findFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
-		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
 			var params struct {
 				Name       string   `json:"name"`
 				Path       string   `json:"path,omitempty"`
@@ -326,24 +315,24 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 				MaxResults *int     `json:"max_results,omitempty"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", nil, fmt.Errorf("parse input: %w", err)
+				return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Name == "" {
-				return "", nil, fmt.Errorf("name is required")
+				return tool.StructuredResult{}, fmt.Errorf("name is required")
 			}
 			// Validate the glob early so a malformed pattern returns a
 			// clean error before any directory walk begins. filepath.Match
 			// returns ErrBadPattern for unbalanced brackets, etc.
 			if _, err := filepath.Match(params.Name, ""); err != nil {
-				return "", nil, fmt.Errorf("invalid glob pattern %q: %w", params.Name, err)
+				return tool.StructuredResult{}, fmt.Errorf("invalid glob pattern %q: %w", params.Name, err)
 			}
 			maxResults := findDefaultMaxResults
 			if params.MaxResults != nil {
 				if *params.MaxResults < 1 {
-					return "", nil, fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
+					return tool.StructuredResult{}, fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
 				}
 				if *params.MaxResults > findAbsoluteMax {
-					return "", nil, fmt.Errorf("max_results must be <= %d, got %d", findAbsoluteMax, *params.MaxResults)
+					return tool.StructuredResult{}, fmt.Errorf("max_results must be <= %d, got %d", findAbsoluteMax, *params.MaxResults)
 				}
 				maxResults = *params.MaxResults
 			}
@@ -353,53 +342,102 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 			}
 			resolvedDir, err := exec.ResolvePath(searchDir)
 			if err != nil {
-				return "", nil, fmt.Errorf("resolve search path: %w", err)
-			}
-			text, err := findNative(resolvedDir, params.Name, params.Include, params.Exclude, maxResults)
-			if err != nil {
-				return "", nil, err
+				return tool.StructuredResult{}, fmt.Errorf("resolve search path: %w", err)
 			}
 
-			// Derive the typed path list from the canonical newline-joined
-			// rendering so the text stays byte-identical (issue #231).
-			paths := parseFindPaths(text)
+			// findNative returns the typed path list directly; the text is
+			// derived from it so a path containing a newline-free colon (or any
+			// other char) cannot diverge the two representations (issue #231).
+			paths, err := findNative(resolvedDir, params.Name, params.Include, params.Exclude, maxResults)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+
 			structured, marshalErr := json.Marshal(findResult{
-				Paths:     paths,
+				Paths:     pathsOrEmpty(paths),
 				Truncated: len(paths) >= maxResults,
 			})
 			if marshalErr != nil {
-				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
+				return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
 			}
-			return text, structured, nil
+			return tool.StructuredResult{
+				Text:       renderFindText(paths),
+				Structured: structured,
+				Kind:       kindFindResult,
+			}, nil
 		},
 	}
 }
 
-// parseFindPaths converts the canonical newline-joined find_files rendering
-// into a typed path list, the inverse of the text findNative produces. The
-// "No matches found." sentinel and blank lines yield an empty (non-nil) slice.
-func parseFindPaths(text string) []string {
-	paths := make([]string, 0)
-	if text == "" || text == noMatchesText {
-		return paths
+// pathsOrEmpty guarantees a non-nil slice so the marshalled findResult always
+// carries a "paths" array rather than null.
+func pathsOrEmpty(p []string) []string {
+	if p == nil {
+		return []string{}
 	}
-	for _, line := range strings.Split(text, "\n") {
-		if line == "" {
-			continue
-		}
-		paths = append(paths, line)
-	}
-	return paths
+	return p
 }
 
-// grepViaRipgrep runs `rg --line-number --no-heading --color never` and
-// converts the result. The bool return reports whether rg produced a usable
-// answer (true) or hit an unexpected error code that warrants falling back
-// to the Go-native walker (false). Error returns are reserved for executor
-// failures that the caller surfaces directly.
-func grepViaRipgrep(ctx context.Context, exec executor.Executor, dir, pattern string, include, exclude []string, maxResults int) (string, bool, error) {
+// renderFindText produces the canonical newline-joined find_files rendering:
+// one workspace-relative path per line, or the no-matches sentinel when empty.
+func renderFindText(paths []string) string {
+	if len(paths) == 0 {
+		return noMatchesText
+	}
+	return strings.Join(paths, "\n")
+}
+
+// rgJSONEvent is the subset of ripgrep's `--json` event stream we consume. rg
+// emits one JSON object per line; "match" events carry the path, line number,
+// and matched line text as structured fields, so a colon in the path or the
+// matched text can never be misattributed the way splitting rendered
+// "path:line:text" text would. Non-UTF-8 paths/text arrive base64-encoded under
+// "bytes" instead of "text"; we decode that so the structured match still
+// carries the real bytes.
+type rgJSONEvent struct {
+	Type string `json:"type"`
+	Data struct {
+		Path  rgJSONText `json:"path"`
+		Lines rgJSONText `json:"lines"`
+		Line  int        `json:"line_number"`
+	} `json:"data"`
+}
+
+// rgJSONText is ripgrep's tagged string: valid UTF-8 under "text", otherwise
+// base64-encoded raw bytes under "bytes".
+type rgJSONText struct {
+	Text  string `json:"text"`
+	Bytes string `json:"bytes"`
+}
+
+// value returns the decoded string, preferring the UTF-8 "text" form and
+// falling back to base64-decoded "bytes". A bytes value that fails to decode is
+// returned verbatim, which only happens on malformed rg output.
+func (t rgJSONText) value() string {
+	if t.Text != "" {
+		return t.Text
+	}
+	if t.Bytes != "" {
+		if raw, err := base64.StdEncoding.DecodeString(t.Bytes); err == nil {
+			return string(raw)
+		}
+		return t.Bytes
+	}
+	return ""
+}
+
+// grepViaRipgrep runs `rg --json` and builds searchMatch structs directly from
+// the structured events rather than parsing rendered text. The bool return
+// reports whether rg produced a usable answer (true) or hit an unexpected error
+// code that warrants falling back to the Go-native walker (false). Error
+// returns are reserved for executor failures that the caller surfaces directly.
+//
+// Reconstructing "path:line:text" from these fields (renderGrepText) is
+// byte-identical to rg's `--no-heading --line-number` text output for the
+// directory-target invocation used here.
+func grepViaRipgrep(ctx context.Context, exec executor.Executor, dir, pattern string, include, exclude []string, maxResults int) ([]searchMatch, bool, error) {
 	var args []string
-	args = append(args, "rg", "--line-number", "--no-heading", "--color", "never",
+	args = append(args, "rg", "--json", "--color", "never",
 		"--max-count", fmt.Sprintf("%d", maxResults),
 		"-e", shellQuote(pattern))
 	for _, g := range include {
@@ -413,30 +451,57 @@ func grepViaRipgrep(ctx context.Context, exec executor.Executor, dir, pattern st
 
 	result, err := exec.Exec(ctx, cmd, searchTimeout)
 	if err != nil {
-		return "", false, fmt.Errorf("rg invocation failed: %w", err)
+		return nil, false, fmt.Errorf("rg invocation failed: %w", err)
 	}
 	// rg exit code 0 == matches found; 1 == no matches (clean); 2+ ==
 	// real error (bad regex, IO failure, etc.). We treat 2+ as a soft
 	// failure and let the caller fall back to the native walker.
 	switch result.ExitCode {
 	case 0:
-		out := strings.TrimSpace(result.Stdout)
-		// Cap output at max_results lines defensively — rg's --max-count
-		// is per-file, so a workspace with many files could exceed the
-		// global bound the caller asked for.
-		lines := strings.Split(out, "\n")
-		if len(lines) > maxResults {
-			lines = lines[:maxResults]
-		}
-		if len(lines) == 0 || (len(lines) == 1 && lines[0] == "") {
-			return "No matches found.", true, nil
-		}
-		return strings.Join(lines, "\n"), true, nil
+		matches := parseRipgrepJSON(result.Stdout, maxResults)
+		return matches, true, nil
 	case 1:
-		return "No matches found.", true, nil
+		return nil, true, nil
 	default:
-		return "", false, nil
+		return nil, false, nil
 	}
+}
+
+// parseRipgrepJSON walks rg's newline-delimited JSON event stream and collects
+// the "match" events into searchMatch structs, capped at maxResults. rg's
+// --max-count is per-file, so a workspace with many files can exceed the global
+// bound; the cap here enforces it. Non-"match" events (begin/end/summary) and
+// any line that does not parse as a JSON object are skipped — rg only emits
+// well-formed objects, so a parse miss is a defensive no-op, never a dropped
+// match for a colon-bearing path.
+func parseRipgrepJSON(stdout string, maxResults int) []searchMatch {
+	var matches []searchMatch
+	for _, line := range strings.Split(stdout, "\n") {
+		if line == "" {
+			continue
+		}
+		var ev rgJSONEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		if ev.Type != "match" {
+			continue
+		}
+		// rg's matched-line text carries the file's trailing newline; strip a
+		// single trailing "\n" so the text matches the per-line rendering the
+		// native walker and rg's own text mode produce. A CRLF line keeps its
+		// "\r" (the native walker splits on "\n" only), so we do NOT strip it.
+		text := strings.TrimSuffix(ev.Data.Lines.value(), "\n")
+		matches = append(matches, searchMatch{
+			Path: ev.Data.Path.value(),
+			Line: ev.Data.Line,
+			Text: text,
+		})
+		if len(matches) >= maxResults {
+			break
+		}
+	}
+	return matches
 }
 
 // grepNative walks `dir` and matches `re` against each file's contents. It
@@ -444,8 +509,8 @@ func grepViaRipgrep(ctx context.Context, exec executor.Executor, dir, pattern st
 // and predictable behaviour in containers without rg matters more than
 // throughput. Binary files are skipped (heuristic: NUL byte in the first
 // chunk) to avoid spamming gibberish into the model's context.
-func grepNative(dir string, re *regexp.Regexp, include, exclude []string, maxResults int) (string, error) {
-	var results []string
+func grepNative(dir string, re *regexp.Regexp, include, exclude []string, maxResults int) ([]searchMatch, error) {
+	var results []searchMatch
 	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			// Skip entries we cannot stat (permissions, race) rather
@@ -490,7 +555,10 @@ func grepNative(dir string, re *regexp.Regexp, include, exclude []string, maxRes
 				if relErr != nil {
 					rel = path
 				}
-				results = append(results, fmt.Sprintf("%s:%d:%s", rel, lineNum+1, line))
+				// Build the typed match directly; the text rendering is
+				// derived from these fields by renderGrepText, so a colon in
+				// rel or line never confuses path/line/text (issue #231).
+				results = append(results, searchMatch{Path: rel, Line: lineNum + 1, Text: line})
 				if len(results) >= maxResults {
 					return errStopWalk
 				}
@@ -499,18 +567,17 @@ func grepNative(dir string, re *regexp.Regexp, include, exclude []string, maxRes
 		return nil
 	})
 	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
-		return "", fmt.Errorf("search failed: %w", walkErr)
+		return nil, fmt.Errorf("search failed: %w", walkErr)
 	}
-	if len(results) == 0 {
-		return "No matches found.", nil
-	}
-	return strings.Join(results, "\n"), nil
+	return results, nil
 }
 
 // findNative walks `dir` and collects files whose names match the glob. We
 // match against the basename only (consistent with `find -name`), then apply
-// the include/exclude glob filters against the relative path.
-func findNative(dir, name string, include, exclude []string, maxResults int) (string, error) {
+// the include/exclude glob filters against the relative path. It returns the
+// workspace-relative path list directly; the text rendering is derived from it
+// by renderFindText.
+func findNative(dir, name string, include, exclude []string, maxResults int) ([]string, error) {
 	var results []string
 	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -546,12 +613,9 @@ func findNative(dir, name string, include, exclude []string, maxResults int) (st
 		return nil
 	})
 	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
-		return "", fmt.Errorf("find failed: %w", walkErr)
+		return nil, fmt.Errorf("find failed: %w", walkErr)
 	}
-	if len(results) == 0 {
-		return "No matches found.", nil
-	}
-	return strings.Join(results, "\n"), nil
+	return results, nil
 }
 
 // errStopWalk is the sentinel filepath.WalkDir callbacks return to stop the

--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -167,7 +168,7 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       grepFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
-		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
 			var params struct {
 				Pattern    string   `json:"pattern"`
 				Path       string   `json:"path,omitempty"`
@@ -176,10 +177,10 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 				MaxResults *int     `json:"max_results,omitempty"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", fmt.Errorf("parse input: %w", err)
+				return "", nil, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Pattern == "" {
-				return "", fmt.Errorf("pattern is required")
+				return "", nil, fmt.Errorf("pattern is required")
 			}
 			// Compile the pattern early so a bad regex returns a clean
 			// error before the executor is even touched. Models often
@@ -187,15 +188,15 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 			// message is the clearest signal we can give them.
 			re, err := regexp.Compile(params.Pattern)
 			if err != nil {
-				return "", fmt.Errorf("invalid regex pattern: %w", err)
+				return "", nil, fmt.Errorf("invalid regex pattern: %w", err)
 			}
 			maxResults := grepDefaultMaxResults
 			if params.MaxResults != nil {
 				if *params.MaxResults < 1 {
-					return "", fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
+					return "", nil, fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
 				}
 				if *params.MaxResults > grepAbsoluteMax {
-					return "", fmt.Errorf("max_results must be <= %d, got %d", grepAbsoluteMax, *params.MaxResults)
+					return "", nil, fmt.Errorf("max_results must be <= %d, got %d", grepAbsoluteMax, *params.MaxResults)
 				}
 				maxResults = *params.MaxResults
 			}
@@ -205,33 +206,100 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 			}
 			resolvedDir, err := exec.ResolvePath(searchDir)
 			if err != nil {
-				return "", fmt.Errorf("resolve search path: %w", err)
+				return "", nil, fmt.Errorf("resolve search path: %w", err)
 			}
 
+			text := ""
 			if defaultRipgrepDetector.detect() && exec.Capabilities().CanExec {
-				out, ok, err := grepViaRipgrep(ctx, exec, resolvedDir, params.Pattern, params.Include, params.Exclude, maxResults)
+				out, ok, rgErr := grepViaRipgrep(ctx, exec, resolvedDir, params.Pattern, params.Include, params.Exclude, maxResults)
 				switch {
-				case err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)):
+				case rgErr != nil && (errors.Is(rgErr, context.Canceled) || errors.Is(rgErr, context.DeadlineExceeded)):
 					// Context-cancellation must propagate — the caller asked
 					// to stop. Don't paper over it by re-walking natively.
-					return "", err
-				case err != nil:
+					return "", nil, rgErr
+				case rgErr != nil:
 					// Executor transport failure (Docker socket timeout,
 					// container restart, etc.) — treat the same as an rg
 					// exit code >= 2 and fall through to the native walker.
 					// A transient transport flake should not be more fatal
 					// than a real rg error.
-					slog.WarnContext(ctx, "rg invocation failed, falling back to native grep", "err", err)
+					slog.WarnContext(ctx, "rg invocation failed, falling back to native grep", "err", rgErr)
 				case ok:
-					return out, nil
+					text = out
 				}
 				// rg exited with an unexpected error code, or its transport
 				// failed; fall through to the Go-native walker so the
 				// caller still gets an answer.
 			}
-			return grepNative(resolvedDir, re, params.Include, params.Exclude, maxResults)
+			if text == "" {
+				native, nativeErr := grepNative(resolvedDir, re, params.Include, params.Exclude, maxResults)
+				if nativeErr != nil {
+					return "", nil, nativeErr
+				}
+				text = native
+			}
+
+			// Parse the canonical "path:line:text" rendering back into typed
+			// matches for the structured payload (issue #231). Both the rg
+			// and native paths emit this shape, so parsing keeps the text
+			// rendering byte-identical while still surfacing stable fields.
+			matches := parseGrepMatches(text)
+			structured, marshalErr := json.Marshal(searchResult{
+				Matches:   matches,
+				Truncated: len(matches) >= maxResults,
+			})
+			if marshalErr != nil {
+				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
+			}
+			return text, structured, nil
 		},
 	}
+}
+
+// noMatchesText is the sentinel both search paths return when nothing matched.
+const noMatchesText = "No matches found."
+
+// parseGrepMatches converts the canonical "path:line:text" grep rendering into
+// typed matches. It is the inverse of the text both grepNative and
+// grepViaRipgrep emit, so the structured payload can be derived without
+// re-running the search and without perturbing the text. The "No matches
+// found." sentinel and blank lines parse to an empty (non-nil) slice.
+//
+// A line is split on its first two colons: anything after the second colon is
+// the match text verbatim (so a match containing colons is preserved). A line
+// that does not parse into path/line/text — e.g. a path containing a colon
+// that confuses the split, which neither path produces in practice — is
+// skipped rather than guessed at; the verbatim text rendering still carries it
+// for the model.
+func parseGrepMatches(text string) []searchMatch {
+	matches := make([]searchMatch, 0)
+	if text == "" || text == noMatchesText {
+		return matches
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if line == "" {
+			continue
+		}
+		firstColon := strings.IndexByte(line, ':')
+		if firstColon < 0 {
+			continue
+		}
+		rest := line[firstColon+1:]
+		secondColon := strings.IndexByte(rest, ':')
+		if secondColon < 0 {
+			continue
+		}
+		lineNum, err := strconv.Atoi(rest[:secondColon])
+		if err != nil {
+			continue
+		}
+		matches = append(matches, searchMatch{
+			Path: line[:firstColon],
+			Line: lineNum,
+			Text: rest[secondColon+1:],
+		})
+	}
+	return matches
 }
 
 // FindFilesTool returns a tool that searches for file names matching a
@@ -249,7 +317,7 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       findFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
-		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
 			var params struct {
 				Name       string   `json:"name"`
 				Path       string   `json:"path,omitempty"`
@@ -258,24 +326,24 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 				MaxResults *int     `json:"max_results,omitempty"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", fmt.Errorf("parse input: %w", err)
+				return "", nil, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Name == "" {
-				return "", fmt.Errorf("name is required")
+				return "", nil, fmt.Errorf("name is required")
 			}
 			// Validate the glob early so a malformed pattern returns a
 			// clean error before any directory walk begins. filepath.Match
 			// returns ErrBadPattern for unbalanced brackets, etc.
 			if _, err := filepath.Match(params.Name, ""); err != nil {
-				return "", fmt.Errorf("invalid glob pattern %q: %w", params.Name, err)
+				return "", nil, fmt.Errorf("invalid glob pattern %q: %w", params.Name, err)
 			}
 			maxResults := findDefaultMaxResults
 			if params.MaxResults != nil {
 				if *params.MaxResults < 1 {
-					return "", fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
+					return "", nil, fmt.Errorf("max_results must be >= 1, got %d", *params.MaxResults)
 				}
 				if *params.MaxResults > findAbsoluteMax {
-					return "", fmt.Errorf("max_results must be <= %d, got %d", findAbsoluteMax, *params.MaxResults)
+					return "", nil, fmt.Errorf("max_results must be <= %d, got %d", findAbsoluteMax, *params.MaxResults)
 				}
 				maxResults = *params.MaxResults
 			}
@@ -285,11 +353,43 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 			}
 			resolvedDir, err := exec.ResolvePath(searchDir)
 			if err != nil {
-				return "", fmt.Errorf("resolve search path: %w", err)
+				return "", nil, fmt.Errorf("resolve search path: %w", err)
 			}
-			return findNative(resolvedDir, params.Name, params.Include, params.Exclude, maxResults)
+			text, err := findNative(resolvedDir, params.Name, params.Include, params.Exclude, maxResults)
+			if err != nil {
+				return "", nil, err
+			}
+
+			// Derive the typed path list from the canonical newline-joined
+			// rendering so the text stays byte-identical (issue #231).
+			paths := parseFindPaths(text)
+			structured, marshalErr := json.Marshal(findResult{
+				Paths:     paths,
+				Truncated: len(paths) >= maxResults,
+			})
+			if marshalErr != nil {
+				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
+			}
+			return text, structured, nil
 		},
 	}
+}
+
+// parseFindPaths converts the canonical newline-joined find_files rendering
+// into a typed path list, the inverse of the text findNative produces. The
+// "No matches found." sentinel and blank lines yield an empty (non-nil) slice.
+func parseFindPaths(text string) []string {
+	paths := make([]string, 0)
+	if text == "" || text == noMatchesText {
+		return paths
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if line == "" {
+			continue
+		}
+		paths = append(paths, line)
+	}
+	return paths
 }
 
 // grepViaRipgrep runs `rg --line-number --no-heading --color never` and

--- a/harness/internal/tool/builtins/search_test.go
+++ b/harness/internal/tool/builtins/search_test.go
@@ -74,7 +74,7 @@ func TestGrepNative_PermissionDeniedSubdirSkipped(t *testing.T) {
 
 	grep := GrepFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"pattern": "needle"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("permission-denied dir must not surface as an error; got: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestFindNative_PermissionDeniedSubdirSkipped(t *testing.T) {
 
 	find := FindFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"name": "*.go"})
-	out, err := find.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), find, input)
 	if err != nil {
 		t.Fatalf("permission-denied dir must not surface as an error; got: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestGrepFilesTool_NativeMatchesContent(t *testing.T) {
 
 	grep := GrepFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"pattern": "Hello"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestGrepFilesTool_InvalidRegex(t *testing.T) {
 	// `[` is an unbalanced character class — a common mistake for models
 	// that confuse shell globs with regexes.
 	input, _ := json.Marshal(map[string]any{"pattern": "["})
-	_, err := grep.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), grep, input)
 	if err == nil {
 		t.Fatal("expected error for invalid regex")
 	}
@@ -204,7 +204,7 @@ func TestGrepFilesTool_MaxResultsBound(t *testing.T) {
 	}
 	grep := GrepFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"pattern": "needle", "max_results": 2})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestGrepFilesTool_IncludeExclude(t *testing.T) {
 		"include": []string{"*.go"},
 		"exclude": []string{"skip.go"},
 	})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestGrepFilesTool_NoMatches(t *testing.T) {
 
 	grep := GrepFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"pattern": "absent_pattern"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestGrepFilesTool_BinaryFilesSkipped(t *testing.T) {
 
 	grep := GrepFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"pattern": "match"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestGrepFilesTool_RipgrepPathSelected(t *testing.T) {
 		"include": []string{"*.go"},
 		"exclude": []string{"vendor/**"},
 	})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestGrepFilesTool_RipgrepFallsBackOnHardError(t *testing.T) {
 	}
 	grep := GrepFilesTool(fe)
 	input, _ := json.Marshal(map[string]any{"pattern": "foo"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestGrepNative_SkipsSymlinks(t *testing.T) {
 
 	grep := GrepFilesTool(&fsExecutor{root: workspace})
 	input, _ := json.Marshal(map[string]any{"pattern": "match-target"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestGrepViaRipgrep_TransportErrorFallsBackToNative(t *testing.T) {
 	}
 	grep := GrepFilesTool(fe)
 	input, _ := json.Marshal(map[string]any{"pattern": "needle"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("transport error must not surface; expected native fallback, got: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestGrepViaRipgrep_ContextCancelPropagates(t *testing.T) {
 	}
 	grep := GrepFilesTool(fe)
 	input, _ := json.Marshal(map[string]any{"pattern": "needle"})
-	_, err := grep.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), grep, input)
 	if err == nil {
 		t.Fatal("expected context.Canceled to propagate")
 	}
@@ -451,7 +451,7 @@ func TestGrepFilesTool_PathTraversalRejected(t *testing.T) {
 	}
 	grep := GrepFilesTool(mock)
 	input, _ := json.Marshal(map[string]any{"pattern": "secret", "path": "../../etc"})
-	_, err := grep.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), grep, input)
 	if err == nil {
 		t.Fatal("expected resolve-path error")
 	}
@@ -469,7 +469,7 @@ func TestFindFilesTool_GlobMatch(t *testing.T) {
 
 	find := FindFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"name": "*.go"})
-	out, err := find.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), find, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -491,7 +491,7 @@ func TestFindFilesTool_RecursesIntoSubdirs(t *testing.T) {
 
 	find := FindFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"name": "handler_*.go"})
-	out, err := find.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), find, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -507,7 +507,7 @@ func TestFindFilesTool_MaxResultsBound(t *testing.T) {
 	}
 	find := FindFilesTool(&fsExecutor{root: dir})
 	input, _ := json.Marshal(map[string]any{"name": "*.go", "max_results": 2})
-	out, err := find.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), find, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -520,7 +520,7 @@ func TestFindFilesTool_MaxResultsBound(t *testing.T) {
 func TestFindFilesTool_NoMatches(t *testing.T) {
 	find := FindFilesTool(&fsExecutor{root: t.TempDir()})
 	input, _ := json.Marshal(map[string]any{"name": "*.nope"})
-	out, err := find.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), find, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -533,7 +533,7 @@ func TestFindFilesTool_InvalidGlob(t *testing.T) {
 	find := FindFilesTool(&fsExecutor{root: t.TempDir()})
 	// An unbalanced bracket is rejected by filepath.Match.
 	input, _ := json.Marshal(map[string]any{"name": "[broken"})
-	_, err := find.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), find, input)
 	if err == nil {
 		t.Fatal("expected error for invalid glob")
 	}
@@ -550,7 +550,7 @@ func TestFindFilesTool_PathTraversalRejected(t *testing.T) {
 	}
 	find := FindFilesTool(mock)
 	input, _ := json.Marshal(map[string]any{"name": "*.go", "path": "../../etc"})
-	_, err := find.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), find, input)
 	if err == nil {
 		t.Fatal("expected resolve-path error")
 	}
@@ -564,14 +564,14 @@ func TestFindFilesTool_MaxResultsValidation(t *testing.T) {
 
 	// Below the minimum.
 	input, _ := json.Marshal(map[string]any{"name": "*.go", "max_results": 0})
-	_, err := find.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), find, input)
 	if err == nil || !strings.Contains(err.Error(), "max_results must be >=") {
 		t.Errorf("expected lower-bound error, got %v", err)
 	}
 
 	// Above the maximum.
 	input, _ = json.Marshal(map[string]any{"name": "*.go", "max_results": 5000})
-	_, err = find.Handler(context.Background(), input)
+	_, err = invokeText(context.Background(), find, input)
 	if err == nil || !strings.Contains(err.Error(), "max_results must be <=") {
 		t.Errorf("expected upper-bound error, got %v", err)
 	}
@@ -582,13 +582,13 @@ func TestGrepFilesTool_MaxResultsValidation(t *testing.T) {
 	grep := GrepFilesTool(&fsExecutor{root: t.TempDir()})
 
 	input, _ := json.Marshal(map[string]any{"pattern": "x", "max_results": 0})
-	_, err := grep.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), grep, input)
 	if err == nil || !strings.Contains(err.Error(), "max_results must be >=") {
 		t.Errorf("expected lower-bound error, got %v", err)
 	}
 
 	input, _ = json.Marshal(map[string]any{"pattern": "x", "max_results": 5000})
-	_, err = grep.Handler(context.Background(), input)
+	_, err = invokeText(context.Background(), grep, input)
 	if err == nil || !strings.Contains(err.Error(), "max_results must be <=") {
 		t.Errorf("expected upper-bound error, got %v", err)
 	}
@@ -597,7 +597,7 @@ func TestGrepFilesTool_MaxResultsValidation(t *testing.T) {
 func TestGrepFilesTool_EmptyPattern(t *testing.T) {
 	grep := GrepFilesTool(&fsExecutor{root: t.TempDir()})
 	input, _ := json.Marshal(map[string]any{"pattern": ""})
-	_, err := grep.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), grep, input)
 	if err == nil || !strings.Contains(err.Error(), "pattern is required") {
 		t.Errorf("expected pattern-required error, got %v", err)
 	}
@@ -629,7 +629,7 @@ func TestFindFilesTool_SchemaBasenameSemantics(t *testing.T) {
 func TestFindFilesTool_EmptyName(t *testing.T) {
 	find := FindFilesTool(&fsExecutor{root: t.TempDir()})
 	input, _ := json.Marshal(map[string]any{"name": ""})
-	_, err := find.Handler(context.Background(), input)
+	_, err := invokeText(context.Background(), find, input)
 	if err == nil || !strings.Contains(err.Error(), "name is required") {
 		t.Errorf("expected name-required error, got %v", err)
 	}
@@ -647,7 +647,7 @@ func TestGrepFilesTool_RipgrepNoMatches(t *testing.T) {
 	}
 	grep := GrepFilesTool(fe)
 	input, _ := json.Marshal(map[string]any{"pattern": "absent"})
-	out, err := grep.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), grep, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -733,7 +733,7 @@ func TestFindFilesTool_DoubleStarGlob(t *testing.T) {
 		"name":    "*.go",
 		"include": []string{"pkg/**"},
 	})
-	out, err := find.Handler(context.Background(), input)
+	out, err := invokeText(context.Background(), find, input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/harness/internal/tool/builtins/search_test.go
+++ b/harness/internal/tool/builtins/search_test.go
@@ -289,7 +289,10 @@ func TestGrepFilesTool_RipgrepPathSelected(t *testing.T) {
 		canExec: true,
 		execFn: func(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error) {
 			capturedCmd = command
-			return &executor.ExecResult{ExitCode: 0, Stdout: "x.go:1:hit\n"}, nil
+			return &executor.ExecResult{
+				ExitCode: 0,
+				Stdout:   `{"type":"match","data":{"path":{"text":"x.go"},"lines":{"text":"hit\n"},"line_number":1}}` + "\n",
+			}, nil
 		},
 	}
 	grep := GrepFilesTool(fe)
@@ -305,8 +308,13 @@ func TestGrepFilesTool_RipgrepPathSelected(t *testing.T) {
 	if !strings.HasPrefix(capturedCmd, "rg ") {
 		t.Errorf("expected rg command, got %q", capturedCmd)
 	}
-	if !strings.Contains(out, "x.go:1:hit") {
-		t.Errorf("expected rg stdout in result, got %q", out)
+	if !strings.Contains(capturedCmd, "--json") {
+		t.Errorf("expected --json in rg invocation, got %q", capturedCmd)
+	}
+	// The rendered text is reconstructed from the JSON fields and must match
+	// the historical "path:line:text" form byte-for-byte.
+	if out != "x.go:1:hit" {
+		t.Errorf("expected reconstructed rg text 'x.go:1:hit', got %q", out)
 	}
 	// Each include glob must be passed to rg as --glob 'pattern' and each
 	// exclude glob as --glob '!pattern' — the two for-loops in

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -40,51 +40,72 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       runCommandSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
-		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
 			var params struct {
 				Command string `json:"command"`
 				Timeout *int   `json:"timeout"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", fmt.Errorf("parse input: %w", err)
+				return "", nil, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Command == "" {
-				return "", fmt.Errorf("command is required")
+				return "", nil, fmt.Errorf("command is required")
 			}
 
-			timeout := 30 * time.Second
+			timeoutSeconds := 30
 			if params.Timeout != nil {
-				t := *params.Timeout
-				if t <= 0 {
-					t = 30
+				timeoutSeconds = *params.Timeout
+				if timeoutSeconds <= 0 {
+					timeoutSeconds = 30
 				}
-				if t > 300 {
-					t = 300
+				if timeoutSeconds > 300 {
+					timeoutSeconds = 300
 				}
-				timeout = time.Duration(t) * time.Second
 			}
+			timeout := time.Duration(timeoutSeconds) * time.Second
 
 			result, err := exec.Exec(ctx, params.Command, timeout)
 			if err != nil {
-				return "", err
+				return "", nil, err
 			}
 
-			var out strings.Builder
-			if result.Stdout != "" {
-				out.WriteString(result.Stdout)
-			}
-			if result.Stderr != "" {
-				if out.Len() > 0 {
-					out.WriteString("\n")
-				}
-				out.WriteString("STDERR:\n")
-				out.WriteString(result.Stderr)
-			}
-			if result.ExitCode != 0 {
-				fmt.Fprintf(&out, "\n[exit code: %d]", result.ExitCode)
+			structured, marshalErr := json.Marshal(commandResult{
+				Stdout:   result.Stdout,
+				Stderr:   result.Stderr,
+				ExitCode: result.ExitCode,
+				// A timeout surfaces as the err above, so a result reaching
+				// here always completed within the bound.
+				TimedOut:       false,
+				TimeoutSeconds: timeoutSeconds,
+			})
+			if marshalErr != nil {
+				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
 			}
 
-			return out.String(), nil
+			return formatRunCommand(result.Stdout, result.Stderr, result.ExitCode), structured, nil
 		},
 	}
+}
+
+// formatRunCommand renders the canonical text output for run_command:
+// stdout, then a "STDERR:" block when stderr is non-empty, then a
+// "[exit code: N]" line when the command exited non-zero. This is the
+// text fallback every provider can accept and must stay byte-identical to
+// the pre-#231 rendering.
+func formatRunCommand(stdout, stderr string, exitCode int) string {
+	var out strings.Builder
+	if stdout != "" {
+		out.WriteString(stdout)
+	}
+	if stderr != "" {
+		if out.Len() > 0 {
+			out.WriteString("\n")
+		}
+		out.WriteString("STDERR:\n")
+		out.WriteString(stderr)
+	}
+	if exitCode != 0 {
+		fmt.Fprintf(&out, "\n[exit code: %d]", exitCode)
+	}
+	return out.String()
 }

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -40,16 +40,16 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 		InputSchema:       runCommandSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
-		StructuredHandler: func(ctx context.Context, input json.RawMessage) (string, json.RawMessage, error) {
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
 			var params struct {
 				Command string `json:"command"`
 				Timeout *int   `json:"timeout"`
 			}
 			if err := json.Unmarshal(input, &params); err != nil {
-				return "", nil, fmt.Errorf("parse input: %w", err)
+				return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
 			}
 			if params.Command == "" {
-				return "", nil, fmt.Errorf("command is required")
+				return tool.StructuredResult{}, fmt.Errorf("command is required")
 			}
 
 			timeoutSeconds := 30
@@ -66,7 +66,7 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 
 			result, err := exec.Exec(ctx, params.Command, timeout)
 			if err != nil {
-				return "", nil, err
+				return tool.StructuredResult{}, err
 			}
 
 			structured, marshalErr := json.Marshal(commandResult{
@@ -79,10 +79,14 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 				TimeoutSeconds: timeoutSeconds,
 			})
 			if marshalErr != nil {
-				return "", nil, fmt.Errorf("marshal structured result: %w", marshalErr)
+				return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
 			}
 
-			return formatRunCommand(result.Stdout, result.Stderr, result.ExitCode), structured, nil
+			return tool.StructuredResult{
+				Text:       formatRunCommand(result.Stdout, result.Stderr, result.ExitCode),
+				Structured: structured,
+				Kind:       kindCommandResult,
+			}, nil
 		},
 	}
 }

--- a/harness/internal/tool/builtins/structured.go
+++ b/harness/internal/tool/builtins/structured.go
@@ -8,6 +8,17 @@ package builtins
 // already produced is unchanged and remains the canonical fallback; these
 // structs are purely additive.
 
+// Kind discriminators identify which struct a ToolResult.Structured payload
+// carries (issue #231). B2's MCP bridge and provider adapters route by these
+// stable values rather than JSON-sniffing the payload, which would violate the
+// typed-not-`any` rule. Each StructuredHandler returns the matching kind.
+const (
+	kindCommandResult = "command_result"
+	kindSearchResult  = "search_result"
+	kindFindResult    = "find_result"
+	kindFileExcerpt   = "file_excerpt"
+)
+
 // commandResult is the structured payload for run_command. timedOut reports
 // whether the command was killed by its timeout; in the current executor
 // contract a timeout surfaces as a handler error before the structured payload

--- a/harness/internal/tool/builtins/structured.go
+++ b/harness/internal/tool/builtins/structured.go
@@ -1,0 +1,67 @@
+package builtins
+
+// The structured result types in this file are the typed envelopes built-in
+// tools marshal into ToolResult.Structured (issue #231). They are deliberately
+// concrete Go structs rather than map[string]any: the project's no-`any` rule
+// (wave-2 design D13) requires every structured producer to declare its shape
+// so the JSON contract is reviewable and stable. The text rendering each tool
+// already produced is unchanged and remains the canonical fallback; these
+// structs are purely additive.
+
+// commandResult is the structured payload for run_command. timedOut reports
+// whether the command was killed by its timeout; in the current executor
+// contract a timeout surfaces as a handler error before the structured payload
+// is built, so on the success path timedOut is always false and timeoutSeconds
+// records the bound that was in effect. The field is retained so a future
+// executor that returns partial output on timeout can populate it without a
+// schema change.
+type commandResult struct {
+	Stdout         string `json:"stdout"`
+	Stderr         string `json:"stderr"`
+	ExitCode       int    `json:"exit_code"`
+	TimedOut       bool   `json:"timed_out"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+// searchMatch is a single hit from grep_files. Column is 1-indexed and present
+// only when the search path can report it; the byte-offset is omitted (column
+// 0) for the Go-native walker and the rg path, neither of which currently
+// emits column information. Text is the full matched line, verbatim.
+type searchMatch struct {
+	Path   string `json:"path"`
+	Line   int    `json:"line"`
+	Column int    `json:"column,omitempty"`
+	Text   string `json:"text"`
+}
+
+// searchResult is the structured payload for grep_files: the ordered list of
+// matches and whether the result was capped by max_results. Matches is an
+// empty (non-nil) slice when there were no hits so the JSON always carries a
+// "matches" array rather than null.
+type searchResult struct {
+	Matches   []searchMatch `json:"matches"`
+	Truncated bool          `json:"truncated"`
+}
+
+// findResult is the structured payload for find_files: the ordered list of
+// workspace-relative paths and whether the result was capped by max_results.
+type findResult struct {
+	Paths     []string `json:"paths"`
+	Truncated bool     `json:"truncated"`
+}
+
+// fileExcerpt is the structured payload for read_file. StartLine and EndLine
+// are 1-indexed and inclusive, matching the line numbers in the text
+// rendering. Truncated reports whether the file had more lines than the
+// returned window (start_line+limit did not reach end of file). Lines holds
+// the excerpt content without the line-number prefixes the text rendering
+// adds. PastEOF is set when start_line was beyond the end of the file, in
+// which case Lines is empty and the text rendering is the past-EOF notice.
+type fileExcerpt struct {
+	Path      string   `json:"path"`
+	StartLine int      `json:"start_line"`
+	EndLine   int      `json:"end_line"`
+	Truncated bool     `json:"truncated"`
+	PastEOF   bool     `json:"past_eof,omitempty"`
+	Lines     []string `json:"lines"`
+}

--- a/harness/internal/tool/builtins/structured_test.go
+++ b/harness/internal/tool/builtins/structured_test.go
@@ -1,0 +1,245 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+)
+
+// These tests cover issue #231 B1: every structured built-in must populate a
+// correct, typed structured payload AND leave the text fallback byte-identical
+// to the pre-#231 rendering.
+
+func TestRunCommandTool_StructuredAndText(t *testing.T) {
+	mock := &mockExecutor{
+		execFunc: func(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error) {
+			return &executor.ExecResult{ExitCode: 3, Stdout: "out-data", Stderr: "err-data"}, nil
+		},
+	}
+	runTool := RunCommandTool(mock)
+	if runTool.StructuredHandler == nil {
+		t.Fatal("run_command must expose a StructuredHandler")
+	}
+
+	input, _ := json.Marshal(map[string]any{"command": "go test ./...", "timeout": 120})
+	text, structured, err := runTool.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Text fallback must match the legacy concatenation exactly.
+	wantText := "out-data\nSTDERR:\nerr-data\n[exit code: 3]"
+	if text != wantText {
+		t.Errorf("text mismatch\n got: %q\nwant: %q", text, wantText)
+	}
+
+	var got commandResult
+	if err := json.Unmarshal(structured, &got); err != nil {
+		t.Fatalf("structured payload is not a commandResult: %v\nraw: %s", err, structured)
+	}
+	want := commandResult{Stdout: "out-data", Stderr: "err-data", ExitCode: 3, TimedOut: false, TimeoutSeconds: 120}
+	if got != want {
+		t.Errorf("structured mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestReadFileTool_StructuredAndText(t *testing.T) {
+	mock := &mockExecutor{
+		readFileFunc: func(ctx context.Context, path string) (string, error) {
+			return "one\ntwo\nthree\nfour\nfive\n", nil
+		},
+	}
+	readTool := ReadFileTool(mock)
+	if readTool.StructuredHandler == nil {
+		t.Fatal("read_file must expose a StructuredHandler")
+	}
+
+	input, _ := json.Marshal(map[string]any{"path": "f.go", "start_line": 2, "limit": 2})
+	text, structured, err := readTool.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Text fallback must remain the line-numbered rendering.
+	if want := "2\ttwo\n3\tthree"; text != want {
+		t.Errorf("text mismatch\n got: %q\nwant: %q", text, want)
+	}
+
+	var got fileExcerpt
+	if err := json.Unmarshal(structured, &got); err != nil {
+		t.Fatalf("structured payload is not a fileExcerpt: %v\nraw: %s", err, structured)
+	}
+	if got.Path != "f.go" || got.StartLine != 2 || got.EndLine != 3 {
+		t.Errorf("window mismatch: %+v", got)
+	}
+	if !got.Truncated {
+		t.Errorf("expected truncated=true: a 5-line file read with a 2-line window stops short of EOF")
+	}
+	if want := []string{"two", "three"}; !equalStrings(got.Lines, want) {
+		t.Errorf("lines mismatch\n got: %v\nwant: %v", got.Lines, want)
+	}
+}
+
+func TestReadFileTool_StructuredPastEOF(t *testing.T) {
+	mock := &mockExecutor{
+		readFileFunc: func(ctx context.Context, path string) (string, error) {
+			return "only one line\n", nil
+		},
+	}
+	readTool := ReadFileTool(mock)
+
+	input, _ := json.Marshal(map[string]any{"path": "f.txt", "start_line": 500})
+	_, structured, err := readTool.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("expected non-error for past-EOF, got %v", err)
+	}
+	var got fileExcerpt
+	if err := json.Unmarshal(structured, &got); err != nil {
+		t.Fatalf("structured payload is not a fileExcerpt: %v", err)
+	}
+	if !got.PastEOF || len(got.Lines) != 0 {
+		t.Errorf("expected past_eof with empty lines, got: %+v", got)
+	}
+}
+
+func TestGrepFilesTool_StructuredMatches(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("alpha needle\nplain\nneedle again\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	grep := GrepFilesTool(&fsExecutor{root: dir})
+	if grep.StructuredHandler == nil {
+		t.Fatal("grep_files must expose a StructuredHandler")
+	}
+
+	input, _ := json.Marshal(map[string]any{"pattern": "needle"})
+	text, structured, err := grep.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got searchResult
+	if err := json.Unmarshal(structured, &got); err != nil {
+		t.Fatalf("structured payload is not a searchResult: %v\nraw: %s", err, structured)
+	}
+	if len(got.Matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d (%+v)", len(got.Matches), got.Matches)
+	}
+	// Structured matches must agree with the text rendering line for line.
+	for _, m := range got.Matches {
+		if m.Path != "a.go" {
+			t.Errorf("unexpected path %q", m.Path)
+		}
+		if m.Text == "" || m.Line == 0 {
+			t.Errorf("match missing line/text: %+v", m)
+		}
+	}
+	if got.Matches[0].Line != 1 || got.Matches[0].Text != "alpha needle" {
+		t.Errorf("first match wrong: %+v", got.Matches[0])
+	}
+	if got.Matches[1].Line != 3 || got.Matches[1].Text != "needle again" {
+		t.Errorf("second match wrong: %+v", got.Matches[1])
+	}
+	if got.Truncated {
+		t.Errorf("did not expect truncation for 2 matches under the default cap")
+	}
+	// The text rendering is the canonical "path:line:match" form.
+	if want := "a.go:1:alpha needle\na.go:3:needle again"; text != want {
+		t.Errorf("text mismatch\n got: %q\nwant: %q", text, want)
+	}
+}
+
+func TestGrepFilesTool_StructuredNoMatches(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("nothing here\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	grep := GrepFilesTool(&fsExecutor{root: dir})
+
+	input, _ := json.Marshal(map[string]any{"pattern": "absent_pattern"})
+	text, structured, err := grep.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text != noMatchesText {
+		t.Errorf("expected no-matches sentinel, got %q", text)
+	}
+	var got searchResult
+	if err := json.Unmarshal(structured, &got); err != nil {
+		t.Fatalf("structured payload is not a searchResult: %v", err)
+	}
+	if got.Matches == nil {
+		t.Error("matches must be an empty array, not null")
+	}
+	if len(got.Matches) != 0 {
+		t.Errorf("expected zero matches, got %+v", got.Matches)
+	}
+}
+
+func TestGrepFilesTool_StructuredTruncated(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("hit one\nhit two\nhit three\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	grep := GrepFilesTool(&fsExecutor{root: dir})
+
+	input, _ := json.Marshal(map[string]any{"pattern": "hit", "max_results": 2})
+	_, structured, err := grep.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got searchResult
+	if err := json.Unmarshal(structured, &got); err != nil {
+		t.Fatalf("structured payload is not a searchResult: %v", err)
+	}
+	if len(got.Matches) != 2 || !got.Truncated {
+		t.Errorf("expected 2 matches with truncated=true, got %d matches truncated=%v", len(got.Matches), got.Truncated)
+	}
+}
+
+func TestFindFilesTool_StructuredPaths(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"one.go", "two.go", "skip.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+	}
+	find := FindFilesTool(&fsExecutor{root: dir})
+	if find.StructuredHandler == nil {
+		t.Fatal("find_files must expose a StructuredHandler")
+	}
+
+	input, _ := json.Marshal(map[string]any{"name": "*.go"})
+	text, structured, err := find.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got findResult
+	if err := json.Unmarshal(structured, &got); err != nil {
+		t.Fatalf("structured payload is not a findResult: %v\nraw: %s", err, structured)
+	}
+	if len(got.Paths) != 2 {
+		t.Errorf("expected 2 paths, got %v", got.Paths)
+	}
+	// The structured paths must be exactly the lines of the text rendering.
+	if want := parseFindPaths(text); !equalStrings(got.Paths, want) {
+		t.Errorf("structured paths diverge from text\n got: %v\ntext: %v", got.Paths, want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/harness/internal/tool/builtins/structured_test.go
+++ b/harness/internal/tool/builtins/structured_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,8 +13,8 @@ import (
 )
 
 // These tests cover issue #231 B1: every structured built-in must populate a
-// correct, typed structured payload AND leave the text fallback byte-identical
-// to the pre-#231 rendering.
+// correct, typed structured payload with the right Kind discriminator AND leave
+// the text fallback byte-identical to the pre-#231 rendering.
 
 func TestRunCommandTool_StructuredAndText(t *testing.T) {
 	mock := &mockExecutor{
@@ -27,24 +28,51 @@ func TestRunCommandTool_StructuredAndText(t *testing.T) {
 	}
 
 	input, _ := json.Marshal(map[string]any{"command": "go test ./...", "timeout": 120})
-	text, structured, err := runTool.StructuredHandler(context.Background(), input)
+	res, err := runTool.StructuredHandler(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Kind != "command_result" {
+		t.Errorf("expected kind command_result, got %q", res.Kind)
 	}
 
 	// Text fallback must match the legacy concatenation exactly.
 	wantText := "out-data\nSTDERR:\nerr-data\n[exit code: 3]"
-	if text != wantText {
-		t.Errorf("text mismatch\n got: %q\nwant: %q", text, wantText)
+	if res.Text != wantText {
+		t.Errorf("text mismatch\n got: %q\nwant: %q", res.Text, wantText)
 	}
 
 	var got commandResult
-	if err := json.Unmarshal(structured, &got); err != nil {
-		t.Fatalf("structured payload is not a commandResult: %v\nraw: %s", err, structured)
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a commandResult: %v\nraw: %s", err, res.Structured)
 	}
 	want := commandResult{Stdout: "out-data", Stderr: "err-data", ExitCode: 3, TimedOut: false, TimeoutSeconds: 120}
 	if got != want {
 		t.Errorf("structured mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestRunCommandTool_StructuredDefaultTimeout exercises the params.Timeout==nil
+// branch (R2): omitting timeout must default TimeoutSeconds to 30.
+func TestRunCommandTool_StructuredDefaultTimeout(t *testing.T) {
+	mock := &mockExecutor{
+		execFunc: func(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error) {
+			return &executor.ExecResult{ExitCode: 0, Stdout: "ok"}, nil
+		},
+	}
+	runTool := RunCommandTool(mock)
+
+	input, _ := json.Marshal(map[string]any{"command": "ls"})
+	res, err := runTool.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got commandResult
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a commandResult: %v", err)
+	}
+	if got.TimeoutSeconds != 30 {
+		t.Errorf("expected default TimeoutSeconds 30, got %d", got.TimeoutSeconds)
 	}
 }
 
@@ -60,19 +88,22 @@ func TestReadFileTool_StructuredAndText(t *testing.T) {
 	}
 
 	input, _ := json.Marshal(map[string]any{"path": "f.go", "start_line": 2, "limit": 2})
-	text, structured, err := readTool.StructuredHandler(context.Background(), input)
+	res, err := readTool.StructuredHandler(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if res.Kind != "file_excerpt" {
+		t.Errorf("expected kind file_excerpt, got %q", res.Kind)
+	}
 
 	// Text fallback must remain the line-numbered rendering.
-	if want := "2\ttwo\n3\tthree"; text != want {
-		t.Errorf("text mismatch\n got: %q\nwant: %q", text, want)
+	if want := "2\ttwo\n3\tthree"; res.Text != want {
+		t.Errorf("text mismatch\n got: %q\nwant: %q", res.Text, want)
 	}
 
 	var got fileExcerpt
-	if err := json.Unmarshal(structured, &got); err != nil {
-		t.Fatalf("structured payload is not a fileExcerpt: %v\nraw: %s", err, structured)
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a fileExcerpt: %v\nraw: %s", err, res.Structured)
 	}
 	if got.Path != "f.go" || got.StartLine != 2 || got.EndLine != 3 {
 		t.Errorf("window mismatch: %+v", got)
@@ -94,12 +125,12 @@ func TestReadFileTool_StructuredPastEOF(t *testing.T) {
 	readTool := ReadFileTool(mock)
 
 	input, _ := json.Marshal(map[string]any{"path": "f.txt", "start_line": 500})
-	_, structured, err := readTool.StructuredHandler(context.Background(), input)
+	res, err := readTool.StructuredHandler(context.Background(), input)
 	if err != nil {
 		t.Fatalf("expected non-error for past-EOF, got %v", err)
 	}
 	var got fileExcerpt
-	if err := json.Unmarshal(structured, &got); err != nil {
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
 		t.Fatalf("structured payload is not a fileExcerpt: %v", err)
 	}
 	if !got.PastEOF || len(got.Lines) != 0 {
@@ -108,6 +139,7 @@ func TestReadFileTool_StructuredPastEOF(t *testing.T) {
 }
 
 func TestGrepFilesTool_StructuredMatches(t *testing.T) {
+	withRipgrepProbe(t, false) // force the Go-native walker for determinism
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("alpha needle\nplain\nneedle again\n"), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
@@ -118,43 +150,78 @@ func TestGrepFilesTool_StructuredMatches(t *testing.T) {
 	}
 
 	input, _ := json.Marshal(map[string]any{"pattern": "needle"})
-	text, structured, err := grep.StructuredHandler(context.Background(), input)
+	res, err := grep.StructuredHandler(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if res.Kind != "search_result" {
+		t.Errorf("expected kind search_result, got %q", res.Kind)
+	}
 
 	var got searchResult
-	if err := json.Unmarshal(structured, &got); err != nil {
-		t.Fatalf("structured payload is not a searchResult: %v\nraw: %s", err, structured)
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a searchResult: %v\nraw: %s", err, res.Structured)
 	}
 	if len(got.Matches) != 2 {
 		t.Fatalf("expected 2 matches, got %d (%+v)", len(got.Matches), got.Matches)
 	}
-	// Structured matches must agree with the text rendering line for line.
-	for _, m := range got.Matches {
-		if m.Path != "a.go" {
-			t.Errorf("unexpected path %q", m.Path)
-		}
-		if m.Text == "" || m.Line == 0 {
-			t.Errorf("match missing line/text: %+v", m)
-		}
-	}
-	if got.Matches[0].Line != 1 || got.Matches[0].Text != "alpha needle" {
+	if got.Matches[0] != (searchMatch{Path: "a.go", Line: 1, Text: "alpha needle"}) {
 		t.Errorf("first match wrong: %+v", got.Matches[0])
 	}
-	if got.Matches[1].Line != 3 || got.Matches[1].Text != "needle again" {
+	if got.Matches[1] != (searchMatch{Path: "a.go", Line: 3, Text: "needle again"}) {
 		t.Errorf("second match wrong: %+v", got.Matches[1])
 	}
 	if got.Truncated {
 		t.Errorf("did not expect truncation for 2 matches under the default cap")
 	}
 	// The text rendering is the canonical "path:line:match" form.
-	if want := "a.go:1:alpha needle\na.go:3:needle again"; text != want {
-		t.Errorf("text mismatch\n got: %q\nwant: %q", text, want)
+	if want := "a.go:1:alpha needle\na.go:3:needle again"; res.Text != want {
+		t.Errorf("text mismatch\n got: %q\nwant: %q", res.Text, want)
+	}
+}
+
+// TestGrepFilesTool_ColonInPathAndText is the [B1] regression: a path AND a
+// matched line that both contain colons must round-trip into searchMatch
+// fields exactly, with the rendered text still byte-identical. The old
+// re-parse-the-text approach silently dropped or corrupted such matches.
+func TestGrepFilesTool_ColonInPathAndText(t *testing.T) {
+	withRipgrepProbe(t, false) // exercise the native walker explicitly
+	dir := t.TempDir()
+	// A subdirectory whose name contains a colon (legal on Linux/macOS).
+	sub := filepath.Join(dir, "a:b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir colon dir: %v", err)
+	}
+	// The matched line also contains colons.
+	if err := os.WriteFile(filepath.Join(sub, "c.go"), []byte("key: needle: value\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	grep := GrepFilesTool(&fsExecutor{root: dir})
+
+	input, _ := json.Marshal(map[string]any{"pattern": "needle"})
+	res, err := grep.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got searchResult
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a searchResult: %v", err)
+	}
+	if len(got.Matches) != 1 {
+		t.Fatalf("colon-bearing match was dropped: got %d matches (%+v)", len(got.Matches), got.Matches)
+	}
+	want := searchMatch{Path: filepath.Join("a:b", "c.go"), Line: 1, Text: "key: needle: value"}
+	if got.Matches[0] != want {
+		t.Errorf("colon match corrupted\n got: %+v\nwant: %+v", got.Matches[0], want)
+	}
+	// Text rendering must still be the exact "path:line:text" form.
+	if wantText := want.Path + ":1:key: needle: value"; res.Text != wantText {
+		t.Errorf("text mismatch\n got: %q\nwant: %q", res.Text, wantText)
 	}
 }
 
 func TestGrepFilesTool_StructuredNoMatches(t *testing.T) {
+	withRipgrepProbe(t, false)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("nothing here\n"), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
@@ -162,15 +229,15 @@ func TestGrepFilesTool_StructuredNoMatches(t *testing.T) {
 	grep := GrepFilesTool(&fsExecutor{root: dir})
 
 	input, _ := json.Marshal(map[string]any{"pattern": "absent_pattern"})
-	text, structured, err := grep.StructuredHandler(context.Background(), input)
+	res, err := grep.StructuredHandler(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if text != noMatchesText {
-		t.Errorf("expected no-matches sentinel, got %q", text)
+	if res.Text != noMatchesText {
+		t.Errorf("expected no-matches sentinel, got %q", res.Text)
 	}
 	var got searchResult
-	if err := json.Unmarshal(structured, &got); err != nil {
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
 		t.Fatalf("structured payload is not a searchResult: %v", err)
 	}
 	if got.Matches == nil {
@@ -182,6 +249,7 @@ func TestGrepFilesTool_StructuredNoMatches(t *testing.T) {
 }
 
 func TestGrepFilesTool_StructuredTruncated(t *testing.T) {
+	withRipgrepProbe(t, false)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("hit one\nhit two\nhit three\n"), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
@@ -189,12 +257,12 @@ func TestGrepFilesTool_StructuredTruncated(t *testing.T) {
 	grep := GrepFilesTool(&fsExecutor{root: dir})
 
 	input, _ := json.Marshal(map[string]any{"pattern": "hit", "max_results": 2})
-	_, structured, err := grep.StructuredHandler(context.Background(), input)
+	res, err := grep.StructuredHandler(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var got searchResult
-	if err := json.Unmarshal(structured, &got); err != nil {
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
 		t.Fatalf("structured payload is not a searchResult: %v", err)
 	}
 	if len(got.Matches) != 2 || !got.Truncated {
@@ -215,20 +283,91 @@ func TestFindFilesTool_StructuredPaths(t *testing.T) {
 	}
 
 	input, _ := json.Marshal(map[string]any{"name": "*.go"})
-	text, structured, err := find.StructuredHandler(context.Background(), input)
+	res, err := find.StructuredHandler(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if res.Kind != "find_result" {
+		t.Errorf("expected kind find_result, got %q", res.Kind)
+	}
 	var got findResult
-	if err := json.Unmarshal(structured, &got); err != nil {
-		t.Fatalf("structured payload is not a findResult: %v\nraw: %s", err, structured)
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a findResult: %v\nraw: %s", err, res.Structured)
 	}
 	if len(got.Paths) != 2 {
 		t.Errorf("expected 2 paths, got %v", got.Paths)
 	}
 	// The structured paths must be exactly the lines of the text rendering.
-	if want := parseFindPaths(text); !equalStrings(got.Paths, want) {
-		t.Errorf("structured paths diverge from text\n got: %v\ntext: %v", got.Paths, want)
+	var textLines []string
+	if res.Text != noMatchesText {
+		textLines = strings.Split(res.Text, "\n")
+	}
+	if !equalStrings(got.Paths, textLines) {
+		t.Errorf("structured paths diverge from text\n got: %v\ntext: %v", got.Paths, textLines)
+	}
+}
+
+// TestFindFilesTool_StructuredTruncated (R1): mirror the grep truncation test
+// for find_files.
+func TestFindFilesTool_StructuredTruncated(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"one.go", "two.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+	}
+	find := FindFilesTool(&fsExecutor{root: dir})
+
+	input, _ := json.Marshal(map[string]any{"name": "*.go", "max_results": 1})
+	res, err := find.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got findResult
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a findResult: %v", err)
+	}
+	if len(got.Paths) != 1 || !got.Truncated {
+		t.Errorf("expected 1 path with truncated=true, got %d paths truncated=%v", len(got.Paths), got.Truncated)
+	}
+}
+
+// TestGrepFilesTool_RipgrepJSONPath exercises the rg --json path explicitly via
+// a stubbed executor, asserting matches are built from JSON (not re-parsed
+// text) and that a colon in path/text survives, and that the rendered text is
+// byte-identical to rg's historical "path:line:text" output.
+func TestGrepFilesTool_RipgrepJSONPath(t *testing.T) {
+	withRipgrepProbe(t, true)
+	rgJSON := strings.Join([]string{
+		`{"type":"begin","data":{"path":{"text":"/ws/a:b/c.go"}}}`,
+		`{"type":"match","data":{"path":{"text":"/ws/a:b/c.go"},"lines":{"text":"key: needle: value\n"},"line_number":7}}`,
+		`{"type":"end","data":{"path":{"text":"/ws/a:b/c.go"}}}`,
+		`{"type":"summary","data":{}}`,
+	}, "\n")
+	exec := &fsExecutor{
+		root:    "/ws",
+		canExec: true,
+		execFn: func(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error) {
+			return &executor.ExecResult{ExitCode: 0, Stdout: rgJSON}, nil
+		},
+	}
+	grep := GrepFilesTool(exec)
+
+	input, _ := json.Marshal(map[string]any{"pattern": "needle"})
+	res, err := grep.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got searchResult
+	if err := json.Unmarshal(res.Structured, &got); err != nil {
+		t.Fatalf("structured payload is not a searchResult: %v", err)
+	}
+	want := searchMatch{Path: "/ws/a:b/c.go", Line: 7, Text: "key: needle: value"}
+	if len(got.Matches) != 1 || got.Matches[0] != want {
+		t.Fatalf("rg --json match wrong: %+v", got.Matches)
+	}
+	if wantText := "/ws/a:b/c.go:7:key: needle: value"; res.Text != wantText {
+		t.Errorf("rg text mismatch\n got: %q\nwant: %q", res.Text, wantText)
 	}
 }
 

--- a/harness/internal/tool/tool.go
+++ b/harness/internal/tool/tool.go
@@ -27,6 +27,24 @@ type AsyncDispatch struct {
 	Timeout time.Duration
 }
 
+// StructuredResult is the return value of a StructuredHandler (issue #231). It
+// carries the canonical Text fallback (always populated, identical to what a
+// plain Handler would return) plus an optional typed Structured payload and a
+// Kind discriminator naming the payload's shape.
+//
+// The zero value (empty Text, nil Structured, empty Kind) is a valid
+// "text-only" result; in practice a StructuredHandler always sets Text, and
+// sets Structured+Kind together. Kind lets B2's MCP bridge and provider
+// adapters route the payload by shape without unmarshalling it (which would
+// violate the typed-not-`any` rule). A non-empty Structured with an empty Kind
+// is a producer bug — dispatch does not enforce it, but consumers may treat an
+// unknown/empty kind as opaque.
+type StructuredResult struct {
+	Text       string
+	Structured json.RawMessage
+	Kind       string
+}
+
 // Tool represents a single tool that the model can invoke.
 //
 // WorkspaceMutating and RequiresApproval are deliberately separate flags
@@ -80,13 +98,13 @@ type Tool struct {
 	// StructuredHandler, when non-nil, is preferred over Handler for
 	// synchronous dispatch. It returns the same canonical text the plain
 	// Handler would (so the text fallback is unchanged) plus an optional
-	// typed structured payload marshalled into a json.RawMessage (issue
-	// #231). A nil payload is equivalent to having only Handler set — the
-	// result carries text but no structured envelope. Tool authors must
-	// marshal a typed Go struct into the payload, never a map[string]any
-	// (wave-2 design D13). The dispatch path scrubs the payload on the same
-	// footing as the text before it reaches a persisted trace.
-	StructuredHandler func(ctx context.Context, input json.RawMessage) (text string, structured json.RawMessage, err error)
+	// typed structured payload (issue #231). A zero StructuredResult is
+	// equivalent to having only Handler set — the result carries text but no
+	// structured envelope. Tool authors must marshal a typed Go struct into
+	// the payload, never a map[string]any (wave-2 design D13). The dispatch
+	// path scrubs the payload on the same footing as the text before it
+	// reaches a persisted trace.
+	StructuredHandler func(ctx context.Context, input json.RawMessage) (StructuredResult, error)
 
 	// AsyncHandler, when non-nil, marks the tool as async. The loop calls
 	// it after permission/security checks and uses the returned

--- a/harness/internal/tool/tool.go
+++ b/harness/internal/tool/tool.go
@@ -58,9 +58,11 @@ type AsyncDispatch struct {
 //     per-call timeout. The control plane's response payload becomes the
 //     tool's output; its is_error flag becomes ToolResult.IsError.
 //
-// If both Handler and AsyncHandler are set, the loop prefers AsyncHandler.
-// If neither is set the tool is unusable (Resolve returns it but dispatch
-// will fail with a "tool has no handler" error).
+// For synchronous tools the loop prefers StructuredHandler over Handler when
+// both are set, so a structured-aware tool need not also populate Handler.
+// AsyncHandler takes priority over both. If none of the three is set the tool
+// is unusable (Resolve returns it but dispatch will fail with a "tool has no
+// handler" error).
 //
 // Async tools require a transport that can deliver control-plane responses.
 // Sub-agents run with NullTransport (whose OnControl is a no-op), so an
@@ -74,6 +76,17 @@ type Tool struct {
 	WorkspaceMutating bool
 	RequiresApproval  bool
 	Handler           func(ctx context.Context, input json.RawMessage) (string, error)
+
+	// StructuredHandler, when non-nil, is preferred over Handler for
+	// synchronous dispatch. It returns the same canonical text the plain
+	// Handler would (so the text fallback is unchanged) plus an optional
+	// typed structured payload marshalled into a json.RawMessage (issue
+	// #231). A nil payload is equivalent to having only Handler set — the
+	// result carries text but no structured envelope. Tool authors must
+	// marshal a typed Go struct into the payload, never a map[string]any
+	// (wave-2 design D13). The dispatch path scrubs the payload on the same
+	// footing as the text before it reaches a persisted trace.
+	StructuredHandler func(ctx context.Context, input json.RawMessage) (text string, structured json.RawMessage, err error)
 
 	// AsyncHandler, when non-nil, marks the tool as async. The loop calls
 	// it after permission/security checks and uses the returned

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -257,6 +257,9 @@ func (e *JSONLTraceEmitter) Close() error {
 //     wrapped as a JSON string literal so the on-disk shape stays a
 //     valid json.RawMessage).
 //   - turn.ToolCalls[*].Output (string).
+//   - turn.ToolCalls[*].Structured (raw JSON; scrubbed via scrubRawJSON like
+//     the tool-call Input, since the structured envelope carries the same
+//     untrusted content as Output).
 func scrubTurnRecord(t types.TurnRecord) types.TurnRecord {
 	out := types.TurnRecord{
 		Turn:        t.Turn,
@@ -272,6 +275,12 @@ func scrubTurnRecord(t types.TurnRecord) types.TurnRecord {
 			Output:     security.Scrub(tc.Output),
 			DurationMs: tc.DurationMs,
 			Success:    tc.Success,
+			// The structured payload (issue #231) carries the same
+			// untrusted content as Output — a command transcript or file
+			// excerpt that can hold credentials — so it is scrubbed on the
+			// same footing. scrubRawJSON preserves a valid json.RawMessage
+			// shape on disk even when a secret straddles a JSON token.
+			Structured: scrubRawJSON(tc.Structured),
 		}
 	}
 	return out

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -333,6 +333,13 @@ func scrubContentBlocks(blocks []types.ContentBlock) []types.ContentBlock {
 // boundary breaks a JSON literal), the entire payload is replaced by a
 // JSON string literal carrying the scrubbed text so the on-disk shape
 // stays parseable.
+//
+// Assumes the caller produced the json.RawMessage with encoding/json's default
+// (non-HTML-escaping) marshaller. An HTML-escaping encoder (json.HTMLEscape, or
+// json.Encoder without SetEscapeHTML(false)) would emit `<`, `>`, `&` and
+// U+2028/U+2029 as \uXXXX sequences in the raw byte stream, which can cause a
+// secret regex anchored on those characters to miss. Do not pipe HTMLEscape
+// output through this function.
 func scrubRawJSON(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
 		return raw

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -304,6 +304,47 @@ func TestJSONLTraceEmitter_RecordTurnRecord_Scrubs(t *testing.T) {
 	}
 }
 
+// TestJSONLTraceEmitter_RecordTurnRecord_ScrubsStructured pins the issue #231
+// requirement that the structured tool-result payload is scrubbed on the same
+// footing as the text Output: a command transcript or file excerpt carried in
+// ToolCallRecord.Structured must never reach disk with a secret in the clear.
+func TestJSONLTraceEmitter_RecordTurnRecord_ScrubsStructured(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+
+	emitter.Start("run-scrub-structured", nil)
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 1,
+		ToolCalls: []types.ToolCallRecord{
+			{
+				Name:    "run_command",
+				Input:   json.RawMessage(`{"command":"cat .env"}`),
+				Output:  "redacted in text already",
+				Success: true,
+				Structured: json.RawMessage(
+					`{"stdout":"API_KEY=sk-ant-api03-structuredleak","stderr":"","exit_code":0}`,
+				),
+			},
+		},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	onDisk := buf.String()
+	if strings.Contains(onDisk, "sk-ant-api03-structuredleak") {
+		t.Errorf("scrubber missed secret in structured payload on disk:\n%s", onDisk)
+	}
+	if !strings.Contains(onDisk, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] placeholder proving the structured scrub ran, got:\n%s", onDisk)
+	}
+	// The on-disk structured payload must remain a parseable JSON object,
+	// not a mangled fragment — scrubRawJSON preserves a valid shape.
+	if !strings.Contains(onDisk, `"structured"`) {
+		t.Errorf("expected the structured field to survive scrubbing in the trace, got:\n%s", onDisk)
+	}
+}
+
 // TestJSONLTraceEmitter_PartialStream pins the SIGKILL-safety property:
 // when a run is interrupted between RecordTurnRecord and Finish, the
 // on-disk file is still parseable up to the last completed event.

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -343,6 +343,14 @@ func TestJSONLTraceEmitter_RecordTurnRecord_ScrubsStructured(t *testing.T) {
 	if !strings.Contains(onDisk, `"structured"`) {
 		t.Errorf("expected the structured field to survive scrubbing in the trace, got:\n%s", onDisk)
 	}
+	// R3 guard: scrubRawJSON scrubs the raw byte stream and assumes a
+	// non-HTML-escaping marshaller. None of this fixture's strings contain
+	// HTML-special chars, so no \uXXXX escapes must appear on disk; if a
+	// future change pipes HTMLEscape output through scrubRawJSON this fails,
+	// flagging that secret regexes could miss escaped bytes.
+	if strings.Contains(onDisk, `\u`) {
+		t.Errorf("unexpected \\u escape on disk — an HTML-escaping encoder would defeat raw-byte scrubbing:\n%s", onDisk)
+	}
 }
 
 // TestJSONLTraceEmitter_PartialStream pins the SIGKILL-safety property:

--- a/types/messages.go
+++ b/types/messages.go
@@ -61,10 +61,23 @@ type ToolCall struct {
 }
 
 // ToolResult represents the result of a tool invocation.
+//
+// Content is the canonical text rendering of the result and is always
+// populated — it is the fallback every provider can accept. Structured is
+// an optional, purely additive typed payload (issue #231): producers that
+// can describe their output as stable fields (a command's stdout/stderr/exit
+// code, a search's path/line/text matches, a file excerpt's line window)
+// marshal a typed Go struct into it so downstream consumers can parse the
+// result without re-deriving it from the text. The zero value (nil) means
+// "no structured data", so a text-only result serialises byte-identically to
+// the pre-#231 shape via omitempty. Whether a provider receives Content or
+// Structured on the wire is decided by the provider adapters (issue #231 B2),
+// not here; the harness always keeps Content populated as the safe fallback.
 type ToolResult struct {
-	ToolUseID string `json:"tool_use_id"`
-	Content   string `json:"content"`
-	IsError   bool   `json:"is_error,omitempty"`
+	ToolUseID  string          `json:"tool_use_id"`
+	Content    string          `json:"content"`
+	IsError    bool            `json:"is_error,omitempty"`
+	Structured json.RawMessage `json:"structured,omitempty"`
 }
 
 // Artifact represents a named output produced during a run.

--- a/types/messages.go
+++ b/types/messages.go
@@ -73,11 +73,18 @@ type ToolCall struct {
 // the pre-#231 shape via omitempty. Whether a provider receives Content or
 // Structured on the wire is decided by the provider adapters (issue #231 B2),
 // not here; the harness always keeps Content populated as the safe fallback.
+//
+// Kind names the shape of the Structured payload (e.g. "command_result",
+// "file_excerpt") so B2's provider adapters and MCP bridge can route it by a
+// stable discriminator instead of unmarshalling and sniffing the JSON (which
+// would breach the typed-not-`any` rule). It is empty for text-only results
+// and so omitted from the wire, preserving byte-identical pre-#231 output.
 type ToolResult struct {
 	ToolUseID  string          `json:"tool_use_id"`
 	Content    string          `json:"content"`
 	IsError    bool            `json:"is_error,omitempty"`
 	Structured json.RawMessage `json:"structured,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
 }
 
 // Artifact represents a named output produced during a run.

--- a/types/messages_test.go
+++ b/types/messages_test.go
@@ -1,0 +1,58 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestToolResult_StructuredOmitemptyByteIdentical pins the issue #231
+// invariant that the additive Structured field is invisible on the wire when
+// unset: a text-only ToolResult must serialise byte-for-byte the way it did
+// before the field existed.
+func TestToolResult_StructuredOmitemptyByteIdentical(t *testing.T) {
+	r := ToolResult{ToolUseID: "tu_1", Content: "hello", IsError: false}
+	got, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"tool_use_id":"tu_1","content":"hello"}`
+	if string(got) != want {
+		t.Errorf("text-only ToolResult JSON changed\n got: %s\nwant: %s", got, want)
+	}
+	if strings.Contains(string(got), "structured") {
+		t.Errorf("nil Structured must be omitted, got: %s", got)
+	}
+}
+
+func TestToolResult_StructuredRoundTrip(t *testing.T) {
+	payload := json.RawMessage(`{"exit_code":0,"stdout":"ok"}`)
+	r := ToolResult{ToolUseID: "tu_2", Content: "ok", Structured: payload}
+	raw, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back ToolResult
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Content != "ok" {
+		t.Errorf("text fallback lost: %q", back.Content)
+	}
+	if string(back.Structured) != string(payload) {
+		t.Errorf("structured payload not preserved\n got: %s\nwant: %s", back.Structured, payload)
+	}
+}
+
+// TestToolCallRecord_StructuredOmitempty mirrors the invariant for the trace
+// record so an existing text-only trace line is unchanged.
+func TestToolCallRecord_StructuredOmitempty(t *testing.T) {
+	rec := ToolCallRecord{ID: "id", Name: "read_file", Input: json.RawMessage(`{}`), Output: "x", Success: true}
+	got, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(got), "structured") {
+		t.Errorf("nil Structured must be omitted from ToolCallRecord, got: %s", got)
+	}
+}

--- a/types/messages_test.go
+++ b/types/messages_test.go
@@ -23,11 +23,14 @@ func TestToolResult_StructuredOmitemptyByteIdentical(t *testing.T) {
 	if strings.Contains(string(got), "structured") {
 		t.Errorf("nil Structured must be omitted, got: %s", got)
 	}
+	if strings.Contains(string(got), "kind") {
+		t.Errorf("empty Kind must be omitted, got: %s", got)
+	}
 }
 
 func TestToolResult_StructuredRoundTrip(t *testing.T) {
 	payload := json.RawMessage(`{"exit_code":0,"stdout":"ok"}`)
-	r := ToolResult{ToolUseID: "tu_2", Content: "ok", Structured: payload}
+	r := ToolResult{ToolUseID: "tu_2", Content: "ok", Structured: payload, Kind: "command_result"}
 	raw, err := json.Marshal(r)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -42,6 +45,9 @@ func TestToolResult_StructuredRoundTrip(t *testing.T) {
 	if string(back.Structured) != string(payload) {
 		t.Errorf("structured payload not preserved\n got: %s\nwant: %s", back.Structured, payload)
 	}
+	if back.Kind != "command_result" {
+		t.Errorf("kind not preserved: %q", back.Kind)
+	}
 }
 
 // TestToolCallRecord_StructuredOmitempty mirrors the invariant for the trace
@@ -54,5 +60,8 @@ func TestToolCallRecord_StructuredOmitempty(t *testing.T) {
 	}
 	if strings.Contains(string(got), "structured") {
 		t.Errorf("nil Structured must be omitted from ToolCallRecord, got: %s", got)
+	}
+	if strings.Contains(string(got), "kind") {
+		t.Errorf("empty Kind must be omitted from ToolCallRecord, got: %s", got)
 	}
 }

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -153,6 +153,8 @@ type ModelInput struct {
 // persisted trace. It is scrubbed for secret-shaped content at record time on
 // the same footing as Output — a file excerpt or command transcript captured
 // in the structured payload can contain credentials just as the text can.
+// Kind names the Structured payload's shape (see ToolResult.Kind); empty and
+// omitted for text-only calls.
 type ToolCallRecord struct {
 	ID         string          `json:"id"`
 	Name       string          `json:"name"`
@@ -161,6 +163,7 @@ type ToolCallRecord struct {
 	DurationMs int64           `json:"durationMs"`
 	Success    bool            `json:"success"`
 	Structured json.RawMessage `json:"structured,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
 }
 
 // RunRecording is a full recording of a run.

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -147,6 +147,12 @@ type ModelInput struct {
 }
 
 // ToolCallRecord records a single tool call and its result.
+//
+// Structured carries the optional typed result envelope (issue #231) when the
+// tool produced one; it is nil for text-only tools and so omitted from the
+// persisted trace. It is scrubbed for secret-shaped content at record time on
+// the same footing as Output — a file excerpt or command transcript captured
+// in the structured payload can contain credentials just as the text can.
 type ToolCallRecord struct {
 	ID         string          `json:"id"`
 	Name       string          `json:"name"`
@@ -154,6 +160,7 @@ type ToolCallRecord struct {
 	Output     string          `json:"output"`
 	DurationMs int64           `json:"durationMs"`
 	Success    bool            `json:"success"`
+	Structured json.RawMessage `json:"structured,omitempty"`
 }
 
 // RunRecording is a full recording of a run.


### PR DESCRIPTION
## Summary

First chunk of **Wave 4 / #231** (structured tool results). Adds a structured payload to tool results alongside the existing text, and populates it from the built-in command/search/read tools. The MCP bridge and provider serialization (which decide *when* to send structured vs text) are the next chunk (B2) — **no `mcp/` or `provider/` files are touched here.**

Stacked: `#321` ← `#322` (A1) ← `#323` (A2) ← **B1**. Auto-retargets as lower PRs merge.

## What lands

- **`types.ToolResult` / `types.ToolCallRecord`** gain `Structured json.RawMessage` (`omitempty`) + a `Kind string` discriminator (`omitempty`). Text `Content` is unchanged and remains the canonical fallback; the nil zero-value serializes byte-identically to pre-#231, so every existing text-only result is unaffected.
- **Typed per-tool structs** (no `map[string]any`, per project rule) in `tool/builtins/structured.go`: `commandResult` (stdout/stderr/exit_code/timeout), `searchMatch`+`searchResult`, `findResult`, `fileExcerpt`.
- **Built-ins populate both**: `run_command` → `command_result`, `grep_files` → `search_result`, `find_files` → `find_result`, `read_file` → `file_excerpt`.
- **Dispatch seam**: an optional `Tool.StructuredHandler` returning `(text, structured, err)` (precedence Async > Structured > plain); `dispatchToolCallCategorized` carries a `structuredOutput{payload, kind}` through to both the result and the trace record. All failure paths return a nil payload.
- **Trace scrubbing**: the structured payload passes through `scrubRawJSON` on the same footing as text, so secrets in command output / file excerpts are redacted before persistence (verified across all sinks by the security review).

## Review hardening (post-review remediation)

- **Structured/text agreement is now structural**: search matches are built from **source data** (native walker fields; ripgrep switched to `rg --json`), and the rendered text is derived *from the typed structs* — so a path or match text containing a colon can no longer drop or corrupt a structured match (the prior re-parse-the-text approach did). Byte-identity of rendered output verified against the real `rg` binary incl. CRLF.
- Added the `Kind` discriminator now (one line per handler) so B2's MCP bridge / provider adapters can route payload shapes without JSON-sniffing — retrofitting it after B2 ships serialization would be a coordinated two-chunk schema change.
- `scrubRawJSON` non-HTML-escape assumption pinned by comment + test assertion.

## Test plan

- [x] `just` (build + test) + `just lint` green
- [x] each built-in populates a correct typed structured payload + unchanged text
- [x] colon-in-path/text fixture: structured `Path`/`Line`/`Text` exact (native + `rg --json`)
- [x] nil structured omits the `structured` key (byte-identical to old results)
- [x] secret-shaped string in a structured payload is `[REDACTED]` on disk, field stays valid JSON
- [x] `find_files` truncation + `run_command` default-timeout structured cases
- [ ] consumed by provider serialization + MCP bridge (B2)

Part of #231 (envelope + built-ins). MCP preservation + provider fallback + docs follow in B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)