### PR TITLE
tools: provider-friendly toolset profiles and aliases (Wave 5 C1, closes #234)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -412,6 +412,16 @@ broaden capability — it cannot surface a tool the registry did not
 register, and an alias for a tool a read-only mode excluded does not
 exist because the excluded tool is never registered to alias.
 
+Every gating and guard surface keys on the internal tool ID, never the
+alias: the permission policy, the workspace-mutation guard, the
+guardrail's `PhasePreTool` classifier input, and the sub-agent
+recursion filter all see `grep_files`, not `grep`. **Cedar policies and
+permission configs must reference internal tool IDs** (`run_command`,
+`grep_files`, `edit_file`, …), not profile aliases. A Cedar rule that
+forbids `"bash"` under the `coding-classic` profile matches nothing —
+the policy engine is never shown the alias. Write the rule against
+`run_command`.
+
 Existing configs keep working. Because the default profile is the
 identity presentation, a config that names tools by their internal IDs
 in `tools.builtIn` (or a model that calls them by those IDs) continues
@@ -428,7 +438,12 @@ the binding never silently routes a call to the wrong handler.
 Traces record both names. Each tool-call trace and record carries the
 model-facing `name` and, when an alias was resolved, the internal
 `internalName`; under the default profile the two coincide and
-`internalName` is omitted, keeping the trace wire shape unchanged.
+`internalName` is omitted, keeping the trace wire shape unchanged. An
+absent `internalName` is therefore ambiguous in isolation — it means
+either "called by internal name under the default profile" or "the name
+did not resolve to a known tool under a non-default profile". The active
+`tools.profile` is recorded in the trace's attached `RunConfig`, so the
+two cases are distinguishable by reading it alongside the record.
 
 ## Limits and budgets
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,6 +268,7 @@ Walkthrough: [`azure-workload-identity.md`](azure-workload-identity.md).
 | `--git-strategy` | `none` | One of `none`, `deterministic`. |
 | `--permission-policy-file` | (none) | Path to a Cedar policy file. When set and the policy type is unset elsewhere, implies `permissionPolicy.type=policy-engine`. Starters live under [`examples/policies/`](../examples/policies/). |
 | `--code-scanner` | (none) | One of `none`, `patterns`, `semgrep`. `composite` is accepted only via `--config` (it requires `codeScanner.scanners`). Empty defers to the mode-aware default (`patterns` for execution, `none` for read-only modes). |
+| `--tools-profile` | (none) | Model-facing toolset profile. Closed enum: `""`/`default` (no aliasing, internal tool names) or `coding-classic` (terse coding-CLI aliases). Changes only the names the model sees; dispatch identities and gating are unchanged. JSON path: `tools.profile`. See [Toolset profiles](#toolset-profiles). |
 
 ### Transport
 
@@ -391,6 +392,43 @@ The read-only modes differ from each other only in prompt template:
 `planning` for "describe and reason before acting" first-touch use,
 `review` for change-review tasks, `research` for investigation across
 a codebase or the web, and `toil` for structured-briefing workflows.
+
+## Toolset profiles
+
+`tools.profile` selects the *model-facing presentation* of the tool
+set — the names and descriptions a model sees on the wire — without
+changing the tools the harness dispatches to. It is a closed enum:
+
+| Value | Presentation |
+|---|---|
+| `""` / `default` | Identity. Tools present under their internal names (`grep_files`, `find_files`, `run_command`, `edit_file`, …). This is the zero value, so a config that omits the field behaves exactly as before profiles existed. |
+| `coding-classic` | Presents the terse coding-CLI aliases some models call by reflex: `grep_files` → `grep`, `find_files` → `find`, `run_command` → `bash`. Tools not in the alias table (including `read_file`, `edit_file`, and every MCP tool) present unchanged. |
+
+An alias changes only the name. The internal dispatch identity is
+untouched: a model that calls `grep` reaches the same `grep_files`
+handler, the permission policy still gates it as `grep_files`, and the
+security guard still keys on `grep_files`. Aliasing therefore cannot
+broaden capability — it cannot surface a tool the registry did not
+register, and an alias for a tool a read-only mode excluded does not
+exist because the excluded tool is never registered to alias.
+
+Existing configs keep working. Because the default profile is the
+identity presentation, a config that names tools by their internal IDs
+in `tools.builtIn` (or a model that calls them by those IDs) continues
+to resolve under any profile — the internal name is always accepted in
+addition to the alias.
+
+Alias collisions — two tools whose profile aliases land on the same
+string — are resolved by the same deterministic normalization the
+provider function-name layer uses (see
+[`provider-quirks.md`](provider-quirks.md) and the `toolname` package):
+one keeps the bare alias, the other gains a short stable hash suffix, so
+the binding never silently routes a call to the wrong handler.
+
+Traces record both names. Each tool-call trace and record carries the
+model-facing `name` and, when an alias was resolved, the internal
+`internalName`; under the default profile the two coincide and
+`internalName` is omitted, keeping the trace wire shape unchanged.
 
 ## Limits and budgets
 

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -116,6 +116,12 @@ type harnessCLIOptions struct {
 	// flag is empty by default so a bare invocation does not opt into a
 	// compat shape.
 	CompatProfile string
+
+	// ToolsProfile selects the model-facing toolset profile (issue #234).
+	// Closed set, validated by ValidateRunConfig. Empty by default, which
+	// is the identity presentation: a bare invocation presents tools under
+	// their internal names exactly as before.
+	ToolsProfile  string
 	Model         string
 	Workspace     string
 	MaxTurns      int
@@ -376,6 +382,11 @@ func buildHarnessRunConfigCore(opts harnessCLIOptions) (*types.RunConfig, error)
 		EditStrategy: types.EditStrategyConfig{Type: editStrategyType},
 		Verifier:     types.VerifierConfig{Type: verifierType},
 		GitStrategy:  types.GitStrategyConfig{Type: gitStrategyType},
+		// Tools.BuiltIn is left empty here (the validator treats an empty
+		// list as "all built-ins"); only the model-facing profile is set
+		// from the flag. applyModeDefaults fills BuiltIn for read-only
+		// modes afterwards and leaves Profile untouched.
+		Tools:        types.ToolsConfig{Profile: opts.ToolsProfile},
 		Transport:    types.TransportConfig{Type: opts.TransportType, Address: opts.TransportAddr},
 		TraceEmitter: traceEmitter,
 		MaxTurns:     opts.MaxTurns,
@@ -872,6 +883,9 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 	}
 	if changed("provider-compat-profile") {
 		cfg.Provider.CompatProfile, _ = f.GetString("provider-compat-profile")
+	}
+	if changed("tools-profile") {
+		cfg.Tools.Profile, _ = f.GetString("tools-profile")
 	}
 	if changed("gcp-project") {
 		cfg.Provider.GCPProject, _ = f.GetString("gcp-project")

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -346,6 +346,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 	apiKeyHeader, _ := f.GetString("api-key-header")
 	queryParamRaw, _ := f.GetStringArray("query-param")
 	compatProfile, _ := f.GetString("provider-compat-profile")
+	toolsProfile, _ := f.GetString("tools-profile")
 	gcpProject, _ := f.GetString("gcp-project")
 	gcpLocation, _ := f.GetString("gcp-location")
 	gcpCredentialsFile, _ := f.GetString("gcp-credentials-file")
@@ -432,6 +433,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 		APIKeyHeader:                 apiKeyHeader,
 		QueryParams:                  queryParams,
 		CompatProfile:                compatProfile,
+		ToolsProfile:                 toolsProfile,
 		APIKeyRef:                    apiKeyRef,
 		GCPProject:                   gcpProject,
 		GCPLocation:                  gcpLocation,

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -104,6 +104,90 @@ func TestBuildRunConfig_FlagOnlyMatchesBuildHarnessRunConfig(t *testing.T) {
 	}
 }
 
+// TestBuildRunConfig_ToolsProfileFlag pins that --tools-profile threads
+// onto RunConfig.Tools.Profile on the flag-only path and that omitting it
+// leaves the default (empty) identity profile, so a bare invocation does
+// not opt into aliasing (issue #234).
+func TestBuildRunConfig_ToolsProfileFlag(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{
+		"--mode", "execution",
+		"--prompt", "x",
+		"--tools-profile", "coding-classic",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	cfg, err := BuildRunConfig(RunConfigSources{Cmd: cmd, Resolve: ResolveAll})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.Tools.Profile != "coding-classic" {
+		t.Errorf("Tools.Profile = %q, want coding-classic", cfg.Tools.Profile)
+	}
+	if err := types.ValidateRunConfig(cfg); err != nil {
+		t.Errorf("config with tools-profile should validate, got: %v", err)
+	}
+
+	// Without the flag, the profile stays empty (the default identity
+	// presentation).
+	bare := newTestHarnessCommand()
+	if err := bare.ParseFlags([]string{"--mode", "execution", "--prompt", "x"}); err != nil {
+		t.Fatalf("ParseFlags(bare): %v", err)
+	}
+	bareCfg, err := BuildRunConfig(RunConfigSources{Cmd: bare, Resolve: ResolveAll})
+	if err != nil {
+		t.Fatalf("BuildRunConfig(bare): %v", err)
+	}
+	if bareCfg.Tools.Profile != "" {
+		t.Errorf("bare Tools.Profile = %q, want empty (default)", bareCfg.Tools.Profile)
+	}
+}
+
+// TestBuildRunConfig_ToolsProfileOverridesBase pins that --tools-profile
+// overrides a base config's tools.profile and that omitting the flag
+// preserves the base value (the applyOverrides Changed() guard).
+func TestBuildRunConfig_ToolsProfileOverridesBase(t *testing.T) {
+	var base types.RunConfig
+	if err := json.Unmarshal([]byte(minimalRunConfigJSON(t)), &base); err != nil {
+		t.Fatalf("unmarshal base: %v", err)
+	}
+	base.Tools.Profile = "coding-classic"
+	baseJSON, err := json.Marshal(base)
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
+
+	// No flag: base profile preserved.
+	cmd := newTestHarnessCommand()
+	if err := cmd.ParseFlags([]string{"--max-turns", "5"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	cfg, err := BuildRunConfig(RunConfigSources{
+		Stdin: strings.NewReader(string(baseJSON)), Cmd: cmd, Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg.Tools.Profile != "coding-classic" {
+		t.Errorf("base profile not preserved: got %q", cfg.Tools.Profile)
+	}
+
+	// Explicit flag wins over the base.
+	cmd2 := newTestHarnessCommand()
+	if err := cmd2.ParseFlags([]string{"--tools-profile", "default"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	cfg2, err := BuildRunConfig(RunConfigSources{
+		Stdin: strings.NewReader(string(baseJSON)), Cmd: cmd2, Resolve: ResolveBase,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunConfig: %v", err)
+	}
+	if cfg2.Tools.Profile != "default" {
+		t.Errorf("flag did not override base profile: got %q", cfg2.Tools.Profile)
+	}
+}
+
 // TestBuildRunConfig_StdinBaseWithFlagOverride exercises the canonical
 // pipeline shape: a JSON RunConfig arrives on stdin and an explicit
 // flag overrides one field. The base survives intact for every field

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -29,6 +29,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.String("api-key-header", "", "Header name for sending the API key. Empty = Authorization: Bearer (default). Set to \"api-key\" for Azure OpenAI key auth.")
 	f.StringArray("query-param", nil, "Repeatable key=value query parameter appended to every provider request URL (e.g. api-version=preview). Used by the openai-* adapters.")
 	f.String("provider-compat-profile", "", "Optional compatibility profile selecting a pre-defined provider-quirks rule. Closed set; current legal values: \"\" (no profile), \"zai-glm\" (Z.ai GLM tool_stream + legacy max_tokens).")
+	f.String("tools-profile", "", "Model-facing toolset profile (sets tools.profile). Closed set; current legal values: \"\"/\"default\" (no aliasing, internal tool names), \"coding-classic\" (terse coding-CLI aliases: grep, find, bash). Dispatch identities are unchanged regardless of profile.")
 	f.String("gcp-project", "", "GCP project ID hosting the Vertex AI usage. Required when --provider=gemini.")
 	f.String("gcp-location", "global", "Vertex AI location: \"global\" or a region (e.g. us-central1). Determines the URL host and project location segment.")
 	f.String("gcp-credentials-file", "", "Path to a Google service account JSON key file. When set, implies credential.type=gcp-service-account.")
@@ -126,6 +127,7 @@ func addRunConfigFlagCompletions(cmd *cobra.Command) {
 	staticValues("code-scanner", types.ValidCodeScannerTypeValues())
 	staticValues("guardrail", types.ValidGuardRailTypeValues())
 	staticValues("provider-compat-profile", types.ValidCompatProfileValues())
+	staticValues("tools-profile", types.ValidToolsProfileValues())
 
 	// log-level and api-key-header are not declared as validator-closed
 	// sets in types/runconfig.go, but operators benefit from a hinted

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -134,6 +134,26 @@ func (l *AgenticLoop) planAndDispatch(
 			internalName: call.Name,
 		}
 
+		// Resolve up front so every gating surface below keys on the
+		// internal tool ID rather than the model-facing alias (issue #234).
+		// Resolve is a pure lookup; an Unknown tool resolves to nil and
+		// falls through to dispatchToolCall, which fails fast as today.
+		t := l.Tools.Resolve(call.Name)
+		// guardToolName is the name the guardrail classifier sees: the
+		// internal ID when resolved, falling back to the model-supplied
+		// name for an unknown tool. A guardrail rule written against an
+		// internal name must fire under any toolset profile.
+		guardToolName := call.Name
+		if t != nil {
+			// Record the canonical internal tool ID resolved from the
+			// model-facing name. Under a toolset profile call.Name is an
+			// alias; t.Name is always the internal identity (Resolve
+			// returns the underlying tool unchanged), so this is the
+			// alias→internal binding the trace captures.
+			plan[i].internalName = t.Name
+			guardToolName = t.Name
+		}
+
 		// PhasePreTool guard: same semantics as the sequential code. A
 		// deny short-circuits dispatch as a tool failure. Pass the
 		// tool-span ctx so guard.pre_tool nests under tool.<name>.
@@ -141,7 +161,7 @@ func (l *AgenticLoop) planAndDispatch(
 			Phase:     guard.PhasePreTool,
 			Content:   string(call.Input),
 			Source:    "tool_call:" + call.Name,
-			ToolName:  call.Name,
+			ToolName:  guardToolName,
 			ToolInput: call.Input,
 			Mode:      config.Mode,
 			RunID:     config.RunID,
@@ -167,18 +187,6 @@ func (l *AgenticLoop) planAndDispatch(
 			continue
 		}
 
-		// Resolve to decide sync vs async. An Unknown tool falls through
-		// to dispatchToolCall which fails fast with the same error path
-		// as today — treat it as sync.
-		t := l.Tools.Resolve(call.Name)
-		if t != nil {
-			// Record the canonical internal tool ID resolved from the
-			// model-facing name. Under a toolset profile call.Name is an
-			// alias; t.Name is always the internal identity (Resolve
-			// returns the underlying tool unchanged), so this is the
-			// alias→internal binding the trace captures.
-			plan[i].internalName = t.Name
-		}
 		if t != nil && t.AsyncHandler != nil {
 			asyncIndices = append(asyncIndices, i)
 			continue

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -32,15 +32,22 @@ const unknownToolMetricName = "__unknown__"
 // the WaitGroup happens-before relation publishes them to the caller of
 // planAndDispatch.
 type pendingCall struct {
-	call        types.ToolCall
-	span        oteltrace.Span
-	spanCtx     context.Context //nolint:containedctx // span parent ctx threaded into dispatch
-	startedAt   time.Time
-	output      string
-	structured  structuredOutput // optional typed result payload + kind (issue #231); zero value for text-only tools and every failure path
-	success     bool
-	errorReason string // guard-deny reason; written to trace (apply security.Scrub before setting)
-	denied      bool   // PhasePreTool deny path; takes priority over (output, success)
+	call      types.ToolCall
+	span      oteltrace.Span
+	spanCtx   context.Context //nolint:containedctx // span parent ctx threaded into dispatch
+	startedAt time.Time
+	// internalName is the canonical internal tool ID call.Name resolved to
+	// under the active toolset profile (issue #234). call.Name is the
+	// model-facing alias; both are recorded in the trace. Equal to
+	// call.Name under the default profile and for unknown tools (no
+	// registry entry), so the trace's InternalName mirrors Name in those
+	// cases and omitempty keeps the wire shape unchanged.
+	internalName string
+	output       string
+	structured   structuredOutput // optional typed result payload + kind (issue #231); zero value for text-only tools and every failure path
+	success      bool
+	errorReason  string // guard-deny reason; written to trace (apply security.Scrub before setting)
+	denied       bool   // PhasePreTool deny path; takes priority over (output, success)
 	// failureCategory is the bounded ToolFailureCategory describing why
 	// this call failed. Always empty when success is true; one of the
 	// observability.ToolFailureCategory enum values otherwise. Read in
@@ -119,6 +126,12 @@ func (l *AgenticLoop) planAndDispatch(
 			span:      toolSpan,
 			spanCtx:   toolSpanCtx,
 			startedAt: callStart,
+			// Default the internal name to the model-facing name; it is
+			// refined to the resolved tool's internal ID below once the
+			// registry lookup succeeds. Denied and unknown-tool calls keep
+			// this default (alias == internal), which is the correct trace
+			// shape for both.
+			internalName: call.Name,
 		}
 
 		// PhasePreTool guard: same semantics as the sequential code. A
@@ -158,6 +171,14 @@ func (l *AgenticLoop) planAndDispatch(
 		// to dispatchToolCall which fails fast with the same error path
 		// as today — treat it as sync.
 		t := l.Tools.Resolve(call.Name)
+		if t != nil {
+			// Record the canonical internal tool ID resolved from the
+			// model-facing name. Under a toolset profile call.Name is an
+			// alias; t.Name is always the internal identity (Resolve
+			// returns the underlying tool unchanged), so this is the
+			// alias→internal binding the trace captures.
+			plan[i].internalName = t.Name
+		}
 		if t != nil && t.AsyncHandler != nil {
 			asyncIndices = append(asyncIndices, i)
 			continue
@@ -281,8 +302,17 @@ func (l *AgenticLoop) planAndDispatch(
 		case !p.success:
 			errorReason = security.Scrub(p.output)
 		}
+		// Emit InternalName only when an alias was actually resolved (it
+		// differs from the model-facing name). Under the default profile
+		// the two are equal, so the field stays empty and omitempty keeps
+		// the trace wire shape byte-identical to the pre-profile behaviour.
+		internalForTrace := ""
+		if p.internalName != p.call.Name {
+			internalForTrace = p.internalName
+		}
 		l.Trace.RecordToolCall(types.ToolCallTrace{
 			Name:          p.call.Name,
+			InternalName:  internalForTrace,
 			DurationMs:    callDuration.Milliseconds(),
 			Success:       p.success,
 			ErrorReason:   errorReason,
@@ -339,14 +369,15 @@ func (l *AgenticLoop) planAndDispatch(
 		// RecordTurnRecord call after planAndDispatch returns is a pure
 		// data hand-off.
 		toolRecords[i] = types.ToolCallRecord{
-			ID:         p.call.ID,
-			Name:       p.call.Name,
-			Input:      p.call.Input,
-			Output:     p.output,
-			DurationMs: callDuration.Milliseconds(),
-			Success:    p.success,
-			Structured: p.structured.payload,
-			Kind:       p.structured.kind,
+			ID:           p.call.ID,
+			Name:         p.call.Name,
+			InternalName: internalForTrace,
+			Input:        p.call.Input,
+			Output:       p.output,
+			DurationMs:   callDuration.Milliseconds(),
+			Success:      p.success,
+			Structured:   p.structured.payload,
+			Kind:         p.structured.kind,
 		}
 
 		if err := l.Transport.Emit(types.HarnessEvent{

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -555,6 +555,29 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		addApprovalTool(pp, "spawn_agent")
 	}
 
+	// Apply the toolset-profile presentation (issue #234) last, after every
+	// tool (built-ins, MCP, spawn_agent) is registered, so the alias mapping
+	// covers the complete tool set. The presenter wraps the registry for the
+	// loop's List/Resolve seam only; the permission policy, mutating-tool
+	// set, and MCP registration above all keep operating on the raw registry
+	// and the internal tool IDs, so aliasing changes the model-facing name
+	// without touching dispatch gating. The profile name passed ValidateRunConfig
+	// already; ProfileFor returning false here would mean a profile in the
+	// validator's closed set has no table, which is a build-time bug we fail
+	// loudly on rather than silently presenting no aliases.
+	profile, ok := tool.ProfileFor(config.Tools.Profile)
+	if !ok {
+		cleanup()
+		return nil, fmt.Errorf("tools.profile %q has no presentation table", config.Tools.Profile)
+	}
+	presenter, err := tool.NewPresenter(registry, profile)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("build tool profile presenter: %w", err)
+	}
+	loop.Tools = presenter
+	loop.ToolProfile = profile
+
 	return loop, nil
 }
 

--- a/harness/internal/core/integration_test.go
+++ b/harness/internal/core/integration_test.go
@@ -339,10 +339,17 @@ func TestBuildLoop_ResearchModeWebFetchEndToEnd(t *testing.T) {
 
 	// Replace web_fetch with a stub so the test does not depend on
 	// network access. The permission policy runs *before* the handler,
-	// so this still exercises the WP1 gating path.
-	registry, ok := loop.Tools.(*tool.Registry)
+	// so this still exercises the WP1 gating path. loop.Tools is the
+	// profile Presenter (issue #234); unwrap to the underlying registry
+	// to swap a handler — web_fetch is unaliased under the default
+	// profile, so the presented name is unchanged by the re-registration.
+	presenter, ok := loop.Tools.(*tool.Presenter)
 	if !ok {
-		t.Fatalf("expected *tool.Registry, got %T", loop.Tools)
+		t.Fatalf("expected *tool.Presenter, got %T", loop.Tools)
+	}
+	registry, ok := presenter.Unwrap().(*tool.Registry)
+	if !ok {
+		t.Fatalf("expected *tool.Registry under presenter, got %T", presenter.Unwrap())
 	}
 	original := registry.Resolve("web_fetch")
 	if original == nil {

--- a/harness/internal/core/profile_dispatch_test.go
+++ b/harness/internal/core/profile_dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"sync"
 	"testing"
 
 	"go.opentelemetry.io/otel/trace/noop"
@@ -12,6 +13,7 @@ import (
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/guard"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
@@ -167,4 +169,54 @@ func mustProfile(t *testing.T, name string) *tool.Profile {
 		t.Fatalf("ProfileFor(%q) not found", name)
 	}
 	return p
+}
+
+// toolNameCapturingGuard records the ToolName it sees on each PhasePreTool
+// check so a test can assert which name reaches the guardrail classifier.
+type toolNameCapturingGuard struct {
+	mu        sync.Mutex
+	toolNames []string
+}
+
+func (g *toolNameCapturingGuard) Check(_ context.Context, in guard.Input) (*guard.Decision, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if in.Phase == guard.PhasePreTool {
+		g.toolNames = append(g.toolNames, in.ToolName)
+	}
+	return &guard.Decision{Verdict: guard.VerdictAllow, GuardID: "capture"}, nil
+}
+
+// The PhasePreTool guardrail must see the INTERNAL tool ID, not the alias
+// (issue #234 B1b): a guardrail rule written against an internal name has
+// to fire under any toolset profile. The model calls "grep"; the guard
+// must observe "grep_files".
+func TestProfileDispatch_GuardrailSeesInternalToolName(t *testing.T) {
+	var ran bool
+	reg := tool.NewRegistry()
+	reg.Register(grepFilesTestTool(&ran))
+
+	rec := &recordingTraceEmitter{}
+	loop := buildProfileDispatchLoop(t, reg, mustProfile(t, "coding-classic"), rec)
+	g := &toolNameCapturingGuard{}
+	loop.GuardRail = g
+
+	cfg := &types.RunConfig{Mode: "execution", RunID: "guard-name"}
+	_, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc1", Name: "grep", Input: json.RawMessage(`{}`)}},
+		&stallDetector{}, "anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome: %q", outcome)
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.toolNames) != 1 {
+		t.Fatalf("expected 1 PhasePreTool check, got %d", len(g.toolNames))
+	}
+	if g.toolNames[0] != "grep_files" {
+		t.Errorf("guardrail saw ToolName %q, want internal id %q", g.toolNames[0], "grep_files")
+	}
 }

--- a/harness/internal/core/profile_dispatch_test.go
+++ b/harness/internal/core/profile_dispatch_test.go
@@ -1,0 +1,170 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
+	"github.com/rxbynerd/stirrup/harness/internal/edit"
+	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/permission"
+	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+	"github.com/rxbynerd/stirrup/harness/internal/router"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/harness/internal/verifier"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// grepFilesTestTool is a minimal grep_files stand-in whose handler records
+// that it ran, so a profile-alias dispatch test can prove the alias routed
+// to this internal tool.
+func grepFilesTestTool(ran *bool) *tool.Tool {
+	return &tool.Tool{
+		Name:        "grep_files",
+		Description: "regex content search",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(context.Context, json.RawMessage) (string, error) {
+			*ran = true
+			return "grep_files ran", nil
+		},
+	}
+}
+
+// buildProfileDispatchLoop wires a loop whose Tools is a profile Presenter
+// over the given registry, with a recording trace emitter so the test can
+// assert the trace shape.
+func buildProfileDispatchLoop(t *testing.T, reg *tool.Registry, profile *tool.Profile, rec *recordingTraceEmitter) *AgenticLoop {
+	t.Helper()
+	presenter, err := tool.NewPresenter(reg, profile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+	return &AgenticLoop{
+		Router:       router.NewStaticRouter("anthropic", "claude-sonnet-4-6"),
+		Prompt:       prompt.NewDefaultPromptBuilder(),
+		Context:      contextpkg.NewSlidingWindowStrategy(),
+		Tools:        presenter,
+		ToolProfile:  profile,
+		Edit:         edit.NewWholeFileStrategy(),
+		Verifier:     verifier.NewNoneVerifier(),
+		Permissions:  permission.NewAllowAll(),
+		Git:          git.NewNoneGitStrategy(),
+		Transport:    transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{}),
+		Trace:        rec,
+		Tracer:       noop.NewTracerProvider().Tracer(""),
+		TraceContext: context.Background(),
+		Metrics:      observability.NewNoopMetrics(),
+		Logger:       slog.Default(),
+	}
+}
+
+// A profile presents an alias; the model calls by the alias; dispatch
+// resolves the alias to the internal tool, executes it, and the trace
+// records BOTH the model-facing alias and the internal tool identity.
+func TestProfileDispatch_AliasResolvesAndTraceRecordsBothNames(t *testing.T) {
+	var ran bool
+	reg := tool.NewRegistry()
+	reg.Register(grepFilesTestTool(&ran))
+
+	rec := &recordingTraceEmitter{}
+	loop := buildProfileDispatchLoop(t, reg, mustProfile(t, "coding-classic"), rec)
+
+	cfg := &types.RunConfig{Mode: "execution", RunID: "profile-dispatch"}
+	stall := &stallDetector{}
+
+	// The model calls "grep" — the coding-classic alias for grep_files.
+	results, records, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc1", Name: "grep", Input: json.RawMessage(`{}`)}},
+		stall, "anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome: %q", outcome)
+	}
+	if !ran {
+		t.Fatal("grep_files handler did not run — alias did not resolve to the internal tool")
+	}
+	if len(results) != 1 || results[0].IsError {
+		t.Fatalf("expected one successful result, got %+v", results)
+	}
+	if results[0].Content != "grep_files ran" {
+		t.Errorf("result content %q, want %q", results[0].Content, "grep_files ran")
+	}
+
+	// Trace: ToolCallTrace must carry the alias as Name and the internal ID
+	// as InternalName.
+	_, calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 recorded tool call, got %d", len(calls))
+	}
+	if calls[0].Name != "grep" {
+		t.Errorf("trace Name = %q, want alias %q", calls[0].Name, "grep")
+	}
+	if calls[0].InternalName != "grep_files" {
+		t.Errorf("trace InternalName = %q, want %q", calls[0].InternalName, "grep_files")
+	}
+
+	// The full record carries both names too.
+	if len(records) != 1 {
+		t.Fatalf("expected 1 tool record, got %d", len(records))
+	}
+	if records[0].Name != "grep" || records[0].InternalName != "grep_files" {
+		t.Errorf("record names: Name=%q InternalName=%q, want grep/grep_files",
+			records[0].Name, records[0].InternalName)
+	}
+}
+
+// Existing configs that name tools by their internal IDs keep working:
+// under the default profile, calling grep_files by its internal name
+// dispatches and the trace omits InternalName (alias == internal), so the
+// trace wire shape is byte-identical to the pre-profile behaviour.
+func TestProfileDispatch_DefaultProfileInternalNameStillWorks(t *testing.T) {
+	var ran bool
+	reg := tool.NewRegistry()
+	reg.Register(grepFilesTestTool(&ran))
+
+	rec := &recordingTraceEmitter{}
+	loop := buildProfileDispatchLoop(t, reg, mustProfile(t, "default"), rec)
+
+	cfg := &types.RunConfig{Mode: "execution", RunID: "default-dispatch"}
+	stall := &stallDetector{}
+
+	results, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc1", Name: "grep_files", Input: json.RawMessage(`{}`)}},
+		stall, "anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome: %q", outcome)
+	}
+	if !ran || len(results) != 1 || results[0].IsError {
+		t.Fatalf("default profile + internal name should dispatch: ran=%v results=%+v", ran, results)
+	}
+
+	_, calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 recorded tool call, got %d", len(calls))
+	}
+	if calls[0].Name != "grep_files" {
+		t.Errorf("trace Name = %q, want %q", calls[0].Name, "grep_files")
+	}
+	if calls[0].InternalName != "" {
+		t.Errorf("default profile must omit InternalName (alias == internal), got %q", calls[0].InternalName)
+	}
+}
+
+func mustProfile(t *testing.T, name string) *tool.Profile {
+	t.Helper()
+	p, ok := tool.ProfileFor(name)
+	if !ok {
+		t.Fatalf("ProfileFor(%q) not found", name)
+	}
+	return p
+}

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -68,8 +68,21 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 		mode = parentConfig.Mode
 	}
 
-	// Build a child tool registry that excludes spawn_agent to prevent recursion.
-	childTools := filterToolRegistry(parent.Tools, "spawn_agent")
+	// Build a child tool registry that excludes spawn_agent to prevent
+	// recursion. filterToolRegistry rebuilds a plain registry keyed by the
+	// internal tool IDs (Resolve returns tools whose Name is the internal
+	// identity), so the child starts from internal names regardless of the
+	// parent's presentation. Re-wrap it under the parent's toolset profile
+	// (issue #234) so a sub-agent sees the same aliases the parent does;
+	// NewPresenter on a default/nil profile is the identity presentation,
+	// so the non-profile path is unchanged. A presenter build failure here
+	// would only arise from an alias collision the parent already resolved,
+	// so fall back to the unaliased child registry rather than aborting the
+	// spawn.
+	var childTools tool.ToolRegistry = filterToolRegistry(parent.Tools, "spawn_agent")
+	if presenter, err := tool.NewPresenter(childTools, parent.ToolProfile); err == nil {
+		childTools = presenter
+	}
 
 	// Use a capture transport to collect the sub-agent's text output.
 	// The capture transport wraps a NullTransport, recording text_delta
@@ -117,6 +130,7 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 		Prompt:      parent.Prompt,
 		Context:     contextpkg.NewSlidingWindowStrategy(),
 		Tools:       childTools,
+		ToolProfile: parent.ToolProfile,
 		Executor:    parent.Executor,
 		Edit:        parent.Edit,
 		Verifier:    verifier.NewNoneVerifier(),

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -82,6 +82,20 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 	var childTools tool.ToolRegistry = filterToolRegistry(parent.Tools, "spawn_agent")
 	if presenter, err := tool.NewPresenter(childTools, parent.ToolProfile); err == nil {
 		childTools = presenter
+	} else {
+		// A build failure here only arises from an alias collision in the
+		// child tool set — which the parent's presenter already resolved
+		// over a superset, so it should not recur. Degrade to the unaliased
+		// child registry rather than aborting the spawn, but never silently:
+		// the child would then run with internal tool names while the
+		// parent context and the model's prior turns used aliases, breaking
+		// tool-name continuity. Surface it so the divergence is auditable.
+		profileName := ""
+		if parent.ToolProfile != nil {
+			profileName = parent.ToolProfile.Name
+		}
+		parent.Logger.Warn("child presenter build failed; sub-agent will use internal tool names",
+			"err", err, "profile", profileName)
 	}
 
 	// Use a capture transport to collect the sub-agent's text output.
@@ -261,7 +275,17 @@ func capSubAgentMaxTurns(requested, parentMaxTurns int) int {
 }
 
 // filterToolRegistry creates a new Registry containing all tools from the
-// source except those whose names match any of the excluded names.
+// source except those whose internal tool IDs match any of the excluded
+// names.
+//
+// Exclusion is checked against the resolved tool's internal Name, not the
+// name from source.List(): when source is a *Presenter (the production
+// case after factory wiring), List() yields the model-facing alias while
+// excludedNames are internal IDs (e.g. "spawn_agent"). Keying the check on
+// def.Name would let a profile that aliases an excluded tool slip it past
+// the filter — defeating the spawn_agent recursion guard. Resolve returns
+// the underlying tool whose Name is always the internal identity, so the
+// check is profile-independent.
 func filterToolRegistry(source tool.ToolRegistry, excludedNames ...string) *tool.Registry {
 	excluded := make(map[string]bool, len(excludedNames))
 	for _, name := range excludedNames {
@@ -270,13 +294,11 @@ func filterToolRegistry(source tool.ToolRegistry, excludedNames ...string) *tool
 
 	filtered := tool.NewRegistry()
 	for _, def := range source.List() {
-		if excluded[def.Name] {
+		t := source.Resolve(def.Name)
+		if t == nil || excluded[t.Name] {
 			continue
 		}
-		t := source.Resolve(def.Name)
-		if t != nil {
-			filtered.Register(t)
-		}
+		filtered.Register(t)
 	}
 	return filtered
 }

--- a/harness/internal/core/subagent_test.go
+++ b/harness/internal/core/subagent_test.go
@@ -290,6 +290,65 @@ func TestFilterToolRegistry_ExcludesSpawnAgent(t *testing.T) {
 	}
 }
 
+// The recursion guard must exclude spawn_agent by its INTERNAL id even
+// when the source registry is a Presenter that aliases spawn_agent to a
+// different model-facing name. Filtering on the presented (alias) name
+// would let the child loop inherit spawn_agent and defeat the guard
+// (issue #234 B1). Here a test profile aliases spawn_agent → "agent";
+// the filtered child must still exclude it and keep the other tools.
+func TestFilterToolRegistry_ExcludesAliasedSpawnAgent(t *testing.T) {
+	registry := tool.NewRegistry()
+	registry.Register(&tool.Tool{
+		Name:        "spawn_agent",
+		Description: "Spawn a sub-agent",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Handler:     func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+	})
+	registry.Register(&tool.Tool{
+		Name:        "run_command",
+		Description: "Run a command",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Handler:     func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+	})
+
+	// Profile aliases spawn_agent to "agent" (and run_command to "bash").
+	profile := tool.NewProfile("alias-spawn", map[string]string{
+		"spawn_agent": "agent",
+		"run_command": "bash",
+	}, nil)
+	presenter, err := tool.NewPresenter(registry, profile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+
+	// Sanity: the presenter does present spawn_agent under its alias, so
+	// this test would catch the alias-keyed bug.
+	var sawAlias bool
+	for _, d := range presenter.List() {
+		if d.Name == "agent" {
+			sawAlias = true
+		}
+	}
+	if !sawAlias {
+		t.Fatal("precondition failed: presenter did not alias spawn_agent to 'agent'")
+	}
+
+	filtered := filterToolRegistry(presenter, "spawn_agent")
+
+	if filtered.Resolve("spawn_agent") != nil {
+		t.Error("aliased spawn_agent leaked past the recursion guard (by internal name)")
+	}
+	if filtered.Resolve("agent") != nil {
+		t.Error("aliased spawn_agent leaked past the recursion guard (by alias name)")
+	}
+	if filtered.Resolve("run_command") == nil {
+		t.Error("run_command should survive filtering")
+	}
+	if len(filtered.List()) != 1 {
+		t.Errorf("expected exactly run_command to remain, got %d tools", len(filtered.List()))
+	}
+}
+
 func TestSpawnSubAgent_InheritsParentMode(t *testing.T) {
 	prov := &mockProvider{
 		events: []types.StreamEvent{

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -56,12 +56,19 @@ const asyncResultTruncationSuffix = "... [truncated by harness]"
 // fields — the loop has no imports from concrete implementations, no environment
 // variable reads, no direct file system access.
 type AgenticLoop struct {
-	Provider     provider.ProviderAdapter
-	Providers    map[string]provider.ProviderAdapter
-	Router       router.ModelRouter
-	Prompt       prompt.PromptBuilder
-	Context      contextpkg.ContextStrategy
-	Tools        tool.ToolRegistry
+	Provider  provider.ProviderAdapter
+	Providers map[string]provider.ProviderAdapter
+	Router    router.ModelRouter
+	Prompt    prompt.PromptBuilder
+	Context   contextpkg.ContextStrategy
+	Tools     tool.ToolRegistry
+	// ToolProfile is the resolved toolset-profile presentation applied to
+	// Tools (issue #234). Nil means the default (identity) profile. Held on
+	// the loop so SpawnSubAgent can re-present the filtered child registry
+	// under the same profile, keeping parent and child tool names
+	// consistent. The factory always sets Tools to a *tool.Presenter built
+	// with this profile.
+	ToolProfile  *tool.Profile
 	Executor     executor.Executor
 	Edit         edit.EditStrategy
 	Verifier     verifier.Verifier

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -302,7 +302,12 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 		return fmt.Sprintf("Invalid input for %s: %v", call.Name, err), false, observability.ToolFailureSchemaValidation, structuredOutput{}
 	}
 
-	if findings := security.GuardToolCall(call.Name, t.WorkspaceMutating, call.Input); len(findings) > 0 {
+	// Key the write-target guard on the internal tool ID (t.Name), not the
+	// model-facing alias (call.Name): a guard rule written against the
+	// internal name must fire under any toolset profile (issue #234). t is
+	// resolved above; the gating layers (permission policy, mutating-tool
+	// set, this guard) all uniformly key on internal identity.
+	if findings := security.GuardToolCall(t.Name, t.WorkspaceMutating, call.Input); len(findings) > 0 {
 		if l.Security != nil {
 			l.Security.ToolCallGuardTriggered(call.Name, findings)
 		}

--- a/harness/internal/tool/profile.go
+++ b/harness/internal/tool/profile.go
@@ -60,6 +60,20 @@ var codingClassicProfile = &Profile{
 	},
 }
 
+// NewProfile constructs a Profile from an internal-ID→alias map and an
+// internal-ID→description map. Either map may be nil (no aliases / no
+// description overrides). The maps are used directly, not copied, so the
+// caller must not mutate them after construction.
+//
+// The built-in profiles are package-private values; this constructor is
+// the supported way to build a custom presentation (e.g. an embedder
+// wiring a provider-native profile, or a test exercising a collision the
+// built-in profiles do not produce). It does not register the profile
+// with ProfileFor — a custom profile is passed straight to NewPresenter.
+func NewProfile(name string, aliases, descriptions map[string]string) *Profile {
+	return &Profile{Name: name, aliases: aliases, descriptions: descriptions}
+}
+
 // ProfileFor returns the Profile table for a RunConfig.Tools.Profile
 // value. The empty string and "default" both select the identity
 // presentation. An unknown name returns the default profile and false;

--- a/harness/internal/tool/profile.go
+++ b/harness/internal/tool/profile.go
@@ -1,0 +1,260 @@
+package tool
+
+import (
+	"fmt"
+
+	"github.com/rxbynerd/stirrup/harness/internal/tool/toolname"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// Profile is a model-facing presentation for a set of registered tools
+// (issue #234). It remaps internal tool IDs to provider-friendly aliases
+// and optional alternate descriptions without touching dispatch
+// identities: a tool aliased to "grep" still resolves to grep_files and
+// runs the same handler. Tools absent from the table are presented under
+// their internal name unchanged.
+//
+// A Profile carries presentation data only. It cannot add, remove, or
+// re-gate tools — the presenter applies a Profile over whatever the
+// underlying registry already holds, so a tool a read-only mode declined
+// to register has no alias and cannot be smuggled in via a profile.
+type Profile struct {
+	// Name is the closed-set RunConfig.Tools.Profile value this table
+	// implements ("default", "coding-classic", …). Stored for diagnostics
+	// and so a presenter can report which profile produced an alias.
+	Name string
+	// aliases maps internal tool ID → model-facing alias. An entry whose
+	// alias equals the key is allowed (an explicit identity) but pointless;
+	// omit it instead. An internal ID with no entry is presented under its
+	// own name.
+	aliases map[string]string
+	// descriptions maps internal tool ID → an alternate model-facing
+	// description. Empty for a tool means "present the registered
+	// description unchanged". Kept separate from aliases so a profile can
+	// re-describe a tool without renaming it (and vice versa).
+	descriptions map[string]string
+}
+
+// defaultProfile is the identity presentation: no aliases, no description
+// overrides. ProfileFor("") and ProfileFor("default") both return it, so
+// a bare run presents tools exactly as registered.
+var defaultProfile = &Profile{Name: "default"}
+
+// codingClassicProfile presents the terse coding-CLI names that models
+// with strong shell/coding priors call by reflex. The targets are the
+// canonical Unix tool names (grep, find) plus "bash" for the shell, which
+// several model families bias toward over "run_command". read_file,
+// list_directory, and write_file/edit_file keep their internal names —
+// they are already the idiomatic descriptive forms and renaming them
+// would lose more recognition than it gains.
+//
+// Only the built-in coding primitives are remapped; MCP tools (namespaced
+// mcp_*) and any tool absent from this table present unchanged.
+var codingClassicProfile = &Profile{
+	Name: "coding-classic",
+	aliases: map[string]string{
+		"grep_files":  "grep",
+		"find_files":  "find",
+		"run_command": "bash",
+	},
+}
+
+// ProfileFor returns the Profile table for a RunConfig.Tools.Profile
+// value. The empty string and "default" both select the identity
+// presentation. An unknown name returns the default profile and false;
+// callers that have already passed ValidateRunConfig will never see
+// false, but the factory checks it defensively so a name added to the
+// validator's closed set without a matching table here fails loudly
+// rather than silently presenting no aliases.
+func ProfileFor(name string) (*Profile, bool) {
+	switch name {
+	case "", "default":
+		return defaultProfile, true
+	case "coding-classic":
+		return codingClassicProfile, true
+	default:
+		return defaultProfile, false
+	}
+}
+
+// aliasTarget returns the model-facing alias for an internal tool ID
+// before collision resolution, falling back to the internal ID when the
+// profile does not remap it.
+func (p *Profile) aliasTarget(internal string) string {
+	if p == nil {
+		return internal
+	}
+	if alias, ok := p.aliases[internal]; ok && alias != "" {
+		return alias
+	}
+	return internal
+}
+
+// describe returns the model-facing description for an internal tool ID,
+// falling back to the registered description when the profile does not
+// override it.
+func (p *Profile) describe(internal, registered string) string {
+	if p == nil {
+		return registered
+	}
+	if d, ok := p.descriptions[internal]; ok && d != "" {
+		return d
+	}
+	return registered
+}
+
+// Presenter wraps a ToolRegistry and applies a Profile so the loop and
+// the provider adapters see model-facing aliases while dispatch keeps
+// resolving to internal tool IDs (issue #234).
+//
+// Construction builds a single toolname.Mapping over the *alias targets*
+// of the wrapped registry's current tool set. Reusing toolname.Build is
+// deliberate: alias collisions (two internal tools whose profile aliases
+// land on the same string) are resolved by exactly the same deterministic
+// hash-suffix disambiguation that provider function-name normalization
+// uses (#223), so there is no second collision algorithm to keep in sync.
+// The mapping's external side is the presented name; its internal side is
+// recovered for Resolve.
+//
+// The presented name set is computed once at construction. The registry a
+// Presenter wraps is the post-MCP-discovery registry the factory builds,
+// which is not mutated after the loop starts, so a snapshot is correct.
+type Presenter struct {
+	inner   ToolRegistry
+	profile *Profile
+
+	// presentedFor maps internal name → presented (alias, collision-
+	// resolved) name. Used by List to rename definitions and by callers
+	// that need the model-facing name for a known internal tool (trace).
+	presentedFor map[string]string
+	// internalFor maps presented name → internal name. The Resolve
+	// reverse lookup. Internal names are also inserted as identity keys so
+	// a config or model that calls a tool by its internal name still
+	// resolves — this is the config-compatibility guarantee.
+	internalFor map[string]string
+}
+
+// Compile-time assertion that Presenter satisfies ToolRegistry. Kept in
+// the (*Impl)(nil) form rather than the concrete-value form the linter
+// suggests so the guard cannot be silently weakened — see CLAUDE.md
+// "Known false positives".
+var _ ToolRegistry = (*Presenter)(nil)
+
+// NewPresenter wraps inner with the named profile's presentation. The
+// default profile (and an empty name) produces an identity presenter:
+// List and Resolve behave exactly as the wrapped registry, so the
+// presenter is safe to install unconditionally.
+//
+// Returns an error only when alias-target collision resolution fails
+// inside toolname.Build (e.g. a pathological alias that cannot be made
+// unique under the policy). The policy used is the permissive ASCII set
+// (hyphen and leading digit allowed) because alias targets are author-
+// controlled clean names defined in this package, not arbitrary MCP
+// strings; per-provider wire normalization still runs downstream in the
+// NormalizingAdapter, so this build's only job is collision resolution.
+func NewPresenter(inner ToolRegistry, profile *Profile) (*Presenter, error) {
+	if profile == nil {
+		profile = defaultProfile
+	}
+	p := &Presenter{
+		inner:        inner,
+		profile:      profile,
+		presentedFor: map[string]string{},
+		internalFor:  map[string]string{},
+	}
+
+	defs := inner.List()
+
+	// Map each internal name to its alias target, then resolve collisions
+	// among the targets through toolname.Build. The internal-name slice
+	// passed to Build is the alias-target slice, so Build's output keyed by
+	// alias target gives the collision-resolved presented name. Two tools
+	// aliasing to the same target are disambiguated by Build's hash suffix
+	// exactly as a provider name collision would be.
+	targets := make([]string, len(defs))
+	for i, d := range defs {
+		targets[i] = profile.aliasTarget(d.Name)
+	}
+
+	mapping, err := toolname.BuildSorted(targets, aliasPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("tool profile %q alias collision: %w", profile.Name, err)
+	}
+
+	for _, d := range defs {
+		internal := d.Name
+		presented := mapping.Translate(profile.aliasTarget(internal))
+		p.presentedFor[internal] = presented
+		p.internalFor[presented] = internal
+		// Insert the internal name as an identity key too so a model or
+		// config that calls the tool by its internal ID still resolves.
+		// Skip when it would clobber a distinct mapping (a presented alias
+		// equal to some *other* tool's internal name): the alias mapping
+		// wins, and the colliding internal-name call falls through to the
+		// renamed-tool / unknown-tool path, which is the safe outcome.
+		if _, taken := p.internalFor[internal]; !taken {
+			p.internalFor[internal] = internal
+		}
+	}
+
+	return p, nil
+}
+
+// aliasPolicy is the toolname.Policy used to resolve alias-target
+// collisions. Alias targets are clean author-controlled ASCII, so the
+// permissive set (hyphen + leading digit allowed, 64-char cap) suffices;
+// the strict per-provider normalization that turns a presented name into
+// a wire-safe function name runs later in the NormalizingAdapter.
+var aliasPolicy = toolname.Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+
+// List returns the wrapped registry's definitions with names (and
+// descriptions, when the profile overrides them) rewritten to the
+// model-facing presentation. Order matches the wrapped registry's List.
+func (p *Presenter) List() []types.ToolDefinition {
+	defs := p.inner.List()
+	out := make([]types.ToolDefinition, len(defs))
+	for i, d := range defs {
+		out[i] = d
+		if presented, ok := p.presentedFor[d.Name]; ok {
+			out[i].Name = presented
+		}
+		out[i].Description = p.profile.describe(d.Name, d.Description)
+	}
+	return out
+}
+
+// Resolve looks up a tool by its model-facing presented name or by its
+// internal ID, returning the underlying *Tool from the wrapped registry.
+// Returns nil when neither resolves. The returned tool's Name is the
+// internal identity — dispatch, permission checks, and the security guard
+// all key on it, so aliasing changes only the name the model uses, never
+// the tool that runs.
+func (p *Presenter) Resolve(name string) *Tool {
+	if internal, ok := p.internalFor[name]; ok {
+		return p.inner.Resolve(internal)
+	}
+	return p.inner.Resolve(name)
+}
+
+// Unwrap returns the ToolRegistry the presenter wraps. It exists so a
+// caller that holds the loop's Tools (a *Presenter) can reach the
+// underlying registry for operations the presentation layer does not
+// expose (e.g. a test swapping a tool's handler via *Registry.Register).
+// Production dispatch should go through Resolve so the alias→internal
+// binding is honoured; Unwrap is an escape hatch, not the common path.
+func (p *Presenter) Unwrap() ToolRegistry {
+	return p.inner
+}
+
+// InternalName returns the internal tool ID for a model-facing name,
+// falling back to the input when the name is not a known alias. Used by
+// the dispatch trace path to record the internal identity alongside the
+// model-facing alias (issue #234 acceptance criterion). The fallback
+// keeps the call site terse: a name that is already an internal ID, or an
+// unknown tool name the model invented, round-trips unchanged.
+func (p *Presenter) InternalName(name string) string {
+	if internal, ok := p.internalFor[name]; ok {
+		return internal
+	}
+	return name
+}

--- a/harness/internal/tool/profile.go
+++ b/harness/internal/tool/profile.go
@@ -2,6 +2,7 @@ package tool
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/rxbynerd/stirrup/harness/internal/tool/toolname"
 	"github.com/rxbynerd/stirrup/types"
@@ -165,25 +166,39 @@ func NewPresenter(inner ToolRegistry, profile *Profile) (*Presenter, error) {
 
 	defs := inner.List()
 
-	// Map each internal name to its alias target, then resolve collisions
-	// among the targets through toolname.Build. The internal-name slice
-	// passed to Build is the alias-target slice, so Build's output keyed by
-	// alias target gives the collision-resolved presented name. Two tools
-	// aliasing to the same target are disambiguated by Build's hash suffix
-	// exactly as a provider name collision would be.
-	targets := make([]string, len(defs))
-	for i, d := range defs {
-		targets[i] = profile.aliasTarget(d.Name)
+	// Resolve alias collisions through toolname.BuildFromCandidates, the
+	// shared collision core (#223). The keys are the internal tool IDs
+	// (unique, the registry contract), and the candidate for each key is
+	// its profile alias target. Keying disambiguation off the internal ID
+	// — not the alias — is what lets two tools alias to the same target:
+	// the IDs are distinct, so Build sees a candidate collision (not a
+	// duplicate-key error) and disambiguates one alias with the same
+	// deterministic SHA-suffix a provider name collision would get. No
+	// second collision algorithm exists.
+	// Sort by internal ID before resolving so the collision disambiguation
+	// is independent of registration order: two runs of the same tool set
+	// pin the same alias to the same internal ID regardless of the order
+	// the registry happened to list them in. Mirrors the BuildSorted
+	// rationale in the provider normalizer.
+	sortedDefs := make([]types.ToolDefinition, len(defs))
+	copy(sortedDefs, defs)
+	sort.Slice(sortedDefs, func(i, j int) bool { return sortedDefs[i].Name < sortedDefs[j].Name })
+
+	keys := make([]string, len(sortedDefs))
+	candidates := make([]string, len(sortedDefs))
+	for i, d := range sortedDefs {
+		keys[i] = d.Name
+		candidates[i] = profile.aliasTarget(d.Name)
 	}
 
-	mapping, err := toolname.BuildSorted(targets, aliasPolicy)
+	mapping, err := toolname.BuildFromCandidates(keys, candidates, aliasPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("tool profile %q alias collision: %w", profile.Name, err)
 	}
 
 	for _, d := range defs {
 		internal := d.Name
-		presented := mapping.Translate(profile.aliasTarget(internal))
+		presented := mapping.Translate(internal) // internal ID → collision-resolved alias
 		p.presentedFor[internal] = presented
 		p.internalFor[presented] = internal
 		// Insert the internal name as an identity key too so a model or

--- a/harness/internal/tool/profile_test.go
+++ b/harness/internal/tool/profile_test.go
@@ -207,6 +207,49 @@ func TestPresenter_AliasCollisionResolvedByToolname(t *testing.T) {
 	}
 }
 
+// Collision resolution must be independent of registration order:
+// NewPresenter sorts by internal ID before calling BuildFromCandidates,
+// so the same tool set always pins the same alias to the same tool no
+// matter which order the registry listed them in. Registering the two
+// colliding tools in both orders must yield identical presented-name
+// mappings (same bare-alias winner, same disambiguated suffix).
+func TestPresenter_CollisionOrderIndependent(t *testing.T) {
+	collide := &Profile{
+		Name: "collide",
+		aliases: map[string]string{
+			"grep_files": "search",
+			"find_files": "search",
+		},
+	}
+
+	presentedFor := func(first, second string) map[string]string {
+		reg := newRegistryWith(
+			fixedTool(first, "f"),
+			fixedTool(second, "s"),
+		)
+		p, err := NewPresenter(reg, collide)
+		if err != nil {
+			t.Fatalf("NewPresenter(%s,%s): %v", first, second, err)
+		}
+		// Map internal ID → presented name, independent of List order.
+		m := map[string]string{}
+		for _, d := range p.List() {
+			m[p.InternalName(d.Name)] = d.Name
+		}
+		return m
+	}
+
+	forward := presentedFor("grep_files", "find_files")
+	reverse := presentedFor("find_files", "grep_files")
+
+	for _, internal := range []string{"grep_files", "find_files"} {
+		if forward[internal] != reverse[internal] {
+			t.Errorf("presented name for %q depends on registration order: %q vs %q",
+				internal, forward[internal], reverse[internal])
+		}
+	}
+}
+
 func TestPresenter_ResolveUnknownReturnsNil(t *testing.T) {
 	reg := newRegistryWith(fixedTool("read_file", "read"))
 	p, err := NewPresenter(reg, codingClassicProfile)

--- a/harness/internal/tool/profile_test.go
+++ b/harness/internal/tool/profile_test.go
@@ -1,0 +1,234 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// fixedTool builds a no-op tool for presenter tests.
+func fixedTool(name, desc string) *Tool {
+	return &Tool{
+		Name:        name,
+		Description: desc,
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Handler: func(context.Context, json.RawMessage) (string, error) {
+			return name, nil
+		},
+	}
+}
+
+func newRegistryWith(tools ...*Tool) *Registry {
+	r := NewRegistry()
+	for _, t := range tools {
+		r.Register(t)
+	}
+	return r
+}
+
+func TestProfileFor(t *testing.T) {
+	for _, name := range []string{"", "default"} {
+		p, ok := ProfileFor(name)
+		if !ok {
+			t.Fatalf("ProfileFor(%q) ok=false, want true", name)
+		}
+		if p != defaultProfile {
+			t.Errorf("ProfileFor(%q) did not return the default profile", name)
+		}
+	}
+	if p, ok := ProfileFor("coding-classic"); !ok || p.Name != "coding-classic" {
+		t.Fatalf("ProfileFor(coding-classic) = %v, %v", p, ok)
+	}
+	if _, ok := ProfileFor("does-not-exist"); ok {
+		t.Error("ProfileFor(unknown) ok=true, want false")
+	}
+}
+
+// Default profile presents tools under their internal names and resolves
+// them unchanged: a config that names tools by their internal IDs keeps
+// working (the config-compatibility guarantee).
+func TestPresenter_DefaultProfileIsIdentity(t *testing.T) {
+	reg := newRegistryWith(
+		fixedTool("grep_files", "regex search"),
+		fixedTool("edit_file", "edit"),
+	)
+	p, err := NewPresenter(reg, defaultProfile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+	defs := p.List()
+	if len(defs) != 2 || defs[0].Name != "grep_files" || defs[1].Name != "edit_file" {
+		t.Fatalf("default profile changed presented names: %+v", defs)
+	}
+	for _, name := range []string{"grep_files", "edit_file"} {
+		if got := p.Resolve(name); got == nil || got.Name != name {
+			t.Errorf("Resolve(%q) = %v, want tool with that internal name", name, got)
+		}
+	}
+}
+
+// A profile presents aliases; dispatch resolves the alias to the internal
+// tool, and the internal name is still callable for config compatibility.
+func TestPresenter_AliasPresentationAndResolution(t *testing.T) {
+	reg := newRegistryWith(
+		fixedTool("grep_files", "regex search"),
+		fixedTool("find_files", "glob search"),
+		fixedTool("run_command", "shell"),
+		fixedTool("read_file", "read"),
+	)
+	p, err := NewPresenter(reg, codingClassicProfile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+
+	wantPresented := map[string]string{
+		"grep_files":  "grep",
+		"find_files":  "find",
+		"run_command": "bash",
+		"read_file":   "read_file", // unaliased: presented unchanged
+	}
+	defs := p.List()
+	gotPresented := map[string]bool{}
+	for _, d := range defs {
+		gotPresented[d.Name] = true
+	}
+	for internal, alias := range wantPresented {
+		if !gotPresented[alias] {
+			t.Errorf("List did not present %q as %q; defs=%+v", internal, alias, defs)
+		}
+	}
+
+	// Resolve by alias returns the internal tool unchanged.
+	for internal, alias := range wantPresented {
+		got := p.Resolve(alias)
+		if got == nil {
+			t.Fatalf("Resolve(alias %q) = nil", alias)
+		}
+		if got.Name != internal {
+			t.Errorf("Resolve(alias %q).Name = %q, want internal %q", alias, got.Name, internal)
+		}
+		// Internal name still resolves (config compatibility).
+		if byInternal := p.Resolve(internal); byInternal == nil || byInternal.Name != internal {
+			t.Errorf("Resolve(internal %q) = %v, want the tool", internal, byInternal)
+		}
+		if p.InternalName(alias) != internal {
+			t.Errorf("InternalName(%q) = %q, want %q", alias, p.InternalName(alias), internal)
+		}
+	}
+}
+
+// A profile may re-describe a tool without renaming it.
+func TestPresenter_DescriptionOverride(t *testing.T) {
+	reg := newRegistryWith(fixedTool("read_file", "original"))
+	profile := &Profile{
+		Name:         "describe-test",
+		descriptions: map[string]string{"read_file": "rewritten for this provider"},
+	}
+	p, err := NewPresenter(reg, profile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+	defs := p.List()
+	if defs[0].Name != "read_file" {
+		t.Errorf("description override should not rename: got %q", defs[0].Name)
+	}
+	if defs[0].Description != "rewritten for this provider" {
+		t.Errorf("description not overridden: got %q", defs[0].Description)
+	}
+}
+
+// A deliberate alias collision (two internal tools aliasing to the same
+// target) must be resolved by the shared toolname collision code: both
+// presented names are distinct and both resolve back to their own
+// internal tool. Proves the presenter routes through toolname rather than
+// hand-rolling a second algorithm.
+func TestPresenter_AliasCollisionResolvedByToolname(t *testing.T) {
+	reg := newRegistryWith(
+		fixedTool("grep_files", "regex"),
+		fixedTool("find_files", "glob"),
+	)
+	// Both alias to "search" — a collision toolname.Build must disambiguate.
+	collide := &Profile{
+		Name: "collide",
+		aliases: map[string]string{
+			"grep_files": "search",
+			"find_files": "search",
+		},
+	}
+	p, err := NewPresenter(reg, collide)
+	if err != nil {
+		t.Fatalf("NewPresenter on collision: %v", err)
+	}
+
+	defs := p.List()
+	presented := make([]string, len(defs))
+	for i, d := range defs {
+		presented[i] = d.Name
+	}
+	if presented[0] == presented[1] {
+		t.Fatalf("collision not disambiguated: both presented as %q", presented[0])
+	}
+
+	// Exactly one presented name keeps the bare "search" target; the other
+	// carries toolname's deterministic "_<6 hex>" disambiguation suffix.
+	// Asserting the suffix shape (rather than just "they differ") proves
+	// the presenter reused the toolname collision algorithm rather than
+	// inventing its own scheme.
+	var bare, suffixed string
+	for _, name := range presented {
+		if name == "search" {
+			bare = name
+		} else {
+			suffixed = name
+		}
+	}
+	if bare == "" || suffixed == "" {
+		t.Fatalf("expected one bare and one suffixed name, got %v", presented)
+	}
+	if len(suffixed) != len("search")+7 || suffixed[:len("search")+1] != "search_" {
+		t.Errorf("suffixed name %q is not toolname's search_<6hex> form", suffixed)
+	}
+
+	// Each presented name resolves back to its own internal tool.
+	for _, d := range defs {
+		got := p.Resolve(d.Name)
+		if got == nil {
+			t.Fatalf("Resolve(presented %q) = nil", d.Name)
+		}
+		if got.Name != "grep_files" && got.Name != "find_files" {
+			t.Errorf("Resolve(presented %q) = %q, not an internal tool", d.Name, got.Name)
+		}
+	}
+	// The two presented names map to two distinct internal tools.
+	a := p.Resolve(presented[0]).Name
+	b := p.Resolve(presented[1]).Name
+	if a == b {
+		t.Errorf("both presented names resolved to the same internal tool %q", a)
+	}
+}
+
+func TestPresenter_ResolveUnknownReturnsNil(t *testing.T) {
+	reg := newRegistryWith(fixedTool("read_file", "read"))
+	p, err := NewPresenter(reg, codingClassicProfile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+	if got := p.Resolve("not_a_tool"); got != nil {
+		t.Errorf("Resolve(unknown) = %v, want nil", got)
+	}
+	// InternalName falls through for an unknown name.
+	if p.InternalName("not_a_tool") != "not_a_tool" {
+		t.Errorf("InternalName(unknown) should round-trip")
+	}
+}
+
+func TestPresenter_Unwrap(t *testing.T) {
+	reg := newRegistryWith(fixedTool("read_file", "read"))
+	p, err := NewPresenter(reg, defaultProfile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+	if p.Unwrap() != reg {
+		t.Error("Unwrap did not return the wrapped registry")
+	}
+}

--- a/harness/internal/tool/profile_test.go
+++ b/harness/internal/tool/profile_test.go
@@ -222,6 +222,40 @@ func TestPresenter_ResolveUnknownReturnsNil(t *testing.T) {
 	}
 }
 
+// The presenter only aliases tools that are actually registered. A
+// profile aliasing a tool a read-only mode declined to register (here
+// run_command -> bash, with run_command absent from the registry)
+// produces no "bash" alias and no way to reach the excluded tool — the
+// alias cannot smuggle an unregistered tool past the registry. This is
+// the registry-level half of the issue #234 read-only-mode invariant
+// (the config-level half is enforced by ValidateRunConfig).
+func TestPresenter_AliasCannotSurfaceUnregisteredTool(t *testing.T) {
+	// A read-only-style registry: no run_command / edit_file registered.
+	reg := newRegistryWith(
+		fixedTool("read_file", "read"),
+		fixedTool("grep_files", "regex"),
+		fixedTool("find_files", "glob"),
+	)
+	p, err := NewPresenter(reg, codingClassicProfile)
+	if err != nil {
+		t.Fatalf("NewPresenter: %v", err)
+	}
+
+	// "bash" is run_command's alias, but run_command was never registered,
+	// so no presented name should be "bash" and Resolve("bash") is nil.
+	for _, d := range p.List() {
+		if d.Name == "bash" {
+			t.Fatalf("alias 'bash' present for an unregistered tool: %+v", d)
+		}
+	}
+	if got := p.Resolve("bash"); got != nil {
+		t.Errorf("Resolve('bash') = %v, want nil — alias must not surface an unregistered tool", got)
+	}
+	if got := p.Resolve("run_command"); got != nil {
+		t.Errorf("Resolve('run_command') = %v, want nil — tool was never registered", got)
+	}
+}
+
 func TestPresenter_Unwrap(t *testing.T) {
 	reg := newRegistryWith(fixedTool("read_file", "read"))
 	p, err := NewPresenter(reg, defaultProfile)

--- a/harness/internal/tool/toolname/toolname.go
+++ b/harness/internal/tool/toolname/toolname.go
@@ -149,56 +149,82 @@ func (m *Mapping) Reverse(external string) string {
 // twice). Failing closed is the correct behaviour for the loop: a
 // silent alias would route a tool call to the wrong handler.
 func Build(internalNames []string, policy Policy) (*Mapping, error) {
-	m := &Mapping{
-		ExternalFor: make(map[string]string, len(internalNames)),
-		InternalFor: make(map[string]string, len(internalNames)),
+	// First pass: compute the candidate external name for every internal
+	// name by normalising it onto the policy's character set. The
+	// candidate slice is positionally aligned with internalNames, so the
+	// collision resolver below can key disambiguation off the internal
+	// name while colliding on the candidate.
+	candidates := make([]string, len(internalNames))
+	for i, name := range internalNames {
+		candidates[i] = sanitize(name, policy)
+	}
+	return BuildFromCandidates(internalNames, candidates, policy)
+}
+
+// BuildFromCandidates resolves collisions among caller-supplied external
+// candidate names and returns the round-trip Mapping. It is the shared
+// core of the collision algorithm: Build calls it after sanitising each
+// internal name onto the policy character set, and the toolset-profile
+// presenter (issue #234) calls it with each tool's profile alias as the
+// candidate so alias collisions are disambiguated by exactly the same
+// deterministic hash-suffix scheme — there is no second algorithm.
+//
+// keys are the unique identities the disambiguation suffix is derived
+// from (the internal tool IDs); candidates[i] is the desired external
+// name for keys[i]. The two slices must be the same length. A duplicate
+// key is a caller bug (the registry contract is that internal names are
+// unique) and is rejected; two distinct keys whose candidates collide are
+// disambiguated by appending the SHA-256-derived suffix of the colliding
+// key, within the policy's length budget. A collision the suffix cannot
+// resolve fails closed — a silent alias would route a tool call to the
+// wrong handler.
+func BuildFromCandidates(keys, candidates []string, policy Policy) (*Mapping, error) {
+	if len(keys) != len(candidates) {
+		return nil, fmt.Errorf("toolname: keys/candidates length mismatch (%d vs %d)", len(keys), len(candidates))
 	}
 
-	// Deduplicate — a single internal name passed twice is a caller
+	m := &Mapping{
+		ExternalFor: make(map[string]string, len(keys)),
+		InternalFor: make(map[string]string, len(keys)),
+	}
+
+	// Deduplicate keys — a single internal name passed twice is a caller
 	// bug, not a collision. The registry contract is that names are
-	// unique, but tests and embedding callers may bypass it; surface
-	// the duplicate as an explicit error rather than silently
-	// overwriting the first entry.
-	seen := make(map[string]struct{}, len(internalNames))
-	for _, n := range internalNames {
+	// unique, but tests and embedding callers may bypass it; surface the
+	// duplicate as an explicit error rather than silently overwriting the
+	// first entry.
+	seen := make(map[string]struct{}, len(keys))
+	for _, n := range keys {
 		if _, dup := seen[n]; dup {
 			return nil, fmt.Errorf("toolname: duplicate internal tool name %q", n)
 		}
 		seen[n] = struct{}{}
 	}
 
-	// First pass: compute the candidate external name for every
-	// internal name. Iterate the input order so the mapping building
-	// is deterministic for a given input.
-	candidates := make([]string, len(internalNames))
-	for i, name := range internalNames {
-		candidates[i] = sanitize(name, policy)
-	}
-
-	// Second pass: detect collisions among the candidates. When two
-	// candidates collide, derive a disambiguating suffix from the
-	// internal name's SHA-256 hash. This is deterministic, keeps the
-	// suffix short, and survives reordering of the input slice.
+	// Detect collisions among the candidates. When two candidates collide,
+	// derive a disambiguating suffix from the colliding key's SHA-256
+	// hash. This is deterministic, keeps the suffix short, and survives
+	// reordering of the input slice.
 	//
-	// The suffix is appended within the MaxLen budget — sanitize may
-	// produce a name shorter than MaxLen, in which case the suffix is
-	// added directly; if sanitize already returned a MaxLen-truncated
-	// name, the truncation is shortened to make room.
-	used := make(map[string]string, len(candidates)) // external → internal
+	// The suffix is appended within the MaxLen budget — a candidate may be
+	// shorter than MaxLen, in which case the suffix is added directly; a
+	// MaxLen-truncated candidate has its truncation shortened to make
+	// room.
+	used := make(map[string]string, len(candidates)) // external → key
 	for i, ext := range candidates {
-		internal := internalNames[i]
-		if existing, taken := used[ext]; taken && existing != internal {
-			ext = disambiguate(ext, internal, policy)
-			if other, stillCollides := used[ext]; stillCollides && other != internal {
+		key := keys[i]
+		if existing, taken := used[ext]; taken && existing != key {
+			ext = disambiguate(ext, key, policy)
+			if other, stillCollides := used[ext]; stillCollides && other != key {
 				return nil, fmt.Errorf(
 					"toolname: cannot resolve collision between %q and %q (both normalise to %q under policy MaxLen=%d AllowHyphen=%v AllowLeadingDigit=%v)",
-					internal, other, ext, policy.MaxLen, policy.AllowHyphen, policy.AllowLeadingDigit,
+					key, other, ext, policy.MaxLen, policy.AllowHyphen, policy.AllowLeadingDigit,
 				)
 			}
 		}
-		used[ext] = internal
-		m.ExternalFor[internal] = ext
-		m.InternalFor[ext] = internal
+		used[ext] = key
+		m.ExternalFor[key] = ext
+		m.InternalFor[ext] = key
 	}
 
 	return m, nil

--- a/harness/internal/tool/toolname/toolname_test.go
+++ b/harness/internal/tool/toolname/toolname_test.go
@@ -281,6 +281,80 @@ func TestMapping_MissingKeyPassThrough(t *testing.T) {
 	}
 }
 
+// BuildFromCandidates is the shared collision core the toolset-profile
+// presenter (issue #234) routes alias resolution through. Two distinct
+// keys whose candidates are the identical string must be disambiguated by
+// the same hash-suffix scheme Build uses for sanitize collisions — not
+// rejected as a duplicate (the keys differ; only the candidates collide).
+func TestBuildFromCandidates_IdenticalCandidatesDisambiguated(t *testing.T) {
+	keys := []string{"grep_files", "find_files"}
+	candidates := []string{"search", "search"}
+	policy := Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true}
+
+	m, err := BuildFromCandidates(keys, candidates, policy)
+	if err != nil {
+		t.Fatalf("BuildFromCandidates: %v", err)
+	}
+
+	gf := m.Translate("grep_files")
+	ff := m.Translate("find_files")
+	if gf == ff {
+		t.Fatalf("identical candidates not disambiguated: both %q", gf)
+	}
+	// Exactly one keeps the bare candidate; the other carries the
+	// "_<6hex>" suffix Build derives from the colliding key.
+	bareCount := 0
+	for _, ext := range []string{gf, ff} {
+		if ext == "search" {
+			bareCount++
+		}
+	}
+	if bareCount != 1 {
+		t.Errorf("expected exactly one bare 'search', got gf=%q ff=%q", gf, ff)
+	}
+	// Round-trip both back to their keys.
+	if m.Reverse(gf) != "grep_files" || m.Reverse(ff) != "find_files" {
+		t.Errorf("reverse failed: Reverse(%q)=%q Reverse(%q)=%q", gf, m.Reverse(gf), ff, m.Reverse(ff))
+	}
+}
+
+// A duplicate KEY (not candidate) is still a caller bug and rejected, so
+// the presenter's registry-uniqueness contract is enforced.
+func TestBuildFromCandidates_DuplicateKeyRejected(t *testing.T) {
+	_, err := BuildFromCandidates(
+		[]string{"dup", "dup"},
+		[]string{"a", "b"},
+		Policy{MaxLen: 64, AllowHyphen: true, AllowLeadingDigit: true},
+	)
+	if err == nil {
+		t.Fatal("expected duplicate-key error, got nil")
+	}
+}
+
+func TestBuildFromCandidates_LengthMismatchRejected(t *testing.T) {
+	_, err := BuildFromCandidates(
+		[]string{"a", "b"},
+		[]string{"x"},
+		Policy{MaxLen: 64},
+	)
+	if err == nil {
+		t.Fatal("expected length-mismatch error, got nil")
+	}
+}
+
+// Build must continue to delegate to BuildFromCandidates unchanged: the
+// existing sanitize+collision behaviour is preserved.
+func TestBuild_StillResolvesSanitizeCollisions(t *testing.T) {
+	names := []string{"mcp_jira-issue", "mcp_jira.issue"}
+	m, err := Build(names, PolicyFor("gemini"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if m.Translate(names[0]) == m.Translate(names[1]) {
+		t.Fatal("sanitize collision no longer resolved after refactor")
+	}
+}
+
 func TestBuild_AcceptsAllProviderNamesForCommonRegistry(t *testing.T) {
 	// Smoke test: a realistic registry should normalise cleanly under
 	// every provider's policy.

--- a/types/messages_test.go
+++ b/types/messages_test.go
@@ -65,3 +65,48 @@ func TestToolCallRecord_StructuredOmitempty(t *testing.T) {
 		t.Errorf("empty Kind must be omitted from ToolCallRecord, got: %s", got)
 	}
 }
+
+// TestToolCall_InternalNameOmittedOnWire pins the issue #234 back-compat
+// guarantee at the WIRE level (not just in memory): under the default
+// profile InternalName is empty and the "internalName" key must be
+// physically absent from the marshalled JSON of every tool-call trace
+// shape, so a default-profile trace is byte-compatible with pre-profile
+// consumers. The positive case confirms the key appears when set.
+func TestToolCall_InternalNameOmittedOnWire(t *testing.T) {
+	t.Run("summary", func(t *testing.T) {
+		b, err := json.Marshal(ToolCallSummary{Name: "grep_files", Success: true})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(b), "internalName") {
+			t.Errorf("empty InternalName must be omitted from ToolCallSummary, got: %s", b)
+		}
+	})
+	t.Run("trace", func(t *testing.T) {
+		b, err := json.Marshal(ToolCallTrace{Name: "grep_files", Success: true})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(b), "internalName") {
+			t.Errorf("empty InternalName must be omitted from ToolCallTrace, got: %s", b)
+		}
+	})
+	t.Run("record", func(t *testing.T) {
+		b, err := json.Marshal(ToolCallRecord{ID: "id", Name: "grep_files", Input: json.RawMessage(`{}`), Output: "x", Success: true})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(b), "internalName") {
+			t.Errorf("empty InternalName must be omitted from ToolCallRecord, got: %s", b)
+		}
+	})
+	t.Run("present_when_set", func(t *testing.T) {
+		b, err := json.Marshal(ToolCallTrace{Name: "grep", InternalName: "grep_files", Success: true})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !strings.Contains(string(b), `"internalName":"grep_files"`) {
+			t.Errorf("a set InternalName must appear on the wire, got: %s", b)
+		}
+	})
+}

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1115,6 +1115,15 @@ type ResultSinkConfig struct {
 type ToolsConfig struct {
 	BuiltIn    []string          `json:"builtIn,omitempty"`    // which built-in tools to enable
 	MCPServers []MCPServerConfig `json:"mcpServers,omitempty"` // MCP server connections
+	// Profile selects a model-facing presentation for the registered
+	// tools (issue #234). It controls only the names/descriptions a model
+	// sees on the wire — internal dispatch identities are unchanged, so a
+	// config that names tools by their internal IDs (grep_files,
+	// edit_file, …) keeps working under any profile. The zero value
+	// ("default") is the identity presentation: a bare run is byte-
+	// identical to the pre-profile behaviour. Closed set, validated by
+	// ValidateRunConfig.
+	Profile string `json:"profile,omitempty"`
 }
 
 // MCPServerConfig describes a single MCP server connection.
@@ -1155,6 +1164,28 @@ var validBatchProviderTypes = map[string]bool{
 var validCompatProfiles = map[string]bool{
 	"":        true, // explicit empty is the default (no profile)
 	"zai-glm": true,
+}
+
+// validToolsProfiles is the closed set of ToolsConfig.Profile values
+// accepted by ValidateRunConfig (issue #234). The empty string and
+// "default" are both the identity presentation (no aliasing) so a
+// config that omits the field and one that sets it to "default" behave
+// identically and validate cleanly.
+//
+// Adding an entry requires a matching profile table in
+// harness/internal/tool/profile.go; an entry here without one would
+// validate at config time but present no aliases, which is a silent
+// no-op rather than a clear error.
+//
+// "coding-classic" is the one alternate shipped in v1: it presents the
+// terse, widely-recognised coding-tool names (read_file→read_file is a
+// no-op, grep_files→grep, find_files→find, run_command→bash) that
+// models with strong coding-CLI priors call by reflex, while dispatch
+// still resolves them to the internal tools.
+var validToolsProfiles = map[string]bool{
+	"":               true, // explicit empty is the default (no aliasing)
+	"default":        true,
+	"coding-classic": true,
 }
 
 // gcpProjectIDPattern matches the GCP project ID rules: starts with a
@@ -1710,6 +1741,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateProviderConfigs(config, retryDefaulted, &errs)
 	validateAPIKeyRefs(config, &errs)
 	validateBuiltInTools(config.Tools.BuiltIn, &errs)
+	validateToolsProfile(config.Tools.Profile, &errs)
 	validateCredentialConfig(config.Provider.Credential, "provider.credential", &errs)
 	for name, prov := range config.Providers {
 		validateCredentialConfig(prov.Credential, fmt.Sprintf("providers[%s].credential", name), &errs)
@@ -1830,6 +1862,21 @@ func validateCompatProfile(path, value string, errs *[]string) {
 	*errs = append(*errs, fmt.Sprintf(
 		"%s %q is not a recognised compat profile; legal values: \"\", \"zai-glm\"",
 		path, value,
+	))
+}
+
+// validateToolsProfile enforces the closed set of legal
+// ToolsConfig.Profile values (issue #234). Empty string and "default"
+// are the identity presentation and validate cleanly. Unknown values
+// fail loudly with the legal-set list so a typo surfaces at startup
+// rather than as a silently un-aliased run.
+func validateToolsProfile(value string, errs *[]string) {
+	if validToolsProfiles[value] {
+		return
+	}
+	*errs = append(*errs, fmt.Sprintf(
+		"tools.profile %q is not a recognised toolset profile; legal values: \"\" (default), \"default\", \"coding-classic\"",
+		value,
 	))
 }
 

--- a/types/runconfig_completions.go
+++ b/types/runconfig_completions.go
@@ -82,6 +82,13 @@ func ValidGuardRailTypeValues() []string { return sortedKeys(validGuardRailTypes
 // typeable values.
 func ValidCompatProfileValues() []string { return sortedNonEmptyKeys(validCompatProfiles) }
 
+// ValidToolsProfileValues returns the toolset profiles accepted on
+// RunConfig.Tools.Profile (issue #234). The "" (default/no-aliasing)
+// entry is filtered out so the completion list contains only the
+// typeable values; "default" is retained because it is a typeable
+// synonym for the empty value.
+func ValidToolsProfileValues() []string { return sortedNonEmptyKeys(validToolsProfiles) }
+
 func sortedKeys(m map[string]bool) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -385,6 +385,28 @@ func TestValidateRunConfig_KnownToolsProfilesAccepted(t *testing.T) {
 	}
 }
 
+// TestToolsConfig_ProfileOmittedOnWire pins the issue #234 back-compat
+// guarantee at the wire level: an empty Profile must not emit a "profile"
+// key, so a config written before profiles existed round-trips
+// byte-identically. The positive case confirms the key appears when set.
+func TestToolsConfig_ProfileOmittedOnWire(t *testing.T) {
+	b, err := json.Marshal(ToolsConfig{BuiltIn: []string{"read_file"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "profile") {
+		t.Errorf("empty Profile must be omitted from ToolsConfig, got: %s", b)
+	}
+
+	withProfile, err := json.Marshal(ToolsConfig{Profile: "coding-classic"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(withProfile), `"profile":"coding-classic"`) {
+		t.Errorf("a set Profile must appear on the wire, got: %s", withProfile)
+	}
+}
+
 func TestValidateRunConfig_MaxTurnsExceedsLimit(t *testing.T) {
 	c := validConfig()
 	c.MaxTurns = 101

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -359,6 +359,32 @@ func TestValidateRunConfig_InvalidBuiltInTool(t *testing.T) {
 	}
 }
 
+func TestValidateRunConfig_UnknownToolsProfile(t *testing.T) {
+	c := validConfig()
+	c.Tools.Profile = "provider-native-but-unimplemented"
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for unknown tools.profile")
+	}
+	if !strings.Contains(err.Error(), "tools.profile") {
+		t.Errorf("expected error to mention tools.profile, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_KnownToolsProfilesAccepted(t *testing.T) {
+	// Empty (default), explicit "default", and the one shipped alternate
+	// all validate. The empty value is the byte-identical-to-today path.
+	for _, profile := range []string{"", "default", "coding-classic"} {
+		t.Run(profile, func(t *testing.T) {
+			c := validConfig()
+			c.Tools.Profile = profile
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("profile %q should validate, got: %v", profile, err)
+			}
+		})
+	}
+}
+
 func TestValidateRunConfig_MaxTurnsExceedsLimit(t *testing.T) {
 	c := validConfig()
 	c.MaxTurns = 101
@@ -478,6 +504,32 @@ func TestValidateRunConfig_ReadOnlyModeWithWriteToolInList(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// A toolset profile must not loosen the read-only-mode write-tool
+// exclusion. Profile selection presents aliases for tools that are
+// already enabled; it cannot smuggle a write tool past validation, so a
+// read-only mode that lists a write tool is still rejected regardless of
+// the profile. (Issue #234 hard constraint.)
+func TestValidateRunConfig_ReadOnlyModeProfileDoesNotBypassWriteExclusion(t *testing.T) {
+	for _, profile := range []string{"default", "coding-classic"} {
+		t.Run(profile, func(t *testing.T) {
+			c := validConfig()
+			c.Mode = "research"
+			c.PermissionPolicy = PermissionPolicyConfig{Type: "deny-side-effects"}
+			c.Tools = ToolsConfig{
+				BuiltIn: []string{"read_file", "run_command"},
+				Profile: profile,
+			}
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("profile %q must not let a write tool into read-only mode", profile)
+			}
+			if !strings.Contains(err.Error(), "read-only mode") || !strings.Contains(err.Error(), "run_command") {
+				t.Errorf("expected read-only-mode rejection mentioning run_command, got: %v", err)
+			}
+		})
 	}
 }
 

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -41,6 +41,12 @@ type RunTrace struct {
 // InternalName is omitted from the wire to keep the existing trace shape
 // byte-identical; a non-default profile records both so a trace is
 // auditable and the alias→internal binding is recoverable.
+//
+// An empty InternalName is ambiguous in isolation: it means the tool was
+// called by its internal name under the default profile, OR the name did
+// not resolve to a known tool under a non-default profile. The active
+// profile is recorded in the run's RunConfig (tools.profile); read it
+// alongside the record to disambiguate.
 type ToolCallSummary struct {
 	Name         string `json:"name"`
 	InternalName string `json:"internalName,omitempty"`
@@ -120,7 +126,9 @@ func (t TurnTrace) IsBatch() bool {
 //
 // Name is the model-facing name (the alias under a toolset profile);
 // InternalName is the internal tool ID it dispatched to (issue #234).
-// See ToolCallSummary for the omitempty rationale.
+// See ToolCallSummary for the omitempty rationale and the empty-value
+// ambiguity (default profile vs unresolved name under a non-default
+// profile).
 type ToolCallTrace struct {
 	Name         string `json:"name"`
 	InternalName string `json:"internalName,omitempty"`

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -33,13 +33,22 @@ type RunTrace struct {
 }
 
 // ToolCallSummary records a single tool call's outcome for the trace.
+//
+// Name is the model-facing name the call arrived under: under a toolset
+// profile (issue #234) this is the alias presented to the model.
+// InternalName is the canonical internal tool ID the alias dispatched to.
+// Under the default profile (no aliasing) the two are equal, and
+// InternalName is omitted from the wire to keep the existing trace shape
+// byte-identical; a non-default profile records both so a trace is
+// auditable and the alias→internal binding is recoverable.
 type ToolCallSummary struct {
-	Name        string `json:"name"`
-	DurationMs  int64  `json:"durationMs"`
-	Success     bool   `json:"success"`
-	ErrorReason string `json:"errorReason,omitempty"`
-	InputSize   int    `json:"inputSize,omitempty"`
-	OutputSize  int    `json:"outputSize,omitempty"`
+	Name         string `json:"name"`
+	InternalName string `json:"internalName,omitempty"`
+	DurationMs   int64  `json:"durationMs"`
+	Success      bool   `json:"success"`
+	ErrorReason  string `json:"errorReason,omitempty"`
+	InputSize    int    `json:"inputSize,omitempty"`
+	OutputSize   int    `json:"outputSize,omitempty"`
 	// RunID identifies the run that produced this tool call. Populated only
 	// when the call originated in a sub-agent run forwarded to a parent
 	// emitter; absent (omitempty) on parent-emitted events to preserve
@@ -108,13 +117,18 @@ func (t TurnTrace) IsBatch() bool {
 //
 // Field order MUST match ToolCallSummary so the cast in trace emitters
 // (types.ToolCallSummary(tc)) remains valid.
+//
+// Name is the model-facing name (the alias under a toolset profile);
+// InternalName is the internal tool ID it dispatched to (issue #234).
+// See ToolCallSummary for the omitempty rationale.
 type ToolCallTrace struct {
-	Name        string `json:"name"`
-	DurationMs  int64  `json:"durationMs"`
-	Success     bool   `json:"success"`
-	ErrorReason string `json:"errorReason,omitempty"`
-	InputSize   int    `json:"inputSize,omitempty"`
-	OutputSize  int    `json:"outputSize,omitempty"`
+	Name         string `json:"name"`
+	InternalName string `json:"internalName,omitempty"`
+	DurationMs   int64  `json:"durationMs"`
+	Success      bool   `json:"success"`
+	ErrorReason  string `json:"errorReason,omitempty"`
+	InputSize    int    `json:"inputSize,omitempty"`
+	OutputSize   int    `json:"outputSize,omitempty"`
 	// RunID identifies the run that produced this tool call. Populated only
 	// when the call originated in a sub-agent run forwarded to a parent
 	// emitter; absent (omitempty) on parent-emitted events to preserve
@@ -156,14 +170,18 @@ type ModelInput struct {
 // Kind names the Structured payload's shape (see ToolResult.Kind); empty and
 // omitted for text-only calls.
 type ToolCallRecord struct {
-	ID         string          `json:"id"`
-	Name       string          `json:"name"`
-	Input      json.RawMessage `json:"input"`
-	Output     string          `json:"output"`
-	DurationMs int64           `json:"durationMs"`
-	Success    bool            `json:"success"`
-	Structured json.RawMessage `json:"structured,omitempty"`
-	Kind       string          `json:"kind,omitempty"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// InternalName is the canonical internal tool ID the model-facing Name
+	// dispatched to under a toolset profile (issue #234). Equal to Name and
+	// omitted from the wire under the default (no-alias) profile.
+	InternalName string          `json:"internalName,omitempty"`
+	Input        json.RawMessage `json:"input"`
+	Output       string          `json:"output"`
+	DurationMs   int64           `json:"durationMs"`
+	Success      bool            `json:"success"`
+	Structured   json.RawMessage `json:"structured,omitempty"`
+	Kind         string          `json:"kind,omitempty"`
 }
 
 // RunRecording is a full recording of a run.


### PR DESCRIPTION
## Summary

First chunk of **Wave 5** (the capstone wave). Adds explicit, config-selected **toolset profiles** that present provider-friendly tool aliases to the model while dispatching to unchanged internal tool IDs — without breaking existing configs. **Closes #234.**

Stacked on the open Wave 4 stack: `#322`→`#323`→`#324`→`#325` ← **C1**. Auto-retargets as lower PRs merge.

## What lands

- **`tools.profile`** on `RunConfig` — a closed enum: `default` (zero value, identity, byte-identical to today) + `coding-classic` (`grep_files`→`grep`, `find_files`→`find`, `run_command`→`bash`). `provider-native` is intentionally deferred (it depends on the #222/#228 schema-variant work). Unknown profiles are rejected by `ValidateRunConfig`; CLI flag wired.
- **`tool.Presenter`** wraps the registry: `List()` renames defs to aliases on the wire; `Resolve()` accepts both the alias and the internal name and returns the tool with its internal `.Name` intact. The factory builds the presenter last and assigns it to `loop.Tools`; permission policy + the mutating-tool set keep using the raw registry.
- **All gating/guard layers key on the internal tool ID** — permission checks, mutating-tool classification, `GuardToolCall`, the `PhasePreTool` guardrail, and the sub-agent recursion guard. An alias can never reach a tool a read-only mode excluded, and an operator policy/guard written against the internal name still fires under any profile.
- **Alias collisions reuse the Wave 1 `toolname` normalization** via an extracted `BuildFromCandidates` (internal IDs as keys, aliases as candidates) — one deterministic, order-independent collision algorithm, no second implementation.
- **Traces record both names**: `internalName` (omitempty) alongside the model-facing alias.
- **Docs**: `docs/configuration.md` profile selection + compatibility; policies must reference internal tool IDs (called out explicitly).

## Security

The central risk — aliasing as a gating bypass — is closed: every authorization/guard layer resolves to and keys on the internal tool ID. A regression test (`TestFilterToolRegistry_ExcludesAliasedSpawnAgent`) proves an aliased `spawn_agent` is still excluded from a spawned sub-agent, so a future aliasing profile cannot silently defeat the recursion guard.

## Test plan

- [x] `just` (build + test) + `just lint` green
- [x] profile presents aliases; dispatch resolves alias→internal and executes the internal tool; both names accepted
- [x] default-profile config back-compat; `internalName`/`profile` omitted from the wire when empty (asserted on marshalled JSON)
- [x] unknown profile rejected by `ValidateRunConfig`
- [x] alias collisions resolved deterministically + order-independently via shared `toolname` code
- [x] read-only / recursion-guard invariants hold under aliasing

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)