### PR TITLE
tools: MCP structured preservation + provider serialization + docs (Wave 4 B2, closes #231)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,7 +340,9 @@ preserved verbatim into `Structured`, and every non-text content item
 type) is represented as an explicit typed descriptor — kind, URI,
 mime type, and a bounded text prefix for inlined resources — rather
 than being silently discarded. The envelope's `Kind` is
-`mcp_tool_result`.
+`mcp_tool_result`. MCP `annotations` (audience/priority hints on
+content items per the 2025-06-18 spec) are intentionally not decoded or
+forwarded; they are client-filtering metadata, not model-facing payload.
 
 MCP server output is untrusted, so the preserved structure is bounded
 at the trust boundary: `structuredContent` larger than the size cap is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -280,6 +280,48 @@ Eight built-in tools ship in `harness/internal/tool/builtins/`:
 link-local, multicast), DNS resolution validation, and a 100 KB
 response cap.
 
+### Structured tool results
+
+A `ToolResult` always carries a canonical text rendering in `Content`;
+that text is the fallback every provider can accept and is never
+dropped. Tools that can describe their output as stable fields
+additionally populate an optional typed envelope — `Structured`
+(a `json.RawMessage`) plus a `Kind` discriminator naming the payload's
+shape. The built-in producers emit four shapes: `command_result`
+(`stdout`, `stderr`, `exit_code`, timeout metadata), `search_result`
+(per-match `path`/`line`/`column`/`text`), `find_result`
+(workspace-relative paths), and `file_excerpt` (line window with
+truncation state). Each shape is a concrete Go struct in
+`harness/internal/tool/builtins/structured.go`, not a `map[string]any`,
+so the JSON contract is reviewable and stable.
+
+Whether the structured envelope reaches the model on the wire is a
+per-provider decision, gated by the `StructuredToolResults` capability
+resolved through the [provider-quirks layer](#provider-quirks-layer).
+The capability is a cross-provider concept the loop reasons about
+uniformly even though each family encodes a structured result
+differently:
+
+- **Anthropic** — the Messages API's `tool_result` `content` accepts a
+  content-block array. The adapter emits the canonical text part plus a
+  text part carrying the structured JSON, so the model receives both
+  renderings.
+- **Gemini** — `functionResponse.response` is a free-form JSON object.
+  The adapter embeds the envelope under `structured`/`kind` alongside
+  the canonical `content` key.
+- **OpenAI (Chat Completions and Responses)** — the tool message /
+  `function_call_output` is a plain string on the wire, so these
+  adapters carry no capability and send the text fallback only.
+
+The default is text-only and fail-safe: when the capability is unset or
+false — every provider with no rule, including Bedrock — the adapter
+sends `Content` verbatim and the wire body is byte-identical to the
+pre-structured shape. Structured data is purely additive; an adapter
+that has not opted in never sees it. Trace output includes the
+structured payload, scrubbed on the same footing as the text (the
+secret scrubber runs over `Structured` wherever it appears — the tool
+record and the message history).
+
 ### MCP
 
 The MCP client (`harness/internal/mcp/client.go`) connects to remote
@@ -289,6 +331,26 @@ management. Tool names are namespaced as `mcp_{serverName}_{toolName}`
 to avoid collisions. Tools default to `sideEffects: true`. Connection
 failures log a warning and skip that server's tools rather than
 failing the entire run.
+
+A `tools/call` result is mapped into the
+[structured-result envelope](#structured-tool-results): text content
+becomes the canonical `Content` fallback, `structuredContent` is
+preserved verbatim into `Structured`, and every non-text content item
+(resource link, embedded resource, image, audio, or an unrecognised
+type) is represented as an explicit typed descriptor — kind, URI,
+mime type, and a bounded text prefix for inlined resources — rather
+than being silently discarded. The envelope's `Kind` is
+`mcp_tool_result`.
+
+MCP server output is untrusted, so the preserved structure is bounded
+at the trust boundary: `structuredContent` larger than the size cap is
+dropped (with a marker noting the omission), embedded-resource text is
+truncated to a per-resource limit, and image/audio bytes and binary
+blobs are never inlined — the URI is the durable handle the model uses
+to re-fetch them. The preserved content is not scrubbed in the bridge;
+it rides the same dispatch path as every other tool result, so it
+passes through the secret scrubber before reaching a trace or the model
+history.
 
 ### Provider-facing tool name normalization
 

--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -120,10 +120,37 @@ type ProviderQuirks struct {
     EnumCoercions   map[string]map[string]string // caller value → wire value
     ReplayFields    []string                  // assistant-message paths to preserve (parse-side only in v1)
 
+    // Cross-provider capabilities (top-level, not per-adapter).
+    ToolChoice            ToolChoiceCapability           // native tool_choice support (auto/required/none/named)
+    StructuredToolResults StructuredToolResultCapability // accepts a non-string tool-result payload, and in which shape
+
     // Behaviour flags (per-adapter typed sub-structs).
     BehaviourFlags  ProviderBehaviourFlags
 }
+```
 
+A **capability** is a top-level field rather than a per-adapter
+behaviour flag when it expresses a concept the loop reasons about
+uniformly across families even though each provider encodes it
+differently. `ToolChoice` and `StructuredToolResults` are the two:
+every family has *some* form of tool-choice control and *some*
+notion of (or lack of) a structured tool result, so modelling either
+under one provider's sub-struct would force the other adapters to
+reach across family boundaries to read it, which the behaviour-flag
+ownership rule forbids. Each capability's zero value advertises no
+support, so an adapter resolving a provider with no rule emits the
+pre-capability wire shape — the graceful default the
+`StreamParams`/`ToolResult` contracts require.
+
+`StructuredToolResults` (issue #231) gates whether the structured
+tool-result envelope is serialised onto the wire. The first-party
+rules opt in Anthropic (content-block array form) and Gemini
+(`functionResponse.response` object); OpenAI and any unruled provider
+stay text-only. See the
+[structured tool results](architecture.md#structured-tool-results)
+section of the architecture doc for the per-provider wire shapes.
+
+```go
 type ProviderBehaviourFlags struct {
     OpenAI OpenAIBehaviourFlags
     Gemini GeminiBehaviourFlags

--- a/harness/internal/context/offload.go
+++ b/harness/internal/context/offload.go
@@ -106,6 +106,13 @@ func (o *OffloadToFileStrategy) Prepare(ctx context.Context, messages []types.Me
 					filePath,
 				)
 			}
+			// Drop the structured envelope (issue #231) alongside the
+			// offloaded/truncated text: the structured payload mirrors the
+			// same large output, so retaining it would defeat the offload
+			// it was meant to shrink. The text fallback the model now sees
+			// points at the offload file, which is the authoritative copy.
+			newContent[j].Structured = nil
+			newContent[j].Kind = ""
 			modified = true
 		}
 

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -160,6 +160,10 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	var mcpClient *mcp.Client
 	if len(config.Tools.MCPServers) > 0 {
 		mcpClient = mcp.NewClient(registry, nil)
+		// Wire the logger before Connect so the per-server tool-count cap
+		// warning (emitted during tools/list) reaches operators. Metrics is
+		// field-injected later, after the run's metrics instance exists.
+		mcpClient.Logger = logger
 		ownedClosers = append(ownedClosers, mcpClient)
 		for _, srv := range config.Tools.MCPServers {
 			if err := mcpClient.Connect(ctx, srv, secrets); err != nil {

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -511,10 +511,12 @@ func appendToolResults(messages []types.Message, results []types.ToolResult) []t
 	blocks := make([]types.ContentBlock, len(results))
 	for i, r := range results {
 		blocks[i] = types.ContentBlock{
-			Type:      "tool_result",
-			ToolUseID: r.ToolUseID,
-			Content:   r.Content,
-			IsError:   r.IsError,
+			Type:       "tool_result",
+			ToolUseID:  r.ToolUseID,
+			Content:    r.Content,
+			IsError:    r.IsError,
+			Structured: r.Structured,
+			Kind:       r.Kind,
 		}
 	}
 	return append(messages, types.Message{

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -653,6 +653,12 @@ func estimateCurrentTokens(messages []types.Message) int {
 			total += len(block.ID) / tokenEstimationDivisor
 			total += len(block.Name) / tokenEstimationDivisor
 			total += len(block.ToolUseID) / tokenEstimationDivisor
+			// The structured envelope (issue #231) rides on tool_result
+			// blocks and, for a Gemini object-response result, can be up to
+			// maxMCPStructuredSize; counting it keeps the budget estimate from
+			// under-shooting and triggering a mid-run context overflow. Kind
+			// is a short discriminator and not worth counting.
+			total += len(block.Structured) / tokenEstimationDivisor
 		}
 	}
 	if total == 0 {

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -52,6 +53,18 @@ const maxMCPStructuredSize = 256 * 1024
 // is the durable handle.
 const maxMCPEmbeddedResourceTextLen = 8 * 1024
 
+// maxMCPContentItems caps the number of content items the bridge will
+// process from a single tools/call response before building the non-text
+// descriptor slice. A hostile 10 MB response can pack ~700K minimal items
+// (e.g. {"type":"image"} at ~15 bytes each); iterating them all would grow
+// the NonText slice to tens of megabytes (with slice-doubling overhead)
+// before the final marshalled-size check fires, a transient spike
+// repeatable every tool turn (CWE-789/400). Capping the input count BEFORE
+// the loop bounds the allocation up front. 512 is far above any realistic
+// tool result while keeping the worst-case descriptor slice small; overflow
+// is marked, not silently dropped.
+const maxMCPContentItems = 512
+
 // kindMCPToolResult is the ToolResult.Kind discriminator for the structured
 // envelope the MCP bridge produces. It is distinct from the built-in kinds
 // (command_result, etc.) because an MCP result is a heterogeneous container
@@ -77,11 +90,18 @@ const maxMCPToolNameLen = 128
 // misconfigured servers.
 const maxMCPToolsPerServer = 64
 
-// sanitizeMCPToolName truncates a remote tool name to maxMCPToolNameLen.
-// Returns the input unchanged when it is already within the cap.
+// sanitizeMCPToolName truncates a remote tool name to maxMCPToolNameLen
+// runes. Returns the input unchanged when it is already within the cap.
+//
+// The cap is on runes, not bytes: a byte-slice truncation (s[:128]) could
+// split a multi-byte UTF-8 name mid-codepoint and emit an invalid-UTF-8
+// string, which then becomes both a registry map key and the `tool.name`
+// OTLP attribute on stirrup.mcp.calls — OpenTelemetry SDKs treat invalid
+// attribute values as implementation-defined and may reject the export.
 func sanitizeMCPToolName(s string) string {
-	if len(s) > maxMCPToolNameLen {
-		return s[:maxMCPToolNameLen]
+	runes := []rune(s)
+	if len(runes) > maxMCPToolNameLen {
+		return string(runes[:maxMCPToolNameLen])
 	}
 	return s
 }
@@ -219,8 +239,23 @@ type Client struct {
 	// callers.
 	Metrics *observability.Metrics
 
+	// Logger is optional. When set, the client emits structured warnings for
+	// operator-visible anomalies — notably a server advertising more tools
+	// than maxMCPToolsPerServer (the overflow is dropped). A nil Logger is
+	// safe everywhere; the helper guards it. Field-injected for the same
+	// backwards-compatibility reason as Metrics.
+	Logger *slog.Logger
+
 	mu       sync.Mutex
 	sessions map[string]*serverSession // keyed by server URI
+}
+
+// warn emits a structured warning when a Logger is wired, and is a no-op
+// otherwise. Centralised so call sites do not repeat the nil guard.
+func (c *Client) warn(msg string, args ...any) {
+	if c.Logger != nil {
+		c.Logger.Warn(msg, args...)
+	}
 }
 
 // serverSession holds per-server connection state.
@@ -305,6 +340,11 @@ func (c *Client) Connect(ctx context.Context, config types.MCPServerConfig, secr
 	// can investigate; the first maxMCPToolsPerServer tools are
 	// still usable.
 	if len(tools) > maxMCPToolsPerServer {
+		c.warn("mcp tool count exceeded cap; overflow dropped",
+			"server", config.Name,
+			"registered", maxMCPToolsPerServer,
+			"total", len(tools),
+		)
 		tools = tools[:maxMCPToolsPerServer]
 	}
 
@@ -394,6 +434,12 @@ func (c *Client) callToolInner(ctx context.Context, sess *serverSession, name st
 
 	text := strings.Join(textContentItems(result.Content), "\n")
 	structured := buildMCPStructured(result)
+	// Defence-in-depth: treat a literal JSON null envelope as absent so a
+	// "null" payload can never reach the dispatch path and fabricate a
+	// structured turn (the StructuredHandler keys on len(structured) > 0).
+	if string(structured) == "null" {
+		structured = nil
+	}
 	return text, structured, nil
 }
 
@@ -421,20 +467,38 @@ func textContentItems(items []contentItem) []string {
 func buildMCPStructured(result toolsCallResult) json.RawMessage {
 	env := mcpStructuredResult{}
 
-	// structuredContent: preserve verbatim when present and within bound.
-	if len(result.StructuredContent) > 0 {
-		if len(result.StructuredContent) <= maxMCPStructuredSize {
-			env.StructuredContent = result.StructuredContent
-		} else {
-			// Mark the omission so a reader of the envelope (and the model,
-			// via the descriptor) can tell the server returned structured
-			// content that was too large to retain rather than that there
-			// was none.
-			env.NonText = append(env.NonText, mcpNonTextContent{
-				Kind: "unsupported",
-				Name: "structuredContent dropped: exceeds size bound",
-			})
-		}
+	// Cap the content item count BEFORE the loop so a hostile response cannot
+	// force an unbounded descriptor-slice allocation ahead of the final
+	// marshalled-size check (CWE-789/400). The overflow is marked, not
+	// silently dropped, so an oversized server is visible in the envelope.
+	if len(result.Content) > maxMCPContentItems {
+		result.Content = result.Content[:maxMCPContentItems]
+		env.NonText = append(env.NonText, mcpNonTextContent{
+			Kind: "unsupported",
+			Name: "content items truncated: exceeds item-count bound",
+		})
+	}
+
+	// structuredContent: preserve verbatim when present, non-null, and within
+	// bound. An explicit JSON null is treated as ABSENT — a non-nil
+	// json.RawMessage("null") would otherwise pass the len>0 guard and, since
+	// omitempty does not omit a non-nil slice, serialise "structured_content":null
+	// onto the wire, fabricating a structured turn for a server that signalled
+	// no structured content.
+	switch {
+	case len(result.StructuredContent) == 0 || string(result.StructuredContent) == "null":
+		// Absent: nothing to preserve.
+	case len(result.StructuredContent) <= maxMCPStructuredSize:
+		env.StructuredContent = result.StructuredContent
+	default:
+		// Mark the omission so a reader of the envelope (and the model,
+		// via the descriptor) can tell the server returned structured
+		// content that was too large to retain rather than that there
+		// was none.
+		env.NonText = append(env.NonText, mcpNonTextContent{
+			Kind: "unsupported",
+			Name: "structuredContent dropped: exceeds size bound",
+		})
 	}
 
 	// Non-text content items: represent each explicitly.
@@ -478,8 +542,20 @@ func buildMCPStructured(result toolsCallResult) json.RawMessage {
 		return nil
 	}
 	// Final defence: if the assembled envelope still exceeds the bound (e.g. a
-	// flood of non-text descriptors), drop it. The text content survives.
+	// flood of non-text descriptors that individually passed), replace it with
+	// a marker envelope rather than silently returning nil — the
+	// represent-or-mark contract means a reader can distinguish "no structured
+	// content" from "envelope too large". The text content survives either way.
 	if len(encoded) > maxMCPStructuredSize {
+		fallback := mcpStructuredResult{
+			NonText: []mcpNonTextContent{{
+				Kind: "unsupported",
+				Name: "envelope dropped: assembled size exceeds bound",
+			}},
+		}
+		if fb, err := json.Marshal(fallback); err == nil && len(fb) <= maxMCPStructuredSize {
+			return fb
+		}
 		return nil
 	}
 	return encoded

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -28,6 +28,38 @@ import (
 
 const maxMCPResponseSize = 10 * 1024 * 1024 // 10 MB
 
+// maxMCPStructuredSize bounds the byte size of the structured envelope the
+// bridge preserves from a single tools/call response (the marshalled
+// mcpStructuredResult: structuredContent plus the non-text content
+// descriptors). MCP server output is UNTRUSTED — a hostile or misconfigured
+// server could return a multi-megabyte structuredContent object (still
+// within the 10 MB transport cap) that would then be threaded into every
+// subsequent turn's message history AND the persisted trace, multiplying the
+// memory and storage cost (CWE-400). When the marshalled envelope exceeds
+// this cap the bridge drops the structured payload and keeps only the text
+// content, with a marker noting the omission, so the model still receives a
+// usable result without the harness retaining an unbounded blob. 256 KB is
+// generous for a legitimate structured result while well below the transport
+// ceiling.
+const maxMCPStructuredSize = 256 * 1024
+
+// maxMCPEmbeddedResourceTextLen bounds the inlined text the bridge preserves
+// from a single embedded-resource content item. Embedded resources can carry
+// arbitrarily large text/blob bodies; the bridge records a bounded prefix
+// plus the resource URI/mime so the model knows the resource exists and can
+// re-fetch it, rather than inlining an unbounded (untrusted) body into the
+// envelope. The full body is never required for the model to act — the URI
+// is the durable handle.
+const maxMCPEmbeddedResourceTextLen = 8 * 1024
+
+// kindMCPToolResult is the ToolResult.Kind discriminator for the structured
+// envelope the MCP bridge produces. It is distinct from the built-in kinds
+// (command_result, etc.) because an MCP result is a heterogeneous container
+// (structuredContent + typed descriptors for non-text content) rather than a
+// single built-in shape. Consumers route on this value to know the payload is
+// an mcpStructuredResult.
+const kindMCPToolResult = "mcp_tool_result"
+
 // maxMCPToolNameLen caps the length of a per-tool name as reported by a
 // remote MCP server. mt.Name is taken verbatim from the wire response and
 // becomes a metric attribute (`tool.name`) on stirrup.mcp.calls; an
@@ -91,14 +123,82 @@ type toolsListResult struct {
 	Tools []mcpTool `json:"tools"`
 }
 
+// contentItem is one entry in a tools/call result's content array (MCP spec
+// 2025-06-18 §server/tools). The harness reads `text` for the canonical
+// fallback and the remaining fields to describe non-text content explicitly
+// rather than discarding it. Only the fields the bridge acts on are
+// unmarshalled; unknown fields are ignored.
+//
+//	type=="text"          → Text
+//	type=="image"|"audio" → MimeType (the bytes are not inlined)
+//	type=="resource_link" → URI / Name / MimeType
+//	type=="resource"      → Resource (an embedded resource body)
 type contentItem struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type     string               `json:"type"`
+	Text     string               `json:"text"`
+	MimeType string               `json:"mimeType"`
+	URI      string               `json:"uri"`
+	Name     string               `json:"name"`
+	Resource *mcpEmbeddedResource `json:"resource"`
 }
 
+// mcpEmbeddedResource is the `resource` field of a type=="resource" content
+// item — an inlined resource the server chose to embed in the result. The
+// text/blob body is UNTRUSTED and potentially large; the bridge records a
+// bounded prefix of Text and never inlines Blob (binary), keeping the URI as
+// the durable handle.
+type mcpEmbeddedResource struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text"`
+	Blob     string `json:"blob"`
+}
+
+// toolsCallResult is the tools/call response. StructuredContent is the
+// optional typed object an MCP tool returns when it declares an outputSchema
+// (MCP spec 2025-06-18). It is captured as raw JSON and preserved into the
+// B1 envelope. Meta is ignored beyond decoding tolerance.
 type toolsCallResult struct {
-	Content []contentItem `json:"content"`
-	IsError bool          `json:"isError"`
+	Content           []contentItem   `json:"content"`
+	StructuredContent json.RawMessage `json:"structuredContent"`
+	IsError           bool            `json:"isError"`
+}
+
+// mcpStructuredResult is the typed envelope the bridge marshals into
+// ToolResult.Structured for an MCP tools/call result (issue #231 B2). It is a
+// concrete Go struct, not a map[string]any (wave-2 design D13): StructuredContent
+// carries the server's typed object verbatim (bounded), and NonText explicitly
+// describes every content item the harness does not inline as text, so a
+// resource link / embedded resource / image is REPRESENTED rather than silently
+// dropped. The whole envelope is scrubbed and size-bounded before it reaches a
+// trace or the model history (see callToolStructured).
+type mcpStructuredResult struct {
+	// StructuredContent is the server's structuredContent object, preserved
+	// verbatim when present and within the size bound. Omitted when the
+	// server returned none.
+	StructuredContent json.RawMessage `json:"structured_content,omitempty"`
+
+	// NonText lists a typed descriptor for every non-text content item.
+	// Empty (omitted) when the result was text-only.
+	NonText []mcpNonTextContent `json:"non_text_content,omitempty"`
+}
+
+// mcpNonTextContent is the explicit, marked representation of one non-text
+// content item from a tools/call result. The harness does not forward image
+// or audio bytes or unbounded embedded-resource bodies; instead it records
+// what the item was (Kind), its addressing (URI/MimeType/Name), and — for an
+// embedded text resource — a bounded prefix (Text, with Truncated set when
+// the body was longer). This is the "represent-or-mark, never silently drop"
+// contract from issue #231.
+type mcpNonTextContent struct {
+	// Kind is the MCP content type: "image", "audio", "resource_link",
+	// "resource", or "unsupported" for a type the bridge does not recognise.
+	Kind      string `json:"kind"`
+	URI       string `json:"uri,omitempty"`
+	MimeType  string `json:"mime_type,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Text      string `json:"text,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
 }
 
 // --- Client ---
@@ -242,21 +342,31 @@ func (c *Client) listTools(ctx context.Context, sess *serverSession) ([]mcpTool,
 	return result.Tools, nil
 }
 
-// callTool sends a tools/call JSON-RPC request and returns the text result.
-// It records stirrup.mcp.calls and stirrup.mcp.duration_ms when Metrics is
-// set. The serverName argument is the operator-supplied logical name (used
-// for the server.name attribute) — distinct from sess.uri so dashboards
-// group by intent rather than transport target.
-func (c *Client) callTool(ctx context.Context, sess *serverSession, serverName, name string, arguments json.RawMessage) (string, error) {
+// callTool sends a tools/call JSON-RPC request and returns the canonical
+// text result plus a structured envelope (issue #231 B2). It records
+// stirrup.mcp.calls and stirrup.mcp.duration_ms when Metrics is set. The
+// serverName argument is the operator-supplied logical name (used for the
+// server.name attribute) — distinct from sess.uri so dashboards group by
+// intent rather than transport target.
+//
+// The returned structured envelope is the marshalled mcpStructuredResult or
+// nil for a text-only result. It is NOT scrubbed here: scrubbing happens on
+// the same footing as the text Content in the core dispatch path (the value
+// flows back through tool.StructuredResult → dispatch → trace scrub). Size
+// bounding, however, is enforced here at the trust boundary so an oversized
+// untrusted payload is never materialised into the loop in the first place.
+func (c *Client) callTool(ctx context.Context, sess *serverSession, serverName, name string, arguments json.RawMessage) (string, json.RawMessage, error) {
 	start := time.Now()
-	out, err := c.callToolInner(ctx, sess, name, arguments)
+	text, structured, err := c.callToolInner(ctx, sess, name, arguments)
 	c.recordCall(ctx, serverName, name, err == nil, time.Since(start))
-	return out, err
+	return text, structured, err
 }
 
-// callToolInner is the original tools/call body, factored out so
-// callTool's metric recording wraps both happy and error paths uniformly.
-func (c *Client) callToolInner(ctx context.Context, sess *serverSession, name string, arguments json.RawMessage) (string, error) {
+// callToolInner is the tools/call body, factored out so callTool's metric
+// recording wraps both happy and error paths uniformly. It returns the
+// canonical concatenated text, the bounded structured envelope (nil when the
+// result is text-only), and an error for transport/protocol/tool failures.
+func (c *Client) callToolInner(ctx context.Context, sess *serverSession, name string, arguments json.RawMessage) (string, json.RawMessage, error) {
 	params := struct {
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`
@@ -267,33 +377,139 @@ func (c *Client) callToolInner(ctx context.Context, sess *serverSession, name st
 
 	raw, err := c.call(ctx, sess, "tools/call", params)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	var result toolsCallResult
 	if err := json.Unmarshal(raw, &result); err != nil {
-		return "", fmt.Errorf("decode tools/call result: %w", err)
+		return "", nil, fmt.Errorf("decode tools/call result: %w", err)
 	}
 
 	if result.IsError {
-		// Collect text content items into the error message.
-		var texts []string
-		for _, item := range result.Content {
-			if item.Type == "text" {
-				texts = append(texts, item.Text)
-			}
-		}
-		return "", fmt.Errorf("mcp tool error: %s", strings.Join(texts, "; "))
+		// A tool-reported error surfaces as a Go error built from the text
+		// content; structured content on an error result is not preserved
+		// (the dispatch error path carries no structured payload).
+		return "", nil, fmt.Errorf("mcp tool error: %s", strings.Join(textContentItems(result.Content), "; "))
 	}
 
-	// Concatenate text content items.
+	text := strings.Join(textContentItems(result.Content), "\n")
+	structured := buildMCPStructured(result)
+	return text, structured, nil
+}
+
+// textContentItems collects the Text of every type=="text" content item, in
+// order. This is the canonical text fallback the model always receives,
+// independent of structured support.
+func textContentItems(items []contentItem) []string {
 	var texts []string
-	for _, item := range result.Content {
+	for _, item := range items {
 		if item.Type == "text" {
 			texts = append(texts, item.Text)
 		}
 	}
-	return strings.Join(texts, "\n"), nil
+	return texts
+}
+
+// buildMCPStructured assembles the bounded mcpStructuredResult envelope from a
+// successful tools/call result and returns its marshalled form, or nil when
+// there is nothing structured to preserve. It enforces the untrusted-input
+// size bounds (CWE-400): structuredContent over maxMCPStructuredSize is
+// dropped (with a marker), embedded-resource text is truncated to
+// maxMCPEmbeddedResourceTextLen, and image/audio bytes are never inlined.
+// Non-text content is always represented (never silently discarded) so the
+// model knows the item existed even when the bytes are not forwarded.
+func buildMCPStructured(result toolsCallResult) json.RawMessage {
+	env := mcpStructuredResult{}
+
+	// structuredContent: preserve verbatim when present and within bound.
+	if len(result.StructuredContent) > 0 {
+		if len(result.StructuredContent) <= maxMCPStructuredSize {
+			env.StructuredContent = result.StructuredContent
+		} else {
+			// Mark the omission so a reader of the envelope (and the model,
+			// via the descriptor) can tell the server returned structured
+			// content that was too large to retain rather than that there
+			// was none.
+			env.NonText = append(env.NonText, mcpNonTextContent{
+				Kind: "unsupported",
+				Name: "structuredContent dropped: exceeds size bound",
+			})
+		}
+	}
+
+	// Non-text content items: represent each explicitly.
+	for _, item := range result.Content {
+		switch item.Type {
+		case "text":
+			// Canonical fallback; handled by textContentItems.
+		case "image", "audio":
+			env.NonText = append(env.NonText, mcpNonTextContent{
+				Kind:     item.Type,
+				MimeType: item.MimeType,
+			})
+		case "resource_link":
+			env.NonText = append(env.NonText, mcpNonTextContent{
+				Kind:     "resource_link",
+				URI:      item.URI,
+				MimeType: item.MimeType,
+				Name:     item.Name,
+			})
+		case "resource":
+			env.NonText = append(env.NonText, embeddedResourceDescriptor(item.Resource))
+		default:
+			// An unrecognised content type is still represented, not dropped,
+			// so a future MCP content kind surfaces as a visible marker.
+			env.NonText = append(env.NonText, mcpNonTextContent{
+				Kind: "unsupported",
+				Name: item.Type,
+			})
+		}
+	}
+
+	if len(env.StructuredContent) == 0 && len(env.NonText) == 0 {
+		return nil
+	}
+
+	encoded, err := json.Marshal(env)
+	if err != nil {
+		// A marshal failure means the (untrusted) structuredContent was not
+		// valid JSON to re-emit; drop the structured envelope entirely rather
+		// than risk an invalid payload. The text fallback is unaffected.
+		return nil
+	}
+	// Final defence: if the assembled envelope still exceeds the bound (e.g. a
+	// flood of non-text descriptors), drop it. The text content survives.
+	if len(encoded) > maxMCPStructuredSize {
+		return nil
+	}
+	return encoded
+}
+
+// embeddedResourceDescriptor builds the bounded descriptor for a
+// type=="resource" content item. The URI/mime are the durable handle; the
+// inlined text body is truncated to maxMCPEmbeddedResourceTextLen and binary
+// blobs are never inlined (only noted via Truncated when present).
+func embeddedResourceDescriptor(res *mcpEmbeddedResource) mcpNonTextContent {
+	d := mcpNonTextContent{Kind: "resource"}
+	if res == nil {
+		return d
+	}
+	d.URI = res.URI
+	d.MimeType = res.MimeType
+	switch {
+	case res.Text != "":
+		if len(res.Text) > maxMCPEmbeddedResourceTextLen {
+			d.Text = res.Text[:maxMCPEmbeddedResourceTextLen]
+			d.Truncated = true
+		} else {
+			d.Text = res.Text
+		}
+	case res.Blob != "":
+		// Binary body: never inlined. Mark that a blob exists so the model
+		// knows to fetch the resource by URI if it needs the bytes.
+		d.Truncated = true
+	}
+	return d
 }
 
 // recordCall emits the per-invocation MCP counter and duration histogram.
@@ -417,8 +633,26 @@ func (c *Client) registerMCPTool(serverName string, sess *serverSession, mt mcpT
 		// loop on remote tool execution.
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
-		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
-			return c.callTool(ctx, remoteSess, remoteServerName, remoteName, input)
+		// StructuredHandler (not Handler) so the bridge can preserve
+		// structuredContent and non-text descriptors into the #231 envelope.
+		// The canonical text is always populated as the fallback, so a
+		// resolution against a provider with no structured capability still
+		// sends exactly the text the plain Handler would have returned. The
+		// returned Structured payload is bounded at the trust boundary
+		// (callTool) and scrubbed downstream by the dispatch path, never
+		// here — MCP output is untrusted and must not bypass the shared
+		// scrub on its way to a trace.
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
+			text, structured, err := c.callTool(ctx, remoteSess, remoteServerName, remoteName, input)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			res := tool.StructuredResult{Text: text}
+			if len(structured) > 0 {
+				res.Structured = structured
+				res.Kind = kindMCPToolResult
+			}
+			return res, nil
 		},
 	})
 }

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -119,6 +119,25 @@ func writeJSONRPCError(w http.ResponseWriter, id int64, code int, message string
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// callMCPText invokes a registered MCP tool's StructuredHandler and returns
+// the canonical text fallback. MCP tools register a StructuredHandler (issue
+// #231 B2) rather than a plain Handler, so tests exercising only the text
+// result route through this helper. callMCPStructured returns the full
+// StructuredResult for tests that assert the structured envelope.
+func callMCPText(t *testing.T, tl *tool.Tool, input json.RawMessage) (string, error) {
+	t.Helper()
+	res, err := callMCPStructured(t, tl, input)
+	return res.Text, err
+}
+
+func callMCPStructured(t *testing.T, tl *tool.Tool, input json.RawMessage) (tool.StructuredResult, error) {
+	t.Helper()
+	if tl.StructuredHandler == nil {
+		t.Fatalf("tool %q has no StructuredHandler", tl.Name)
+	}
+	return tl.StructuredHandler(context.Background(), input)
+}
+
 func TestConnect_ToolDiscovery(t *testing.T) {
 	tools := []mcpTool{
 		{
@@ -195,7 +214,7 @@ func TestConnect_ToolCallDispatch(t *testing.T) {
 		t.Fatal("tool not found")
 	}
 
-	result, err := resolved.Handler(context.Background(), json.RawMessage(`{}`))
+	result, err := callMCPText(t, resolved, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Handler: %v", err)
 	}
@@ -238,7 +257,7 @@ func TestConnect_SessionIDManagement(t *testing.T) {
 	if resolved == nil {
 		t.Fatal("tool not found")
 	}
-	_, _ = resolved.Handler(context.Background(), json.RawMessage(`{}`))
+	_, _ = callMCPText(t, resolved, json.RawMessage(`{}`))
 
 	reqs = log.get()
 	if len(reqs) < 2 {
@@ -456,7 +475,7 @@ func TestConnect_ToolCallError(t *testing.T) {
 		t.Fatal("tool not found")
 	}
 
-	_, err := resolved.Handler(context.Background(), json.RawMessage(`{}`))
+	_, err := callMCPText(t, resolved, json.RawMessage(`{}`))
 	if err == nil {
 		t.Fatal("expected error from tool call")
 	}
@@ -593,7 +612,7 @@ func TestMCPCall_RecordsMetrics_Success(t *testing.T) {
 	if resolved == nil {
 		t.Fatal("tool not found")
 	}
-	if _, err := resolved.Handler(context.Background(), json.RawMessage(`{}`)); err != nil {
+	if _, err := callMCPText(t, resolved, json.RawMessage(`{}`)); err != nil {
 		t.Fatalf("Handler: %v", err)
 	}
 
@@ -675,7 +694,7 @@ func TestMCPCall_RecordsMetrics_Failure(t *testing.T) {
 	if resolved == nil {
 		t.Fatal("tool not found")
 	}
-	if _, err := resolved.Handler(context.Background(), json.RawMessage(`{}`)); err == nil {
+	if _, err := callMCPText(t, resolved, json.RawMessage(`{}`)); err == nil {
 		t.Fatal("expected handler error from isError=true response")
 	}
 
@@ -831,7 +850,7 @@ func TestRegisterMCPTool_RecordsTruncatedToolName(t *testing.T) {
 	if resolved == nil {
 		t.Fatal("registered tool not found")
 	}
-	if _, err := resolved.Handler(context.Background(), json.RawMessage(`{}`)); err != nil {
+	if _, err := callMCPText(t, resolved, json.RawMessage(`{}`)); err != nil {
 		t.Fatalf("Handler: %v", err)
 	}
 

--- a/harness/internal/mcp/structured_test.go
+++ b/harness/internal/mcp/structured_test.go
@@ -1,0 +1,231 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// mcpServerReturningCallResult stands up a fake MCP server that advertises a
+// single tool and returns the supplied raw JSON object as the tools/call
+// result. The raw form lets a test express content shapes (resource links,
+// embedded resources, structuredContent) that the production wire types only
+// partially decode, exercising the bridge's full preservation path.
+func mcpServerReturningCallResult(t *testing.T, toolName, rawCallResult string) *httptest.Server {
+	t.Helper()
+	tools := []mcpTool{{Name: toolName, Description: "x", InputSchema: json.RawMessage(`{"type":"object"}`)}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "tools/list":
+			writeJSONRPCResult(w, req.ID, toolsListResult{Tools: tools})
+		case "tools/call":
+			resp := jsonRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(rawCallResult)}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			writeJSONRPCError(w, req.ID, -32601, "method not found")
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// connectAndResolve connects the client to srv and returns the registered
+// tool for serverName/toolName.
+func connectAndResolve(t *testing.T, srv *httptest.Server, serverName, toolName string) *tool.Tool {
+	t.Helper()
+	registry := tool.NewRegistry()
+	client := NewClient(registry, srv.Client())
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+	if err := client.Connect(context.Background(), types.MCPServerConfig{Name: serverName, URI: srv.URL}, secrets); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	resolved := registry.Resolve("mcp_" + serverName + "_" + toolName)
+	if resolved == nil {
+		t.Fatalf("tool mcp_%s_%s not registered", serverName, toolName)
+	}
+	return resolved
+}
+
+// TestMCP_PreservesStructuredContent pins that a tools/call response carrying
+// structuredContent is preserved into the #231 envelope under the
+// mcp_tool_result kind, with the text content kept as the canonical fallback.
+func TestMCP_PreservesStructuredContent(t *testing.T) {
+	raw := `{
+		"content": [{"type": "text", "text": "42 rows"}],
+		"structuredContent": {"rows": 42, "table": "users"}
+	}`
+	resolved := connectAndResolve(t, mcpServerReturningCallResult(t, "query", raw), "db", "query")
+
+	res, err := callMCPStructured(t, resolved, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if res.Text != "42 rows" {
+		t.Errorf("text fallback = %q, want %q", res.Text, "42 rows")
+	}
+	if res.Kind != kindMCPToolResult {
+		t.Errorf("kind = %q, want %q", res.Kind, kindMCPToolResult)
+	}
+	var env mcpStructuredResult
+	if err := json.Unmarshal(res.Structured, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nstructured: %s", err, res.Structured)
+	}
+	var sc map[string]any
+	if err := json.Unmarshal(env.StructuredContent, &sc); err != nil {
+		t.Fatalf("decode structuredContent: %v", err)
+	}
+	if sc["rows"] != float64(42) || sc["table"] != "users" {
+		t.Errorf("structuredContent = %v, want rows=42 table=users", sc)
+	}
+}
+
+// TestMCP_MarksNonTextContent pins that resource links, embedded resources,
+// and unrecognised content types are represented explicitly in the envelope
+// rather than silently dropped, while the text content remains the fallback.
+func TestMCP_MarksNonTextContent(t *testing.T) {
+	raw := `{
+		"content": [
+			{"type": "text", "text": "see attached"},
+			{"type": "resource_link", "uri": "file:///report.pdf", "name": "report", "mimeType": "application/pdf"},
+			{"type": "resource", "resource": {"uri": "file:///note.txt", "mimeType": "text/plain", "text": "inline note"}},
+			{"type": "image", "mimeType": "image/png", "data": "BASE64"},
+			{"type": "future_kind"}
+		]
+	}`
+	resolved := connectAndResolve(t, mcpServerReturningCallResult(t, "fetch", raw), "files", "fetch")
+
+	res, err := callMCPStructured(t, resolved, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if res.Text != "see attached" {
+		t.Errorf("text fallback = %q, want %q", res.Text, "see attached")
+	}
+	var env mcpStructuredResult
+	if err := json.Unmarshal(res.Structured, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	byKind := map[string]mcpNonTextContent{}
+	for _, n := range env.NonText {
+		byKind[n.Kind] = n
+	}
+	if len(env.NonText) != 4 {
+		t.Fatalf("expected 4 non-text descriptors (link, resource, image, unsupported), got %d: %+v", len(env.NonText), env.NonText)
+	}
+	if rl, ok := byKind["resource_link"]; !ok || rl.URI != "file:///report.pdf" || rl.Name != "report" {
+		t.Errorf("resource_link descriptor wrong/missing: %+v", rl)
+	}
+	if rs, ok := byKind["resource"]; !ok || rs.URI != "file:///note.txt" || rs.Text != "inline note" {
+		t.Errorf("embedded resource descriptor wrong/missing: %+v", rs)
+	}
+	if img, ok := byKind["image"]; !ok || img.MimeType != "image/png" {
+		t.Errorf("image descriptor wrong/missing: %+v", img)
+	}
+	if un, ok := byKind["unsupported"]; !ok || un.Name != "future_kind" {
+		t.Errorf("unsupported descriptor wrong/missing (a new content kind must be marked, not dropped): %+v", un)
+	}
+}
+
+// TestMCP_BoundsOversizedStructuredContent pins that a structuredContent
+// object larger than the size bound is dropped (with a marker), not retained,
+// so an untrusted server cannot blow up memory/trace via a giant payload. The
+// text fallback survives intact.
+func TestMCP_BoundsOversizedStructuredContent(t *testing.T) {
+	huge := strings.Repeat("A", maxMCPStructuredSize+1)
+	rawResult, err := json.Marshal(map[string]any{
+		"content":           []map[string]any{{"type": "text", "text": "ok"}},
+		"structuredContent": map[string]any{"blob": huge},
+	})
+	if err != nil {
+		t.Fatalf("marshal raw result: %v", err)
+	}
+	resolved := connectAndResolve(t, mcpServerReturningCallResult(t, "big", string(rawResult)), "hostile", "big")
+
+	res, err := callMCPStructured(t, resolved, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if res.Text != "ok" {
+		t.Errorf("text fallback = %q, want %q", res.Text, "ok")
+	}
+	if len(res.Structured) > maxMCPStructuredSize {
+		t.Fatalf("structured envelope %d bytes exceeds bound %d — oversized content not dropped", len(res.Structured), maxMCPStructuredSize)
+	}
+	var env mcpStructuredResult
+	if err := json.Unmarshal(res.Structured, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if len(env.StructuredContent) != 0 {
+		t.Errorf("oversized structuredContent should have been dropped, got %d bytes", len(env.StructuredContent))
+	}
+	if len(env.NonText) != 1 || env.NonText[0].Kind != "unsupported" {
+		t.Errorf("expected an 'unsupported' marker for the dropped content, got %+v", env.NonText)
+	}
+}
+
+// TestMCP_BoundsEmbeddedResourceText pins that an oversized embedded-resource
+// text body is truncated to the per-resource bound and flagged Truncated,
+// rather than inlined whole.
+func TestMCP_BoundsEmbeddedResourceText(t *testing.T) {
+	huge := strings.Repeat("B", maxMCPEmbeddedResourceTextLen+500)
+	rawResult, err := json.Marshal(map[string]any{
+		"content": []map[string]any{
+			{"type": "text", "text": "ok"},
+			{"type": "resource", "resource": map[string]any{"uri": "file:///big.txt", "text": huge}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal raw result: %v", err)
+	}
+	resolved := connectAndResolve(t, mcpServerReturningCallResult(t, "bigres", string(rawResult)), "hostile", "bigres")
+
+	res, err := callMCPStructured(t, resolved, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	var env mcpStructuredResult
+	if err := json.Unmarshal(res.Structured, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if len(env.NonText) != 1 {
+		t.Fatalf("expected 1 resource descriptor, got %+v", env.NonText)
+	}
+	d := env.NonText[0]
+	if d.Kind != "resource" || !d.Truncated {
+		t.Errorf("descriptor = %+v, want kind=resource truncated=true", d)
+	}
+	if len(d.Text) != maxMCPEmbeddedResourceTextLen {
+		t.Errorf("inlined text = %d bytes, want exactly %d (truncated)", len(d.Text), maxMCPEmbeddedResourceTextLen)
+	}
+}
+
+// TestMCP_TextOnlyResultHasNoStructured pins the no-regression path: a
+// text-only tools/call result produces no structured envelope and no kind, so
+// the result is byte-identical to the pre-#231 text-only shape downstream.
+func TestMCP_TextOnlyResultHasNoStructured(t *testing.T) {
+	raw := `{"content": [{"type": "text", "text": "plain"}]}`
+	resolved := connectAndResolve(t, mcpServerReturningCallResult(t, "echo", raw), "srv", "echo")
+
+	res, err := callMCPStructured(t, resolved, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if res.Text != "plain" {
+		t.Errorf("text = %q, want %q", res.Text, "plain")
+	}
+	if len(res.Structured) != 0 {
+		t.Errorf("text-only result must carry no structured envelope, got %s", res.Structured)
+	}
+	if res.Kind != "" {
+		t.Errorf("text-only result must carry no kind, got %q", res.Kind)
+	}
+}

--- a/harness/internal/mcp/structured_test.go
+++ b/harness/internal/mcp/structured_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/types"
@@ -98,6 +99,7 @@ func TestMCP_MarksNonTextContent(t *testing.T) {
 			{"type": "resource_link", "uri": "file:///report.pdf", "name": "report", "mimeType": "application/pdf"},
 			{"type": "resource", "resource": {"uri": "file:///note.txt", "mimeType": "text/plain", "text": "inline note"}},
 			{"type": "image", "mimeType": "image/png", "data": "BASE64"},
+			{"type": "audio", "mimeType": "audio/mpeg", "data": "BASE64"},
 			{"type": "future_kind"}
 		]
 	}`
@@ -118,8 +120,8 @@ func TestMCP_MarksNonTextContent(t *testing.T) {
 	for _, n := range env.NonText {
 		byKind[n.Kind] = n
 	}
-	if len(env.NonText) != 4 {
-		t.Fatalf("expected 4 non-text descriptors (link, resource, image, unsupported), got %d: %+v", len(env.NonText), env.NonText)
+	if len(env.NonText) != 5 {
+		t.Fatalf("expected 5 non-text descriptors (link, resource, image, audio, unsupported), got %d: %+v", len(env.NonText), env.NonText)
 	}
 	if rl, ok := byKind["resource_link"]; !ok || rl.URI != "file:///report.pdf" || rl.Name != "report" {
 		t.Errorf("resource_link descriptor wrong/missing: %+v", rl)
@@ -129,6 +131,9 @@ func TestMCP_MarksNonTextContent(t *testing.T) {
 	}
 	if img, ok := byKind["image"]; !ok || img.MimeType != "image/png" {
 		t.Errorf("image descriptor wrong/missing: %+v", img)
+	}
+	if au, ok := byKind["audio"]; !ok || au.MimeType != "audio/mpeg" {
+		t.Errorf("audio descriptor wrong/missing (shares the image arm but the discriminator must be 'audio'): %+v", au)
 	}
 	if un, ok := byKind["unsupported"]; !ok || un.Name != "future_kind" {
 		t.Errorf("unsupported descriptor wrong/missing (a new content kind must be marked, not dropped): %+v", un)
@@ -227,5 +232,157 @@ func TestMCP_TextOnlyResultHasNoStructured(t *testing.T) {
 	}
 	if res.Kind != "" {
 		t.Errorf("text-only result must carry no kind, got %q", res.Kind)
+	}
+}
+
+// TestMCP_NullStructuredContentIsAbsent (BLK-2) pins that an explicit
+// "structuredContent": null does NOT fabricate a structured turn. A non-nil
+// json.RawMessage("null") would otherwise pass the len>0 guard and, since
+// omitempty does not omit a non-nil slice, serialise "structured_content":null
+// onto the wire — a spurious structured result for a server that signalled it
+// has none.
+func TestMCP_NullStructuredContentIsAbsent(t *testing.T) {
+	raw := `{"content":[{"type":"text","text":"x"}],"structuredContent":null}`
+	resolved := connectAndResolve(t, mcpServerReturningCallResult(t, "nullsc", raw), "srv", "nullsc")
+
+	res, err := callMCPStructured(t, resolved, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if res.Text != "x" {
+		t.Errorf("text = %q, want %q", res.Text, "x")
+	}
+	if len(res.Structured) != 0 {
+		t.Errorf("null structuredContent must produce no envelope, got %s", res.Structured)
+	}
+	if res.Kind != "" {
+		t.Errorf("null structuredContent must produce no kind, got %q", res.Kind)
+	}
+}
+
+// TestMCP_CapsContentItemCount (BLK-3) pins that the content item-count cap
+// fires BEFORE the descriptor slice is fully built: the envelope retains at
+// most maxMCPContentItems descriptors plus a truncation marker, stays within
+// the size bound, and the overflow is marked rather than silently dropped.
+// Calling buildMCPStructured directly keeps the assertion on the allocation
+// boundary the cap protects.
+func TestMCP_CapsContentItemCount(t *testing.T) {
+	items := make([]contentItem, maxMCPContentItems+200)
+	for i := range items {
+		items[i] = contentItem{Type: "image", MimeType: "image/png"}
+	}
+	encoded := buildMCPStructured(toolsCallResult{Content: items})
+	if len(encoded) == 0 {
+		t.Fatal("expected a non-nil envelope")
+	}
+	if len(encoded) > maxMCPStructuredSize {
+		t.Fatalf("envelope %d bytes exceeds bound %d", len(encoded), maxMCPStructuredSize)
+	}
+	var env mcpStructuredResult
+	if err := json.Unmarshal(encoded, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	// maxMCPContentItems image descriptors + 1 truncation marker.
+	if len(env.NonText) != maxMCPContentItems+1 {
+		t.Fatalf("expected %d descriptors (cap + marker), got %d", maxMCPContentItems+1, len(env.NonText))
+	}
+	var marked bool
+	for _, n := range env.NonText {
+		if n.Kind == "unsupported" && strings.Contains(n.Name, "item-count bound") {
+			marked = true
+		}
+	}
+	if !marked {
+		t.Errorf("expected a truncation marker for the dropped items, got %+v", env.NonText)
+	}
+}
+
+// TestMCP_OversizedAssembledEnvelopeIsMarked (REC-2) pins that when many
+// individually-valid non-text descriptors push the assembled envelope past the
+// size bound, the bridge returns a marker envelope rather than silently
+// dropping everything — preserving the represent-or-mark contract.
+func TestMCP_OversizedAssembledEnvelopeIsMarked(t *testing.T) {
+	// Each resource_link carries a long URI; enough of them (under the item
+	// count cap) exceed maxMCPStructuredSize once assembled.
+	longURI := "file:///" + strings.Repeat("a", 2048)
+	const n = 200 // 200 * ~2KB ~= 400KB > 256KB, but well under maxMCPContentItems
+	items := make([]contentItem, n)
+	for i := range items {
+		items[i] = contentItem{Type: "resource_link", URI: longURI}
+	}
+	encoded := buildMCPStructured(toolsCallResult{Content: items})
+	if len(encoded) == 0 {
+		t.Fatal("expected a non-nil marker envelope, got nil")
+	}
+	if len(encoded) > maxMCPStructuredSize {
+		t.Fatalf("marker envelope %d bytes exceeds bound %d", len(encoded), maxMCPStructuredSize)
+	}
+	var env mcpStructuredResult
+	if err := json.Unmarshal(encoded, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if len(env.NonText) != 1 || env.NonText[0].Kind != "unsupported" || !strings.Contains(env.NonText[0].Name, "envelope dropped") {
+		t.Errorf("expected a single 'envelope dropped' marker, got %+v", env.NonText)
+	}
+}
+
+// TestMCP_BinaryBlobResourceNotInlined (REC-4) pins that an embedded resource
+// carrying a binary blob (not text) is flagged Truncated with no inlined body
+// — the bridge never forwards untrusted binary bytes, only the URI handle.
+func TestMCP_BinaryBlobResourceNotInlined(t *testing.T) {
+	raw := `{"content":[{"type":"text","text":"ok"},{"type":"resource","resource":{"uri":"file:///img.png","mimeType":"image/png","blob":"BASE64DATA=="}}]}`
+	resolved := connectAndResolve(t, mcpServerReturningCallResult(t, "blobres", raw), "files", "blobres")
+
+	res, err := callMCPStructured(t, resolved, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	var env mcpStructuredResult
+	if err := json.Unmarshal(res.Structured, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if len(env.NonText) != 1 {
+		t.Fatalf("expected 1 resource descriptor, got %+v", env.NonText)
+	}
+	d := env.NonText[0]
+	if d.Kind != "resource" {
+		t.Errorf("kind = %q, want resource", d.Kind)
+	}
+	if !d.Truncated {
+		t.Errorf("binary blob resource must be flagged Truncated, got %+v", d)
+	}
+	if d.Text != "" {
+		t.Errorf("binary blob must not be inlined as text, got %q", d.Text)
+	}
+	if d.URI != "file:///img.png" {
+		t.Errorf("URI = %q, want file:///img.png (the durable handle)", d.URI)
+	}
+}
+
+// TestSanitizeMCPToolName_RuneSafe (BLK-1) pins that truncation is rune-safe:
+// a name of 65 three-byte runes (195 bytes) truncates to exactly
+// maxMCPToolNameLen runes and stays valid UTF-8 — a byte-slice cut would split
+// a codepoint and emit an invalid string into the tool.name metric attribute.
+func TestSanitizeMCPToolName_RuneSafe(t *testing.T) {
+	// "世" is a 3-byte UTF-8 rune.
+	long := strings.Repeat("世", maxMCPToolNameLen+20)
+	got := sanitizeMCPToolName(long)
+	if !utf8.ValidString(got) {
+		t.Fatalf("sanitised name is not valid UTF-8: %q", got)
+	}
+	if n := utf8.RuneCountInString(got); n != maxMCPToolNameLen {
+		t.Errorf("rune count = %d, want %d", n, maxMCPToolNameLen)
+	}
+
+	// A short name is returned unchanged.
+	short := "echo"
+	if sanitizeMCPToolName(short) != short {
+		t.Errorf("short name was altered: %q", sanitizeMCPToolName(short))
+	}
+
+	// An ASCII name exactly at the cap is unchanged.
+	atCap := strings.Repeat("a", maxMCPToolNameLen)
+	if got := sanitizeMCPToolName(atCap); got != atCap {
+		t.Errorf("at-cap name altered: len %d", len(got))
 	}
 }

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -294,7 +294,12 @@ func anthropicToolResultContent(b types.ContentBlock, cap quirks.StructuredToolR
 	if b.Type != "tool_result" {
 		return nil
 	}
-	if cap.Supported && cap.ContentBlockArray && len(b.Structured) > 0 {
+	// The array form requires a non-empty canonical text: an empty first part
+	// ({"type":"text","text":""}) is meaningless and diverges from the
+	// pre-#231 shape for empty-content results (which omitted the content key
+	// entirely). When Content is empty, fall through to the nil-return below
+	// regardless of the structured payload.
+	if cap.Supported && cap.ContentBlockArray && len(b.Structured) > 0 && b.Content != "" {
 		parts := []anthropicToolResultPart{
 			{Type: "text", Text: b.Content},
 			{Type: "text", Text: string(b.Structured)},

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -215,6 +215,14 @@ type anthropicMessage struct {
 // documents support for it. Provider-private state added to
 // types.ContentBlock by some other adapter is, by default, dropped on
 // egress to Anthropic.
+// Content is a json.RawMessage rather than a string because the Messages
+// API accepts a tool_result block's `content` as either a JSON string or an
+// array of content blocks. The string form is the default (a JSON-encoded
+// string literal); the array form is emitted only when the resolved
+// StructuredToolResults capability is on and the result carries a structured
+// envelope (issue #231 B2). A nil Content omits the key (omitempty), so a
+// text block or tool_use block — which never set Content — serialises
+// byte-identically to the pre-#231 shape.
 type anthropicContentBlock struct {
 	Type      string          `json:"type"`
 	Text      string          `json:"text,omitempty"`
@@ -222,8 +230,19 @@ type anthropicContentBlock struct {
 	Name      string          `json:"name,omitempty"`
 	Input     json.RawMessage `json:"input,omitempty"`
 	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Content   string          `json:"content,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
 	IsError   bool            `json:"is_error,omitempty"`
+}
+
+// anthropicToolResultPart is one entry in the array form of a tool_result
+// block's content. The Messages API's tool_result content array accepts
+// "text" (and "image") parts; the harness uses only "text", carrying the
+// structured envelope as a JSON-serialised text part alongside the canonical
+// text part. There is no native JSON content type for tool_result, so this
+// is the faithful representation of "structured data the model can read".
+type anthropicToolResultPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
 }
 
 // translateMessagesAnthropic copies a slice of types.Message into the
@@ -235,7 +254,7 @@ type anthropicContentBlock struct {
 // otherwise have been forwarded to api.anthropic.com via the model
 // router); the same mechanism covers any provider-private field added
 // to the shared carrier in the future.
-func translateMessagesAnthropic(messages []types.Message) []anthropicMessage {
+func translateMessagesAnthropic(messages []types.Message, cap quirks.StructuredToolResultCapability) []anthropicMessage {
 	out := make([]anthropicMessage, len(messages))
 	for i, msg := range messages {
 		blocks := make([]anthropicContentBlock, len(msg.Content))
@@ -247,7 +266,7 @@ func translateMessagesAnthropic(messages []types.Message) []anthropicMessage {
 				Name:      b.Name,
 				Input:     b.Input,
 				ToolUseID: b.ToolUseID,
-				Content:   b.Content,
+				Content:   anthropicToolResultContent(b, cap),
 				IsError:   b.IsError,
 			}
 		}
@@ -257,6 +276,47 @@ func translateMessagesAnthropic(messages []types.Message) []anthropicMessage {
 		}
 	}
 	return out
+}
+
+// anthropicToolResultContent renders the `content` field of one content
+// block for the Anthropic wire. For non-tool_result blocks it returns nil so
+// the key is omitted (text/tool_use blocks never carry tool-result content).
+// For tool_result blocks it returns the JSON-string form by default; when the
+// resolved capability accepts the content-block array shape and the block
+// carries a structured envelope, it returns the array form — the canonical
+// text part plus a text part holding the structured JSON — so the model
+// receives both renderings and the text fallback survives even if a consumer
+// reads only the first part.
+//
+// A marshalling failure falls back to the plain string content: structured
+// serialisation is purely additive and must never drop the canonical text.
+func anthropicToolResultContent(b types.ContentBlock, cap quirks.StructuredToolResultCapability) json.RawMessage {
+	if b.Type != "tool_result" {
+		return nil
+	}
+	if cap.Supported && cap.ContentBlockArray && len(b.Structured) > 0 {
+		parts := []anthropicToolResultPart{
+			{Type: "text", Text: b.Content},
+			{Type: "text", Text: string(b.Structured)},
+		}
+		if raw, err := json.Marshal(parts); err == nil {
+			return raw
+		}
+	}
+	// Preserve the pre-#231 omitempty behaviour: an empty tool-result
+	// content omitted the `content` key entirely. Returning nil keeps that
+	// byte-for-byte. A non-empty string is emitted as a JSON string literal,
+	// identical to what the old `Content string` field produced.
+	if b.Content == "" {
+		return nil
+	}
+	raw, err := json.Marshal(b.Content)
+	if err != nil {
+		// json.Marshal on a string cannot fail in practice; emit an empty
+		// JSON string so the wire shape stays valid.
+		return json.RawMessage(`""`)
+	}
+	return raw
 }
 
 // SSE event types from the Anthropic API.
@@ -298,12 +358,14 @@ type sseMessageDelta struct {
 // non-streaming caller (batch submission, phase 2 of issue #133) can reuse
 // the same projection without duplicating field-by-field copying.
 //
-// q carries the resolved per-(provider, model) quirks. Today the only
-// load-bearing field for the Anthropic build path is the cross-provider
-// ToolChoice capability, which gates whether StreamParams.ToolChoice is
-// projected onto the tool_choice object. A zero-value q (Supported=false)
-// emits no tool_choice field, so callers that do not route through the
-// registry produce the pre-#230 wire shape.
+// q carries the resolved per-(provider, model) quirks. Two cross-provider
+// capabilities are load-bearing on the Anthropic build path: ToolChoice gates
+// whether StreamParams.ToolChoice is projected onto the tool_choice object,
+// and StructuredToolResults gates whether a tool_result block carrying a
+// structured envelope is serialised as the content-block array form rather
+// than the plain string. A zero-value q (both Supported=false) emits no
+// tool_choice field and string-only tool results, so callers that do not
+// route through the registry produce the pre-#230/#231 wire shape.
 //
 // TODO(batch): if the batch endpoint rejects fields the streaming endpoint
 // accepts (e.g. thinking_config), change the return type to
@@ -312,7 +374,7 @@ func buildAnthropicRequest(params types.StreamParams, stream bool, q quirks.Prov
 	return anthropicRequest{
 		Model:    params.Model,
 		System:   params.System,
-		Messages: translateMessagesAnthropic(params.Messages),
+		Messages: translateMessagesAnthropic(params.Messages, q.StructuredToolResults),
 		// slices.Clone avoids aliasing params.Tools into the returned
 		// struct. translateMessagesAnthropic / translateTools(Responses)
 		// allocate fresh output slices for messages and tools on the

--- a/harness/internal/provider/gemini_request.go
+++ b/harness/internal/provider/gemini_request.go
@@ -65,7 +65,7 @@ func BuildGenerateContentRequest(
 	safety []types.GeminiSafetySetting,
 	q quirks.ProviderQuirks,
 ) (body []byte, toolNameByID map[string]string, err error) {
-	contents, toolNameByID, err := translateMessagesGemini(params.System, params.Messages)
+	contents, toolNameByID, err := translateMessagesGemini(params.System, params.Messages, q.StructuredToolResults)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,7 +180,7 @@ func BuildGenerateContentRequest(
 // pinned ordering, where function_call_output items precede the next user
 // turn's instructions). Without that ordering, Vertex receives a user-text
 // turn before a function-response, which violates its own expectations.
-func translateMessagesGemini(system string, messages []types.Message) ([]geminiContent, map[string]string, error) {
+func translateMessagesGemini(system string, messages []types.Message, cap quirks.StructuredToolResultCapability) ([]geminiContent, map[string]string, error) {
 	_ = system // consumed by geminiSystemFromMessages, not here
 	out := make([]geminiContent, 0, len(messages))
 	toolNameByID := make(map[string]string)
@@ -259,11 +259,9 @@ func translateMessagesGemini(system string, messages []types.Message) ([]geminiC
 					if !ok {
 						return nil, nil, fmt.Errorf("messages[%d].content[%d]: tool_result references unknown tool_use_id %q", i, j, block.ToolUseID)
 					}
-					response := map[string]interface{}{
-						"content": block.Content,
-					}
-					if block.IsError {
-						response["error"] = true
+					response, err := geminiToolResultResponse(block, cap)
+					if err != nil {
+						return nil, nil, fmt.Errorf("messages[%d].content[%d]: %w", i, j, err)
 					}
 					out = append(out, geminiContent{
 						Role: "function",
@@ -316,6 +314,30 @@ func geminiSystemFromMessages(system string, messages []types.Message) string {
 		}
 	}
 	return strings.Join(parts, "\n\n")
+}
+
+// geminiToolResultResponse marshals one tool_result block into the JSON
+// object Vertex expects in functionResponse.response. The canonical text
+// always populates "content" (the fallback the model can read regardless of
+// structured support). When the resolved capability accepts the object-
+// response shape and the block carries a structured envelope, the envelope is
+// embedded verbatim under "structured" with its discriminator under "kind";
+// otherwise the response is the text-only {"content": ...} (with "error" on a
+// failed call) that is byte-identical to the pre-#231 map form.
+func geminiToolResultResponse(block types.ContentBlock, cap quirks.StructuredToolResultCapability) (json.RawMessage, error) {
+	body := geminiFunctionResponseBody{
+		Content: block.Content,
+		Error:   block.IsError,
+	}
+	if cap.Supported && cap.ObjectResponse && len(block.Structured) > 0 {
+		body.Structured = block.Structured
+		body.Kind = block.Kind
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal functionResponse body: %w", err)
+	}
+	return raw, nil
 }
 
 // normaliseToolArgs returns an argument JSON object suitable for Gemini's

--- a/harness/internal/provider/gemini_types.go
+++ b/harness/internal/provider/gemini_types.go
@@ -84,12 +84,35 @@ type geminiFunctionCall struct {
 // there is no ID echo, so the request builder maintains its own ID→name
 // map (toolNameByID) to populate this field correctly.
 //
-// Response is a free-form JSON object. The harness convention is
-// {"content": <result-string>}; an additional {"error": true} key is set
-// when the tool call failed so the model can react.
+// Response is the free-form JSON object Vertex requires
+// (FunctionResponse.response is a Struct). It is a json.RawMessage rather
+// than a map[string]any so the request builder marshals a typed
+// geminiFunctionResponseBody (the no-`any` rule, wave-2 design D13); the
+// raw form also lets the builder embed a structured envelope (issue #231 B2)
+// without re-deriving an untyped map. The harness convention is
+// {"content": <result-string>} with an optional {"error": true} on failure,
+// plus an optional structured payload under the kind-named key when the
+// resolved capability accepts it.
 type geminiFunctionResponse struct {
-	Name     string                 `json:"name"`
-	Response map[string]interface{} `json:"response"`
+	Name     string          `json:"name"`
+	Response json.RawMessage `json:"response"`
+}
+
+// geminiFunctionResponseBody is the typed shape marshalled into
+// geminiFunctionResponse.Response. Content is the canonical text fallback and
+// is always present so a model that ignores the structured fields still
+// receives the result. Error is set only on a failed call. Structured carries
+// the issue #231 envelope verbatim and is emitted only when the resolved
+// StructuredToolResults capability accepts the object-response shape; Kind
+// names its discriminator so a consumer can route without sniffing. All three
+// extension fields are omitempty, so a text-only result on a non-structured
+// resolution marshals to {"content": ...} — byte-identical to the pre-#231
+// map form (which carried exactly that key).
+type geminiFunctionResponseBody struct {
+	Content    string          `json:"content"`
+	Error      bool            `json:"error,omitempty"`
+	Structured json.RawMessage `json:"structured,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
 }
 
 // geminiTools wraps a list of declarations. Vertex accepts multiple Tools

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -305,6 +305,59 @@ func BuiltinRules() []Rule {
 				}
 			},
 		},
+		// --- Structured tool-result capability rules (#231, Wave 4 B2) ---
+		//
+		// "tool results can carry structure" is a cross-provider concept, so
+		// the resolved capability lives on the top-level
+		// ProviderQuirks.StructuredToolResults field rather than a provider
+		// sub-struct. Each first-party provider declares a base "*" rule
+		// advertising the wire shape its API actually accepts; the adapters
+		// gate serialisation on the resolved capability and send only the
+		// text Content when Supported is false. A provider with no rule here
+		// (e.g. bedrock) therefore stays text-only by construction.
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "*",
+			Description:  "Anthropic: tool_result content accepts a content-block array (text + structured JSON block)",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// Anthropic's Messages API accepts tool_result `content`
+				// as either a plain string or an array of content blocks
+				// (https://docs.anthropic.com/en/api/messages — tool_result
+				// content is `string | Array<text|image>`). There is no
+				// native JSON content type, so the structured envelope is
+				// carried as an additional `text` block alongside the
+				// canonical text block. A model (or downstream tool) that
+				// only reads the first block still receives the text
+				// fallback verbatim.
+				q.StructuredToolResults = StructuredToolResultCapability{
+					Supported:         true,
+					ContentBlockArray: true,
+				}
+			},
+		},
+		{
+			ProviderType: "gemini",
+			ModelMatch:   "*",
+			Description:  "Gemini: functionResponse.response is a free-form JSON object (carries structured envelope)",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// Vertex AI's functionResponse.response field is a free-form
+				// JSON object (https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling
+				// — FunctionResponse.response is a Struct). The structured
+				// envelope maps directly into that object; the canonical
+				// text rides alongside under a reserved "content" key so a
+				// model that ignores the structured fields still sees the
+				// text fallback. OpenAI is deliberately absent from this rule
+				// set: a Chat Completions `tool` message and a Responses
+				// function_call_output are both plain strings on the wire, so
+				// the OpenAI adapters stay text-only with no capability.
+				q.StructuredToolResults = StructuredToolResultCapability{
+					Supported:      true,
+					ObjectResponse: true,
+				}
+			},
+		},
 		{
 			ProviderType: "gemini",
 			ModelMatch:   "gemini-3*",

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -57,6 +57,17 @@ type ProviderQuirks struct {
 	// graceful no-op the StreamParams.ToolChoice contract requires.
 	ToolChoice ToolChoiceCapability `json:"toolChoice"`
 
+	// StructuredToolResults declares whether the resolved (provider, model)
+	// accepts a structured (non-string) tool-result payload on the wire, and
+	// in which wire shape. Like ToolChoice it is a TOP-LEVEL capability: a
+	// tool result carrying structure is a cross-provider concept the loop
+	// reasons about uniformly even though each family encodes it differently
+	// (Anthropic content-block array, Gemini functionResponse object, OpenAI
+	// plain string). The zero value advertises no support, so an adapter for
+	// a provider with no rule sends only the text Content — byte-identical to
+	// the pre-#231 wire shape, with the canonical text fallback intact.
+	StructuredToolResults StructuredToolResultCapability `json:"structuredToolResults"`
+
 	// --- Behaviour flags ---
 
 	// BehaviourFlags carries adapter-internal behaviour flags that cannot be

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -602,6 +602,65 @@ func TestToolChoiceRulesSetSupportedWhenAnyMode(t *testing.T) {
 	}
 }
 
+// TestStructuredToolResultCapabilityRules pins that each first-party
+// provider's base rule advertises the structured tool-result wire shape its
+// API actually accepts, that the capability lands on the top-level
+// ProviderQuirks.StructuredToolResults field, and that a provider with no
+// rule resolves the zero value (text-only). OpenAI is the load-bearing
+// negative: its tool messages are plain strings on the wire, so it must NOT
+// gain the capability — the no-regression guarantee for the OpenAI adapters.
+func TestStructuredToolResultCapabilityRules(t *testing.T) {
+	t.Run("anthropic advertises content-block array", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("anthropic", "claude-sonnet-4-5")
+		want := StructuredToolResultCapability{Supported: true, ContentBlockArray: true}
+		if q.StructuredToolResults != want {
+			t.Errorf("anthropic: StructuredToolResults = %+v, want %+v", q.StructuredToolResults, want)
+		}
+	})
+
+	t.Run("gemini advertises object response", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("gemini", "gemini-2.5-pro")
+		want := StructuredToolResultCapability{Supported: true, ObjectResponse: true}
+		if q.StructuredToolResults != want {
+			t.Errorf("gemini: StructuredToolResults = %+v, want %+v", q.StructuredToolResults, want)
+		}
+	})
+
+	t.Run("openai-compatible stays text-only", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("openai-compatible", "gpt-4o")
+		if q.StructuredToolResults != (StructuredToolResultCapability{}) {
+			t.Errorf("openai-compatible: StructuredToolResults = %+v, want zero value (text-only)", q.StructuredToolResults)
+		}
+	})
+
+	t.Run("unknown provider resolves zero (text-only)", func(t *testing.T) {
+		q := DefaultRegistry().Resolve("mystery-provider", "some-model")
+		if q.StructuredToolResults != (StructuredToolResultCapability{}) {
+			t.Errorf("unknown provider: StructuredToolResults = %+v, want zero value (text-only)", q.StructuredToolResults)
+		}
+	})
+}
+
+// TestStructuredToolResultRulesSetSupportedWhenAnyShape pins the structural
+// relationship the adapters depend on: any first-party rule that turns on a
+// structured wire-shape bool must also set Supported. An adapter checks
+// Supported as the master gate, so a rule that set ObjectResponse without
+// Supported would silently keep the provider text-only.
+func TestStructuredToolResultRulesSetSupportedWhenAnyShape(t *testing.T) {
+	for i, rule := range BuiltinRules() {
+		if rule.Apply == nil {
+			continue
+		}
+		q := freshQuirks()
+		rule.Apply(&q)
+		sr := q.StructuredToolResults
+		anyShape := sr.ObjectResponse || sr.ContentBlockArray
+		if anyShape && !sr.Supported {
+			t.Errorf("BuiltinRules()[%d] (%q): a structured-result shape is set but Supported is false", i, rule.Description)
+		}
+	}
+}
+
 // freshQuirks returns a ProviderQuirks with the same map/slice
 // pre-initialisation Resolve performs, for rule-materialisation tests
 // that call Apply directly.

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -633,6 +633,16 @@ func TestStructuredToolResultCapabilityRules(t *testing.T) {
 		}
 	})
 
+	t.Run("bedrock stays text-only", func(t *testing.T) {
+		// builtin.go names bedrock as the load-bearing negative: a provider
+		// with no rule stays text-only by construction. Pin it so a future
+		// bedrock rule flipping Supported=true cannot land unnoticed.
+		q := DefaultRegistry().Resolve("bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0")
+		if q.StructuredToolResults != (StructuredToolResultCapability{}) {
+			t.Errorf("bedrock: StructuredToolResults = %+v, want zero value (text-only)", q.StructuredToolResults)
+		}
+	})
+
 	t.Run("unknown provider resolves zero (text-only)", func(t *testing.T) {
 		q := DefaultRegistry().Resolve("mystery-provider", "some-model")
 		if q.StructuredToolResults != (StructuredToolResultCapability{}) {

--- a/harness/internal/provider/quirks/structuredresult.go
+++ b/harness/internal/provider/quirks/structuredresult.go
@@ -1,0 +1,47 @@
+package quirks
+
+// StructuredToolResultCapability declares whether a resolved (provider,
+// model) pair accepts a structured (non-string) tool-result payload on the
+// wire, alongside the canonical text fallback the harness always produces
+// (issue #231). It is the cross-provider capability the adapters consult
+// before serialising a types.ToolResult.Structured envelope.
+//
+// Modelled as a top-level ProviderQuirks field rather than a per-provider
+// behaviour flag for the same reason ToolChoiceCapability is (see
+// quirks.go): "tool results can carry structure" is a concept every family
+// expresses differently (Anthropic's tool_result content-block array,
+// Gemini's functionResponse.response object, OpenAI's plain-string tool
+// message) but that the loop reasons about uniformly. Placing it under one
+// provider's sub-struct would force the others to reach across family
+// boundaries to read it, which the BehaviourFlags ownership rule forbids.
+//
+// The zero value advertises NO support: Supported is false. An adapter
+// resolving a provider with no structured-result rule therefore sends only
+// the text Content, leaving the request byte-identical to the pre-#231
+// shape. This is the no-regression guarantee — a provider stays text-only
+// until a rule opts it in, and the text fallback is never dropped.
+type StructuredToolResultCapability struct {
+	// Supported is the master switch. When false, the adapter MUST NOT
+	// emit any structured representation of a tool result regardless of
+	// the shape below; it sends the text Content only. A rule that sets
+	// any shape bool is expected to also set Supported; the registry
+	// self-test pins that relationship.
+	Supported bool `json:"supported"`
+
+	// ObjectResponse reports whether the provider's tool-result slot is a
+	// free-form JSON object (Gemini's functionResponse.response). When set,
+	// the adapter places the structured envelope directly into that object
+	// slot; the text fallback rides alongside it under a reserved key so a
+	// provider that ignores the extra fields still receives the canonical
+	// rendering.
+	ObjectResponse bool `json:"objectResponse"`
+
+	// ContentBlockArray reports whether the provider's tool-result content
+	// is a typed content-block array that can carry a JSON-serialised block
+	// in addition to the text block (Anthropic's tool_result content array).
+	// When set, the adapter emits the content as an array: the canonical
+	// text block plus a text block carrying the structured JSON, so the
+	// model receives both renderings and a provider that only reads the
+	// first block still sees the text fallback.
+	ContentBlockArray bool `json:"contentBlockArray"`
+}

--- a/harness/internal/provider/structuredresult_test.go
+++ b/harness/internal/provider/structuredresult_test.go
@@ -145,6 +145,26 @@ func TestAnthropicStructuredToolResult_TextByDefault(t *testing.T) {
 	}
 }
 
+// TestAnthropicToolResultContent_EmptyContentCapabilityOn (REC-1) pins that an
+// empty canonical text with a non-empty structured payload does NOT emit the
+// array form with a meaningless empty-string first part. It falls through to a
+// nil return — the pre-#231 omitempty shape for an empty-content tool result —
+// regardless of the structured envelope.
+func TestAnthropicToolResultContent_EmptyContentCapabilityOn(t *testing.T) {
+	cap := quirks.StructuredToolResultCapability{Supported: true, ContentBlockArray: true}
+	block := types.ContentBlock{
+		Type:       "tool_result",
+		ToolUseID:  "call_1",
+		Content:    "",
+		Structured: json.RawMessage(`{"exit_code":0}`),
+		Kind:       "command_result",
+	}
+	got := anthropicToolResultContent(block, cap)
+	if got != nil {
+		t.Errorf("empty content with structured must return nil (no empty-string array part), got %s", got)
+	}
+}
+
 // TestGeminiStructuredToolResult_CapabilityOn pins that the Gemini builder
 // embeds the structured envelope under functionResponse.response.structured
 // (with kind) alongside the canonical content when the capability accepts it.

--- a/harness/internal/provider/structuredresult_test.go
+++ b/harness/internal/provider/structuredresult_test.go
@@ -1,0 +1,334 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// structuredToolResultMessages returns a multi-turn history whose final user
+// message carries a tool_result block with a structured envelope. The same
+// history is reused across the adapter tests so a single fixture pins both
+// the structured-on and the text-fallback shapes.
+func structuredToolResultMessages() []types.Message {
+	return []types.Message{
+		{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "run it"}}},
+		{Role: "assistant", Content: []types.ContentBlock{
+			{Type: "tool_use", ID: "call_1", Name: "run_command", Input: json.RawMessage(`{"command":"echo hi"}`)},
+		}},
+		{Role: "user", Content: []types.ContentBlock{
+			{
+				Type:       "tool_result",
+				ToolUseID:  "call_1",
+				Content:    "hi\n(exit 0)",
+				Structured: json.RawMessage(`{"stdout":"hi\n","stderr":"","exit_code":0}`),
+				Kind:       "command_result",
+			},
+		}},
+	}
+}
+
+// textOnlyToolResultMessages is structuredToolResultMessages with the
+// envelope stripped — the pre-#231 shape. A capability-off serialisation of
+// the structured history must equal the serialisation of this history, which
+// is how the tests prove "text-by-default is byte-identical to today".
+func textOnlyToolResultMessages() []types.Message {
+	msgs := structuredToolResultMessages()
+	last := msgs[len(msgs)-1].Content
+	last[0].Structured = nil
+	last[0].Kind = ""
+	return msgs
+}
+
+func anthropicTools() []types.ToolDefinition {
+	return []types.ToolDefinition{{
+		Name:        "run_command",
+		Description: "Run a shell command",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"command":{"type":"string"}}}`),
+	}}
+}
+
+// TestAnthropicStructuredToolResult_CapabilityOn pins that the Anthropic
+// builder emits the content-block array form (canonical text + structured
+// JSON text part) for a structured tool result when the capability accepts
+// it. The default registry resolves the capability on for every Anthropic
+// model.
+func TestAnthropicStructuredToolResult_CapabilityOn(t *testing.T) {
+	q := quirks.DefaultRegistry().Resolve("anthropic", "claude-sonnet-4-5")
+	if !q.StructuredToolResults.Supported {
+		t.Fatalf("precondition: anthropic structured capability resolved off")
+	}
+	body := buildAnthropicRequest(types.StreamParams{
+		Model:     "claude-sonnet-4-5",
+		MaxTokens: 1024,
+		Tools:     anthropicTools(),
+		Messages:  structuredToolResultMessages(),
+	}, true, q)
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded struct {
+		Messages []struct {
+			Content []struct {
+				Type    string          `json:"type"`
+				Content json.RawMessage `json:"content"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// The third message is the user tool_result turn.
+	trBlock := decoded.Messages[2].Content[0]
+	if trBlock.Type != "tool_result" {
+		t.Fatalf("expected tool_result block, got %q", trBlock.Type)
+	}
+	var parts []anthropicToolResultPart
+	if err := json.Unmarshal(trBlock.Content, &parts); err != nil {
+		t.Fatalf("tool_result content is not an array (capability-on must emit array form): %v\ncontent: %s", err, trBlock.Content)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 content parts (text + structured), got %d: %+v", len(parts), parts)
+	}
+	if parts[0].Type != "text" || parts[0].Text != "hi\n(exit 0)" {
+		t.Errorf("part[0] = %+v, want canonical text fallback", parts[0])
+	}
+	if parts[1].Type != "text" {
+		t.Errorf("part[1].type = %q, want text", parts[1].Type)
+	}
+	if !json.Valid([]byte(parts[1].Text)) {
+		t.Errorf("part[1].text is not valid JSON (structured payload): %q", parts[1].Text)
+	}
+	var sp map[string]any
+	if err := json.Unmarshal([]byte(parts[1].Text), &sp); err != nil {
+		t.Fatalf("structured part not decodable: %v", err)
+	}
+	if sp["exit_code"] != float64(0) {
+		t.Errorf("structured exit_code = %v, want 0", sp["exit_code"])
+	}
+}
+
+// TestAnthropicStructuredToolResult_TextByDefault pins the no-regression
+// guarantee: with the capability unset (zero ProviderQuirks) the structured
+// history serialises byte-identically to the same history with the envelope
+// stripped. The structured envelope must not leak onto the wire when the
+// provider has not opted in.
+func TestAnthropicStructuredToolResult_TextByDefault(t *testing.T) {
+	var zero quirks.ProviderQuirks
+
+	withStructured := mustMarshal(t, buildAnthropicRequest(types.StreamParams{
+		Model:     "claude-sonnet-4-5",
+		MaxTokens: 1024,
+		Tools:     anthropicTools(),
+		Messages:  structuredToolResultMessages(),
+	}, true, zero))
+
+	textOnly := mustMarshal(t, buildAnthropicRequest(types.StreamParams{
+		Model:     "claude-sonnet-4-5",
+		MaxTokens: 1024,
+		Tools:     anthropicTools(),
+		Messages:  textOnlyToolResultMessages(),
+	}, true, zero))
+
+	if !bytes.Equal(withStructured, textOnly) {
+		t.Errorf("capability-off body must be byte-identical to text-only history\n with-structured: %s\n text-only:       %s", withStructured, textOnly)
+	}
+	if bytes.Contains(withStructured, []byte("exit_code")) {
+		t.Errorf("structured payload leaked onto the wire with capability off: %s", withStructured)
+	}
+}
+
+// TestGeminiStructuredToolResult_CapabilityOn pins that the Gemini builder
+// embeds the structured envelope under functionResponse.response.structured
+// (with kind) alongside the canonical content when the capability accepts it.
+func TestGeminiStructuredToolResult_CapabilityOn(t *testing.T) {
+	q := quirks.DefaultRegistry().Resolve("gemini", "gemini-2.5-pro")
+	if !q.StructuredToolResults.ObjectResponse {
+		t.Fatalf("precondition: gemini object-response capability resolved off")
+	}
+	body, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model:    "gemini-2.5-pro",
+		Tools:    anthropicTools(),
+		Messages: structuredToolResultMessages(),
+	}, nil, q)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	resp := geminiFunctionResponseFromBody(t, body)
+	var got struct {
+		Content    string          `json:"content"`
+		Error      bool            `json:"error"`
+		Structured json.RawMessage `json:"structured"`
+		Kind       string          `json:"kind"`
+	}
+	if err := json.Unmarshal(resp, &got); err != nil {
+		t.Fatalf("decode response object: %v\nresponse: %s", err, resp)
+	}
+	if got.Content != "hi\n(exit 0)" {
+		t.Errorf("response.content = %q, want canonical text", got.Content)
+	}
+	if got.Kind != "command_result" {
+		t.Errorf("response.kind = %q, want command_result", got.Kind)
+	}
+	if len(got.Structured) == 0 {
+		t.Fatalf("response.structured missing with capability on")
+	}
+	var sp map[string]any
+	if err := json.Unmarshal(got.Structured, &sp); err != nil {
+		t.Fatalf("structured not decodable: %v", err)
+	}
+	if sp["exit_code"] != float64(0) {
+		t.Errorf("structured exit_code = %v, want 0", sp["exit_code"])
+	}
+}
+
+// TestGeminiStructuredToolResult_TextByDefault pins the no-regression
+// guarantee for Gemini: capability-off serialisation equals the text-only
+// history, and the structured payload never appears on the wire.
+func TestGeminiStructuredToolResult_TextByDefault(t *testing.T) {
+	var zero quirks.ProviderQuirks
+
+	withStructured, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model:    "gemini-2.5-pro",
+		Tools:    anthropicTools(),
+		Messages: structuredToolResultMessages(),
+	}, nil, zero)
+	if err != nil {
+		t.Fatalf("build with-structured: %v", err)
+	}
+	textOnly, _, err := BuildGenerateContentRequest(types.StreamParams{
+		Model:    "gemini-2.5-pro",
+		Tools:    anthropicTools(),
+		Messages: textOnlyToolResultMessages(),
+	}, nil, zero)
+	if err != nil {
+		t.Fatalf("build text-only: %v", err)
+	}
+	if !bytes.Equal(withStructured, textOnly) {
+		t.Errorf("capability-off body must be byte-identical to text-only history\n with-structured: %s\n text-only:       %s", withStructured, textOnly)
+	}
+	if bytes.Contains(withStructured, []byte("exit_code")) {
+		t.Errorf("structured payload leaked onto the wire with capability off: %s", withStructured)
+	}
+}
+
+// TestOpenAIStructuredToolResult_AlwaysText pins that the OpenAI Chat
+// Completions adapter is text-only regardless of a structured envelope:
+// OpenAI has no structured capability rule, and a `tool` message's content is
+// a plain string on the wire. The structured and text-only histories must
+// serialise identically and the payload must never leak.
+func TestOpenAIStructuredToolResult_AlwaysText(t *testing.T) {
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", "gpt-4o")
+	if q.StructuredToolResults.Supported {
+		t.Fatalf("precondition: openai must not resolve a structured capability")
+	}
+
+	withStructured, err := buildOpenAIRequest(types.StreamParams{
+		Model:    "gpt-4o",
+		Tools:    anthropicTools(),
+		Messages: structuredToolResultMessages(),
+	}, true, q, nil)
+	if err != nil {
+		t.Fatalf("build with-structured: %v", err)
+	}
+	textOnly, err := buildOpenAIRequest(types.StreamParams{
+		Model:    "gpt-4o",
+		Tools:    anthropicTools(),
+		Messages: textOnlyToolResultMessages(),
+	}, true, q, nil)
+	if err != nil {
+		t.Fatalf("build text-only: %v", err)
+	}
+
+	a := mustMarshal(t, withStructured)
+	b := mustMarshal(t, textOnly)
+	if !bytes.Equal(a, b) {
+		t.Errorf("openai body must be byte-identical regardless of structured envelope\n with-structured: %s\n text-only:       %s", a, b)
+	}
+	if bytes.Contains(a, []byte("exit_code")) {
+		t.Errorf("structured payload leaked into the openai request: %s", a)
+	}
+}
+
+// TestOpenAIResponsesStructuredToolResult_AlwaysText is the Responses-API
+// analogue: function_call_output.output is a plain string, so the adapter
+// stays text-only and the payload never reaches the wire.
+func TestOpenAIResponsesStructuredToolResult_AlwaysText(t *testing.T) {
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", "gpt-4o")
+
+	withStructured, err := buildResponsesRequest(types.StreamParams{
+		Model:    "gpt-4o",
+		Tools:    anthropicTools(),
+		Messages: structuredToolResultMessages(),
+	}, q, nil)
+	if err != nil {
+		t.Fatalf("build with-structured: %v", err)
+	}
+	textOnly, err := buildResponsesRequest(types.StreamParams{
+		Model:    "gpt-4o",
+		Tools:    anthropicTools(),
+		Messages: textOnlyToolResultMessages(),
+	}, q, nil)
+	if err != nil {
+		t.Fatalf("build text-only: %v", err)
+	}
+
+	a := mustMarshal(t, withStructured)
+	b := mustMarshal(t, textOnly)
+	if !bytes.Equal(a, b) {
+		t.Errorf("responses body must be byte-identical regardless of structured envelope\n with-structured: %s\n text-only:       %s", a, b)
+	}
+	if bytes.Contains(a, []byte("exit_code")) {
+		t.Errorf("structured payload leaked into the responses request: %s", a)
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// geminiFunctionResponseFromBody extracts the functionResponse.response raw
+// object from the first function-role content in a serialised Gemini request
+// body. Fails the test if the shape is not present.
+func geminiFunctionResponseFromBody(t *testing.T, body []byte) json.RawMessage {
+	t.Helper()
+	var decoded struct {
+		Contents []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				FunctionResponse *struct {
+					Name     string          `json:"name"`
+					Response json.RawMessage `json:"response"`
+				} `json:"functionResponse"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal gemini body: %v", err)
+	}
+	for _, c := range decoded.Contents {
+		if c.Role != "function" {
+			continue
+		}
+		for _, p := range c.Parts {
+			if p.FunctionResponse != nil {
+				return p.FunctionResponse.Response
+			}
+		}
+	}
+	t.Fatalf("no functionResponse in body: %s", body)
+	return nil
+}

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -308,6 +308,15 @@ func scrubModelInput(in types.ModelInput) types.ModelInput {
 // scrubContentBlocks scrubs text and tool-result content. Tool-use
 // blocks carry an Input json.RawMessage that may itself encode arbitrary
 // content; we re-use scrubRawJSON to preserve a valid JSON shape.
+//
+// The Structured field on a tool_result block carries the issue #231 typed
+// envelope and, for MCP-derived results, untrusted server output. It is
+// scrubbed on the same footing as Input via scrubRawJSON so a secret-shaped
+// substring in a structured payload (built-in OR MCP) cannot reach the
+// persisted trace unscrubbed. This mirrors the ToolCallRecord.Structured
+// scrub in scrubTurnRecord; both surfaces are scrubbed because the same
+// payload reaches the trace via two routes (the turn record AND the next
+// turn's model input message history).
 func scrubContentBlocks(blocks []types.ContentBlock) []types.ContentBlock {
 	if blocks == nil {
 		return nil
@@ -320,6 +329,9 @@ func scrubContentBlocks(blocks []types.ContentBlock) []types.ContentBlock {
 		}
 		if len(nb.Input) > 0 {
 			nb.Input = scrubRawJSON(nb.Input)
+		}
+		if len(nb.Structured) > 0 {
+			nb.Structured = scrubRawJSON(nb.Structured)
 		}
 		out[i] = nb
 	}

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -353,6 +353,58 @@ func TestJSONLTraceEmitter_RecordTurnRecord_ScrubsStructured(t *testing.T) {
 	}
 }
 
+// TestJSONLTraceEmitter_RecordTurnRecord_ScrubsContentBlockStructured pins the
+// issue #231 B2 requirement that a structured tool-result envelope carried on a
+// message-history ContentBlock is scrubbed before persistence. This is the
+// route MCP-derived structured content (untrusted server output) takes into the
+// trace: it lands on the tool_result block of the NEXT turn's ModelInput, not
+// only on the ToolCallRecord. A secret-shaped substring inside that block's
+// Structured payload must not reach disk in the clear.
+func TestJSONLTraceEmitter_RecordTurnRecord_ScrubsContentBlockStructured(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+
+	emitter.Start("run-scrub-cb-structured", nil)
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 2,
+		ModelInput: types.ModelInput{
+			Model: "claude-3-5-sonnet-latest",
+			Messages: []types.Message{
+				{
+					Role: "user",
+					Content: []types.ContentBlock{
+						{
+							Type:      "tool_result",
+							ToolUseID: "call_1",
+							Content:   "ok",
+							Kind:      "mcp_tool_result",
+							Structured: json.RawMessage(
+								`{"structured_content":{"token":"sk-ant-api03-cbleak"}}`,
+							),
+						},
+					},
+				},
+			},
+		},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	onDisk := buf.String()
+	if strings.Contains(onDisk, "sk-ant-api03-cbleak") {
+		t.Errorf("scrubber missed secret in content-block structured payload on disk:\n%s", onDisk)
+	}
+	if !strings.Contains(onDisk, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] placeholder proving the content-block structured scrub ran, got:\n%s", onDisk)
+	}
+	// The structured field must survive as parseable JSON, not a mangled
+	// fragment — scrubRawJSON preserves a valid shape.
+	if !strings.Contains(onDisk, `"structured"`) {
+		t.Errorf("expected the content-block structured field to survive scrubbing, got:\n%s", onDisk)
+	}
+}
+
 // TestJSONLTraceEmitter_PartialStream pins the SIGKILL-safety property:
 // when a run is interrupted between RecordTurnRecord and Finish, the
 // on-disk file is still parseable up to the last completed event.

--- a/types/messages.go
+++ b/types/messages.go
@@ -44,6 +44,19 @@ type ContentBlock struct {
 	Content          string          `json:"content,omitempty"`
 	IsError          bool            `json:"is_error,omitempty"`
 	ThoughtSignature string          `json:"thought_signature,omitempty"`
+
+	// Structured and Kind carry the optional typed tool-result envelope
+	// (issue #231) from a tool_result ToolResult onto the message-history
+	// content block so the provider adapters can decide, per the resolved
+	// StructuredToolResults capability, whether to serialise the structured
+	// shape or fall back to the text Content. They are populated only on
+	// tool_result blocks and only when the producing tool emitted structured
+	// data; both are omitempty so a text-only result serialises byte-
+	// identically to the pre-#231 shape. Content remains the canonical
+	// fallback and is always populated — an adapter that does not opt into
+	// the structured shape ignores these fields entirely.
+	Structured json.RawMessage `json:"structured,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
 }
 
 // ToolDefinition describes a tool available to the model.


### PR DESCRIPTION
## Summary

Final chunk of **Wave 4 / #231**. Consumes the B1 envelope (`ToolResult.Structured`/`Kind`) to (1) serialize structured tool results onto provider wires only where the provider accepts them, (2) stop the MCP bridge silently discarding non-text `tools/call` content, and (3) document the envelope + fallback. Together with #324 (B1), this **closes #231**.

Stacked: `#321` ← `#322` ← `#323` ← `#324` (B1) ← **B2**. Auto-retargets as lower PRs merge.

## What lands

- **New `ProviderQuirks.StructuredToolResults` capability** (top-level, mirroring A1's `ToolChoice`) with per-provider rules accurate to each wire contract:
  - **Anthropic** — `tool_result.content` has no native JSON type, so the envelope rides as an extra `text` part (`ContentBlockArray`).
  - **Gemini** — `functionResponse.response` is a free-form object, so the envelope embeds under it (`ObjectResponse`).
  - **OpenAI (chat + responses) / Bedrock** — tool messages are plain strings → **text-only**.
- **Adapters serialize structured only when `cap.Supported`**; otherwise the existing text `Content`. **Byte-identical to pre-#231 when the capability is unset** — proven across all adapters by marshalled-bytes tests (and a guard that internal fields like `exit_code` never leak when off).
- **MCP bridge** (`mcp/client.go`) preserves text + `structuredContent` (kind `mcp_tool_result`) and represents resource-links / embedded-resources / image / audio / unknown as explicit typed descriptors — never silently dropped. `annotations` are intentionally not surfaced (client-filtering metadata; documented).
- **Docs**: `docs/architecture.md` (structured-results + MCP subsections) and `docs/provider-quirks.md` (the new capability), impersonal voice.

## Untrusted-MCP hardening (security)

MCP server output is untrusted. Enforced bounds, all before allocation where possible: **item-count cap (512)** with a truncation marker + `slog.Warn`; **256KB** structuredContent cap; **8KB** embedded-text truncation; **binary/image bytes never inlined**; assembled-envelope re-check drops-with-marker. MCP-derived content rides the shared secret-scrub on both persistence routes (`ToolCallRecord.Structured` via `scrubTurnRecord`, `ContentBlock.Structured` via `scrubContentBlocks`) — scrub coverage verified sound across all sinks.

## Review hardening (post-review remediation)

- Rune-safe MCP tool-name truncation (was byte-slicing → invalid UTF-8 in OTLP metric attributes).
- `"structuredContent": null` now omits the structured field (was emitting a spurious `"structured_content":null` turn).
- The untrusted item-count cap (the DoS bound above) — fires before allocation.
- Bedrock text-only pin test, binary-blob + audio descriptor tests, empty-content Anthropic guard, structured payload counted toward the token budget.

## Test plan

- [x] `just` (build + test) + `just lint` green
- [x] capability ON → structured on the wire (Anthropic text part / Gemini object); OFF → byte-identical text-only across all adapters
- [x] MCP structuredContent preserved; non-text marked not dropped; `null` structuredContent omitted
- [x] each untrusted bound (item count, 256KB, 8KB, binary-not-inlined, oversized-envelope) exercised
- [x] MCP-derived content scrubbed before persistence
- [x] `StructuredToolResults` resolves correctly for anthropic/openai/gemini/bedrock

Closes #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)