### PR TITLE
cli: bare-invocation usage hints across stirrup/harness/job (#249)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,12 @@ because its purpose is exact replay; pipe through
   redirection (`< config.json`). Other non-TTY shapes — including
   `< /dev/null` and the stdin handed to tests by `go test` — fall
   through to flag-only construction so the harness does not trap
-  noninteractive automation.
+  noninteractive automation. The auto-stdin trigger fires only for
+  named-pipe and regular-file redirects; a character-device or empty
+  stdin such as `stirrup harness < /dev/null` deliberately falls
+  through to flag-only construction rather than erroring, so an
+  operator who needs stdin treated as a config source must opt in
+  explicitly with `--config -`.
 
 Piping a config into `stirrup harness` consumes stdin at startup,
 before transport initialisation, so the stdio transport sees EOF for

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,13 @@ should use `--transport grpc`.
 `stirrup harness --help` is authoritative. The table below documents
 the same flags grouped by concern.
 
+Without a prompt on an interactive terminal, `stirrup harness` prints a
+curated usage hint — a grouped, example-led subset of the flags below —
+rather than the bare prompt-required error, and a bare `stirrup` prints
+a two-subcommand entry-point hint. Both are first-contact orientation
+only; `stirrup harness --help` remains authoritative for the full flag
+reference.
+
 ### Required
 
 | Flag | Default | Notes |

--- a/harness/cmd/stirrup/cmd/format.go
+++ b/harness/cmd/stirrup/cmd/format.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"io"
+	"strings"
+)
+
+// The CLI entry-point usage hints (issue #249) are static, editor-
+// controlled templates rather than Cobra's generated --help. Each
+// entry point speaks to a different audience: the bare root command
+// orients a first-time operator toward the two subcommands, while a
+// bare `stirrup harness` on an interactive terminal teaches the
+// flag-grouping a real run needs. The full Cobra help (`--help`)
+// remains the authoritative, exhaustive reference; these hints are the
+// short, friendly first contact. They live here so the prose is shaped
+// by hand — generating them from the flag list would drift toward the
+// noise the hint is meant to avoid.
+
+// printRootUsageHint writes the bare-`stirrup` two-subcommand hint to w.
+// Plain text only — no ANSI, no boxes, no headings beyond the single
+// title line — because the hint must read identically whether stdout is
+// a terminal, a pager, or captured into a file. The shape mirrors the
+// issue #249 template verbatim so a future edit to the wording is a
+// deliberate single-site change rather than a regenerated artifact.
+func printRootUsageHint(w io.Writer) {
+	const hint = `stirrup — a coding agent harness
+
+Usage:
+  stirrup harness --prompt "<task>"          Run the agentic loop (interactive use).
+  stirrup job                                Run as a control-plane-driven job.
+
+For full help: stirrup harness --help
+For version:  stirrup --version
+`
+	_, _ = io.WriteString(w, hint)
+}
+
+// printHarnessUsageHint writes the grouped, example-led `stirrup harness`
+// hint to w. It fires only when a bare invocation reaches the
+// prompt-required gate on an interactive terminal (see
+// resolvePromptForRun): scripted, non-TTY use keeps the opaque
+// "prompt is required" error so log aggregators are not flooded with a
+// multi-line template.
+//
+// color is decided by the caller via shouldColor so the TTY / NO_COLOR
+// detection stays in one place (trace.go). When false the function
+// emits plain text — every colorize call collapses to its argument —
+// which is the form a piped `2>&1 | cat` must observe.
+//
+// The grouping mirrors the flag concerns documented in
+// docs/configuration.md (Required, Run shape, Provider, Configuration)
+// so an operator who reads the hint and then the doc sees the same
+// mental model. It is deliberately a curated subset, not the full flag
+// list: `stirrup harness --help` remains authoritative for the rest.
+func printHarnessUsageHint(w io.Writer, color bool) {
+	var b strings.Builder
+
+	heading := func(s string) {
+		b.WriteString(colorize(color, ansiBold, s))
+		b.WriteByte('\n')
+	}
+	// dim renders an example's illustrative value (a model name, a path)
+	// so the command shape itself stays prominent. Grey degrades to the
+	// plain string when color is off.
+	dim := func(s string) string {
+		return colorize(color, ansiGrey, s)
+	}
+
+	b.WriteString(colorize(color, ansiBold, "stirrup harness — run the coding agent harness"))
+	b.WriteString("\n\n")
+	b.WriteString("No prompt supplied. A run needs a task; the most common shapes follow.\n")
+	b.WriteString("Run `stirrup harness --help` for the full flag reference.\n\n")
+
+	heading("USAGE")
+	b.WriteString("  stirrup harness --prompt \"<task>\" [flags]\n")
+	b.WriteString("  stirrup harness \"<task>\" [flags]\n\n")
+
+	heading("REQUIRED")
+	b.WriteString("  --prompt \"<task>\"        The task to run. Also accepted as a positional\n")
+	b.WriteString("                           argument, via --prompt-file, or STIRRUP_PROMPT.\n\n")
+
+	heading("RUN SHAPE")
+	b.WriteString("  --mode " + dim("execution") + "        Enable edits and shell. Default is planning\n")
+	b.WriteString("                           (read-only: no write_file / edit_file / run_command).\n")
+	b.WriteString("  --max-turns " + dim("20") + "          Hard turn cap (max 100).\n")
+	b.WriteString("  --timeout " + dim("600") + "           Wall-clock seconds (max 3600).\n\n")
+
+	heading("PROVIDER")
+	b.WriteString("  --provider " + dim("anthropic") + "     Provider adapter.\n")
+	b.WriteString("  --model " + dim("<model-id>") + "       Model to route to.\n")
+	b.WriteString("  --api-key-ref " + dim("secret://ANTHROPIC_API_KEY") + "\n")
+	b.WriteString("                           Secret reference resolved at runtime (never a raw key).\n\n")
+
+	heading("CONFIGURATION")
+	b.WriteString("  --config <path>          Load a JSON RunConfig; flags then override fields.\n")
+	b.WriteString("                           Pass --config - to read the config from stdin.\n")
+	b.WriteString("  --output-runconfig <path>\n")
+	b.WriteString("                           Write the resolved RunConfig and exit without running\n")
+	b.WriteString("                           ('-' for stdout).\n\n")
+
+	heading("EXAMPLES")
+	b.WriteString("  " + dim("# Plan a change (read-only, safe by default):") + "\n")
+	b.WriteString("  stirrup harness --prompt \"Audit error handling in the executor\"\n\n")
+	b.WriteString("  " + dim("# Execute a change with shell + edits:") + "\n")
+	b.WriteString("  stirrup harness --mode execution --prompt \"Fix the failing TestFoo\"\n\n")
+	b.WriteString("  " + dim("# Capture the resolved config, then replay it via a pipeline:") + "\n")
+	b.WriteString("  stirrup run-config --mode execution | stirrup harness --prompt \"Ship it\"\n")
+
+	_, _ = io.WriteString(w, b.String())
+}

--- a/harness/cmd/stirrup/cmd/format.go
+++ b/harness/cmd/stirrup/cmd/format.go
@@ -5,16 +5,11 @@ import (
 	"strings"
 )
 
-// The CLI entry-point usage hints (issue #249) are static, editor-
-// controlled templates rather than Cobra's generated --help. Each
-// entry point speaks to a different audience: the bare root command
-// orients a first-time operator toward the two subcommands, while a
-// bare `stirrup harness` on an interactive terminal teaches the
-// flag-grouping a real run needs. The full Cobra help (`--help`)
-// remains the authoritative, exhaustive reference; these hints are the
-// short, friendly first contact. They live here so the prose is shaped
-// by hand — generating them from the flag list would drift toward the
-// noise the hint is meant to avoid.
+// The CLI entry-point usage hints (issue #249) are hand-authored
+// templates, NOT generated from Cobra's flag list, so the wording is a
+// single deliberate edit rather than a regenerated artifact that drifts
+// toward the noise the hint exists to avoid. `--help` remains the
+// authoritative, exhaustive reference.
 
 // printRootUsageHint writes the bare-`stirrup` two-subcommand hint to w.
 // Plain text only — no ANSI, no boxes, no headings beyond the single
@@ -59,9 +54,6 @@ func printHarnessUsageHint(w io.Writer, color bool) {
 		b.WriteString(colorize(color, ansiBold, s))
 		b.WriteByte('\n')
 	}
-	// dim renders an example's illustrative value (a model name, a path)
-	// so the command shape itself stays prominent. Grey degrades to the
-	// plain string when color is off.
 	dim := func(s string) string {
 		return colorize(color, ansiGrey, s)
 	}

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1267,13 +1267,16 @@ func runHarness(cmd *cobra.Command, args []string) error {
 		// prompt-required gate with this sentinel (issue #249). Print the
 		// grouped, example-led hint to stderr and exit 0 — returning nil
 		// so Cobra appends neither its error line nor its full usage
-		// block. Colour is auto-detected on stderr (honours NO_COLOR);
-		// piping stderr through `cat` strips ANSI because the destination
-		// is no longer a TTY. Non-TTY callers never produce this sentinel
+		// block. Colour is auto-detected against the SAME writer the hint
+		// is written to: deciding colour off os.Stderr while writing to
+		// cmd.ErrOrStderr() would leak ANSI into a non-TTY sink when a
+		// caller redirected stderr via cmd.SetErr (or a piped
+		// `2>&1 | cat`). Non-TTY callers never produce this sentinel
 		// (resolvePromptForRun returns the opaque errPromptRequired
 		// instead), so scripted use keeps its terse, non-zero failure.
 		if errors.Is(err, errPromptHintRequested) {
-			printHarnessUsageHint(cmd.ErrOrStderr(), shouldColor(colorAuto, os.Stderr))
+			w := cmd.ErrOrStderr()
+			printHarnessUsageHint(w, shouldColor(colorAuto, w))
 			return nil
 		}
 		return err

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1262,6 +1263,19 @@ func runHarness(cmd *cobra.Command, args []string) error {
 		Resolve:    ResolveAll,
 	})
 	if err != nil {
+		// A bare `stirrup harness` on an interactive terminal reaches the
+		// prompt-required gate with this sentinel (issue #249). Print the
+		// grouped, example-led hint to stderr and exit 0 — returning nil
+		// so Cobra appends neither its error line nor its full usage
+		// block. Colour is auto-detected on stderr (honours NO_COLOR);
+		// piping stderr through `cat` strips ANSI because the destination
+		// is no longer a TTY. Non-TTY callers never produce this sentinel
+		// (resolvePromptForRun returns the opaque errPromptRequired
+		// instead), so scripted use keeps its terse, non-zero failure.
+		if errors.Is(err, errPromptHintRequested) {
+			printHarnessUsageHint(cmd.ErrOrStderr(), shouldColor(colorAuto, os.Stderr))
+			return nil
+		}
 		return err
 	}
 

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -5479,6 +5479,53 @@ func TestResolvePromptForRun_NonInteractiveReturnsOpaqueError(t *testing.T) {
 	}
 }
 
+// TestResolvePromptForRun_InteractiveWithStirrupPromptNoHint pins the
+// spec edge case (issue #249): even on an interactive terminal, a
+// resolvable prompt must short-circuit before the hint gate. A
+// STIRRUP_PROMPT-supplied prompt fills cfg.Prompt, so resolvePromptForRun
+// returns nil — the hint sentinel must NOT fire.
+func TestResolvePromptForRun_InteractiveWithStirrupPromptNoHint(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return true }
+	defer func() { stderrIsInteractive = orig }()
+	t.Setenv("STIRRUP_PROMPT", "task from env")
+
+	cmd := newTestHarnessCommand()
+	cfg := &types.RunConfig{}
+	err := resolvePromptForRun(cmd, cfg)
+	if err != nil {
+		t.Fatalf("resolvePromptForRun with STIRRUP_PROMPT on a TTY = %v, want nil (no hint)", err)
+	}
+	if cfg.Prompt != "task from env" {
+		t.Errorf("cfg.Prompt = %q, want the STIRRUP_PROMPT value", cfg.Prompt)
+	}
+}
+
+// TestResolvePromptForRun_InteractiveWithConfigPromptNoHint pins the
+// companion spec edge case: a prompt supplied by a --config file's
+// `prompt` field is already on cfg.Prompt by the time resolvePromptForRun
+// runs (BuildRunConfig loads the base before resolving the prompt chain).
+// The hint sentinel must NOT fire on an interactive terminal when a
+// prompt is already present.
+func TestResolvePromptForRun_InteractiveWithConfigPromptNoHint(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return true }
+	defer func() { stderrIsInteractive = orig }()
+	t.Setenv("STIRRUP_PROMPT", "")
+
+	cmd := newTestHarnessCommand()
+	// Models a --config file whose `prompt` field landed on cfg before
+	// the prompt-resolution chain runs.
+	cfg := &types.RunConfig{Prompt: "prompt-from-config"}
+	err := resolvePromptForRun(cmd, cfg)
+	if err != nil {
+		t.Fatalf("resolvePromptForRun with a config-supplied prompt on a TTY = %v, want nil (no hint)", err)
+	}
+	if cfg.Prompt != "prompt-from-config" {
+		t.Errorf("cfg.Prompt = %q, want the config value preserved", cfg.Prompt)
+	}
+}
+
 // TestRunHarness_BareInteractivePrintsHintAndExitsZero drives the full
 // runHarness path on a TTY with no prompt: it must print the grouped
 // hint to the command's stderr and return nil (exit 0). The
@@ -5488,14 +5535,15 @@ func TestRunHarness_BareInteractivePrintsHintAndExitsZero(t *testing.T) {
 	orig := stderrIsInteractive
 	stderrIsInteractive = func() bool { return true }
 	defer func() { stderrIsInteractive = orig }()
-	// Force colour off so the captured text is plain and stable
-	// regardless of the test host's NO_COLOR / TTY state — the colour
-	// branch is pinned separately by TestPrintHarnessUsageHint_*.
-	t.Setenv("NO_COLOR", "1")
 
 	cmd := newTestHarnessCommand()
 	var errBuf bytes.Buffer
 	cmd.SetErr(&errBuf)
+	// runHarness now decides colour against cmd.ErrOrStderr() — the
+	// injected *bytes.Buffer is not an *os.File, so shouldColor returns
+	// false and the captured text is plain regardless of the host's TTY /
+	// NO_COLOR state. (The colour branch is pinned by
+	// TestPrintHarnessUsageHint_ColorEmitsAnsi.)
 
 	getOut := captureStdout(t)
 	err := runHarness(cmd, nil)
@@ -5506,6 +5554,11 @@ func TestRunHarness_BareInteractivePrintsHintAndExitsZero(t *testing.T) {
 	hint := errBuf.String()
 	if !strings.Contains(hint, "stirrup harness") || !strings.Contains(hint, "USAGE") {
 		t.Errorf("expected grouped hint on stderr, got: %q", hint)
+	}
+	// A non-*os.File destination must never receive ANSI: deciding colour
+	// off the same writer is the writer-consistency fix this asserts.
+	if strings.Contains(hint, "\x1b[") {
+		t.Errorf("hint written to a non-TTY buffer must not contain ANSI escapes, got: %q", hint)
 	}
 	if stdout != "" {
 		t.Errorf("grouped hint must go to stderr, not stdout; stdout = %q", stdout)

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -5398,3 +5398,140 @@ func TestRunHarness_OutputFlagRejectsInvalidValueBeforeOutputRunconfig(t *testin
 		t.Errorf("--output-runconfig=- should not have written to stdout when --output is invalid, got: %q", stdout)
 	}
 }
+
+// TestPrintHarnessUsageHint_ColorEmitsAnsi pins that the grouped hint
+// uses ANSI for headings + dim example values when colour is enabled.
+// Mirrors TestTraceShow_AlwaysEmitsAnsi: the renderer takes an explicit
+// color bool so the test pins the formatting path without a PTY.
+func TestPrintHarnessUsageHint_ColorEmitsAnsi(t *testing.T) {
+	var buf bytes.Buffer
+	printHarnessUsageHint(&buf, true)
+	out := buf.String()
+	if !strings.Contains(out, "\x1b[") {
+		t.Errorf("colour-enabled hint must contain ANSI escapes\n--- output ---\n%s", out)
+	}
+	if !strings.Contains(out, ansiBold) {
+		t.Errorf("colour-enabled hint must bold its headings\n--- output ---\n%s", out)
+	}
+	for _, want := range []string{"USAGE", "REQUIRED", "RUN SHAPE", "PROVIDER", "CONFIGURATION", "EXAMPLES", "--prompt", "--mode"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("hint missing group/flag %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintHarnessUsageHint_PlainStripsAnsi pins the plain path: with
+// colour disabled (non-TTY, NO_COLOR, or a piped 2>&1 | cat) the hint
+// carries no ANSI escapes but keeps the same grouped headings.
+func TestPrintHarnessUsageHint_PlainStripsAnsi(t *testing.T) {
+	var buf bytes.Buffer
+	printHarnessUsageHint(&buf, false)
+	out := buf.String()
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("colour-disabled hint must not contain ANSI escapes\n--- output ---\n%s", out)
+	}
+	for _, want := range []string{"USAGE", "REQUIRED", "RUN SHAPE", "PROVIDER", "CONFIGURATION", "EXAMPLES"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plain hint missing group %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// TestResolvePromptForRun_InteractiveReturnsHintSentinel pins the TTY
+// branch of the prompt-required gate (issue #249): when stderr is
+// interactive and no source supplied a prompt, resolvePromptForRun
+// returns errPromptHintRequested so runHarness can show the grouped hint
+// and exit 0. The interactive decision is injected via the
+// stderrIsInteractive seam rather than a real PTY.
+func TestResolvePromptForRun_InteractiveReturnsHintSentinel(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return true }
+	defer func() { stderrIsInteractive = orig }()
+
+	cmd := newTestHarnessCommand()
+	cfg := &types.RunConfig{}
+	err := resolvePromptForRun(cmd, cfg)
+	if !errors.Is(err, errPromptHintRequested) {
+		t.Fatalf("resolvePromptForRun on a TTY = %v, want errPromptHintRequested", err)
+	}
+}
+
+// TestResolvePromptForRun_NonInteractiveReturnsOpaqueError pins the
+// non-TTY branch: scripted callers keep the verbatim "prompt is
+// required" error and a non-zero exit so log aggregators are not
+// flooded with the multi-line hint.
+func TestResolvePromptForRun_NonInteractiveReturnsOpaqueError(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return false }
+	defer func() { stderrIsInteractive = orig }()
+
+	cmd := newTestHarnessCommand()
+	cfg := &types.RunConfig{}
+	err := resolvePromptForRun(cmd, cfg)
+	if err == nil {
+		t.Fatal("resolvePromptForRun without a prompt = nil, want the prompt-required error")
+	}
+	if errors.Is(err, errPromptHintRequested) {
+		t.Fatalf("non-TTY caller got the interactive hint sentinel: %v", err)
+	}
+	if !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("error = %q, want the opaque prompt-required message", err.Error())
+	}
+}
+
+// TestRunHarness_BareInteractivePrintsHintAndExitsZero drives the full
+// runHarness path on a TTY with no prompt: it must print the grouped
+// hint to the command's stderr and return nil (exit 0). The
+// stderrIsInteractive seam forces the TTY branch; cmd.SetErr captures
+// the hint so the assertion does not depend on a real terminal.
+func TestRunHarness_BareInteractivePrintsHintAndExitsZero(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return true }
+	defer func() { stderrIsInteractive = orig }()
+	// Force colour off so the captured text is plain and stable
+	// regardless of the test host's NO_COLOR / TTY state — the colour
+	// branch is pinned separately by TestPrintHarnessUsageHint_*.
+	t.Setenv("NO_COLOR", "1")
+
+	cmd := newTestHarnessCommand()
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+
+	getOut := captureStdout(t)
+	err := runHarness(cmd, nil)
+	stdout := getOut()
+	if err != nil {
+		t.Fatalf("runHarness on a TTY with no prompt = %v, want nil (exit 0)", err)
+	}
+	hint := errBuf.String()
+	if !strings.Contains(hint, "stirrup harness") || !strings.Contains(hint, "USAGE") {
+		t.Errorf("expected grouped hint on stderr, got: %q", hint)
+	}
+	if stdout != "" {
+		t.Errorf("grouped hint must go to stderr, not stdout; stdout = %q", stdout)
+	}
+}
+
+// TestRunHarness_BareNonInteractiveKeepsError pins the scripted path
+// end-to-end: with a non-TTY stderr and no prompt, runHarness returns
+// the opaque prompt-required error (non-zero exit) and prints no hint.
+func TestRunHarness_BareNonInteractiveKeepsError(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return false }
+	defer func() { stderrIsInteractive = orig }()
+
+	cmd := newTestHarnessCommand()
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+
+	err := runHarness(cmd, nil)
+	if err == nil {
+		t.Fatal("runHarness with no prompt on a non-TTY = nil, want the prompt-required error")
+	}
+	if !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("error = %q, want the opaque prompt-required message", err.Error())
+	}
+	if strings.Contains(errBuf.String(), "USAGE") {
+		t.Errorf("non-TTY path must not print the grouped hint, got: %q", errBuf.String())
+	}
+}

--- a/harness/cmd/stirrup/cmd/job_test.go
+++ b/harness/cmd/stirrup/cmd/job_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRunJob_MissingControlPlaneAddrIsPlain pins issue #249's job
+// contract: the "CONTROL_PLANE_ADDR environment variable is required"
+// error stays plain text with no ANSI escapes. Log aggregators ingest
+// the job's stderr verbatim, so a future help-system refactor that
+// reached for colour here would corrupt every captured line. There is
+// deliberately no behaviour change for the job entry point — this test
+// is the regression guard.
+func TestRunJob_MissingControlPlaneAddrIsPlain(t *testing.T) {
+	// Unset rather than save/restore: t.Setenv("", "") cannot clear a
+	// var, and the test must observe the empty-addr branch. t.Setenv
+	// registers cleanup so a value set by the surrounding environment is
+	// restored for later tests.
+	t.Setenv("CONTROL_PLANE_ADDR", "")
+
+	err := runJob(jobCmd, nil)
+	if err == nil {
+		t.Fatal("runJob returned nil, want an error when CONTROL_PLANE_ADDR is unset")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "CONTROL_PLANE_ADDR environment variable is required") {
+		t.Errorf("error = %q, want the CONTROL_PLANE_ADDR-required message", msg)
+	}
+	if strings.Contains(msg, "\x1b[") {
+		t.Errorf("job error must not contain ANSI escapes (log aggregators ingest it verbatim): %q", msg)
+	}
+}

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -23,6 +23,19 @@ var rootCmd = &cobra.Command{
 	Short:   "A coding agent harness",
 	Long:    "Stirrup is a coding agent harness with swappable components that can be composed via RunConfig.",
 	Version: version.Full(),
+	// Args is NoArgs so a mistyped subcommand (`stirrup harnes`) still
+	// errors via Cobra's unknown-command path rather than silently
+	// printing the orientation hint. A bare `stirrup` (no args, no
+	// --help / --version, which Cobra intercepts before Run) lands here.
+	Args: cobra.NoArgs,
+	// Run (not RunE) so a bare invocation prints the short two-subcommand
+	// orientation hint to stdout and exits 0. Returning an error would
+	// make Cobra append its full usage block — the opposite of the terse
+	// hint issue #249 asks for. --help still reaches Cobra's full help
+	// because the flag is handled before Run fires.
+	Run: func(cmd *cobra.Command, _ []string) {
+		printRootUsageHint(cmd.OutOrStdout())
+	},
 }
 
 // Execute runs the root command. Called from main().

--- a/harness/cmd/stirrup/cmd/root_test.go
+++ b/harness/cmd/stirrup/cmd/root_test.go
@@ -47,6 +47,58 @@ func TestRootCmd_Version(t *testing.T) {
 	}
 }
 
+// TestRootCmd_BareInvocationPrintsHint pins issue #249's root behaviour:
+// a bare `stirrup` (no subcommand, no --help / --version) prints the
+// short two-subcommand orientation hint to stdout and exits 0 — not
+// Cobra's full usage block. The hint is plain text: no ANSI so it reads
+// identically in a terminal, a pager, or a captured file.
+func TestRootCmd_BareInvocationPrintsHint(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetArgs([]string{})
+	// SetArgs does not clear flag values parsed by a prior Execute() on
+	// the shared package-level rootCmd. TestRootCmd_Version leaves the
+	// auto-registered --version bool marked Changed=true, and Cobra
+	// short-circuits to the version output before Run fires. Reset it so
+	// this test observes the bare-invocation Run path regardless of
+	// execution order.
+	if vf := rootCmd.Flags().Lookup("version"); vf != nil {
+		_ = vf.Value.Set("false")
+		vf.Changed = false
+	}
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetArgs(nil)
+	}()
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() returned error: %v (a bare invocation must exit 0)", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"stirrup — a coding agent harness",
+		"stirrup harness --prompt",
+		"stirrup job",
+		"stirrup harness --help",
+		"stirrup --version",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bare-stirrup hint missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+	// The hint must be plain text — no boxes, no headings beyond the
+	// title, and crucially no ANSI escapes.
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("bare-stirrup hint must not contain ANSI escapes\n--- output ---\n%s", out)
+	}
+	// A regression that printed Cobra's full help instead of the hint
+	// would surface its "Available Commands:" / "Flags:" sections.
+	if strings.Contains(out, "Available Commands:") || strings.Contains(out, "Use \"stirrup [command] --help\"") {
+		t.Errorf("bare-stirrup printed Cobra's full help, want the terse hint\n--- output ---\n%s", out)
+	}
+}
+
 // fakeExporter is a workspaceexport.Exporter that returns a fixed
 // error. Used by the exportWorkspace tests to exercise the required /
 // optional error-handling branches without standing up a real GCS

--- a/harness/cmd/stirrup/cmd/runconfig.go
+++ b/harness/cmd/stirrup/cmd/runconfig.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"io"
 	"os"
 
@@ -76,6 +77,17 @@ func runRunConfigWithIO(cmd *cobra.Command, args []string, stdin io.Reader, stdo
 		Resolve:    resolve,
 	})
 	if err != nil {
+		// The interactive usage-hint sentinel is a harness-only affordance
+		// (issue #249): a bare `stirrup harness` on a TTY gets the grouped
+		// hint. run-config has no such hint, so reaching here with the
+		// sentinel — `stirrup run-config --validate` on a TTY with no
+		// prompt — must surface the plain, actionable prompt-required
+		// error instead of leaking the sentinel's internal string to
+		// cobra (which would print "Error: stirrup: interactive prompt
+		// hint requested" and exit non-zero).
+		if errors.Is(err, errPromptHintRequested) {
+			return errPromptRequired
+		}
 		return err
 	}
 

--- a/harness/cmd/stirrup/cmd/runconfig_test.go
+++ b/harness/cmd/stirrup/cmd/runconfig_test.go
@@ -136,6 +136,36 @@ func TestRunRunConfig_ValidateAcceptsValidConfig(t *testing.T) {
 	}
 }
 
+// TestRunRunConfig_ValidateInteractiveNoPromptShowsPlainError pins the
+// fix for the run-config sentinel leak (issue #249 review): the
+// interactive harness usage-hint must NOT fire for run-config. When
+// `stirrup run-config --validate` reaches the prompt-required gate on a
+// TTY with no prompt, resolvePromptForRun returns errPromptHintRequested
+// — runRunConfigWithIO must substitute the actionable plain
+// "prompt is required: ..." error rather than leaking the sentinel's
+// internal "interactive prompt hint requested" string to the operator.
+func TestRunRunConfig_ValidateInteractiveNoPromptShowsPlainError(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return true }
+	defer func() { stderrIsInteractive = orig }()
+	t.Setenv("STIRRUP_PROMPT", "")
+
+	_, err := runRunConfigForTest(t, []string{
+		"--validate",
+		"--mode", "execution",
+	}, "")
+	if err == nil {
+		t.Fatal("run-config --validate with no prompt should fail")
+	}
+	if !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("error should be the actionable prompt-required message, got: %v", err)
+	}
+	// The sentinel's internal string must never reach the operator.
+	if strings.Contains(err.Error(), "interactive prompt hint requested") {
+		t.Errorf("run-config leaked the harness usage-hint sentinel: %v", err)
+	}
+}
+
 // TestRunRunConfig_CompactProducesSingleLine pins acceptance of the
 // --compact flag: the body is a single JSON line (no indentation),
 // still terminated by a newline so shell pipelines see a clean EOF.

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -484,11 +485,40 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 	})
 }
 
+// errPromptHintRequested is a sentinel returned by resolvePromptForRun
+// when a bare `stirrup harness` reaches the prompt-required gate on an
+// interactive terminal (issue #249). It is not an operator-facing error
+// — runHarness recognises it, prints the grouped usage hint to stderr,
+// and exits 0. Scripted (non-TTY) invocations never see it: they get the
+// opaque errPromptRequired message and a non-zero exit so log
+// aggregators are not flooded with a multi-line template.
+var errPromptHintRequested = errors.New("stirrup: interactive prompt hint requested")
+
+// errPromptRequired is the opaque "no prompt anywhere" error surfaced to
+// scripted (non-TTY) callers. Kept as a sentinel so the message lives in
+// one place; the verbatim text matches the pre-#249 paths so
+// harness_test.go's existing fixtures continue to match.
+var errPromptRequired = errors.New("prompt is required: pass via --prompt flag, as a positional argument, --prompt-file, STIRRUP_PROMPT env var, or the prompt field in --config")
+
+// stderrIsInteractive reports whether the prompt-required gate should
+// show the grouped hint instead of the opaque error. It is a package
+// variable, not a direct os.Stderr probe, so tests can pin both branches
+// without allocating a PTY — mirroring how the trace tests inject a
+// colorMode rather than a real terminal. Production points it at
+// os.Stderr's fd.
+var stderrIsInteractive = func() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
 // resolvePromptForRun fills cfg.Prompt from the lower-precedence sources
 // (--prompt-file, STIRRUP_PROMPT) when the higher-precedence ones
-// (--prompt, positional, base RunConfig.prompt) left it empty. Returns
-// the "prompt is required" error verbatim from the pre-refactor paths
-// so harness_test.go's existing fixtures continue to match the message.
+// (--prompt, positional, base RunConfig.prompt) left it empty. When no
+// source supplies a prompt the function distinguishes two callers:
+// reaching the gate on an interactive terminal returns
+// errPromptHintRequested (runHarness then prints the grouped hint and
+// exits 0); a non-TTY caller gets errPromptRequired verbatim so
+// harness_test.go's existing fixtures and scripted automation continue
+// to match the pre-#249 message.
 func resolvePromptForRun(cmd *cobra.Command, cfg *types.RunConfig) error {
 	if cfg.Prompt != "" {
 		return nil
@@ -506,7 +536,10 @@ func resolvePromptForRun(cmd *cobra.Command, cfg *types.RunConfig) error {
 		}
 	}
 	if cfg.Prompt == "" {
-		return fmt.Errorf("prompt is required: pass via --prompt flag, as a positional argument, --prompt-file, STIRRUP_PROMPT env var, or the prompt field in --config")
+		if stderrIsInteractive() {
+			return errPromptHintRequested
+		}
+		return errPromptRequired
 	}
 	return nil
 }

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -391,6 +391,15 @@ func TestBuildRunConfig_ResolveBaseSkipsModeDefaults(t *testing.T) {
 // builder. The message text matches harness_test.go's existing prompt
 // fixtures so the error string is part of the API contract.
 func TestBuildRunConfig_ResolveAllRequiresPrompt(t *testing.T) {
+	// Pin the interactive seam to false: resolvePromptForRun returns the
+	// errPromptHintRequested sentinel (not the documented message) when
+	// stderr is a TTY (issue #249). Without this override the test passes
+	// in CI but fails on a developer's interactive terminal, which would
+	// receive the sentinel rather than the "prompt is required" string.
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return false }
+	defer func() { stderrIsInteractive = orig }()
+
 	cmd := newTestHarnessCommand()
 	if err := cmd.ParseFlags([]string{"--mode", "execution"}); err != nil {
 		t.Fatalf("ParseFlags: %v", err)


### PR DESCRIPTION
## Summary

Tunes the three CLI entry points to their intended audiences (issue #249), plus a docs rider pinning the auto-stdin contract (issue #252).

- **`stirrup`** (bare, no subcommand) — prints a short, plain-text two-subcommand usage hint to stdout and exits 0. No ANSI; suitable for piping/logging. `--help`/`--version` still reach Cobra.
- **`stirrup harness`** (no prompt, interactive stderr) — prints a grouped, formatted usage example (USAGE / REQUIRED / RUN SHAPE / PROVIDER / CONFIGURATION / EXAMPLES) to stderr and exits 0. ANSI only when stderr is a TTY and `NO_COLOR` is unset; plain text otherwise. When stderr is **not** a TTY (scripted use), the existing opaque `prompt is required` error and non-zero exit are preserved unchanged.
- **`stirrup job`** (no `CONTROL_PLANE_ADDR`) — behaviour unchanged (plain text for log aggregators), now pinned by a test asserting no ANSI escapes.

The grouped help is a hand-authored static template (not generated from Cobra's flag list) and reuses the existing `shouldColor` / `colorize` / ANSI infrastructure from `trace.go`/`trace_show.go` rather than introducing a parallel formatter. The examples reference the landed #240 features (`run-config` pipeline, `--config -`, `--output-runconfig`).

## #252 (auto-stdin) — resolved by decision

Per maintainer decision, the narrower auto-stdin trigger introduced in PR #251 (named-pipe + regular-file redirects only) is the intended contract; the broader `!IsTerminal(stdin)` rule from the original #240 spec is rejected (it trips `go test`'s inherited char-device stdin, and `stirrup harness < /dev/null` falling through to flag-only construction is acceptable). This PR adds an operator-facing sentence to `docs/configuration.md` making that contract explicit. Issue #252 is closed as a rejected idea; no behaviour change.

## Review

Reviewed by a wave of functionality, code, consistency, spec-compliance, and doc-tone reviewers. Remediated findings: a blocker where the harness usage-hint sentinel leaked through `stirrup run-config --validate` on a TTY (now mapped back to the plain error); the color decision now uses the same writer it writes to; the interactive seam is pinned in tests that assert the prompt-required message; added edge-case tests confirming the hint does not fire when a prompt resolves from `STIRRUP_PROMPT` or a config file; trimmed cosmetic comments.

## Verification

`just build`, `just lint` (0 issues), and `just test` all green. Driven end-to-end: bare `stirrup` (plain hint, exit 0); `stirrup harness` under a PTY (grouped hint, bold headings + grey example values, exit 0; `NO_COLOR=1` strips ANSI); `stirrup harness < /dev/null` (opaque error, exit 1); `stirrup harness 2>&1 | cat` (ANSI-stripped); `stirrup --version`/`--help`/`harness --help`/`job --help` unchanged; `stirrup job` with no `CONTROL_PLANE_ADDR` (plain error, no ANSI, exit 1).

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)
