### PR TITLE
provider: add Anthropic and Responses request-shape contract fixtures (#224)

### DIFF
--- a/harness/internal/provider/contractfixtures_test.go
+++ b/harness/internal/provider/contractfixtures_test.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirkstest"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// These tests close the #224 gap where the Anthropic and OpenAI Responses
+// adapters had no golden request fixture — their request shape was only
+// validated field-by-field inline, so a change that added or dropped a
+// top-level key could pass unnoticed. AssertWireEqual pins the full canonical
+// body against the committed fixture; the fixture-authoring procedure is in
+// testdata/quirks/README.md.
+//
+// Both use a synthetic tool with no Presentation so the fixtures stay stable
+// regardless of the #222 examples-folding capability (a tool that carries
+// InputExamples would fold them into the schema on these providers).
+
+func contractFixtureTool() types.ToolDefinition {
+	return types.ToolDefinition{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"],"additionalProperties":false}`),
+	}
+}
+
+func contractFixtureMessages() []types.Message {
+	return []types.Message{{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "weather in Paris?"}}}}
+}
+
+// TestAnthropicContract_ToolEnabledRequestBody pins the outbound Anthropic
+// Messages request for a tool-enabled, required-tool-choice turn.
+func TestAnthropicContract_ToolEnabledRequestBody(t *testing.T) {
+	params := types.StreamParams{
+		Model:       "claude-sonnet-4-6",
+		System:      "You are helpful.",
+		Messages:    contractFixtureMessages(),
+		Tools:       []types.ToolDefinition{contractFixtureTool()},
+		MaxTokens:   4096,
+		Temperature: types.Float64Ptr(0.5),
+		ToolChoice:  types.ToolChoiceRequired,
+	}
+	q := quirks.DefaultRegistry().Resolve("anthropic", params.Model)
+	body, err := json.Marshal(buildAnthropicRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath("testdata", "quirks", "anthropic", "claude-sonnet-4-6", "request.json"), body)
+}
+
+// TestResponsesContract_ToolEnabledRequestBody pins the outbound OpenAI
+// Responses request for a tool-enabled turn, including the typed input-item
+// variants (#199) and the flat function-tool shape.
+func TestResponsesContract_ToolEnabledRequestBody(t *testing.T) {
+	params := types.StreamParams{
+		Model:       "gpt-4o",
+		System:      "You are helpful.",
+		Messages:    contractFixtureMessages(),
+		Tools:       []types.ToolDefinition{contractFixtureTool()},
+		MaxTokens:   4096,
+		Temperature: types.Float64Ptr(0.5),
+	}
+	q := quirks.DefaultRegistry().Resolve("openai-responses", params.Model)
+	req, err := buildResponsesRequest(params, q, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	req.Stream = true
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath("testdata", "quirks", "openai-responses", "gpt-4o", "request.json"), body)
+}

--- a/harness/internal/provider/testdata/quirks/README.md
+++ b/harness/internal/provider/testdata/quirks/README.md
@@ -1,0 +1,69 @@
+# Provider contract fixtures
+
+Golden fixtures that pin the outbound request body and inbound streaming
+parse for each provider's tool-calling path (issue #224). They are the first
+line of defence against silent wire-shape drift: a code change that adds,
+drops, or renames a request field fails the matching contract test rather than
+breaking end-to-end against a live provider.
+
+## Layout
+
+```
+testdata/quirks/<provider-type>/<model>/
+    request.json     # golden outbound request body (one tool-enabled turn)
+    response.sse      # captured streaming response for parser tests
+    replay.json       # captured ReplayFields snapshot (parse-side rules)
+```
+
+`<provider-type>` is the `RunConfig` provider type (`anthropic`,
+`openai-compatible`, `openai-responses`, `gemini`); `<model>` is the model the
+fixture was captured for. Not every provider/model carries all three files —
+add only what the test asserts.
+
+## `request.json` format
+
+The first line MAY be a `# synthetic: ...` comment; `quirkstest.LoadFixture`
+strips a leading comment block before parsing, and `AssertWireEqual`
+canonicalises both sides (unmarshal → re-marshal with sorted keys) before
+comparing, so field order and insignificant whitespace do not matter — only
+the set of keys and their values.
+
+Mark a fixture `# synthetic` when it was derived from a builder rather than
+captured from a live provider, and say why. A live capture is preferred where
+one exists (the Gemini 3.x streaming precedent in #191 is why); a synthetic
+fixture is acceptable for a shape the harness fully controls.
+
+## Adding a fixture for a new provider/model
+
+1. Build the request through the adapter's builder with representative,
+   tool-enabled params — `buildAnthropicRequest`, `buildOpenAIRequest`,
+   `buildResponsesRequest`, or `BuildGenerateContentRequest`. Use a synthetic
+   tool with **no** `Presentation` unless the fixture is specifically pinning
+   the #222 examples fold, so the fixture stays stable across capability
+   changes.
+2. Marshal the request and write the JSON under the path above, prefixed with a
+   `# synthetic:` line describing what it pins.
+3. Add a test that rebuilds the same request and calls
+   `quirkstest.AssertWireEqual(t, quirkstest.JoinPath("testdata", "quirks",
+   <provider>, <model>, "request.json"), body)`.
+
+## Refreshing a fixture after an intentional wire change
+
+When a deliberate code change alters a provider's request shape, the contract
+test fails with a diff. Confirm the change is intended, then regenerate the
+fixture from the new builder output (the capture step above) and review the
+diff in the PR exactly as a code change. A fixture must never be regenerated
+blindly to make a red test green — that defeats its purpose.
+
+## Conventions
+
+- **Secrets never appear in fixtures.** Use fake keys/headers only; the
+  registry self-tests assert no `secret://` reference reaches a wire body.
+- **Negative coverage.** "Reject before send" tests live where the harness
+  actually lints a schema: OpenAI strict-mode normalisation
+  (`normalizeStrictWithCache`, fail-closed) and the Gemini schema lint
+  (`LintGeminiSchema`, e.g. `TestGeminiSchemaLint_FailsClosedOnUnsupportedFeature`).
+  The Anthropic adapter forwards `input_schema` verbatim and has no harness-side
+  schema lint, so its pre-send validation is the tool-name normalisation layer
+  (`tool/toolname`), not a schema check — there is no Anthropic schema-rejection
+  fixture by design.

--- a/harness/internal/provider/testdata/quirks/anthropic/claude-sonnet-4-6/request.json
+++ b/harness/internal/provider/testdata/quirks/anthropic/claude-sonnet-4-6/request.json
@@ -1,0 +1,38 @@
+# synthetic: derived from buildAnthropicRequest + DefaultRegistry().Resolve because the harness does not yet carry a live capture. Pins the tool-enabled Anthropic Messages request shape: the tools array carries name/description/input_schema, tool_choice projects ToolChoiceRequired onto {"type":"any"}, and content is a typed block array. See testdata/quirks/README.md to refresh.
+{
+  "model": "claude-sonnet-4-6",
+  "system": "You are helpful.",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "weather in Paris?"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather for a city.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": ["city"],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "max_tokens": 4096,
+  "temperature": 0.5,
+  "tool_choice": {
+    "type": "any"
+  },
+  "stream": true
+}

--- a/harness/internal/provider/testdata/quirks/openai-responses/gpt-4o/request.json
+++ b/harness/internal/provider/testdata/quirks/openai-responses/gpt-4o/request.json
@@ -1,0 +1,38 @@
+# synthetic: derived from buildResponsesRequest + DefaultRegistry().Resolve because the harness does not yet carry a live capture. Pins the tool-enabled OpenAI Responses request shape: tools are the flat function form (type/name/description/parameters), input items use the typed message/input_text variants (the #199 fix), max_output_tokens carries the budget, and store is always emitted. See testdata/quirks/README.md to refresh.
+{
+  "model": "gpt-4o",
+  "instructions": "You are helpful.",
+  "input": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "weather in Paris?"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "Get the current weather for a city.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": ["city"],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "max_output_tokens": 4096,
+  "temperature": 0.5,
+  "stream": true,
+  "store": false
+}


### PR DESCRIPTION
Closes the remaining #224 gap: the Anthropic and OpenAI Responses tool-calling paths were the two without a golden request fixture — their outbound shape was only validated field-by-field inline, so a change adding or dropping a top-level key could land unnoticed.

- Adds `AssertWireEqual` contract tests pinning the full canonical body for a tool-enabled turn on each (Anthropic with required tool_choice; Responses with the typed input-item variants and flat function tools).
- Adds `testdata/quirks/README.md` documenting the fixture layout, the synthetic-vs-captured convention, how to add a fixture, and the refresh procedure for an intentional wire change (overview risk 5). It also records why there is no Anthropic schema-rejection fixture — that adapter forwards `input_schema` verbatim, so "reject before send" coverage lives on the OpenAI strict and Gemini lint paths.

Fixtures use a synthetic tool with no `Presentation`, so they remain stable regardless of the #222 examples-folding capability.

> Merge after #222 (PR #328): independent diff, but the README references #222 behaviour.

Closes #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)