### PR TITLE
tools: complete the model-facing tool contract (#222)

### DIFF
--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -123,6 +123,8 @@ type ProviderQuirks struct {
     // Cross-provider capabilities (top-level, not per-adapter).
     ToolChoice            ToolChoiceCapability           // native tool_choice support (auto/required/none/named)
     StructuredToolResults StructuredToolResultCapability // accepts a non-string tool-result payload, and in which shape
+    ParallelToolCalls     ParallelToolCallsCapability    // native parallel-tool-call control (#222)
+    ToolExamples          ToolExamplesCapability         // accepts the JSON-Schema `examples` keyword in a tool's parameters (#222)
 
     // Behaviour flags (per-adapter typed sub-structs).
     BehaviourFlags  ProviderBehaviourFlags
@@ -132,15 +134,33 @@ type ProviderQuirks struct {
 A **capability** is a top-level field rather than a per-adapter
 behaviour flag when it expresses a concept the loop reasons about
 uniformly across families even though each provider encodes it
-differently. `ToolChoice` and `StructuredToolResults` are the two:
-every family has *some* form of tool-choice control and *some*
-notion of (or lack of) a structured tool result, so modelling either
-under one provider's sub-struct would force the other adapters to
-reach across family boundaries to read it, which the behaviour-flag
+differently. `ToolChoice`, `StructuredToolResults`,
+`ParallelToolCalls`, and `ToolExamples` are the four: every family
+has *some* form of (or lack of) each, so modelling any of them under
+one provider's sub-struct would force the other adapters to reach
+across family boundaries to read it, which the behaviour-flag
 ownership rule forbids. Each capability's zero value advertises no
 support, so an adapter resolving a provider with no rule emits the
 pre-capability wire shape — the graceful default the
 `StreamParams`/`ToolResult` contracts require.
+
+The two `#222` capabilities gate the tool-reliability controls the
+model-facing contract added on top of tool-choice and strict mode:
+
+| Control | Source | OpenAI Chat | OpenAI Responses | Anthropic | Gemini | Bedrock |
+|---|---|---|---|---|---|---|
+| Parallel-tool-call policy | `StreamParams.ParallelToolCalls` | `parallel_tool_calls` | `parallel_tool_calls` | `tool_choice.disable_parallel_tool_use` | — | — |
+| Input examples | `ToolDefinition.Presentation.InputExamples` | schema `examples`¹ | schema `examples`¹ | schema `examples` | —² | — |
+| Tool annotations | `ToolDefinition.Presentation.Annotations` | —³ | —³ | —³ | —³ | —³ |
+
+¹ Folded only on non-strict tools: OpenAI's structured-outputs
+subset rejects the `examples` keyword, so strict tools rely on the
+description text (which carries the same example).
+² Gemini's function-declaration Schema dialect rejects `examples`, so
+the capability stays off and the description text is the carrier.
+³ No first-party provider has a tool-annotation wire field; annotations
+are carried for internal use and round-tripped from MCP servers (see
+[#222](architecture.md)), and are a deliberate no-op on every adapter.
 
 `StructuredToolResults` (issue #231) gates whether the structured
 tool-result envelope is serialised onto the wire. The first-party
@@ -388,16 +408,18 @@ The quirks layer is deliberately scoped to per-(provider, model)
 request-shape and response-parsing divergence. Several adjacent
 concerns are tracked separately:
 
-- **Tool-contract metadata (#222).** Provider-facing tool metadata
-  (strict mode, tool-choice policy, parallel-call policy, input
-  examples, annotations) is a property of `types.ToolDefinition`,
-  keyed by tool name — not by (provider, model). The two
-  cardinalities are different. When #222 lands, each adapter's
-  `translateTools()` will gain the mapping; whether a model supports
-  a given tool feature (e.g. `strict: true`) is a one-line check
-  against the resolved `ProviderQuirks` (likely a `SupportsStrictMode
-  bool` flag on `OpenAIBehaviourFlags`). This is a small extension to
-  the quirks shape, not a redesign.
+- **Tool-contract metadata (#222, landed).** Provider-facing tool
+  metadata splits along its two cardinalities. The per-tool payload —
+  input examples and annotations — lives on
+  `types.ToolDefinition.Presentation`, keyed by tool name. Whether a
+  (provider, model) *accepts* a given control is a check against the
+  resolved `ProviderQuirks`: strict mode is `OpenAIBehaviourFlags.StrictMode`,
+  and the parallel-call and examples controls are the top-level
+  `ParallelToolCalls` / `ToolExamples` capabilities documented in
+  [§2.1](#21-providerquirks). Each adapter's `translateTools()`
+  consults the resolved capability before projecting the per-tool
+  payload onto its wire shape — the per-provider mapping in the §2.1
+  table.
 - **Toolset profiles and aliases (#234, Wave 5).** Operator-facing
   toolset selection is a `RunConfig` concern, not a per-model
   one.

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -965,10 +965,19 @@ func editToolEnabled(enabled []string, actualName string) bool {
 
 func editStrategyTool(es edit.EditStrategy, exec executor.Executor) *tool.Tool {
 	definition := es.ToolDefinition()
+	// Carry the strategy's worked example (#222) onto the registered tool so
+	// Definition() folds it into the schema where the provider supports it.
+	// The strategy owns the example next to its description; nil Presentation
+	// (strategies without an example) leaves InputExamples unset.
+	var inputExamples []json.RawMessage
+	if definition.Presentation != nil {
+		inputExamples = definition.Presentation.InputExamples
+	}
 	return &tool.Tool{
 		Name:              definition.Name,
 		Description:       definition.Description,
 		InputSchema:       definition.InputSchema,
+		InputExamples:     inputExamples,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
 		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {

--- a/harness/internal/edit/multi.go
+++ b/harness/internal/edit/multi.go
@@ -112,6 +112,12 @@ func (m *MultiStrategy) ToolDefinition() types.ToolDefinition {
 			"  - 'patch' applies a unified diff. Requires diff. Useful for multi-hunk edits.\n" +
 			"Example (replace): {\"path\": \"main.go\", \"operation\": \"replace\", \"old_string\": \"return nil\", \"new_string\": \"return err\"}",
 		InputSchema: multiSchema,
+		// #222 structured mirror of the worked example above; editStrategyTool
+		// propagates it onto the registered tool. Pinned to the description by
+		// TestBuiltinInputExamples_MatchDescription.
+		Presentation: &types.ToolPresentation{
+			InputExamples: []json.RawMessage{json.RawMessage(`{"path": "main.go", "operation": "replace", "old_string": "return nil", "new_string": "return err"}`)},
+		},
 	}
 }
 

--- a/harness/internal/edit/multi_test.go
+++ b/harness/internal/edit/multi_test.go
@@ -103,6 +103,17 @@ func TestMultiStrategy_DescriptionEnrichedShape(t *testing.T) {
 	if err := json.Unmarshal([]byte(example), &probe); err != nil {
 		t.Errorf("example is not valid JSON: %v\nexample: %s", err, example)
 	}
+
+	// #222: the structured InputExamples must mirror the description example
+	// byte-for-byte. editStrategyTool propagates this onto the registered
+	// edit_file tool, where adapters fold it into the schema `examples`
+	// keyword for providers that support it.
+	if def.Presentation == nil || len(def.Presentation.InputExamples) != 1 {
+		t.Fatalf("ToolDefinition().Presentation = %+v, want exactly one InputExample", def.Presentation)
+	}
+	if got := string(def.Presentation.InputExamples[0]); got != example {
+		t.Errorf("InputExamples[0] drifted from description:\n got = %s\nwant = %s", got, example)
+	}
 }
 
 // hasPositiveUseThis reports whether desc contains a "Use this" clause
@@ -188,10 +199,11 @@ func extractEditFileJSONExample(desc string) (string, bool) {
 // TestExtractEditFileJSONExample locks the contract of the
 // extractEditFileJSONExample helper directly. The helper duplicates the
 // extractJSONExample helper in harness/internal/tool/builtins; the two
-// suites run independently so the duplication is intentional. A future
-// #222 migration to a structured InputExamples []any field on
-// types.ToolDefinition would replace both helpers — this test pins the
-// edge-case behaviour so the migration stays mechanical.
+// suites run independently so the duplication is intentional. The #222
+// migration has landed — edit_file now carries structured InputExamples on
+// its ToolDefinition.Presentation — and this helper is the oracle
+// TestMultiStrategy_DescriptionEnrichedShape uses to pin that example to the
+// description.
 func TestExtractEditFileJSONExample(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -137,6 +137,15 @@ type mcpTool struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
 	InputSchema json.RawMessage `json:"inputSchema"`
+	// Annotations carries the server-declared MCP tool annotations (spec
+	// 2025-06-18). types.ToolAnnotations mirrors the MCP object field-for-
+	// field, so it doubles as the wire-parse target; absent annotations leave
+	// it nil. The harness surfaces these on the tool's ToolPresentation (#222)
+	// but does not yet act on them — the conservative WorkspaceMutating/
+	// RequiresApproval defaults below still govern gating regardless of what a
+	// remote server claims, so a server cannot relax its own gating by
+	// asserting readOnlyHint.
+	Annotations *types.ToolAnnotations `json:"annotations,omitempty"`
 }
 
 type toolsListResult struct {
@@ -702,6 +711,11 @@ func (c *Client) registerMCPTool(serverName string, sess *serverSession, mt mcpT
 		Name:        prefixedName,
 		Description: mt.Description,
 		InputSchema: mt.InputSchema,
+		// Carry the server-declared annotations through to the tool's
+		// ToolPresentation (#222). They are advisory metadata only — the
+		// conservative WorkspaceMutating/RequiresApproval defaults below are
+		// what govern gating, never these hints.
+		Annotations: mt.Annotations,
 		// MCP tools are remote and opaque to the harness: we cannot
 		// statically tell whether they mutate the workspace, so be
 		// conservative and assume they do. They also require upstream

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -189,6 +189,66 @@ func TestConnect_ToolDiscovery(t *testing.T) {
 	}
 }
 
+// TestConnect_ToolAnnotations verifies the bridge parses server-declared MCP
+// tool annotations (#222) and surfaces them on the registered tool's
+// ToolPresentation, while pinning the invariant that the hints are advisory:
+// a server asserting readOnlyHint must NOT relax the conservative
+// WorkspaceMutating/RequiresApproval gating the harness applies to all remote
+// tools.
+func TestConnect_ToolAnnotations(t *testing.T) {
+	readOnly := true
+	destructive := false
+	tools := []mcpTool{
+		{
+			Name:        "lookup",
+			Description: "Look up a record",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Annotations: &types.ToolAnnotations{
+				Title:           "Lookup",
+				ReadOnlyHint:    &readOnly,
+				DestructiveHint: &destructive,
+			},
+		},
+	}
+
+	srv, _ := fakeMCPServer(t, tools, "")
+	registry := tool.NewRegistry()
+	client := NewClient(registry, srv.Client())
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+	config := types.MCPServerConfig{Name: "svc", URI: srv.URL}
+
+	if err := client.Connect(context.Background(), config, secrets); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	resolved := registry.Resolve("mcp_svc_lookup")
+	if resolved == nil {
+		t.Fatal("Resolve returned nil for mcp_svc_lookup")
+	}
+	if resolved.Annotations == nil {
+		t.Fatal("server annotations were not carried onto the tool")
+	}
+	if resolved.Annotations.Title != "Lookup" {
+		t.Errorf("Annotations.Title = %q, want %q", resolved.Annotations.Title, "Lookup")
+	}
+	if resolved.Annotations.ReadOnlyHint == nil || !*resolved.Annotations.ReadOnlyHint {
+		t.Error("ReadOnlyHint should round-trip as true")
+	}
+	// The advisory hint must not override the conservative gating defaults.
+	if !resolved.WorkspaceMutating || !resolved.RequiresApproval {
+		t.Error("server readOnlyHint must not relax WorkspaceMutating/RequiresApproval")
+	}
+
+	// The annotations also surface on the model-facing Presentation (#222).
+	def := resolved.Definition()
+	if def.Presentation == nil || def.Presentation.Annotations == nil {
+		t.Fatalf("Definition().Presentation.Annotations missing: %+v", def.Presentation)
+	}
+	if def.Presentation.Annotations.Title != "Lookup" {
+		t.Errorf("Presentation Annotations.Title = %q, want %q", def.Presentation.Annotations.Title, "Lookup")
+	}
+}
+
 func TestConnect_ToolCallDispatch(t *testing.T) {
 	tools := []mcpTool{
 		{

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
@@ -154,9 +153,70 @@ type anthropicRequest struct {
 // Anthropic has no native "none" — a no-tools turn is expressed by
 // omitting the tools array — so ToolChoiceNone never produces this
 // struct.
+//
+// DisableParallelToolUse carries the #222 parallel-tool-call control.
+// Anthropic has no top-level parallel field: forbidding parallel tool calls
+// is expressed only as this flag on the tool_choice object. A nil pointer
+// omits the key (parallel is Anthropic's default); applyAnthropicParallel sets
+// it true when the caller requested no-parallel, synthesising an auto
+// tool_choice when none was otherwise produced.
 type anthropicToolChoice struct {
-	Type string `json:"type"`
-	Name string `json:"name,omitempty"`
+	Type                   string `json:"type"`
+	Name                   string `json:"name,omitempty"`
+	DisableParallelToolUse *bool  `json:"disable_parallel_tool_use,omitempty"`
+}
+
+// applyAnthropicParallel folds a requested parallel-disable (#222) onto the
+// tool_choice object. Only the disable direction is expressible — Anthropic's
+// default is parallel-enabled — so a nil or =true StreamParams.ParallelToolCalls
+// is a no-op. When disable is requested and the capability supports it, the
+// flag rides on the tool_choice object, synthesising an auto object if the
+// tool-choice projection produced none. The structural "none" mode is left
+// untouched: there are no tool calls to parallelise and synthesising auto
+// would contradict the caller.
+func applyAnthropicParallel(tc *anthropicToolChoice, params types.StreamParams, capability quirks.ParallelToolCallsCapability) *anthropicToolChoice {
+	if params.ParallelToolCalls == nil || *params.ParallelToolCalls {
+		return tc
+	}
+	if !capability.Supported || !capability.Disable {
+		return tc
+	}
+	if tc == nil {
+		if params.ToolChoice == types.ToolChoiceNone {
+			return nil
+		}
+		tc = &anthropicToolChoice{Type: "auto"}
+	}
+	disable := true
+	tc.DisableParallelToolUse = &disable
+	return tc
+}
+
+// translateToolsAnthropic returns a fresh copy of the tool definitions with
+// each tool's worked examples (#222) folded into its input_schema when the
+// resolved capability supports it. It replaces a bare slices.Clone: the
+// Anthropic adapter serialises types.ToolDefinition onto the wire (Presentation
+// carries json:"-"), so examples must be merged into the schema explicitly.
+// The fresh slice preserves the no-aliasing guarantee buildAnthropicRequest
+// relies on. Anthropic has no strict-mode subset restriction, so examples fold
+// whenever the capability is on. Examples are advisory: a merge that cannot
+// marshal (not reachable for a map just unmarshalled) leaves the schema as-is
+// rather than failing the request — the description still carries the example.
+func translateToolsAnthropic(tools []types.ToolDefinition, examples bool) []types.ToolDefinition {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]types.ToolDefinition, len(tools))
+	copy(out, tools)
+	if !examples {
+		return out
+	}
+	for i := range out {
+		if merged, err := mergeSchemaExamples(out[i].InputSchema, toolInputExamples(out[i])); err == nil {
+			out[i].InputSchema = merged
+		}
+	}
+	return out
 }
 
 // anthropicToolChoiceFromParams projects the provider-neutral
@@ -380,17 +440,14 @@ func buildAnthropicRequest(params types.StreamParams, stream bool, q quirks.Prov
 		Model:    params.Model,
 		System:   params.System,
 		Messages: translateMessagesAnthropic(params.Messages, q.StructuredToolResults),
-		// slices.Clone avoids aliasing params.Tools into the returned
-		// struct. translateMessagesAnthropic / translateTools(Responses)
-		// allocate fresh output slices for messages and tools on the
-		// sibling adapters; the Anthropic path was the only builder
-		// passing the input slice through by reference. Once the phase-2
-		// batch caller retains the returned struct across a retry or
-		// concurrent send, a caller mutating params.Tools would race.
-		Tools:       slices.Clone(params.Tools),
+		// translateToolsAnthropic allocates a fresh slice (so a caller mutating
+		// params.Tools cannot race the returned struct, as the phase-2 batch
+		// caller requires) and folds #222 worked examples into each tool's
+		// input_schema when the resolved capability supports it.
+		Tools:       translateToolsAnthropic(params.Tools, q.ToolExamples.Supported),
 		MaxTokens:   params.MaxTokens,
 		Temperature: params.Temperature,
-		ToolChoice:  anthropicToolChoiceFromParams(params, q.ToolChoice),
+		ToolChoice:  applyAnthropicParallel(anthropicToolChoiceFromParams(params, q.ToolChoice), params, q.ParallelToolCalls),
 		Stream:      stream,
 	}
 }

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -166,6 +166,13 @@ type openaiRequest struct {
 	// advertises support for the requested mode; steers MarshalJSON, it
 	// has no JSON struct tag of its own.
 	ToolChoice any
+	// ParallelToolCalls is the wire value for the top-level
+	// "parallel_tool_calls" bool (#222). A nil pointer omits the field so
+	// the request is byte-identical to the pre-#222 shape; buildOpenAIRequest
+	// populates it only when the caller set StreamParams.ParallelToolCalls and
+	// the resolved capability advertises support. Steered by MarshalJSON, no
+	// struct tag of its own.
+	ParallelToolCalls *bool
 }
 
 // MarshalJSON projects the canonical openaiRequest into the wire body
@@ -206,6 +213,9 @@ func (r openaiRequest) MarshalJSON() ([]byte, error) {
 	}
 	if r.ToolChoice != nil {
 		out["tool_choice"] = r.ToolChoice
+	}
+	if r.ParallelToolCalls != nil {
+		out["parallel_tool_calls"] = *r.ParallelToolCalls
 	}
 	if !r.OmitSamplingParams && r.Temperature != nil {
 		out["temperature"] = *r.Temperature
@@ -277,6 +287,14 @@ func (r *openaiRequest) UnmarshalJSON(data []byte) error {
 		}
 		r.ToolChoice = tc
 		delete(raw, "tool_choice")
+	}
+	if v, ok := raw["parallel_tool_calls"]; ok {
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return fmt.Errorf("openaiRequest.parallel_tool_calls: %w", err)
+		}
+		r.ParallelToolCalls = &b
+		delete(raw, "parallel_tool_calls")
 	}
 	// Token budget: accept either canonical key. MarshalJSON emits
 	// exactly one key, so a valid request body should not contain
@@ -444,6 +462,7 @@ var canonicalOpenAIFields = map[string]struct{}{
 	"top_logprobs":          {},
 	"logit_bias":            {},
 	"stream":                {},
+	"parallel_tool_calls":   {},
 }
 
 // isCanonicalOpenAIField reports whether the given top-level request
@@ -705,7 +724,7 @@ func translateMessages(system string, messages []types.Message) []openaiMessage 
 // Returns an error when strict-mode normalisation rejects a tool's
 // schema — the request must not be sent in that case (design §5
 // fail-closed contract).
-func translateTools(tools []types.ToolDefinition, strict bool, model string, cache *strictSchemaCache) ([]openaiTool, error) {
+func translateTools(tools []types.ToolDefinition, strict, examples bool, model string, cache *strictSchemaCache) ([]openaiTool, error) {
 	if len(tools) == 0 {
 		return nil, nil
 	}
@@ -724,6 +743,18 @@ func translateTools(tools []types.ToolDefinition, strict bool, model string, cac
 			def.Parameters = normalised
 			truthy := true
 			def.Strict = &truthy
+		} else if examples {
+			// Fold worked examples (#222) into the schema's `examples`
+			// keyword — but only for non-strict tools. OpenAI's
+			// structured-outputs subset rejects `examples`, so strict tools
+			// must rely on the description text (which carries the same
+			// example) instead. The strict branch above therefore never
+			// folds; this else-if guarantees the two are mutually exclusive.
+			merged, err := mergeSchemaExamples(def.Parameters, toolInputExamples(t))
+			if err != nil {
+				return nil, fmt.Errorf("tool %q: merge examples: %w", t.Name, err)
+			}
+			def.Parameters = merged
 		}
 		out[i] = openaiTool{
 			Type:     "function",
@@ -779,6 +810,19 @@ func openAIToolChoiceFromParams(params types.StreamParams, capability quirks.Too
 		// nothing rather than an explicit "auto" string.
 		return nil
 	}
+}
+
+// openAIParallelFromParams projects StreamParams.ParallelToolCalls onto the
+// OpenAI top-level parallel_tool_calls bool, gated on the resolved capability.
+// Returns nil — meaning "emit no field" — when the caller did not set the
+// control or the provider does not advertise support, leaving the request
+// byte-identical to the pre-#222 shape. Shared by the Chat and Responses
+// adapters, which use the identical top-level wire field.
+func openAIParallelFromParams(params types.StreamParams, capability quirks.ParallelToolCallsCapability) *bool {
+	if params.ParallelToolCalls == nil || !capability.Supported {
+		return nil
+	}
+	return params.ParallelToolCalls
 }
 
 // warnInvalidToolChoiceName logs a single warn when a ToolChoiceTool
@@ -839,7 +883,7 @@ func mapFinishReason(reason string) string {
 // accepts (e.g. top_p on Responses, equivalent constraints on Chat
 // Completions), apply a batch-specific projection here.
 func buildOpenAIRequest(params types.StreamParams, stream bool, q quirks.ProviderQuirks, strictCache *strictSchemaCache) (openaiRequest, error) {
-	tools, err := translateTools(params.Tools, q.BehaviourFlags.OpenAI.StrictMode, params.Model, strictCache)
+	tools, err := translateTools(params.Tools, q.BehaviourFlags.OpenAI.StrictMode, q.ToolExamples.Supported, params.Model, strictCache)
 	if err != nil {
 		return openaiRequest{}, err
 	}
@@ -854,6 +898,7 @@ func buildOpenAIRequest(params types.StreamParams, stream bool, q quirks.Provide
 		OmitSamplingParams: q.BehaviourFlags.OpenAI.OmitSamplingParams,
 		ExtraBodyFields:    q.BehaviourFlags.OpenAI.ExtraBodyFields,
 		ToolChoice:         openAIToolChoiceFromParams(params, q.ToolChoice),
+		ParallelToolCalls:  openAIParallelFromParams(params, q.ParallelToolCalls),
 	}, nil
 }
 

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -139,6 +139,12 @@ type responsesRequest struct {
 	// but omission is the safer default until that verification lands.
 	Stream bool `json:"stream,omitempty"`
 	Store  bool `json:"store"`
+	// ParallelToolCalls carries the top-level parallel_tool_calls bool (#222),
+	// shared with the Chat Completions API. A nil pointer omits the key so the
+	// body is byte-identical to the pre-#222 shape; buildResponsesRequest sets
+	// it only when the caller requested the control and the resolved capability
+	// advertises support.
+	ParallelToolCalls *bool `json:"parallel_tool_calls,omitempty"`
 }
 
 // responsesInput is one item in the Responses API input array. The Type
@@ -468,7 +474,7 @@ func translateMessagesResponses(messages []types.Message) []responsesInput {
 // strict=true; the cache memoises rewrites within the adapter's
 // lifetime. A schema that fails the lint surfaces as an error here,
 // and the caller MUST NOT send a request.
-func translateToolsResponses(tools []types.ToolDefinition, strict bool, model string, cache *strictSchemaCache) ([]responsesTool, error) {
+func translateToolsResponses(tools []types.ToolDefinition, strict, examples bool, model string, cache *strictSchemaCache) ([]responsesTool, error) {
 	if len(tools) == 0 {
 		return nil, nil
 	}
@@ -488,6 +494,15 @@ func translateToolsResponses(tools []types.ToolDefinition, strict bool, model st
 			entry.Parameters = normalised
 			truthy := true
 			entry.Strict = &truthy
+		} else if examples {
+			// Fold worked examples (#222) into the schema, but only for
+			// non-strict tools: the structured-outputs subset rejects the
+			// `examples` keyword, identical to the Chat Completions side.
+			merged, err := mergeSchemaExamples(entry.Parameters, toolInputExamples(t))
+			if err != nil {
+				return nil, fmt.Errorf("tool %q: merge examples: %w", t.Name, err)
+			}
+			entry.Parameters = merged
 		}
 		out[i] = entry
 	}
@@ -509,18 +524,19 @@ func translateToolsResponses(tools []types.ToolDefinition, strict bool, model st
 // TODO(batch): consider returning json.RawMessage if endpoint-contract drift
 // becomes a maintenance burden.
 func buildResponsesRequest(params types.StreamParams, q quirks.ProviderQuirks, strictCache *strictSchemaCache) (responsesRequest, error) {
-	tools, err := translateToolsResponses(params.Tools, q.BehaviourFlags.OpenAI.StrictMode, params.Model, strictCache)
+	tools, err := translateToolsResponses(params.Tools, q.BehaviourFlags.OpenAI.StrictMode, q.ToolExamples.Supported, params.Model, strictCache)
 	if err != nil {
 		return responsesRequest{}, err
 	}
 	return responsesRequest{
-		Model:           params.Model,
-		Instructions:    params.System,
-		Input:           translateMessagesResponses(params.Messages),
-		Tools:           tools,
-		MaxOutputTokens: params.MaxTokens,
-		Temperature:     params.Temperature,
-		Store:           false,
+		Model:             params.Model,
+		Instructions:      params.System,
+		Input:             translateMessagesResponses(params.Messages),
+		Tools:             tools,
+		MaxOutputTokens:   params.MaxTokens,
+		Temperature:       params.Temperature,
+		Store:             false,
+		ParallelToolCalls: openAIParallelFromParams(params, q.ParallelToolCalls),
 	}, nil
 }
 

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -1386,7 +1386,7 @@ func TestTranslateToolsResponses(t *testing.T) {
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
 	}
-	result, err := translateToolsResponses(tools, false, "gpt-4o", nil)
+	result, err := translateToolsResponses(tools, false, false, "gpt-4o", nil)
 	if err != nil {
 		t.Fatalf("translateToolsResponses: %v", err)
 	}
@@ -1407,10 +1407,10 @@ func TestTranslateToolsResponses(t *testing.T) {
 }
 
 func TestTranslateToolsResponses_Empty(t *testing.T) {
-	if got, err := translateToolsResponses(nil, false, "gpt-4o", nil); err != nil || got != nil {
+	if got, err := translateToolsResponses(nil, false, false, "gpt-4o", nil); err != nil || got != nil {
 		t.Errorf("translateToolsResponses(nil) = (%+v, %v), want (nil, nil)", got, err)
 	}
-	if got, err := translateToolsResponses([]types.ToolDefinition{}, false, "gpt-4o", nil); err != nil || got != nil {
+	if got, err := translateToolsResponses([]types.ToolDefinition{}, false, false, "gpt-4o", nil); err != nil || got != nil {
 		t.Errorf("translateToolsResponses(empty) = (%+v, %v), want (nil, nil)", got, err)
 	}
 }

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -385,5 +385,66 @@ func BuiltinRules() []Rule {
 				)
 			},
 		},
+		// --- Parallel-tool-call + input-example capability rules (#222) ---
+		//
+		// Both are cross-provider capabilities, so the resolved flags live on
+		// the top-level ProviderQuirks.ParallelToolCalls / .ToolExamples
+		// fields rather than a provider sub-struct. Each first-party provider
+		// that has a native parallel control and/or accepts the JSON-Schema
+		// `examples` keyword declares a base "*" rule; the adapters gate
+		// serialisation on the resolved capability and emit nothing when it is
+		// unsupported.
+		//
+		// Gemini and Bedrock are deliberately absent: Gemini has no native
+		// parallel control and its Schema dialect rejects `examples` (the
+		// example still reaches the model via the #227 description text), and
+		// the Bedrock Converse API has neither control. Both therefore stay at
+		// the zero-value (unsupported) capability by construction — pinned by
+		// the negative assertions in TestParallelToolCallsCapabilityRules and
+		// TestToolExamplesCapabilityRules.
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "*",
+			Description:  "Anthropic: disable_parallel_tool_use on tool_choice; accepts schema examples",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// Anthropic expresses "no parallel" via
+				// tool_choice.disable_parallel_tool_use; there is no top-level
+				// field, so the adapter synthesises a tool_choice object when a
+				// disable is requested. The Messages API passes through
+				// arbitrary JSON-Schema keywords in input_schema, so `examples`
+				// reaches the model.
+				q.ParallelToolCalls = ParallelToolCallsCapability{Supported: true, Disable: true}
+				q.ToolExamples = ToolExamplesCapability{Supported: true}
+			},
+		},
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "*",
+			Description:  "OpenAI-compatible: top-level parallel_tool_calls; accepts schema examples",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// OpenAI Chat Completions accepts a top-level
+				// `parallel_tool_calls` bool (either direction) and passes
+				// through the JSON-Schema `examples` keyword in a function's
+				// parameters object.
+				q.ParallelToolCalls = ParallelToolCallsCapability{Supported: true, Disable: true}
+				q.ToolExamples = ToolExamplesCapability{Supported: true}
+			},
+		},
+		{
+			ProviderType: "openai-responses",
+			ModelMatch:   "*",
+			Description:  "OpenAI Responses: top-level parallel_tool_calls; accepts schema examples",
+			LastVerified: Date("2026-05-24"),
+			Apply: func(q *ProviderQuirks) {
+				// The Responses API shares the Chat Completions
+				// `parallel_tool_calls` bool and schema passthrough. This is
+				// the first builtin rule for the openai-responses provider
+				// type — it previously resolved an empty quirks set.
+				q.ParallelToolCalls = ParallelToolCallsCapability{Supported: true, Disable: true}
+				q.ToolExamples = ToolExamplesCapability{Supported: true}
+			},
+		},
 	}
 }

--- a/harness/internal/provider/quirks/examples.go
+++ b/harness/internal/provider/quirks/examples.go
@@ -1,0 +1,28 @@
+package quirks
+
+// ToolExamplesCapability declares whether a resolved (provider, model) pair
+// accepts the JSON-Schema `examples` keyword inside a tool's parameters
+// object (issue #222). It is the cross-provider capability the adapters
+// consult before folding types.ToolPresentation.InputExamples into the
+// emitted schema.
+//
+// `examples` is a standard JSON-Schema 2020-12 keyword. OpenAI Chat/Responses,
+// Anthropic, and Bedrock pass through arbitrary schema keywords in the
+// parameters object, so the structured examples reach the model context
+// alongside the schema. Gemini is the exception: its function-declaration
+// Schema dialect rejects `examples` (it is listed among
+// GeminiBehaviourFlags.SchemaUnsupportedFeatures), so the Gemini rule leaves
+// this capability at its zero value and the adapter never folds examples in —
+// the #227 description text remains the carrier there.
+//
+// The zero value advertises NO support: Supported is false. An adapter
+// resolving a provider with no examples rule therefore emits the schema
+// unchanged, byte-identical to the pre-#222 shape. The example is never lost
+// for those providers — it still rides in the tool description, which is sent
+// to every provider unconditionally.
+type ToolExamplesCapability struct {
+	// Supported is the master switch. When false, the adapter MUST NOT fold
+	// InputExamples into the emitted parameters object; it serialises the
+	// schema as-is.
+	Supported bool `json:"supported"`
+}

--- a/harness/internal/provider/quirks/parallel.go
+++ b/harness/internal/provider/quirks/parallel.go
@@ -1,0 +1,36 @@
+package quirks
+
+// ParallelToolCallsCapability declares the native parallel-tool-call control
+// of a resolved (provider, model) pair. It is the cross-provider capability
+// the adapters consult before serialising a types.StreamParams.ParallelToolCalls
+// onto the wire (issue #222).
+//
+// Modelled as a top-level ProviderQuirks field for the same reason
+// ToolChoiceCapability is (see quirks.go): "limit the model to one tool call
+// per turn" is a concept the loop reasons about uniformly even though each
+// family encodes it differently — OpenAI Chat/Responses expose a top-level
+// `parallel_tool_calls` bool, Anthropic rides it on the tool_choice object via
+// `disable_parallel_tool_use`, and Gemini/Bedrock have no native control.
+//
+// The zero value advertises NO support: Supported is false. An adapter
+// resolving a provider with no parallel rule therefore emits nothing, leaving
+// the request byte-identical to the pre-#222 shape. Parallelism is an
+// efficiency hint, not a correctness lever, so there is no prompt-based
+// fallback for unsupported providers — the field is simply a no-op.
+type ParallelToolCallsCapability struct {
+	// Supported is the master switch. When false, the adapter MUST NOT emit
+	// any parallel-tool-call control regardless of Disable below. A rule
+	// that sets Disable is expected to also set Supported; the registry
+	// self-test pins that relationship.
+	Supported bool `json:"supported"`
+
+	// Disable reports whether the provider can express "do not call tools in
+	// parallel" natively. Every first-party provider with a control can
+	// (OpenAI via `parallel_tool_calls:false`, Anthropic via
+	// `tool_choice.disable_parallel_tool_use:true`), so first-party rules set
+	// it alongside Supported. It is a distinct bool so a future gateway that
+	// accepts only the enable direction can advertise Supported without
+	// Disable, and the adapter can fall back rather than assume the disable
+	// form exists.
+	Disable bool `json:"disable"`
+}

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -68,6 +68,22 @@ type ProviderQuirks struct {
 	// the pre-#231 wire shape, with the canonical text fallback intact.
 	StructuredToolResults StructuredToolResultCapability `json:"structuredToolResults"`
 
+	// ParallelToolCalls declares whether the resolved (provider, model)
+	// supports a native parallel-tool-call control (issue #222). Top-level
+	// for the same cross-provider reason as ToolChoice: limiting the model to
+	// one tool call per turn is a uniform concept the loop reasons about even
+	// though OpenAI, Anthropic, and Gemini encode it differently. The zero
+	// value advertises no support, so an adapter with no rule emits nothing.
+	ParallelToolCalls ParallelToolCallsCapability `json:"parallelToolCalls"`
+
+	// ToolExamples declares whether the resolved (provider, model) accepts
+	// the JSON-Schema `examples` keyword inside a tool's parameters object
+	// (issue #222). The zero value advertises no support, so examples are not
+	// folded into the schema and the #227 description text remains the
+	// carrier. Gemini deliberately stays at the zero value — its Schema
+	// dialect rejects `examples`.
+	ToolExamples ToolExamplesCapability `json:"toolExamples"`
+
 	// --- Behaviour flags ---
 
 	// BehaviourFlags carries adapter-internal behaviour flags that cannot be

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -88,6 +88,7 @@ var canonicalOpenAIFieldNames = map[string]bool{
 	"top_logprobs":          true,
 	"logit_bias":            true,
 	"stream":                true,
+	"parallel_tool_calls":   true,
 }
 
 // TestBuiltinRulesValidate asserts every rule baked into the registry

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -671,6 +671,93 @@ func TestStructuredToolResultRulesSetSupportedWhenAnyShape(t *testing.T) {
 	}
 }
 
+// TestParallelToolCallsCapabilityRules pins which providers advertise a
+// native parallel-tool-call control (#222). Gemini and Bedrock are the
+// load-bearing negatives: builtin.go names them as deliberately absent, so a
+// future rule flipping Supported=true cannot land unnoticed.
+func TestParallelToolCallsCapabilityRules(t *testing.T) {
+	supported := map[string]string{
+		"anthropic":         "claude-sonnet-4-5",
+		"openai-compatible": "gpt-4o",
+		"openai-responses":  "gpt-4o",
+	}
+	for provider, model := range supported {
+		t.Run(provider+" advertises disable", func(t *testing.T) {
+			q := DefaultRegistry().Resolve(provider, model)
+			want := ParallelToolCallsCapability{Supported: true, Disable: true}
+			if q.ParallelToolCalls != want {
+				t.Errorf("%s: ParallelToolCalls = %+v, want %+v", provider, q.ParallelToolCalls, want)
+			}
+		})
+	}
+
+	unsupported := map[string]string{
+		"gemini":         "gemini-2.5-pro",
+		"bedrock":        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"mystery-vendor": "some-model",
+	}
+	for provider, model := range unsupported {
+		t.Run(provider+" stays unsupported", func(t *testing.T) {
+			q := DefaultRegistry().Resolve(provider, model)
+			if q.ParallelToolCalls != (ParallelToolCallsCapability{}) {
+				t.Errorf("%s: ParallelToolCalls = %+v, want zero value (unsupported)", provider, q.ParallelToolCalls)
+			}
+		})
+	}
+}
+
+// TestToolExamplesCapabilityRules pins which providers accept the JSON-Schema
+// `examples` keyword in a tool's parameters (#222). Gemini is the load-bearing
+// negative: its Schema dialect rejects `examples`, so the example must reach
+// the model via the description text instead — never folded into the schema.
+func TestToolExamplesCapabilityRules(t *testing.T) {
+	supported := map[string]string{
+		"anthropic":         "claude-sonnet-4-5",
+		"openai-compatible": "gpt-4o",
+		"openai-responses":  "gpt-4o",
+	}
+	for provider, model := range supported {
+		t.Run(provider+" accepts schema examples", func(t *testing.T) {
+			q := DefaultRegistry().Resolve(provider, model)
+			want := ToolExamplesCapability{Supported: true}
+			if q.ToolExamples != want {
+				t.Errorf("%s: ToolExamples = %+v, want %+v", provider, q.ToolExamples, want)
+			}
+		})
+	}
+
+	unsupported := map[string]string{
+		"gemini":         "gemini-2.5-pro",
+		"bedrock":        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"mystery-vendor": "some-model",
+	}
+	for provider, model := range unsupported {
+		t.Run(provider+" stays unsupported", func(t *testing.T) {
+			q := DefaultRegistry().Resolve(provider, model)
+			if q.ToolExamples != (ToolExamplesCapability{}) {
+				t.Errorf("%s: ToolExamples = %+v, want zero value (unsupported)", provider, q.ToolExamples)
+			}
+		})
+	}
+}
+
+// TestParallelToolCallsRulesSetSupportedWhenDisable pins the structural
+// relationship the adapters depend on: any rule that turns on the Disable bool
+// must also set Supported. An adapter checks Supported as the master gate, so
+// a rule that set Disable without Supported would silently no-op.
+func TestParallelToolCallsRulesSetSupportedWhenDisable(t *testing.T) {
+	for i, rule := range BuiltinRules() {
+		if rule.Apply == nil {
+			continue
+		}
+		q := freshQuirks()
+		rule.Apply(&q)
+		if q.ParallelToolCalls.Disable && !q.ParallelToolCalls.Supported {
+			t.Errorf("BuiltinRules()[%d] (%q): Disable is set but Supported is false", i, rule.Description)
+		}
+	}
+}
+
 // freshQuirks returns a ProviderQuirks with the same map/slice
 // pre-initialisation Resolve performs, for rule-materialisation tests
 // that call Apply directly.

--- a/harness/internal/provider/toolexamples.go
+++ b/harness/internal/provider/toolexamples.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"encoding/json"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// mergeSchemaExamples returns schema with the tool's worked examples injected
+// under the JSON-Schema `examples` keyword (issue #222). It is the shared
+// fold step the OpenAI Chat, OpenAI Responses, and Anthropic adapters use when
+// the resolved ToolExamples capability advertises support: `examples` is a
+// standard JSON-Schema 2020-12 keyword those providers pass through to the
+// model context.
+//
+// The rewrite is purely additive and defensive:
+//   - no examples → the schema is returned untouched;
+//   - a schema that is not a JSON object (or is invalid) → returned untouched,
+//     so a malformed operator/MCP schema cannot turn a tool definition into a
+//     hard error here (the description still carries the example);
+//   - a schema that already declares `examples` → returned untouched, so an
+//     operator-authored explicit examples array wins over the derived one.
+//
+// Callers must NOT apply this to a schema bound for OpenAI strict mode: the
+// structured-outputs subset rejects the `examples` keyword, so the OpenAI
+// adapters fold examples only on non-strict tools.
+func mergeSchemaExamples(schema json.RawMessage, examples []json.RawMessage) (json.RawMessage, error) {
+	if len(examples) == 0 {
+		return schema, nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(schema, &obj); err != nil {
+		return schema, nil
+	}
+	if _, exists := obj["examples"]; exists {
+		return schema, nil
+	}
+	arr, err := json.Marshal(examples)
+	if err != nil {
+		return schema, err
+	}
+	obj["examples"] = arr
+	return json.Marshal(obj)
+}
+
+// toolInputExamples returns the worked examples carried on a tool definition's
+// Presentation (issue #222), or nil when the tool carries none. It centralises
+// the nil-pointer guard the adapters would otherwise repeat.
+func toolInputExamples(t types.ToolDefinition) []json.RawMessage {
+	if t.Presentation == nil {
+		return nil
+	}
+	return t.Presentation.InputExamples
+}

--- a/harness/internal/provider/toolreliability_test.go
+++ b/harness/internal/provider/toolreliability_test.go
@@ -1,0 +1,283 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// These tests pin the wire behaviour of the #222 reliability controls
+// (parallel-tool-call policy and input examples) per provider, gated on the
+// resolved quirks capability. They exercise the builders directly — no live
+// calls — mirroring the existing *_builder_test.go contract pattern.
+
+func toolWith222Example() types.ToolDefinition {
+	return types.ToolDefinition{
+		Name:        "demo",
+		Description: "Demo tool. Example: {\"x\": \"hi\"}",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}`),
+		Presentation: &types.ToolPresentation{
+			InputExamples: []json.RawMessage{json.RawMessage(`{"x":"hi"}`)},
+		},
+	}
+}
+
+func userTurn() []types.Message {
+	return []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "go"}}}}
+}
+
+// decodeObject unmarshals raw JSON into a string-keyed map, failing the test
+// on error. Used to walk a wire body without committing to a typed shape.
+func decodeObject(t *testing.T, raw json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("decode object: %v\nraw: %s", err, raw)
+	}
+	return m
+}
+
+func schemaHasExamples(t *testing.T, schema json.RawMessage) bool {
+	t.Helper()
+	_, ok := decodeObject(t, schema)["examples"]
+	return ok
+}
+
+func TestOpenAIChat_222_ParallelAndExamples_NonStrict(t *testing.T) {
+	disable := false
+	params := types.StreamParams{
+		Model:             "gpt-4o", // non-strict
+		Messages:          userTurn(),
+		Tools:             []types.ToolDefinition{toolWith222Example()},
+		MaxTokens:         100,
+		ParallelToolCalls: &disable,
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	req, err := buildOpenAIRequest(params, true, q, nil)
+	if err != nil {
+		t.Fatalf("buildOpenAIRequest: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	top := decodeObject(t, body)
+	if string(top["parallel_tool_calls"]) != "false" {
+		t.Errorf("parallel_tool_calls = %s, want false", top["parallel_tool_calls"])
+	}
+	// tools[0].function.parameters must carry the folded examples.
+	var tools []json.RawMessage
+	if err := json.Unmarshal(top["tools"], &tools); err != nil {
+		t.Fatalf("tools: %v", err)
+	}
+	fn := decodeObject(t, decodeObject(t, tools[0])["function"])
+	if !schemaHasExamples(t, fn["parameters"]) {
+		t.Errorf("non-strict tool schema is missing the folded examples keyword: %s", fn["parameters"])
+	}
+}
+
+func TestOpenAIChat_222_StrictModelOmitsExamples(t *testing.T) {
+	params := types.StreamParams{
+		Model:     "gpt-5", // strict-mode model
+		Messages:  userTurn(),
+		Tools:     []types.ToolDefinition{toolWith222Example()},
+		MaxTokens: 100,
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	req, err := buildOpenAIRequest(params, true, q, newStrictSchemaCache())
+	if err != nil {
+		t.Fatalf("buildOpenAIRequest: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var tools []json.RawMessage
+	if err := json.Unmarshal(decodeObject(t, body)["tools"], &tools); err != nil {
+		t.Fatalf("tools: %v", err)
+	}
+	fn := decodeObject(t, tools[0])
+	if string(fn["function"]) == "" {
+		t.Fatalf("tool has no function entry: %s", tools[0])
+	}
+	fnObj := decodeObject(t, fn["function"])
+	if string(fnObj["strict"]) != "true" {
+		t.Errorf("strict model should emit strict:true, got %s", fnObj["strict"])
+	}
+	// The structured-outputs subset rejects `examples`, so a strict tool must
+	// NOT carry it; the description text remains the example carrier.
+	if schemaHasExamples(t, fnObj["parameters"]) {
+		t.Errorf("strict tool schema must not carry examples: %s", fnObj["parameters"])
+	}
+}
+
+func TestOpenAIChat_222_DefaultsOmitParallel(t *testing.T) {
+	params := types.StreamParams{
+		Model:     "gpt-4o",
+		Messages:  userTurn(),
+		Tools:     []types.ToolDefinition{toolWith222Example()},
+		MaxTokens: 100,
+		// ParallelToolCalls unset.
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	req, err := buildOpenAIRequest(params, true, q, nil)
+	if err != nil {
+		t.Fatalf("buildOpenAIRequest: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, ok := decodeObject(t, body)["parallel_tool_calls"]; ok {
+		t.Error("parallel_tool_calls must be omitted when the caller did not set it")
+	}
+}
+
+func TestResponses_222_ParallelAndExamples(t *testing.T) {
+	enable := true
+	params := types.StreamParams{
+		Model:             "gpt-4o",
+		Messages:          userTurn(),
+		Tools:             []types.ToolDefinition{toolWith222Example()},
+		MaxTokens:         100,
+		ParallelToolCalls: &enable,
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-responses", params.Model)
+	req, err := buildResponsesRequest(params, q, nil)
+	if err != nil {
+		t.Fatalf("buildResponsesRequest: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	top := decodeObject(t, body)
+	if string(top["parallel_tool_calls"]) != "true" {
+		t.Errorf("parallel_tool_calls = %s, want true", top["parallel_tool_calls"])
+	}
+	var tools []json.RawMessage
+	if err := json.Unmarshal(top["tools"], &tools); err != nil {
+		t.Fatalf("tools: %v", err)
+	}
+	// Responses tools are flat: parameters sits directly on the entry.
+	if !schemaHasExamples(t, decodeObject(t, tools[0])["parameters"]) {
+		t.Errorf("responses tool schema is missing folded examples: %s", tools[0])
+	}
+}
+
+func TestAnthropic_222_ExamplesAndDisableParallel(t *testing.T) {
+	disable := false
+	params := types.StreamParams{
+		Model:             "claude-sonnet-4-5",
+		Messages:          userTurn(),
+		Tools:             []types.ToolDefinition{toolWith222Example()},
+		MaxTokens:         100,
+		ParallelToolCalls: &disable, // request no-parallel
+	}
+	q := quirks.DefaultRegistry().Resolve("anthropic", params.Model)
+	body, err := json.Marshal(buildAnthropicRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	top := decodeObject(t, body)
+
+	// disable_parallel_tool_use rides on a synthesised auto tool_choice.
+	tc := decodeObject(t, top["tool_choice"])
+	if string(tc["type"]) != `"auto"` {
+		t.Errorf("tool_choice.type = %s, want \"auto\"", tc["type"])
+	}
+	if string(tc["disable_parallel_tool_use"]) != "true" {
+		t.Errorf("tool_choice.disable_parallel_tool_use = %s, want true", tc["disable_parallel_tool_use"])
+	}
+
+	// examples fold into input_schema (Anthropic has no strict subset).
+	var tools []json.RawMessage
+	if err := json.Unmarshal(top["tools"], &tools); err != nil {
+		t.Fatalf("tools: %v", err)
+	}
+	if !schemaHasExamples(t, decodeObject(t, tools[0])["input_schema"]) {
+		t.Errorf("anthropic tool input_schema is missing folded examples: %s", tools[0])
+	}
+}
+
+func TestAnthropic_222_ParallelEnabledIsNoOp(t *testing.T) {
+	enable := true
+	params := types.StreamParams{
+		Model:             "claude-sonnet-4-5",
+		Messages:          userTurn(),
+		Tools:             []types.ToolDefinition{toolWith222Example()},
+		MaxTokens:         100,
+		ParallelToolCalls: &enable, // parallel is the default; nothing to emit
+	}
+	q := quirks.DefaultRegistry().Resolve("anthropic", params.Model)
+	body, err := json.Marshal(buildAnthropicRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, ok := decodeObject(t, body)["tool_choice"]; ok {
+		t.Error("enabling parallel (the Anthropic default) must not synthesise a tool_choice object")
+	}
+}
+
+func TestAnthropic_222_RequiredChoiceCarriesDisableParallel(t *testing.T) {
+	disable := false
+	params := types.StreamParams{
+		Model:             "claude-sonnet-4-5",
+		Messages:          userTurn(),
+		Tools:             []types.ToolDefinition{toolWith222Example()},
+		MaxTokens:         100,
+		ToolChoice:        types.ToolChoiceRequired,
+		ParallelToolCalls: &disable,
+	}
+	q := quirks.DefaultRegistry().Resolve("anthropic", params.Model)
+	body, err := json.Marshal(buildAnthropicRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	tc := decodeObject(t, decodeObject(t, body)["tool_choice"])
+	if string(tc["type"]) != `"any"` {
+		t.Errorf("tool_choice.type = %s, want \"any\" (required)", tc["type"])
+	}
+	if string(tc["disable_parallel_tool_use"]) != "true" {
+		t.Errorf("required tool_choice should still carry disable_parallel_tool_use, got %s", tc["disable_parallel_tool_use"])
+	}
+}
+
+func TestGemini_222_NoParallelNoExamples(t *testing.T) {
+	disable := false
+	params := types.StreamParams{
+		Model:             "gemini-2.5-pro",
+		Messages:          userTurn(),
+		Tools:             []types.ToolDefinition{toolWith222Example()},
+		MaxTokens:         100,
+		ParallelToolCalls: &disable, // unsupported on Gemini → no-op
+	}
+	q := quirks.DefaultRegistry().Resolve("gemini", params.Model)
+	body, _, err := BuildGenerateContentRequest(params, nil, q)
+	if err != nil {
+		t.Fatalf("BuildGenerateContentRequest: %v", err)
+	}
+	top := decodeObject(t, body)
+	for _, k := range []string{"parallel_tool_calls", "parallelToolCalls"} {
+		if _, ok := top[k]; ok {
+			t.Errorf("Gemini request must not carry %q (no native control)", k)
+		}
+	}
+	// Gemini's ToolExamples capability is zero, so examples are never folded
+	// into the function-declaration schema; the description text carries them.
+	var tools []json.RawMessage
+	if err := json.Unmarshal(top["tools"], &tools); err != nil {
+		t.Fatalf("tools: %v", err)
+	}
+	decls := decodeObject(t, tools[0])
+	var fnDecls []json.RawMessage
+	if err := json.Unmarshal(decls["functionDeclarations"], &fnDecls); err != nil {
+		t.Fatalf("functionDeclarations: %v", err)
+	}
+	params0 := decodeObject(t, fnDecls[0])["parameters"]
+	if schemaHasExamples(t, params0) {
+		t.Errorf("Gemini tool schema must not carry examples: %s", params0)
+	}
+}

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -697,9 +697,10 @@ func hasPositiveUseThis(desc string) bool {
 //
 // Contract: descriptions must contain at least one capital-`E` "Example"
 // marker followed by a valid JSON object. The rightmost such marker is
-// the one parsed. A future #222 migration that extracts examples into a
-// structured InputExamples []any field on types.ToolDefinition relies on
-// this contract — the helper here is the seam it would replace.
+// the one parsed. The #222 migration has landed — each built-in now carries
+// the same example as structured tool.Tool.InputExamples — so this helper is
+// the oracle TestBuiltinInputExamples_MatchDescription uses to pin those
+// structured examples byte-for-byte to the description.
 func extractJSONExample(desc string) (string, bool) {
 	marker := strings.LastIndex(desc, "Example")
 	if marker < 0 {
@@ -776,6 +777,50 @@ func TestBuiltinDescriptions_EnrichedShape(t *testing.T) {
 			var probe map[string]any
 			if err := json.Unmarshal([]byte(example), &probe); err != nil {
 				t.Errorf("example is not valid JSON: %v\nexample: %s", err, example)
+			}
+		})
+	}
+}
+
+// TestBuiltinInputExamples_MatchDescription pins the #222 invariant that every
+// built-in tool's structured InputExamples is byte-identical to the worked
+// example embedded in its description. The two are authored side by side — the
+// description carries the human-readable example for providers whose schema
+// dialect rejects the `examples` keyword (Gemini), while InputExamples carries
+// the structured form adapters fold into the schema where supported — so this
+// guards against them drifting apart. edit_file is covered separately in the
+// edit package (it is registered via the factory's strategy wrapper).
+func TestBuiltinInputExamples_MatchDescription(t *testing.T) {
+	mock := &mockExecutor{}
+	// Construct directly rather than via RegisterBuiltins so spawn_agent
+	// (registered by the factory in production) is covered here too. The nil
+	// spawner is fine: only Definition() is exercised, not the handler.
+	tools := []*tool.Tool{
+		ReadFileTool(mock),
+		WriteFileTool(mock),
+		ListDirectoryTool(mock),
+		GrepFilesTool(mock),
+		FindFilesTool(mock),
+		RunCommandTool(mock),
+		WebFetchTool(),
+		SpawnAgentTool(nil),
+	}
+	for _, tl := range tools {
+		t.Run(tl.Name, func(t *testing.T) {
+			want, ok := extractJSONExample(tl.Description)
+			if !ok {
+				t.Fatalf("description has no Example marker to mirror")
+			}
+			def := tl.Definition()
+			if def.Presentation == nil || len(def.Presentation.InputExamples) != 1 {
+				t.Fatalf("Definition().Presentation = %+v, want exactly one InputExample", def.Presentation)
+			}
+			if got := string(def.Presentation.InputExamples[0]); got != want {
+				t.Errorf("InputExamples[0] drifted from description:\n got = %s\nwant = %s", got, want)
+			}
+			var probe map[string]any
+			if err := json.Unmarshal(def.Presentation.InputExamples[0], &probe); err != nil {
+				t.Errorf("InputExamples[0] is not valid JSON: %v", err)
 			}
 		})
 	}

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -114,6 +114,11 @@ func ReadFileTool(exec executor.Executor) *tool.Tool {
 			"start_line is 1-indexed and limit caps the lines returned (default 2000, max 5000). " +
 			"When start_line is past end-of-file the tool returns a notice rather than an error, so probing with a guessed start_line is safe. " +
 			"Example: {\"path\": \"path/to/file.go\", \"start_line\": 100, \"limit\": 50}",
+		// InputExamples mirrors the description's worked example as structured
+		// data (#222); adapters fold it into the schema `examples` keyword
+		// where the provider supports it. TestBuiltinInputExamples_MatchDescription
+		// pins it byte-for-byte against the description so the two cannot drift.
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"path": "path/to/file.go", "start_line": 100, "limit": 50}`)},
 		InputSchema:       readFileSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
@@ -253,6 +258,8 @@ func WriteFileTool(exec executor.Executor) *tool.Tool {
 			"Use this when authoring a new file or when a wholesale rewrite is simpler than a targeted change. " +
 			"Do not use for small edits to existing files — prefer edit_file with operation 'replace' or 'patch' so unrelated lines stay untouched. " +
 			"Example: {\"path\": \"cmd/cli/main.go\", \"content\": \"package main\\n\\nfunc main() {}\\n\"}",
+		// #222 structured example, pinned to the description by TestBuiltinInputExamples_MatchDescription.
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"path": "cmd/cli/main.go", "content": "package main\n\nfunc main() {}\n"}`)},
 		InputSchema:       writeFileSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
@@ -286,6 +293,7 @@ func ListDirectoryTool(exec executor.Executor) *tool.Tool {
 			"Use this to discover the shape of an unfamiliar tree; prefer find_files when the goal is to locate files by name across the workspace. " +
 			"Set recursive=true to walk subdirectories up to max_depth (default 3, max 10). Results are capped at max_entries (default 1000, max 10000) and a truncation sentinel is appended when the cap is hit. " +
 			"Example: {\"path\": \"harness/internal\", \"recursive\": true, \"max_depth\": 2}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"path": "harness/internal", "recursive": true, "max_depth": 2}`)},
 		InputSchema:       listDirectorySchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,

--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -165,6 +165,10 @@ func GrepFilesTool(exec executor.Executor) *tool.Tool {
 			// JSON example with `\\b`, which JSON parsers then decode to
 			// `\b` for the regex engine.
 			"Example: {\"pattern\": \"func ReadFile\\\\b\", \"include\": [\"*.go\"], \"path\": \"harness/internal\"}",
+		// #222 structured example. The `\\b` here matches the runtime description
+		// substring (the Go source double-escaped it once); pinned by
+		// TestBuiltinInputExamples_MatchDescription.
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"pattern": "func ReadFile\\b", "include": ["*.go"], "path": "harness/internal"}`)},
 		InputSchema:       grepFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,
@@ -303,6 +307,7 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 			"The name field is a glob (filepath.Match syntax) matched against each file's basename only — '*.go', 'handler_*.ts' — not a regex and not a path. The '**' segment is not supported in name; use the include filter to narrow by path. " +
 			"Results are capped by max_results (default 100, max 1000). " +
 			"Example: {\"name\": \"*_test.go\", \"path\": \"harness/internal\", \"exclude\": [\"*/testdata/*\"]}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"name": "*_test.go", "path": "harness/internal", "exclude": ["*/testdata/*"]}`)},
 		InputSchema:       findFilesSchema,
 		WorkspaceMutating: false,
 		RequiresApproval:  false,

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -37,6 +37,8 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 			"Do not use for filesystem inspection that a dedicated tool covers — prefer read_file, list_directory, grep_files, find_files because they return structured, bounded output and do not need a shell. " +
 			"timeout is in seconds (default 30, max 300); the command is killed when the timeout elapses. " +
 			"Example: {\"command\": \"go test ./harness/internal/tool/...\", \"timeout\": 120}",
+		// #222 structured example, pinned to the description by TestBuiltinInputExamples_MatchDescription.
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"command": "go test ./harness/internal/tool/...", "timeout": 120}`)},
 		InputSchema:       runCommandSchema,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,

--- a/harness/internal/tool/builtins/subagent.go
+++ b/harness/internal/tool/builtins/subagent.go
@@ -50,7 +50,8 @@ func SpawnAgentTool(spawner SubAgentSpawner) *tool.Tool {
 			"Do not use for trivial one-tool-call tasks — the spawn overhead outweighs the benefit. The prompt must be specific and self-contained because the sub-agent cannot see the parent's history. " +
 			"mode defaults to the parent's mode; max_turns bounds the sub-agent at 1-20 turns (default 10). " +
 			"Example: {\"prompt\": \"Find every call site of harness.RunConfig.Redact and list them as path:line.\", \"mode\": \"research\", \"max_turns\": 8}",
-		InputSchema: spawnAgentSchema,
+		InputExamples: []json.RawMessage{json.RawMessage(`{"prompt": "Find every call site of harness.RunConfig.Redact and list them as path:line.", "mode": "research", "max_turns": 8}`)},
+		InputSchema:   spawnAgentSchema,
 		// The spawn_agent tool itself does not mutate the workspace —
 		// the sub-agent it launches is gated by its own permission
 		// policy. We do however require upstream approval because

--- a/harness/internal/tool/builtins/webfetch.go
+++ b/harness/internal/tool/builtins/webfetch.go
@@ -63,7 +63,8 @@ func newWebFetchTool(opts webFetchOptions) *tool.Tool {
 			"Do not use to read files from disk (use read_file) or to call internal services — only http:// and https:// schemes are accepted and private / loopback / link-local hosts are refused. " +
 			"Non-2xx responses are returned as errors. " +
 			"Example: {\"url\": \"https://pkg.go.dev/encoding/json\"}",
-		InputSchema: webFetchSchema,
+		InputExamples: []json.RawMessage{json.RawMessage(`{"url": "https://pkg.go.dev/encoding/json"}`)},
+		InputSchema:   webFetchSchema,
 		// web_fetch does not mutate the workspace, but it makes outbound
 		// network requests on the user's behalf — gate it behind
 		// upstream approval where one is configured.

--- a/harness/internal/tool/tool.go
+++ b/harness/internal/tool/tool.go
@@ -113,15 +113,56 @@ type Tool struct {
 	// emitted; the error message is surfaced to the model as a tool
 	// internal error.
 	AsyncHandler func(ctx context.Context, input json.RawMessage) (AsyncDispatch, error)
+
+	// InputExamples are optional worked example inputs (issue #222), each a
+	// JSON object valid against InputSchema. Built-in tools populate this to
+	// carry the example previously embedded only in the description (#227) as
+	// structured data; adapters fold it into the JSON-Schema `examples`
+	// keyword where the resolved provider capability allows. MCP-imported
+	// tools leave it nil.
+	InputExamples []json.RawMessage
+
+	// Annotations, when non-nil, supplies MCP-style behavioural hints
+	// verbatim and overrides the hints Definition() would otherwise derive
+	// from WorkspaceMutating. The MCP bridge sets it to the server-declared
+	// tool annotations; built-in tools leave it nil and accept the derived
+	// ReadOnlyHint/DestructiveHint.
+	Annotations *types.ToolAnnotations
 }
 
 // Definition converts a Tool to the wire-format ToolDefinition used by the
 // model provider.
 func (t *Tool) Definition() types.ToolDefinition {
 	return types.ToolDefinition{
-		Name:        t.Name,
-		Description: t.Description,
-		InputSchema: t.InputSchema,
+		Name:         t.Name,
+		Description:  t.Description,
+		InputSchema:  t.InputSchema,
+		Presentation: t.presentation(),
+	}
+}
+
+// presentation builds the optional per-tool metadata bundle (issue #222). It
+// returns nil when the tool carries neither examples nor explicit annotations,
+// preserving the byte-identical pre-#222 contract for those tools. When a
+// bundle is warranted, annotations are derived from the WorkspaceMutating flag
+// unless the tool supplied its own (an MCP-imported tool carries the
+// server-declared annotations verbatim).
+func (t *Tool) presentation() *types.ToolPresentation {
+	if len(t.InputExamples) == 0 && t.Annotations == nil {
+		return nil
+	}
+	annotations := t.Annotations
+	if annotations == nil {
+		readOnly := !t.WorkspaceMutating
+		destructive := t.WorkspaceMutating
+		annotations = &types.ToolAnnotations{
+			ReadOnlyHint:    &readOnly,
+			DestructiveHint: &destructive,
+		}
+	}
+	return &types.ToolPresentation{
+		InputExamples: t.InputExamples,
+		Annotations:   annotations,
 	}
 }
 

--- a/types/events.go
+++ b/types/events.go
@@ -157,6 +157,20 @@ type StreamParams struct {
 	// ToolChoiceTool. Ignored for every other mode. An empty value with
 	// ToolChoiceTool degrades to ToolChoiceAuto at the adapter.
 	ToolChoiceName string `json:"toolChoiceName,omitempty"`
+
+	// ParallelToolCalls steers whether the provider may emit more than one
+	// tool call in a single turn (issue #222). It is a *bool, mirroring the
+	// Temperature precedent above: a nil pointer is the zero value and means
+	// "say nothing on the wire", so the request is byte-identical to the
+	// pre-#222 shape and every existing caller is unaffected. A non-nil
+	// value is projected onto the provider's native control only when the
+	// resolved ParallelToolCalls capability advertises support — top-level
+	// `parallel_tool_calls` on OpenAI Chat/Responses, `disable_parallel_tool_use`
+	// inside Anthropic's tool_choice object — and is a graceful no-op
+	// otherwise (Gemini and Bedrock have no native control). Parallelism is
+	// an efficiency hint, not a correctness lever, so an unsupported provider
+	// gets no prompt-based fallback the way ToolChoice does.
+	ParallelToolCalls *bool `json:"parallelToolCalls,omitempty"`
 }
 
 // Float64Ptr returns a pointer to the given float64 value. It is a

--- a/types/messages.go
+++ b/types/messages.go
@@ -64,6 +64,55 @@ type ToolDefinition struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
 	InputSchema json.RawMessage `json:"input_schema"`
+
+	// Presentation carries optional, additive per-tool metadata (issue
+	// #222): worked input examples and behavioural annotations. The
+	// `json:"-"` tag is load-bearing, not cosmetic: the Anthropic adapter
+	// historically serialised ToolDefinition onto the Messages wire
+	// verbatim, and Anthropic rejects unknown top-level keys on a tool
+	// object. Keeping Presentation off the default JSON encoding means the
+	// nil zero value is byte-identical to the pre-#222 wire shape on every
+	// adapter, and an adapter that wants to surface any part of Presentation
+	// must read it explicitly and project it into its own wire struct
+	// (gated on the resolved provider capability). An adapter with no
+	// capability treats Presentation as a deliberate, test-covered no-op.
+	Presentation *ToolPresentation `json:"-"`
+}
+
+// ToolPresentation is the optional per-tool metadata bundle introduced for
+// issue #222. Both fields are advisory: serialisation is gated per-adapter on
+// the resolved quirks capability, and the nil/empty zero value emits nothing.
+type ToolPresentation struct {
+	// InputExamples are worked example inputs for the tool, each a JSON
+	// object valid against InputSchema. They migrate the inline "Example:
+	// {…}" convention enriched into descriptions by #227 into structured
+	// data. Adapters that advertise the examples capability fold these into
+	// the JSON-Schema `examples` keyword inside the emitted parameters
+	// object; adapters without it ignore them. Nothing is lost for the
+	// latter — the #227 description text still carries the example for every
+	// provider, unconditionally.
+	InputExamples []json.RawMessage `json:"inputExamples,omitempty"`
+
+	// Annotations are MCP-style behavioural hints (spec 2025-06-18). No
+	// first-party provider (OpenAI, Anthropic, Gemini, Bedrock) exposes a
+	// tool-annotation wire field today, so these are carried for internal
+	// use and round-tripped from MCP servers; the first-party adapters treat
+	// them as a deliberate, test-covered no-op. Built-in tools derive them
+	// from their WorkspaceMutating flag; MCP-imported tools carry the
+	// server-declared annotations verbatim.
+	Annotations *ToolAnnotations `json:"annotations,omitempty"`
+}
+
+// ToolAnnotations mirrors the MCP tool-annotations object (spec 2025-06-18).
+// Each hint is a *bool so "unset" is distinguishable from an explicit "false":
+// a built-in tool derives ReadOnlyHint/DestructiveHint from its mutation flag,
+// while an MCP server may supply any subset, leaving the rest unset.
+type ToolAnnotations struct {
+	Title           string `json:"title,omitempty"`
+	ReadOnlyHint    *bool  `json:"readOnlyHint,omitempty"`
+	DestructiveHint *bool  `json:"destructiveHint,omitempty"`
+	IdempotentHint  *bool  `json:"idempotentHint,omitempty"`
+	OpenWorldHint   *bool  `json:"openWorldHint,omitempty"`
 }
 
 // ToolCall represents a tool invocation by the model.

--- a/types/messages_test.go
+++ b/types/messages_test.go
@@ -110,3 +110,73 @@ func TestToolCall_InternalNameOmittedOnWire(t *testing.T) {
 		}
 	})
 }
+
+// TestToolDefinition_PresentationByteIdentical pins the issue #222 invariant
+// that the additive Presentation bundle is invisible on the default JSON
+// encoding: a tool definition with no Presentation must serialise byte-for-byte
+// the way it did before the field existed, and a tool WITH Presentation must
+// still omit it (json:"-") so the Anthropic verbatim path never leaks unknown
+// keys onto the wire. Adapters surface Presentation by reading it explicitly,
+// never via the default encoding.
+func TestToolDefinition_PresentationByteIdentical(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object"}`)
+	bare := ToolDefinition{Name: "demo", Description: "d", InputSchema: schema}
+	bareBytes, err := json.Marshal(bare)
+	if err != nil {
+		t.Fatalf("marshal bare: %v", err)
+	}
+
+	withPres := ToolDefinition{
+		Name:        "demo",
+		Description: "d",
+		InputSchema: schema,
+		Presentation: &ToolPresentation{
+			InputExamples: []json.RawMessage{json.RawMessage(`{"a":1}`)},
+			Annotations:   &ToolAnnotations{Title: "Demo"},
+		},
+	}
+	withBytes, err := json.Marshal(withPres)
+	if err != nil {
+		t.Fatalf("marshal with presentation: %v", err)
+	}
+
+	if string(bareBytes) != string(withBytes) {
+		t.Errorf("Presentation leaked onto the wire:\n bare = %s\n with = %s", bareBytes, withBytes)
+	}
+	if strings.Contains(string(withBytes), "Presentation") || strings.Contains(string(withBytes), "inputExamples") || strings.Contains(string(withBytes), "annotations") {
+		t.Errorf("Presentation fields must not appear on the default encoding, got: %s", withBytes)
+	}
+}
+
+// TestToolPresentation_RoundTrip confirms ToolPresentation and ToolAnnotations
+// marshal and unmarshal losslessly when serialised directly (e.g. by an
+// adapter that opts to project them), including the *bool unset-vs-false
+// distinction on the annotation hints.
+func TestToolPresentation_RoundTrip(t *testing.T) {
+	readOnly := true
+	pres := ToolPresentation{
+		InputExamples: []json.RawMessage{json.RawMessage(`{"x":"y"}`)},
+		Annotations: &ToolAnnotations{
+			Title:        "Title",
+			ReadOnlyHint: &readOnly,
+			// DestructiveHint deliberately left unset.
+		},
+	}
+	b, err := json.Marshal(pres)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ToolPresentation
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Annotations == nil || got.Annotations.ReadOnlyHint == nil || !*got.Annotations.ReadOnlyHint {
+		t.Errorf("ReadOnlyHint did not round-trip: %+v", got.Annotations)
+	}
+	if got.Annotations.DestructiveHint != nil {
+		t.Errorf("unset DestructiveHint must stay nil, got %v", *got.Annotations.DestructiveHint)
+	}
+	if len(got.InputExamples) != 1 || string(got.InputExamples[0]) != `{"x":"y"}` {
+		t.Errorf("InputExamples did not round-trip: %v", got.InputExamples)
+	}
+}


### PR DESCRIPTION
Completes issue #222 by adding the three reliability controls Waves 2–5 left unbuilt: **parallel-tool-call policy**, **input examples**, and **tool annotations**. (Tool-choice, strict mode, and structured results already shipped via #230/#228/#231 through other channels.)

## Design
- `types.ToolDefinition` gains a `Presentation *ToolPresentation` neighbour carried as `json:"-"`, so the nil zero value is byte-identical to the pre-#222 wire shape on every adapter — critical because the Anthropic adapter serialises `ToolDefinition` verbatim. `ToolPresentation` holds `InputExamples` and MCP-style `Annotations`.
- `StreamParams.ParallelToolCalls *bool` (nil = omit, mirroring `Temperature`).
- Two cross-provider quirks capabilities: `ParallelToolCallsCapability` and `ToolExamplesCapability`, gated per (provider, model) like the existing tool-choice/structured-result capabilities.

## Per-provider wire mapping
- **OpenAI Chat / Responses**: top-level `parallel_tool_calls`; examples folded into the JSON-Schema `examples` keyword **only for non-strict tools** (the structured-outputs subset rejects `examples`). Responses gains parallel + examples support (it previously had no tool_choice/parallel wiring).
- **Anthropic**: parallel-disable rides on a synthesised `tool_choice.disable_parallel_tool_use`; examples fold into `input_schema`.
- **Gemini / Bedrock**: deliberate no-op (no native control; Gemini's dialect rejects `examples`, so the #227 description text remains the carrier).
- **MCP**: server-declared annotations are now parsed and carried (advisory only — the conservative WorkspaceMutating/RequiresApproval gating still governs).

Built-in tool examples migrated from inline description text to structured `InputExamples`, pinned byte-for-byte to the descriptions by drift-guard tests. Contract tests cover every adapter; `provider-quirks.md` documents the per-provider matrix. `just test` + `just lint` green; the offline tool-use replay gate passes.

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)