### PR TITLE
observability: cardinality hardening and trace render (#309–#312, #314)

### DIFF
--- a/harness/cmd/stirrup/cmd/trace_show.go
+++ b/harness/cmd/stirrup/cmd/trace_show.go
@@ -173,6 +173,14 @@ func toolStatus(tc types.ToolCallSummary, color bool) string {
 	if tc.Success {
 		return colorize(color, ansiGreen, "ok")
 	}
+	// Surface the bounded failure taxonomy when the trace carries it, so
+	// an operator reading the trace sees the same category the metrics
+	// expose (e.g. "fail (unknown_tool)") rather than a bare success bit
+	// (issue #314). ErrorCategory is empty on older traces and on failures
+	// recorded before the taxonomy landed; fall back to "fail" then.
+	if tc.ErrorCategory != "" {
+		return colorize(color, ansiRed, "fail ("+tc.ErrorCategory+")")
+	}
 	return colorize(color, ansiRed, "fail")
 }
 

--- a/harness/cmd/stirrup/cmd/trace_test.go
+++ b/harness/cmd/stirrup/cmd/trace_test.go
@@ -74,6 +74,49 @@ func TestTraceShow_PrintsRecords(t *testing.T) {
 	}
 }
 
+// TestToolStatus_RendersErrorCategory pins the #314 trace-show change:
+// a failed tool call carrying an ErrorCategory must render it inline
+// (e.g. "fail (unknown_tool)") so an operator sees the same bounded
+// taxonomy the metrics expose, while a failure without a category and a
+// success keep their bare renderings.
+func TestToolStatus_RendersErrorCategory(t *testing.T) {
+	cases := []struct {
+		name string
+		tc   types.ToolCallSummary
+		want string
+	}{
+		{"failure with category", types.ToolCallSummary{Success: false, ErrorCategory: "unknown_tool"}, "fail (unknown_tool)"},
+		{"failure without category", types.ToolCallSummary{Success: false}, "fail"},
+		{"success ignores category", types.ToolCallSummary{Success: true, ErrorCategory: "unknown_tool"}, "ok"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := toolStatus(tc.tc, false)
+			if got != tc.want {
+				t.Errorf("toolStatus = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTraceShow_RendersErrorCategoryEndToEnd drives the full trace show
+// path on a trace whose failed call carries a category, confirming the
+// category reaches the operator-facing output (not just the unit-tested
+// helper).
+func TestTraceShow_RendersErrorCategoryEndToEnd(t *testing.T) {
+	traces := sampleTraces()
+	traces[0].ToolCalls[1].ErrorCategory = "permission_denied"
+	path := writeTraceFile(t, traces)
+
+	var out bytes.Buffer
+	if err := runTraceShowWith(path, &out, colorNever); err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if !strings.Contains(out.String(), "fail (permission_denied)") {
+		t.Errorf("trace show output missing rendered error category\n--- output ---\n%s", out.String())
+	}
+}
+
 func TestTraceShow_AlwaysEmitsAnsi(t *testing.T) {
 	path := writeTraceFile(t, sampleTraces())
 	var out bytes.Buffer

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -337,38 +337,7 @@ func (l *AgenticLoop) planAndDispatch(
 			ErrorCategory: errorCategory,
 		})
 
-		// Sentinel substitution for the unknown_tool path: p.call.Name
-		// is model-supplied and unbounded when no registry entry
-		// resolves, so it MUST NOT flow into a TSDB label. An attacker-
-		// or malfunctioning-model loop emitting tool_use blocks with
-		// high-entropy unique names would create O(n) unique
-		// timeseries on stirrup.harness.tool_{calls,errors,failures,
-		// call_duration} (CWE-400). Trace records (ErrorReason,
-		// ToolCallTrace.Name above) retain the raw name for debugging.
-		metricToolName := p.call.Name
-		if p.failureCategory == observability.ToolFailureUnknownTool {
-			metricToolName = unknownToolMetricName
-		}
-		toolNameAttr := l.metricAttrs(attribute.String("tool.name", metricToolName))
-		l.Metrics.ToolCalls.Add(ctx, 1, toolNameAttr)
-		l.Metrics.ToolCallDuration.Record(ctx, float64(callDuration.Milliseconds()), toolNameAttr)
-		if !p.success {
-			l.Metrics.ToolErrors.Add(ctx, 1, toolNameAttr)
-			// Failure-category breakdown for dashboards. Validity is
-			// re-checked here so a producer that forgets to set a
-			// category (Success=false with empty category) still bumps
-			// ToolErrors but does not silently widen ToolFailures
-			// label cardinality with an empty string.
-			if p.failureCategory.IsValid() {
-				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
-					attribute.String("tool.name", metricToolName),
-					attribute.String("category", p.failureCategory.String()),
-					attribute.String("provider.type", providerType),
-					attribute.String("provider.model", providerModel),
-					attribute.String("run.mode", config.Mode),
-				))
-			}
-		}
+		metricToolName := l.emitToolCallMetrics(ctx, p, callDuration, providerType, providerModel, config.Mode)
 
 		toolResults[i] = types.ToolResult{
 			ToolUseID:  p.call.ID,
@@ -455,4 +424,62 @@ func (l *AgenticLoop) planAndDispatch(
 	}
 
 	return toolResults, toolRecords, ""
+}
+
+// emitToolCallMetrics records the per-call observability counters for a
+// completed pendingCall: tool_calls, tool_call_duration, and (on failure)
+// tool_errors plus the failure-category breakdown tool_failures. It
+// returns the bounded metric tool name — the unknown_tool sentinel
+// substitution applied here — so the caller can reuse it for the stall
+// co-emission without re-deriving the substitution.
+//
+// Two cardinality bounds live here and are the reason this is a single
+// seam rather than inline code: the unknown_tool name substitution
+// (model-supplied names must not flow into a TSDB label, CWE-400) and the
+// failureCategory.IsValid() guard on tool_failures (a producer that sets
+// Success=false with an unrecognised category still bumps tool_errors but
+// MUST NOT widen the bounded tool_failures category label). The IsValid()
+// guard in particular has no model-facing trigger, so it is exercised via
+// a synthetic pendingCall in tool_failure_metrics_test.go.
+func (l *AgenticLoop) emitToolCallMetrics(
+	ctx context.Context,
+	p *pendingCall,
+	callDuration time.Duration,
+	providerType string,
+	providerModel string,
+	mode string,
+) string {
+	// Sentinel substitution for the unknown_tool path: p.call.Name is
+	// model-supplied and unbounded when no registry entry resolves, so it
+	// MUST NOT flow into a TSDB label. An attacker- or malfunctioning-
+	// model loop emitting tool_use blocks with high-entropy unique names
+	// would create O(n) unique timeseries on
+	// stirrup.harness.tool_{calls,errors,failures,call_duration}
+	// (CWE-400). Trace records (ErrorReason, ToolCallTrace.Name) retain
+	// the raw name for debugging.
+	metricToolName := p.call.Name
+	if p.failureCategory == observability.ToolFailureUnknownTool {
+		metricToolName = unknownToolMetricName
+	}
+	toolNameAttr := l.metricAttrs(attribute.String("tool.name", metricToolName))
+	l.Metrics.ToolCalls.Add(ctx, 1, toolNameAttr)
+	l.Metrics.ToolCallDuration.Record(ctx, float64(callDuration.Milliseconds()), toolNameAttr)
+	if !p.success {
+		l.Metrics.ToolErrors.Add(ctx, 1, toolNameAttr)
+		// Failure-category breakdown for dashboards. Validity is re-checked
+		// here so a producer that forgets to set a category (Success=false
+		// with empty category) — or sets a free-form one — still bumps
+		// ToolErrors but does not silently widen ToolFailures label
+		// cardinality past the bounded enum.
+		if p.failureCategory.IsValid() {
+			l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
+				attribute.String("tool.name", metricToolName),
+				attribute.String("category", p.failureCategory.String()),
+				attribute.String("provider.type", providerType),
+				attribute.String("provider.model", providerModel),
+				attribute.String("run.mode", mode),
+			))
+		}
+	}
+	return metricToolName
 }

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -101,6 +101,25 @@ func (l *AgenticLoop) planAndDispatch(
 	for i, call := range toolCalls {
 		l.Logger.Info("tool dispatched", "tool", call.Name)
 		callStart := time.Now()
+		// Resolve up front so every gating surface below keys on the
+		// internal tool ID rather than the model-facing alias (issue #234).
+		// Resolve is a pure lookup; an Unknown tool resolves to nil and
+		// falls through to dispatchToolCall, which fails fast as today.
+		// Resolution must precede span creation so the span name can be
+		// bounded against model-controlled tool names (issue #309).
+		t := l.Tools.Resolve(call.Name)
+
+		// Bound the span name's cardinality the same way the metric label
+		// below is bounded: an unknown tool resolves to nil and carries a
+		// model-controlled name, so the span name is substituted with the
+		// __unknown__ sentinel. Trace backends index on span name, so an
+		// unbounded name is the same CWE-400 vector as an unbounded TSDB
+		// label (issue #309). The model-supplied name is still preserved
+		// verbatim in the tool.name attribute for debuggability.
+		spanName := "tool." + call.Name
+		if t == nil {
+			spanName = "tool." + unknownToolMetricName
+		}
 		// Span is parented under l.traceCtx(ctx) (the trace-emitter's root
 		// when OTel is wired) so it nests correctly in the trace backend,
 		// but the propagated span ctx is rooted in the cancellable `ctx`.
@@ -108,13 +127,7 @@ func (l *AgenticLoop) planAndDispatch(
 		// would derive from context.Background() and the dispatch
 		// goroutines below would not observe a run-level cancellation
 		// until the per-call DefaultAsyncToolTimeout (60s) expired.
-		// TODO(#229-followup): the span name uses the raw call.Name
-		// before tool resolution, so an unknown-tool span carries a
-		// model-controlled name. Lower-blast-radius than the metric
-		// label substitution below (per-span storage, not a persistent
-		// TSDB key) so deferred to a follow-up issue rather than
-		// reworking the span lifecycle here.
-		_, toolSpan := l.Tracer.Start(l.traceCtx(ctx), "tool."+call.Name,
+		_, toolSpan := l.Tracer.Start(l.traceCtx(ctx), spanName,
 			oteltrace.WithAttributes(
 				attribute.String("tool.name", call.Name),
 				attribute.Int("tool.input_size", len(call.Input)),
@@ -134,11 +147,6 @@ func (l *AgenticLoop) planAndDispatch(
 			internalName: call.Name,
 		}
 
-		// Resolve up front so every gating surface below keys on the
-		// internal tool ID rather than the model-facing alias (issue #234).
-		// Resolve is a pure lookup; an Unknown tool resolves to nil and
-		// falls through to dispatchToolCall, which fails fast as today.
-		t := l.Tools.Resolve(call.Name)
 		// guardToolName is the name the guardrail classifier sees: the
 		// internal ID when resolved, falling back to the model-supplied
 		// name for an unknown tool. A guardrail rule written against an

--- a/harness/internal/core/dispatch_parallel_test.go
+++ b/harness/internal/core/dispatch_parallel_test.go
@@ -685,6 +685,66 @@ func TestParallelDispatch_OTelSpans_AreSiblingsUnderTurn(t *testing.T) {
 	}
 }
 
+// TestParallelDispatch_UnknownTool_SpanNameSentinel pins the span-name
+// cardinality bound from issue #309: an unknown (unresolved) tool must open
+// its OTel span as "tool.__unknown__" rather than "tool.<model-controlled
+// name>", so a hostile or buggy provider response cannot pollute trace
+// storage with arbitrary span names. The model-supplied name is still
+// preserved verbatim in the tool.name attribute for debuggability.
+func TestParallelDispatch_UnknownTool_SpanNameSentinel(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	tr := newAsyncTestTransport()
+	// Register no tools, so every call resolves to nil (unknown).
+	loop := buildParallelDispatchLoop(t, tr)
+	loop.Tracer = tp.Tracer("test")
+	config := configWithMaxParallel(2)
+
+	const hostileName = "../../etc/passwd; DROP TABLE spans;--"
+	calls := []types.ToolCall{
+		{ID: "tc_unknown_0", Name: hostileName, Input: json.RawMessage(`{}`)},
+	}
+
+	// An unknown tool fails fast inline (no transport round-trip), so no
+	// FireControl is needed; planAndDispatch returns synchronously.
+	results, _, _ := loop.planAndDispatch(context.Background(), config, calls, &stallDetector{}, "", "")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	spans := exporter.GetSpans()
+	var toolSpan *tracetest.SpanStub
+	for i := range spans {
+		if strings.HasPrefix(spans[i].Name, "tool.") {
+			toolSpan = &spans[i]
+			break
+		}
+	}
+	if toolSpan == nil {
+		t.Fatalf("no tool.* span found (spans=%v)", spanNames(spans))
+	}
+	if toolSpan.Name != "tool.__unknown__" {
+		t.Errorf("unknown-tool span name = %q, want %q (model-controlled name must be substituted with the sentinel)",
+			toolSpan.Name, "tool.__unknown__")
+	}
+	// The raw model-supplied name must still be recorded on the attribute.
+	var sawName bool
+	for _, attr := range toolSpan.Attributes {
+		if string(attr.Key) == "tool.name" {
+			sawName = true
+			if attr.Value.AsString() != hostileName {
+				t.Errorf("tool.name attribute = %q, want raw model name %q",
+					attr.Value.AsString(), hostileName)
+			}
+		}
+	}
+	if !sawName {
+		t.Error("tool.name attribute missing from unknown-tool span")
+	}
+}
+
 func spanNames(spans []tracetest.SpanStub) []string {
 	names := make([]string, len(spans))
 	for i, s := range spans {

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -683,7 +683,7 @@ func (l *AgenticLoop) runInnerLoop(
 			// provider failure but not a tool-use failure.
 			if len(toolDefs) > 0 {
 				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
-					attribute.String("tool.name", ""),
+					attribute.String("tool.name", observability.ToolNameProviderScope),
 					attribute.String("category", observability.ToolFailureProviderRequest.String()),
 					attribute.String("provider.type", selection.Provider),
 					attribute.String("provider.model", selection.Model),
@@ -743,7 +743,7 @@ func (l *AgenticLoop) runInnerLoop(
 			// rejected request.
 			if len(toolDefs) > 0 {
 				l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
-					attribute.String("tool.name", ""),
+					attribute.String("tool.name", observability.ToolNameProviderScope),
 					attribute.String("category", observability.ToolFailureProviderStream.String()),
 					attribute.String("provider.type", selection.Provider),
 					attribute.String("provider.model", selection.Model),
@@ -1012,7 +1012,7 @@ func (l *AgenticLoop) applyEscalation(
 	// dynamic category can never widen label cardinality past the enum.
 	if observability.ToolFailureNoToolWhenRequired.IsValid() {
 		l.Metrics.ToolFailures.Add(ctx, 1, l.metricAttrs(
-			attribute.String("tool.name", ""),
+			attribute.String("tool.name", observability.ToolNameProviderScope),
 			attribute.String("category", observability.ToolFailureNoToolWhenRequired.String()),
 			attribute.String("provider.type", providerType),
 			attribute.String("provider.model", model),

--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -537,6 +537,52 @@ func TestToolFailureCategory_BoundedCardinality(t *testing.T) {
 	}
 }
 
+// TestToolFailureCategory_InvalidCategoryDropped asserts the converse of
+// TestToolFailureCategory_BoundedCardinality: a failed call whose
+// failureCategory is NOT a member of the bounded enum must be dropped by
+// the if p.failureCategory.IsValid() guard in emitToolCallMetrics — it
+// still bumps tool_errors but emits NO tool_failures observation, so a
+// free-form / future-renamed category can never widen the bounded
+// category label.
+//
+// The guard has no model-facing trigger (every production producer sets a
+// valid enum member or leaves the category empty), so the rejection
+// branch is exercised here through the emitToolCallMetrics seam with a
+// synthetic pendingCall carrying a deliberately bogus category. A refactor
+// that swapped IsValid() for a weaker check (e.g. != "") would let this
+// observation through and fail the assertion.
+func TestToolFailureCategory_InvalidCategoryDropped(t *testing.T) {
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{trivialTool()}, nil, nil, nil)
+
+	// A failed call with a category that is not in the enum. IsValid()
+	// must reject it: tool_errors increments, tool_failures does not.
+	bogus := &pendingCall{
+		call:            types.ToolCall{ID: "bogus", Name: "trivial", Input: json.RawMessage(`{}`)},
+		startedAt:       time.Now(),
+		internalName:    "trivial",
+		success:         false,
+		failureCategory: observability.ToolFailureCategory("permission_denied_v2"),
+	}
+	// Guard the test's own premise: if this string ever becomes a real
+	// enum member the test is no longer exercising the rejection branch.
+	if bogus.failureCategory.IsValid() {
+		t.Fatalf("test premise broken: %q is now a valid category", bogus.failureCategory)
+	}
+
+	got := loop.emitToolCallMetrics(
+		context.Background(), bogus, 5*time.Millisecond,
+		"anthropic", "claude-sonnet-4-6", "execution",
+	)
+	if got != "trivial" {
+		t.Errorf("metricToolName = %q, want %q (no sentinel substitution for a non-unknown_tool category)", got, "trivial")
+	}
+
+	failures := collectFailures(t, reader)
+	if len(failures) != 0 {
+		t.Fatalf("expected no tool_failures observation for an invalid category, got %d: %+v", len(failures), failures)
+	}
+}
+
 // TestToolFailureCategory_EnumIsValid sanity-checks the enum itself:
 // every exported ToolFailure* constant declared in toolfailure.go must
 // be registered in allToolFailureCategories. A new constant added
@@ -996,20 +1042,76 @@ func TestToolFailureMetrics_AsyncPanic(t *testing.T) {
 	}
 }
 
-// async_internal_error is intentionally untested.
+// TestToolFailureMetrics_AsyncInternalError exercises the defensive
+// "unexpected payload type" branch in dispatchAsyncToolCall: when the
+// correlator's Await returns a payload that is not an asyncToolResult,
+// the type assertion fails and the call is tagged async_internal_error.
 //
-// The category is emitted at types.go's defensive "unexpected payload
-// type" branch in dispatchAsyncToolCall: it only fires if the loop's
-// async correlator were attached with a PayloadExtractor that
-// delivers something other than asyncToolResult. The production code
-// wires extractAsyncToolResult exclusively (see
-// ensureAsyncCorrelator), so the branch is unreachable without
-// exposing a test-only hook on the correlator-attach path or
-// introducing a parallel construction path.
-//
-// Per the synthesis brief's explicit allowance for this gap, the
-// deferral is documented here rather than weakening the seam.
-// TODO(#229-followup): if a future refactor exposes a way to inject
-// a custom PayloadExtractor for tests, add a TestToolFailureMetrics_
-// AsyncInternalError that submits a non-asyncToolResult payload and
-// asserts async_internal_error emission.
+// The production path wires extractAsyncToolResult exclusively, which
+// only ever produces asyncToolResult, so this branch has no model-facing
+// trigger. The test installs a PayloadExtractor override via
+// withAsyncExtractor that returns a string payload keyed by the request
+// ID — the override unblocks Await like the real extractor but delivers
+// the wrong concrete type, driving the fallthrough. This closes the
+// #229-followup gap that previously left the branch untested.
+func TestToolFailureMetrics_AsyncInternalError(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop, reader := buildMetricsHarness(t, []*tool.Tool{asyncEchoTool()}, nil, nil, tr)
+	// Override the extractor BEFORE the first dispatch constructs the
+	// correlator. It matches on tool_result_response (so Await unblocks)
+	// but returns a string rather than an asyncToolResult, forcing the
+	// payload.(asyncToolResult) assertion to fail.
+	loop.withAsyncExtractor(func(event types.ControlEvent) (string, any) {
+		if event.Type != "tool_result_response" {
+			return "", nil
+		}
+		return event.RequestID, "not an asyncToolResult"
+	})
+	cfg := &types.RunConfig{
+		RunID:        "test-run-internal-err",
+		Mode:         "execution",
+		ToolDispatch: &types.ToolDispatchConfig{MaxParallel: 1},
+	}
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if id := tr.lastRequestID("tool_result_request"); id != "" {
+				tr.FireControl(types.ControlEvent{
+					Type:      "tool_result_response",
+					RequestID: id,
+					Content:   "ignored — extractor override discards this",
+				})
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	results, _, outcome := loop.planAndDispatch(
+		context.Background(), cfg,
+		[]types.ToolCall{{ID: "tc_internal", Name: "async_echo", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic", "claude-sonnet-4-6",
+	)
+	if outcome != "" {
+		t.Fatalf("unexpected stall outcome %q", outcome)
+	}
+	if len(results) != 1 || !results[0].IsError {
+		t.Fatalf("expected one errored result, got %+v", results)
+	}
+	if !strings.Contains(results[0].Content, "internal error: unexpected payload type") {
+		t.Errorf("result content missing internal-error prefix, got %q", results[0].Content)
+	}
+	failures := collectFailures(t, reader)
+	var internalHits int64
+	for _, fp := range failures {
+		if fp.category == observability.ToolFailureAsyncInternal.String() {
+			internalHits += fp.value
+			if fp.tool != "async_echo" {
+				t.Errorf("async_internal_error tool.name = %q, want %q", fp.tool, "async_echo")
+			}
+		}
+	}
+	if internalHits != 1 {
+		t.Errorf("async_internal_error count = %d, want exactly 1; full failures = %+v", internalHits, failures)
+	}
+}

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -107,6 +107,16 @@ type AgenticLoop struct {
 	// going through Once.Do.
 	asyncOnce       sync.Once
 	asyncCorrelator atomic.Pointer[transport.Correlator]
+
+	// asyncExtractorOverride, when non-nil, is attached to the async
+	// correlator in place of extractAsyncToolResult. It exists solely as a
+	// test seam: the production path has no way to deliver a non-
+	// asyncToolResult payload to dispatchAsyncToolCall (extractAsyncToolResult
+	// only ever produces asyncToolResult), so the defensive
+	// async_internal_error branch is otherwise unreachable. Tests set this
+	// via withAsyncExtractor before the first dispatch to exercise that
+	// branch. Never set in production wiring.
+	asyncExtractorOverride transport.PayloadExtractor
 }
 
 // asyncToolResult carries the resolved payload of an async tool call from
@@ -150,10 +160,25 @@ func (l *AgenticLoop) ensureAsyncCorrelator() *transport.Correlator {
 	}
 	l.asyncOnce.Do(func() {
 		c := transport.NewCorrelator("async-tool")
-		c.AttachTo(l.Transport, extractAsyncToolResult)
+		extract := extractAsyncToolResult
+		if l.asyncExtractorOverride != nil {
+			extract = l.asyncExtractorOverride
+		}
+		c.AttachTo(l.Transport, extract)
 		l.asyncCorrelator.Store(c)
 	})
 	return l.asyncCorrelator.Load()
+}
+
+// withAsyncExtractor installs a test-only PayloadExtractor override on the
+// async correlator-attach path, used to deliver a payload other than
+// asyncToolResult and exercise dispatchAsyncToolCall's defensive
+// async_internal_error branch. Must be called before the first async
+// dispatch (the correlator is constructed once, lazily). Returns the loop
+// for call-chaining in test setup.
+func (l *AgenticLoop) withAsyncExtractor(extract transport.PayloadExtractor) *AgenticLoop {
+	l.asyncExtractorOverride = extract
+	return l
 }
 
 // asyncCorrelatorForTest returns the loop's async tool correlator if it
@@ -471,13 +496,8 @@ func (l *AgenticLoop) dispatchAsyncToolCall(
 		// Defensive: extractAsyncToolResult only ever delivers
 		// asyncToolResult, so reaching this branch means the correlator
 		// was wired with a different extractor. Treat as a hard error.
-		//
-		// TODO(#229-followup): no dispatch-site test covers this
-		// emission because the production wiring exposes no seam to
-		// inject a non-asyncToolResult payload — ensureAsyncCorrelator
-		// always attaches extractAsyncToolResult. Gap deferred per
-		// the wave-1-issue-229 synthesis brief; revisit if a future
-		// refactor exposes a way to swap the extractor for tests.
+		// Exercised by TestToolFailureMetrics_AsyncInternalError via the
+		// withAsyncExtractor test seam (issue #312).
 		return fmt.Sprintf("async tool %s internal error: unexpected payload type %T", call.Name, payload), false, observability.ToolFailureAsyncInternal
 	}
 	if resp.isError {

--- a/harness/internal/observability/metrics.go
+++ b/harness/internal/observability/metrics.go
@@ -301,7 +301,11 @@ func newMetricsFromMeter(meter metric.Meter, provider *sdkmetric.MeterProvider) 
 	// ToolErrors.
 	m.ToolFailures, err = meter.Int64Counter("stirrup.harness.tool_failures",
 		metric.WithUnit("{failure}"),
-		metric.WithDescription("Tool-use failures decomposed by provider, model, tool, and bounded failure category"),
+		metric.WithDescription("Tool-use failures decomposed by provider, model, tool, and bounded failure category. "+
+			"For provider-scope failures (provider_request_failed, provider_stream_failed) where no individual tool call is in scope, "+
+			"tool.name is the empty string (see observability.ToolNameProviderScope). "+
+			"Stall-terminated batches co-emit one stall_consecutive_failures observation alongside the N per-call failure observations, "+
+			"so sum(stirrup.harness.tool_failures) counts N+1 for such a batch; this double-count is intentional and load-bearing for stall alerts."),
 	)
 	if err != nil {
 		return nil, err

--- a/harness/internal/observability/toolfailure.go
+++ b/harness/internal/observability/toolfailure.go
@@ -118,6 +118,16 @@ const (
 	ToolFailureNoToolWhenRequired ToolFailureCategory = "no_tool_when_required"
 )
 
+// ToolNameProviderScope is the value emitted for the tool.name metric
+// label on tool_failures observations that have no individual tool call
+// in scope — the provider-scope categories ToolFailureProviderRequest
+// and ToolFailureProviderStream, emitted from runInnerLoop where the
+// failure precedes (or supersedes) any per-call dispatch. The wire value
+// is the empty string; the constant exists so the emission-site intent
+// is explicit and dashboard authors can grep for the sentinel rather
+// than puzzle over an unexplained empty-string series.
+const ToolNameProviderScope = ""
+
 // allToolFailureCategories is the closed set of valid category values.
 // Used by IsValid (and tests asserting the cardinality bound) to confirm
 // metric labels are drawn from the enum rather than a free-form string.

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -2460,6 +2460,12 @@ func validateProviderConfigs(config *RunConfig, retryDefaulted map[string]provid
 	// the opaque ValidationException from AWS.
 	validateBedrockModelID(config, errs)
 
+	// Cardinality bound on the provider.model OTel metric label across all
+	// provider types. The Gemini-specific check above is URL-safety; this
+	// one is observability self-harm prevention for anthropic,
+	// openai-compatible, openai-responses, and bedrock (issue #310).
+	validateProviderModelLabel(config, errs)
+
 	checkProviderRef := func(path, name string) {
 		if name == "" {
 			return
@@ -3206,6 +3212,100 @@ func validateBedrockModelID(config *RunConfig, errs *[]string) {
 		if providerIsBedrock(providerName) {
 			checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode), model)
 		}
+	}
+}
+
+// validateProviderModelLabel bounds the character set and length of the
+// router-resolved model string for every provider type, because that
+// value rides on the provider.model OTel metric label (dispatch.go and
+// loop.go). #304 hardened the model-controlled tool.name label; this is
+// the operator-controlled sibling: an operator with RunConfig authoring
+// power (Cloud Run job spec, gRPC submitter) could otherwise set an
+// unbounded or non-printable model string that inflates TSDB cardinality
+// or breaks dashboard label rendering (CWE-400, issue #310). The bound is
+// observabilityLabelPattern — the same ^[A-Za-z0-9._-]{1,64}$ the Gemini
+// precedent (geminiModelNamePattern) and the OTel resource labels already
+// enforce.
+//
+// Scope mirrors validateGeminiModelName: ModelRouter.Model under the
+// resolved default provider, plus each ModeModels override. CheapModel /
+// ExpensiveModel are intentionally not checked here for the same reason
+// validateGeminiModelName skips them — the dynamic router's model
+// selection is not yet exercised by a provider whose label this guards,
+// and adding a check there without a corresponding emission site would be
+// dead validation.
+//
+// Bedrock is special-cased. Its model ids legitimately carry bytes the
+// strict label pattern rejects: a version suffix colon
+// ("anthropic.claude-sonnet-4-5-20250929-v1:0"), or a full inference-
+// profile ARN with colons and slashes. validateBedrockModelID already
+// accepts both shapes, so applying the strict character class here would
+// reject configs the bedrock validator declares valid. Bedrock instead
+// gets a length-plus-printability bound — the actual "unreasonably long
+// or non-printable" cardinality vector the issue names — without
+// constraining the character class. The 256-byte cap sits well above the
+// longest published inference-profile ARN with comfortable headroom.
+func validateProviderModelLabel(config *RunConfig, errs *[]string) {
+	const bedrockModelLabelMaxLen = 256
+
+	resolveType := func(name string) string {
+		if name == "" {
+			return config.Provider.Type
+		}
+		if validProviderTypes[name] {
+			return name
+		}
+		if p, ok := config.Providers[name]; ok {
+			return p.Type
+		}
+		return ""
+	}
+
+	checkModel := func(label, providerType, model string) {
+		if model == "" {
+			return
+		}
+		if providerType == "bedrock" {
+			// Length + printability only; the character class is owned by
+			// validateBedrockModelID, which permits colons and ARN slashes.
+			if len(model) > bedrockModelLabelMaxLen {
+				*errs = append(*errs, fmt.Sprintf(
+					"%s is %d bytes; must be <= %d so the provider.model metric label stays bounded",
+					label, len(model), bedrockModelLabelMaxLen))
+				return
+			}
+			for _, r := range model {
+				if !unicode.IsPrint(r) {
+					*errs = append(*errs, fmt.Sprintf(
+						"%s %q contains a non-printable character; the model name rides on "+
+							"the provider.model metric label and must stay printable",
+						label, model))
+					return
+				}
+			}
+			return
+		}
+		if !observabilityLabelPattern.MatchString(model) {
+			*errs = append(*errs, fmt.Sprintf(
+				"%s %q must match %s; the model name rides on the provider.model "+
+					"metric label and an unbounded or non-printable value inflates "+
+					"observability cardinality",
+				label, model, observabilityLabelPattern))
+		}
+	}
+
+	checkModel("modelRouter.model", resolveType(config.ModelRouter.Provider), config.ModelRouter.Model)
+
+	for mode, spec := range config.ModelRouter.ModeModels {
+		providerName, model, ok := strings.Cut(spec, "/")
+		if !ok {
+			// No provider prefix — inherits ModelRouter.Provider.
+			checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode),
+				resolveType(config.ModelRouter.Provider), spec)
+			continue
+		}
+		checkModel(fmt.Sprintf("modelRouter.modeModels[%s]", mode),
+			resolveType(providerName), model)
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -4728,6 +4728,138 @@ func TestValidateRunConfig_BedrockModelIDShape(t *testing.T) {
 	})
 }
 
+// TestValidateRunConfig_ProviderModelLabelBound pins the cardinality
+// guard from #310: the router-resolved model string rides on the
+// provider.model OTel metric label, so for anthropic, openai-compatible,
+// and openai-responses it must match observabilityLabelPattern
+// (^[A-Za-z0-9._-]{1,64}$). #304 hardened the model-controlled tool.name
+// label; this is the operator-controlled sibling.
+func TestValidateRunConfig_ProviderModelLabelBound(t *testing.T) {
+	// A 65-char model string overruns the 64-char label cap.
+	tooLong := strings.Repeat("a", 65)
+
+	t.Run("rejected", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			provider string
+			model    string
+		}{
+			{"anthropic with space", "anthropic", "claude sonnet"},
+			{"anthropic with slash", "anthropic", "anthropic/claude"},
+			{"anthropic too long", "anthropic", tooLong},
+			{"anthropic with newline", "anthropic", "claude\nsonnet"},
+			{"openai-compatible with colon", "openai-compatible", "gpt-4:turbo"},
+			{"openai-responses with percent", "openai-responses", "gpt%2F4o"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				c := validConfig()
+				c.Provider = ProviderConfig{Type: tc.provider}
+				c.ModelRouter = ModelRouterConfig{Type: "static", Provider: tc.provider, Model: tc.model}
+				err := ValidateRunConfig(c)
+				if err == nil {
+					t.Fatalf("expected %q on %s to be rejected, got nil", tc.model, tc.provider)
+				}
+				if !strings.Contains(err.Error(), "modelRouter.model") {
+					t.Errorf("expected error to name modelRouter.model, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "provider.model") {
+					t.Errorf("expected error to explain the provider.model label rationale, got: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("accepted", func(t *testing.T) {
+		cases := []struct {
+			provider string
+			model    string
+		}{
+			{"anthropic", "claude-sonnet-4-6"},
+			{"anthropic", "claude-opus-4-1"},
+			{"openai-compatible", "gpt-4o"},
+			{"openai-responses", "gpt-4.1"},
+			{"anthropic", strings.Repeat("a", 64)}, // exactly at the cap
+		}
+		for _, tc := range cases {
+			t.Run(tc.provider+"/"+tc.model, func(t *testing.T) {
+				c := validConfig()
+				c.Provider = ProviderConfig{Type: tc.provider}
+				c.ModelRouter = ModelRouterConfig{Type: "static", Provider: tc.provider, Model: tc.model}
+				if err := ValidateRunConfig(c); err != nil {
+					t.Fatalf("expected %q on %s to be accepted, got: %v", tc.model, tc.provider, err)
+				}
+			})
+		}
+	})
+
+	t.Run("per_mode_override_bound", func(t *testing.T) {
+		// The label-bound check resolves through ModeModels "provider/model"
+		// entries too, mirroring the gemini and bedrock validators.
+		c := validConfig()
+		c.Provider = ProviderConfig{Type: "anthropic"}
+		c.ModelRouter = ModelRouterConfig{
+			Type:       "per-mode",
+			Provider:   "anthropic",
+			Model:      "claude-sonnet-4-6",
+			ModeModels: map[string]string{"execution": "anthropic/claude is bad"},
+		}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected per-mode override with an invalid model label to be rejected")
+		}
+		if !strings.Contains(err.Error(), "modelRouter.modeModels[execution]") {
+			t.Errorf("expected error to name the offending mode entry, got: %v", err)
+		}
+	})
+
+	t.Run("bedrock_colon_and_arn_exempt_from_strict_class", func(t *testing.T) {
+		// Bedrock model ids legitimately carry colons (version suffix) and
+		// ARNs carry colons + slashes; the label-bound check must not
+		// reject the shapes validateBedrockModelID already accepts. Only
+		// the length + printability bound applies to bedrock.
+		valid := []string{
+			"anthropic.claude-sonnet-4-5-20250929-v1:0",
+			"meta.llama3-8b-instruct-v1:0",
+			"arn:aws:bedrock:eu-west-1:123456789012:inference-profile/eu.anthropic.claude-sonnet-4-6",
+		}
+		for _, model := range valid {
+			t.Run(model, func(t *testing.T) {
+				c := validConfig()
+				c.Provider = ProviderConfig{
+					Type:       "bedrock",
+					Region:     "us-east-1",
+					Credential: &CredentialConfig{Type: "aws-default"},
+				}
+				c.ModelRouter = ModelRouterConfig{Type: "static", Provider: "bedrock", Model: model}
+				if err := ValidateRunConfig(c); err != nil {
+					t.Fatalf("expected bedrock model %q to be accepted, got: %v", model, err)
+				}
+			})
+		}
+	})
+
+	t.Run("bedrock_non_printable_rejected", func(t *testing.T) {
+		// The bedrock branch drops the strict character class but still
+		// rejects a non-printable byte — the actual cardinality / label-
+		// corruption vector the issue targets.
+		c := validConfig()
+		c.Provider = ProviderConfig{
+			Type:       "bedrock",
+			Region:     "us-east-1",
+			Credential: &CredentialConfig{Type: "aws-default"},
+		}
+		c.ModelRouter = ModelRouterConfig{Type: "static", Provider: "bedrock", Model: "anthropic.claude\x00sonnet"}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected bedrock model with a NUL byte to be rejected")
+		}
+		if !strings.Contains(err.Error(), "non-printable") {
+			t.Errorf("expected error to mention non-printable, got: %v", err)
+		}
+	})
+}
+
 // TestValidateRunConfig_APIKeyRefMustBeSecretReference asserts that
 // every secret-bearing apiKeyRef field is required to use the
 // "secret://" scheme. A literal API key landing in RunConfig is a

--- a/types/runtrace_test.go
+++ b/types/runtrace_test.go
@@ -2,9 +2,117 @@ package types
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+// TestToolCallSummary_StructuralParityWithTrace guards the four
+// types.ToolCallSummary(tc) conversions the harness performs on a
+// ToolCallTrace. The cast is a struct conversion: it only compiles while
+// the two types have identical underlying field shapes, but Go permits
+// the conversion to silently ignore differing struct *tags* and, more
+// dangerously, a future field added to ToolCallTrace without a matching
+// addition to ToolCallSummary would either break the conversion (caught
+// at build) or — if added to ToolCallSummary first — leave the trace
+// struct missing data with no signal. This reflection check fails loudly
+// the moment the field set (name + type + json tag) diverges, so the
+// next person editing one struct is forced to mirror the other (#314).
+func TestToolCallSummary_StructuralParityWithTrace(t *testing.T) {
+	type fieldShape struct {
+		Name string
+		Type string
+		Tag  string
+	}
+	fields := func(rt reflect.Type) []fieldShape {
+		out := make([]fieldShape, 0, rt.NumField())
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			out = append(out, fieldShape{
+				Name: f.Name,
+				Type: f.Type.String(),
+				Tag:  f.Tag.Get("json"),
+			})
+		}
+		return out
+	}
+
+	summary := fields(reflect.TypeOf(ToolCallSummary{}))
+	trace := fields(reflect.TypeOf(ToolCallTrace{}))
+
+	if !reflect.DeepEqual(summary, trace) {
+		t.Errorf("ToolCallSummary and ToolCallTrace field sets diverged; the "+
+			"types.ToolCallSummary(tc) cast would silently drop or misalign data.\n"+
+			"ToolCallSummary: %+v\nToolCallTrace:   %+v\n"+
+			"Add the new field to BOTH structs (same name, type, json tag, and order).",
+			summary, trace)
+	}
+}
+
+// TestToolCallTrace_ErrorCategoryRoundTrip decodes a JSONL trace record
+// and asserts the ErrorCategory field is either empty or a member of the
+// bounded observability.ToolFailureCategory enum's wire-string set.
+// ErrorCategory is a plain string in types because types cannot import
+// harness/internal/observability (the layering is intentional — see
+// docs/architecture.md), so there is no compile-time guard that a write
+// site used a valid member. The valid set is hard-coded here to preserve
+// that layering boundary: if the enum gains a member, this list must be
+// updated in lockstep, which is the explicit reminder the test exists to
+// provide.
+func TestToolCallTrace_ErrorCategoryRoundTrip(t *testing.T) {
+	// Mirror of observability.ToolFailureCategory wire strings. NOT
+	// imported — types must not depend on harness/internal/observability.
+	validCategories := map[string]struct{}{
+		"unknown_tool":                {},
+		"schema_validation_failed":    {},
+		"security_guard_denied":       {},
+		"permission_denied":           {},
+		"permission_error":            {},
+		"guardrail_denied":            {},
+		"handler_error":               {},
+		"handler_missing":             {},
+		"async_preflight_error":       {},
+		"async_transport_unavailable": {},
+		"async_timeout":               {},
+		"async_cancelled":             {},
+		"async_upstream_error":        {},
+		"async_panic":                 {},
+		"async_internal_error":        {},
+		"provider_request_failed":     {},
+		"provider_stream_failed":      {},
+		"stall_repeated_calls":        {},
+		"stall_consecutive_failures":  {},
+		"no_tool_when_required":       {},
+	}
+
+	// A JSONL fixture: one successful call (no category) and one failed
+	// call carrying a category from the bounded set.
+	const fixture = `{"name":"read_file","durationMs":12,"success":true}
+{"name":"missing_tool","durationMs":3,"success":false,"errorReason":"no such tool","errorCategory":"unknown_tool"}`
+
+	for i, line := range strings.Split(strings.TrimSpace(fixture), "\n") {
+		var tc ToolCallTrace
+		if err := json.Unmarshal([]byte(line), &tc); err != nil {
+			t.Fatalf("line %d: Unmarshal: %v", i, err)
+		}
+		if tc.ErrorCategory == "" {
+			continue
+		}
+		if _, ok := validCategories[tc.ErrorCategory]; !ok {
+			t.Errorf("line %d: ErrorCategory %q is not a member of the bounded enum wire-string set", i, tc.ErrorCategory)
+		}
+	}
+
+	// A category outside the bounded set must be flagged by the same
+	// guard, proving the assertion is load-bearing rather than vacuous.
+	var bogus ToolCallTrace
+	if err := json.Unmarshal([]byte(`{"name":"x","success":false,"errorCategory":"made_up_category"}`), &bogus); err != nil {
+		t.Fatalf("Unmarshal bogus: %v", err)
+	}
+	if _, ok := validCategories[bogus.ErrorCategory]; ok {
+		t.Fatalf("test premise broken: %q must not be in the valid set", bogus.ErrorCategory)
+	}
+}
 
 // TestTurnTrace_MarshalRoundTrip pins the wire shape of TurnTrace.Mode
 // and TurnTrace.BatchID added in #138. The omitempty contract is


### PR DESCRIPTION
Bundles the observability/trace review follow-ups from #304:

- **#309** — bound OTel tool span name cardinality: unresolved tool names get the `__unknown__` sentinel (mirrors the metric-label fix).
- **#310** — bound the `provider.model` metric label across all provider types (Bedrock gets a length+printability bound rather than the strict char-class, since its IDs legitimately contain `:` and `/`).
- **#311** — document the empty-string `tool.name` (provider-scope failures) and the stall co-emission double-count in the `tool_failures` metric description; add `ToolNameProviderScope`.
- **#312** — cover the `IsValid()` cardinality guard rejection and the `async_internal_error` emission path via test-only seams (both `TODO(#229-followup)` markers resolved).
- **#314** — render `ErrorCategory` in `stirrup trace show` (`fail (<category>)`); add reflection field-parity and `ErrorCategory` round-trip tests. CLI rendering verified end-to-end.

`just test` + `just lint` green.

Closes #309, #310, #311, #312, #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)