### PR TITLE
tool: read-only git inspection built-ins for review/toil modes (#29)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,8 +281,8 @@ Twelve built-in tools ship in `harness/internal/tool/builtins/`:
 
 The four `git_*` tools are read-only: they neither mutate the
 workspace nor require approval, so the read-only modes (`planning`,
-`review`, `research`, `toil`) enable them by default and can inspect
-a change set without `run_command`. The executor runs commands
+`review`, `research`, `toil`) enable them by default, enabling
+inspection of a change set without `run_command`. The executor runs commands
 through `sh -c`, so each tool builds its git invocation from a fixed
 verb plus single-quoted arguments and validates any `path` (against
 the workspace root) or `ref` (rejecting shell metacharacters and a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -263,7 +263,7 @@ emits a `code_scan_warning` event and continues.
 
 ## Tools
 
-Eight built-in tools ship in `harness/internal/tool/builtins/`:
+Twelve built-in tools ship in `harness/internal/tool/builtins/`:
 
 - `read_file`
 - `list_directory`
@@ -272,8 +272,25 @@ Eight built-in tools ship in `harness/internal/tool/builtins/`:
 - `edit_file` (registered when any of `edit_file`, `write_file`,
   `search_replace`, or `apply_diff` is in `tools.builtIn`)
 - `run_command`
+- `git_status`
+- `git_changed_files`
+- `git_diff`
+- `git_show`
 - `web_fetch`
 - `spawn_agent`
+
+The four `git_*` tools are read-only: they neither mutate the
+workspace nor require approval, so the read-only modes (`planning`,
+`review`, `research`, `toil`) enable them by default and can inspect
+a change set without `run_command`. The executor runs commands
+through `sh -c`, so each tool builds its git invocation from a fixed
+verb plus single-quoted arguments and validates any `path` (against
+the workspace root) or `ref` (rejecting shell metacharacters and a
+leading `-`) before it reaches the shell. Output is bounded — `git_diff`
+and `git_show` cap on bytes and lines with a truncation sentinel, and
+the status/changed-file lists cap on entry count — so a large worktree
+cannot exhaust model context. A non-git workspace returns a clear
+deterministic error rather than a raw git failure.
 
 `web_fetch` enforces SSRF protection: scheme allowlist (`http`,
 `https`), private-IP/reserved-range blocking (RFC 1918, loopback,
@@ -287,11 +304,15 @@ that text is the fallback every provider can accept and is never
 dropped. Tools that can describe their output as stable fields
 additionally populate an optional typed envelope — `Structured`
 (a `json.RawMessage`) plus a `Kind` discriminator naming the payload's
-shape. The built-in producers emit four shapes: `command_result`
+shape. The built-in producers emit eight shapes: `command_result`
 (`stdout`, `stderr`, `exit_code`, timeout metadata), `search_result`
 (per-match `path`/`line`/`column`/`text`), `find_result`
-(workspace-relative paths), and `file_excerpt` (line window with
-truncation state). Each shape is a concrete Go struct in
+(workspace-relative paths), `file_excerpt` (line window with
+truncation state), `git_status` (current branch plus porcelain
+entries with per-path staged/unstaged status letters), `git_changed_files`
+(name-status letters per path), `git_diff` (bounded unified-diff text
+with a truncation flag), and `git_show` (bounded revision output).
+Each shape is a concrete Go struct in
 `harness/internal/tool/builtins/structured.go`, not a `map[string]any`,
 so the JSON contract is reviewable and stable.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -351,7 +351,7 @@ Tools carry two independent permission flags:
 
 | Tool examples | Flags | `allow-all` | `deny-side-effects` | `ask-upstream` |
 |---|---|---|---|---|
-| `read_file`, `list_directory`, `grep_files`, `find_files` | neither flag | Allow | Allow | Allow |
+| `read_file`, `list_directory`, `grep_files`, `find_files`, `git_status`, `git_changed_files`, `git_diff`, `git_show` | neither flag | Allow | Allow | Allow |
 | `web_fetch`, `spawn_agent` | `RequiresApproval` only | Allow | Allow | Prompt |
 | `run_command` | `WorkspaceMutating` + `RequiresApproval` | Allow | Deny | Prompt |
 | `edit_file`, `write_file` | `WorkspaceMutating` + `RequiresApproval` | Allow | Deny | Prompt |

--- a/harness/internal/prompt/systemprompts/planning.md
+++ b/harness/internal/prompt/systemprompts/planning.md
@@ -2,4 +2,4 @@ You are a planning agent with read-only access to the workspace.
 Analyze the codebase and produce a step-by-step implementation plan.
 Structure your output as a numbered list of concrete steps, each referencing the specific files and functions affected.
 Include a risk or edge-case note for any non-obvious steps.
-You can read files and search the codebase. Do not modify any files.
+You can read files and search the codebase. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine existing or in-progress changes when planning around them; they return bounded, structured output without modifying the workspace. Do not modify any files.

--- a/harness/internal/prompt/systemprompts/research.md
+++ b/harness/internal/prompt/systemprompts/research.md
@@ -1,4 +1,4 @@
 You are a research agent with read-only access to the workspace.
 Explore the codebase, read relevant documentation, and synthesize your findings into a clear summary.
 Cite specific file paths and line numbers when referencing code. Conclude with actionable recommendations.
-You can read files, search the codebase, and fetch URLs. Do not modify any files.
+You can read files, search the codebase, and fetch URLs. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine the change history or working-tree state when it informs the research; they return bounded, structured output without modifying the workspace. Do not modify any files.

--- a/harness/internal/prompt/systemprompts/review.md
+++ b/harness/internal/prompt/systemprompts/review.md
@@ -1,4 +1,4 @@
 You are a code review agent with read-only access to the workspace.
 Review the provided changes for: correctness, edge cases, security issues, style violations, and missed test coverage.
 Structure your output with a brief summary, then a list of findings categorized by severity (critical / major / minor / nit).
-You can read files and search the codebase. Do not modify any files.
+You can read files and search the codebase. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine the change set under review; they return bounded, structured output without modifying the workspace. Do not modify any files.

--- a/harness/internal/prompt/systemprompts/toil.md
+++ b/harness/internal/prompt/systemprompts/toil.md
@@ -1,3 +1,3 @@
 You are a monitoring agent with read-only access to the workspace.
 Check for the specified trigger condition. If triggered, prepare a concise briefing for the engineer describing what you found and the recommended action.
-You can read files, search the codebase, and fetch URLs. Do not modify any files.
+You can read files, search the codebase, and fetch URLs. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine recent changes when the trigger condition concerns the working tree; they return bounded, structured output without modifying the workspace. Do not modify any files.

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -622,6 +622,10 @@ func TestRegisterBuiltins(t *testing.T) {
 		"grep_files",
 		"find_files",
 		"run_command",
+		"git_status",
+		"git_changed_files",
+		"git_diff",
+		"git_show",
 		"web_fetch",
 	}
 
@@ -802,6 +806,10 @@ func TestBuiltinInputExamples_MatchDescription(t *testing.T) {
 		GrepFilesTool(mock),
 		FindFilesTool(mock),
 		RunCommandTool(mock),
+		GitStatusTool(mock),
+		GitChangedFilesTool(mock),
+		GitDiffTool(mock),
+		GitShowTool(mock),
 		WebFetchTool(),
 		SpawnAgentTool(nil),
 	}

--- a/harness/internal/tool/builtins/git.go
+++ b/harness/internal/tool/builtins/git.go
@@ -25,34 +25,19 @@ const (
 	gitTimeout             = 30 * time.Second
 )
 
-// Git tools run through the injected executor.Executor, whose Exec runs the
-// command via `sh -c <string>` (see executor/local.go:Exec and
-// executor/container.go:Exec — both wrap in `sh -c`). A naive
-// `"git " + path` would therefore be a shell-injection vector: a path or ref
-// such as `foo; rm -rf /` would execute. Two defences are applied together:
-//
-//  1. Every argv element is single-quoted with shellQuote before being joined
-//     into the command string, so shell metacharacters in a value are treated
-//     as literal text by sh, never as syntax.
-//  2. Path and ref arguments are additionally validated up front
-//     (validateGitPath / validateGitRef): paths are resolved against the
-//     workspace root and rejected if they escape it; refs are rejected if they
-//     contain shell metacharacters or begin with `-` (option injection, e.g.
-//     `--upload-pack=...`). The `--` end-of-options separator is also used so a
-//     validated value can never be reinterpreted as a git flag.
-//
-// Validation alone would be sufficient given shellQuote, but rejecting hostile
-// input early gives a deterministic, legible error instead of a confusing git
-// failure, and keeps the neutralisation auditable.
-
 // gitMetacharacters are shell-significant runes rejected outright in ref
-// arguments. shellQuote already neutralises them, but a ref legitimately never
-// contains these, so rejecting up front yields a clear error and a smaller
-// trusted surface.
+// arguments. shellQuote already neutralises them (see runGit), but a ref
+// legitimately never contains these, so rejecting up front yields a clear
+// error and a smaller trusted surface. `:` is deliberately absent: it is valid
+// treeish syntax (`HEAD:path/to/file`), and the path portion after the first
+// `:` is validated separately (see git_show) so it cannot smuggle traversal.
 const gitMetacharacters = "\x00\n\r;&|`$()<>!*?[]{}\"'\\ \t"
 
-// validateGitRef rejects refs that could inject shell syntax or git options.
-// An empty ref is rejected by the caller before this is reached.
+// validateGitRef rejects refs that could inject git options. A leading `-`
+// would be read as a flag (e.g. `--upload-pack=...`); shellQuote already stops
+// metacharacters from reaching sh as syntax, but a clean ref never carries
+// them, so rejecting early gives a deterministic, legible error. An empty ref
+// is rejected by the caller before this is reached.
 func validateGitRef(ref string) error {
 	if strings.HasPrefix(ref, "-") {
 		return fmt.Errorf("ref %q must not begin with '-' (option injection)", ref)
@@ -63,13 +48,34 @@ func validateGitRef(ref string) error {
 	return nil
 }
 
+// validateColonRefPath enforces workspace containment on the path portion of a
+// treeish ref of the form `<rev>:<path>` (e.g. `HEAD:.env`). git itself blocks
+// OS-level traversal, but a colon-ref with no separate `path` field would
+// otherwise skip the validateGitPath layer entirely — so containment must not
+// depend on which API field the path arrives in. Refs without a `:` are a
+// no-op here. The leading `:./` and `:N:` (stage) prefixes git accepts are not
+// supported; such a path simply fails validateGitPath, which is acceptable for
+// a read-only inspection tool.
+func validateColonRefPath(exec executor.Executor, ref string) error {
+	colon := strings.IndexByte(ref, ':')
+	if colon < 0 {
+		return nil
+	}
+	pathPart := ref[colon+1:]
+	if pathPart == "" {
+		return nil
+	}
+	if _, err := validateGitPath(exec, pathPart); err != nil {
+		return fmt.Errorf("ref path component: %w", err)
+	}
+	return nil
+}
+
 // validateGitPath resolves a workspace-relative path against the workspace
-// root, rejecting traversal (`..`) and absolute paths that escape it, then
-// returns the path to hand to git. The returned value is the original
-// workspace-relative path (git pathspecs are interpreted relative to the
-// working directory, which is the workspace root); ResolvePath is used purely
-// to enforce containment. A path beginning with `-` is rejected to prevent
-// option injection even though `--` is also used at the call site.
+// root, rejecting traversal (`..`) and absolute paths that escape it, so a
+// path argument cannot reach files outside the workspace. A leading `-` is
+// rejected to prevent option injection even though `--` also separates options
+// at the call site.
 func validateGitPath(exec executor.Executor, path string) (string, error) {
 	if strings.HasPrefix(path, "-") {
 		return "", fmt.Errorf("path %q must not begin with '-' (option injection)", path)
@@ -77,12 +83,20 @@ func validateGitPath(exec executor.Executor, path string) (string, error) {
 	if _, err := exec.ResolvePath(path); err != nil {
 		return "", fmt.Errorf("invalid path: %w", err)
 	}
+	// Hand git the original relative form, not the resolved absolute path:
+	// git interprets a pathspec relative to the working directory (the
+	// workspace root) and re-enforces containment itself, so re-resolving here
+	// would only risk a TOCTOU mismatch between the checked and used value for
+	// no gain. ResolvePath above is used purely as the containment gate.
 	return path, nil
 }
 
 // runGit builds a `sh -c`-safe command from a fixed git verb plus already-
-// validated arguments and executes it. Every element is shellQuote'd so no
-// value can break out of its argument position. ensureGitRepo must be called
+// validated arguments and executes it. The injected executor runs every
+// command via `sh -c <string>` (executor/local.go:Exec, container.go:Exec), so
+// an unquoted `"git " + path` would be a shell-injection vector. Every element
+// is single-quoted with shellQuote so a value such as `foo; rm -rf /` is
+// treated as literal text by sh, never as syntax. ensureGitRepo must be called
 // before any data-returning git invocation so a non-git workspace yields a
 // clear error rather than a raw git failure.
 func runGit(ctx context.Context, exec executor.Executor, args ...string) (*executor.ExecResult, error) {
@@ -109,11 +123,15 @@ func ensureGitRepo(ctx context.Context, exec executor.Executor) error {
 	return nil
 }
 
-// currentBranch returns the current branch name, or "HEAD (detached)" when the
-// repository is in detached-HEAD state, or "(unborn)" before the first commit.
+// currentBranch reports the branch for git_status. A non-zero exit (no commit
+// yet) is reported as "(unborn)"; an executor error (e.g. context cancel) is
+// distinct and reported as "(unknown)" so the two are not conflated.
 func currentBranch(ctx context.Context, exec executor.Executor) string {
 	res, err := runGit(ctx, exec, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil || res.ExitCode != 0 {
+	if err != nil {
+		return "(unknown)"
+	}
+	if res.ExitCode != 0 {
 		return "(unborn)"
 	}
 	name := strings.TrimSpace(res.Stdout)
@@ -125,8 +143,6 @@ func currentBranch(ctx context.Context, exec executor.Executor) string {
 	}
 	return name
 }
-
-// --- git_status ---
 
 var gitStatusSchema = json.RawMessage(`{
 	"type": "object",
@@ -140,7 +156,7 @@ func GitStatusTool(exec executor.Executor) *tool.Tool {
 		Name: "git_status",
 		Description: "Report the git working-tree state (porcelain status) as structured entries with per-path staged/unstaged status letters and the current branch. " +
 			"Use this in read-only review or monitoring runs to see what changed without enabling run_command. " +
-			"Output is bounded; a large change set is capped and flagged truncated. " +
+			"Output is bounded; a large change set is capped at an entry limit and flagged as truncated. " +
 			"Example: {}",
 		InputExamples:     []json.RawMessage{json.RawMessage(`{}`)},
 		InputSchema:       gitStatusSchema,
@@ -172,8 +188,6 @@ func GitStatusTool(exec executor.Executor) *tool.Tool {
 	}
 }
 
-// --- git_changed_files ---
-
 var gitChangedFilesSchema = json.RawMessage(`{
 	"type": "object",
 	"properties": {
@@ -192,7 +206,7 @@ func GitChangedFilesTool(exec executor.Executor) *tool.Tool {
 		Name: "git_changed_files",
 		Description: "List changed file paths with their git name-status letter (A/M/D/R/C/T). " +
 			"Use this to enumerate which files differ before reading specific diffs; set staged to inspect the index instead of the working tree. " +
-			"Output is bounded; a large change set is capped and flagged truncated. " +
+			"Output is bounded; a large change set is capped at an entry limit and flagged as truncated. " +
 			"Example: {\"staged\": false}",
 		InputExamples:     []json.RawMessage{json.RawMessage(`{"staged": false}`)},
 		InputSchema:       gitChangedFilesSchema,
@@ -234,8 +248,6 @@ func GitChangedFilesTool(exec executor.Executor) *tool.Tool {
 	}
 }
 
-// --- git_diff ---
-
 var gitDiffSchema = json.RawMessage(`{
 	"type": "object",
 	"properties": {
@@ -257,7 +269,7 @@ func GitDiffTool(exec executor.Executor) *tool.Tool {
 		Name: "git_diff",
 		Description: "Produce a unified diff of the working tree (or the staged changes when staged is true), optionally restricted to one path. " +
 			"Use this to review the exact line-level changes in a read-only run without enabling run_command. " +
-			"Output is bounded by byte and line caps; a large diff is truncated with a sentinel. " +
+			"Output is bounded by byte and line caps; a large diff is truncated and flagged as truncated. " +
 			"Example: {\"path\": \"harness/internal/tool/builtins/git.go\", \"staged\": false}",
 		InputExamples:     []json.RawMessage{json.RawMessage(`{"path": "harness/internal/tool/builtins/git.go", "staged": false}`)},
 		InputSchema:       gitDiffSchema,
@@ -308,8 +320,6 @@ func GitDiffTool(exec executor.Executor) *tool.Tool {
 	}
 }
 
-// --- git_show ---
-
 var gitShowSchema = json.RawMessage(`{
 	"type": "object",
 	"properties": {
@@ -332,7 +342,7 @@ func GitShowTool(exec executor.Executor) *tool.Tool {
 		Name: "git_show",
 		Description: "Show a specific git revision (commit metadata and diff, or a file's content at that revision when path is given). " +
 			"Use this to inspect a commit or a historical file version in a read-only run; ref must name a revision and must not begin with '-'. " +
-			"Output is bounded by byte and line caps; large output is truncated with a sentinel. " +
+			"Output is bounded by byte and line caps; large output is truncated and flagged as truncated. " +
 			"Example: {\"ref\": \"HEAD\", \"path\": \"README.md\"}",
 		InputExamples:     []json.RawMessage{json.RawMessage(`{"ref": "HEAD", "path": "README.md"}`)},
 		InputSchema:       gitShowSchema,
@@ -350,6 +360,9 @@ func GitShowTool(exec executor.Executor) *tool.Tool {
 				return tool.StructuredResult{}, fmt.Errorf("ref is required")
 			}
 			if err := validateGitRef(params.Ref); err != nil {
+				return tool.StructuredResult{}, err
+			}
+			if err := validateColonRefPath(exec, params.Ref); err != nil {
 				return tool.StructuredResult{}, err
 			}
 			if err := ensureGitRepo(ctx, exec); err != nil {
@@ -383,8 +396,6 @@ func GitShowTool(exec executor.Executor) *tool.Tool {
 		},
 	}
 }
-
-// --- shared helpers ---
 
 // gitErrText returns the most useful error text from a non-zero git result,
 // preferring stderr.
@@ -499,10 +510,29 @@ func splitNUL(s string) []string {
 // boundDiff caps diff/show output on both byte and line counts and appends a
 // sentinel when either bound trims the content, so a huge worktree cannot blow
 // up model context. Mirrors list_directory's visible-sentinel truncation.
+//
+// The executor already buffers the full command output before returning (the
+// local executor caps it post-hoc at 1 MB; see executor/local.go:Exec), so
+// boundDiff is the model-context bound, not a memory bound — a pathological
+// single-file diff is bounded only after the executor has it in memory.
+// Streaming that bound into the local executor would change run_command's
+// output path and is tracked as a separate executor-hardening follow-up.
+//
+// The byte cap trims back to the last newline rather than slicing at an
+// arbitrary offset: a raw byte slice can land mid-rune (json.Marshal would
+// then emit a silent U+FFFD) and mid-line (producing a ragged, invalid unified
+// diff). Trimming to the last \n keeps the output both rune-safe and
+// line-complete. When the capped prefix contains no newline at all the result
+// is empty, which the sentinel still makes visible.
 func boundDiff(s string) (string, bool) {
 	truncated := false
 	if len(s) > gitDiffMaxBytes {
 		s = s[:gitDiffMaxBytes]
+		if nl := strings.LastIndexByte(s, '\n'); nl >= 0 {
+			s = s[:nl+1]
+		} else {
+			s = ""
+		}
 		truncated = true
 	}
 	lines := strings.Split(s, "\n")

--- a/harness/internal/tool/builtins/git.go
+++ b/harness/internal/tool/builtins/git.go
@@ -1,0 +1,561 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+)
+
+// Bounds for the read-only VCS tools. Diff and show output is the largest risk
+// to model context, so it is capped on both bytes and lines; the status/changed
+// lists are capped on entry count. Mirrors list_directory's truncation pattern:
+// the slice is cut at the cap and a sentinel makes the truncation visible to
+// the model rather than silently dropping data.
+const (
+	gitDiffMaxBytes        = 256 * 1024 // 256 KB
+	gitDiffMaxLines        = 4000
+	gitStatusMaxEntries    = 2000
+	gitChangedFilesMaxFile = 2000
+	gitDiffTruncSentinel   = "\n[diff truncated]"
+	gitTimeout             = 30 * time.Second
+)
+
+// Git tools run through the injected executor.Executor, whose Exec runs the
+// command via `sh -c <string>` (see executor/local.go:Exec and
+// executor/container.go:Exec — both wrap in `sh -c`). A naive
+// `"git " + path` would therefore be a shell-injection vector: a path or ref
+// such as `foo; rm -rf /` would execute. Two defences are applied together:
+//
+//  1. Every argv element is single-quoted with shellQuote before being joined
+//     into the command string, so shell metacharacters in a value are treated
+//     as literal text by sh, never as syntax.
+//  2. Path and ref arguments are additionally validated up front
+//     (validateGitPath / validateGitRef): paths are resolved against the
+//     workspace root and rejected if they escape it; refs are rejected if they
+//     contain shell metacharacters or begin with `-` (option injection, e.g.
+//     `--upload-pack=...`). The `--` end-of-options separator is also used so a
+//     validated value can never be reinterpreted as a git flag.
+//
+// Validation alone would be sufficient given shellQuote, but rejecting hostile
+// input early gives a deterministic, legible error instead of a confusing git
+// failure, and keeps the neutralisation auditable.
+
+// gitMetacharacters are shell-significant runes rejected outright in ref
+// arguments. shellQuote already neutralises them, but a ref legitimately never
+// contains these, so rejecting up front yields a clear error and a smaller
+// trusted surface.
+const gitMetacharacters = "\x00\n\r;&|`$()<>!*?[]{}\"'\\ \t"
+
+// validateGitRef rejects refs that could inject shell syntax or git options.
+// An empty ref is rejected by the caller before this is reached.
+func validateGitRef(ref string) error {
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("ref %q must not begin with '-' (option injection)", ref)
+	}
+	if strings.ContainsAny(ref, gitMetacharacters) {
+		return fmt.Errorf("ref %q contains an unsupported character", ref)
+	}
+	return nil
+}
+
+// validateGitPath resolves a workspace-relative path against the workspace
+// root, rejecting traversal (`..`) and absolute paths that escape it, then
+// returns the path to hand to git. The returned value is the original
+// workspace-relative path (git pathspecs are interpreted relative to the
+// working directory, which is the workspace root); ResolvePath is used purely
+// to enforce containment. A path beginning with `-` is rejected to prevent
+// option injection even though `--` is also used at the call site.
+func validateGitPath(exec executor.Executor, path string) (string, error) {
+	if strings.HasPrefix(path, "-") {
+		return "", fmt.Errorf("path %q must not begin with '-' (option injection)", path)
+	}
+	if _, err := exec.ResolvePath(path); err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+	return path, nil
+}
+
+// runGit builds a `sh -c`-safe command from a fixed git verb plus already-
+// validated arguments and executes it. Every element is shellQuote'd so no
+// value can break out of its argument position. ensureGitRepo must be called
+// before any data-returning git invocation so a non-git workspace yields a
+// clear error rather than a raw git failure.
+func runGit(ctx context.Context, exec executor.Executor, args ...string) (*executor.ExecResult, error) {
+	quoted := make([]string, 0, len(args)+1)
+	quoted = append(quoted, "git")
+	for _, a := range args {
+		quoted = append(quoted, shellQuote(a))
+	}
+	return exec.Exec(ctx, strings.Join(quoted, " "), gitTimeout)
+}
+
+// ensureGitRepo returns a clear, deterministic error when the workspace is not
+// inside a git work tree, so callers surface that instead of git's own message
+// (which differs across versions). It also catches the case where git is not
+// installed.
+func ensureGitRepo(ctx context.Context, exec executor.Executor) error {
+	res, err := runGit(ctx, exec, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		return fmt.Errorf("git is not available: %w", err)
+	}
+	if res.ExitCode != 0 || strings.TrimSpace(res.Stdout) != "true" {
+		return fmt.Errorf("workspace is not a git repository")
+	}
+	return nil
+}
+
+// currentBranch returns the current branch name, or "HEAD (detached)" when the
+// repository is in detached-HEAD state, or "(unborn)" before the first commit.
+func currentBranch(ctx context.Context, exec executor.Executor) string {
+	res, err := runGit(ctx, exec, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil || res.ExitCode != 0 {
+		return "(unborn)"
+	}
+	name := strings.TrimSpace(res.Stdout)
+	if name == "HEAD" {
+		return "HEAD (detached)"
+	}
+	if name == "" {
+		return "(unborn)"
+	}
+	return name
+}
+
+// --- git_status ---
+
+var gitStatusSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {},
+	"additionalProperties": false
+}`)
+
+// GitStatusTool returns a read-only tool reporting the working-tree state.
+func GitStatusTool(exec executor.Executor) *tool.Tool {
+	return &tool.Tool{
+		Name: "git_status",
+		Description: "Report the git working-tree state (porcelain status) as structured entries with per-path staged/unstaged status letters and the current branch. " +
+			"Use this in read-only review or monitoring runs to see what changed without enabling run_command. " +
+			"Output is bounded; a large change set is capped and flagged truncated. " +
+			"Example: {}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{}`)},
+		InputSchema:       gitStatusSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
+			if err := ensureGitRepo(ctx, exec); err != nil {
+				return tool.StructuredResult{}, err
+			}
+			// -z gives NUL-terminated records with verbatim (unquoted) paths,
+			// so paths containing spaces or unusual bytes parse unambiguously.
+			res, err := runGit(ctx, exec, "status", "--porcelain=v1", "-z")
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			if res.ExitCode != 0 {
+				return tool.StructuredResult{}, fmt.Errorf("git status failed: %s", gitErrText(res))
+			}
+
+			entries, truncated := parsePorcelainZ(res.Stdout, gitStatusMaxEntries)
+			result := gitStatusResult{
+				Branch:    currentBranch(ctx, exec),
+				Clean:     len(entries) == 0,
+				Entries:   entries,
+				Truncated: truncated,
+			}
+			return marshalGit(formatGitStatus(result), result, kindGitStatus)
+		},
+	}
+}
+
+// --- git_changed_files ---
+
+var gitChangedFilesSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"staged": {
+			"type": "boolean",
+			"description": "When true, list staged changes (index vs HEAD). When false or omitted, list unstaged changes (working tree vs index)."
+		}
+	},
+	"additionalProperties": false
+}`)
+
+// GitChangedFilesTool returns a read-only tool listing changed paths with their
+// name-status letters.
+func GitChangedFilesTool(exec executor.Executor) *tool.Tool {
+	return &tool.Tool{
+		Name: "git_changed_files",
+		Description: "List changed file paths with their git name-status letter (A/M/D/R/C/T). " +
+			"Use this to enumerate which files differ before reading specific diffs; set staged to inspect the index instead of the working tree. " +
+			"Output is bounded; a large change set is capped and flagged truncated. " +
+			"Example: {\"staged\": false}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"staged": false}`)},
+		InputSchema:       gitChangedFilesSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
+			var params struct {
+				Staged bool `json:"staged"`
+			}
+			if len(input) > 0 {
+				if err := json.Unmarshal(input, &params); err != nil {
+					return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
+				}
+			}
+			if err := ensureGitRepo(ctx, exec); err != nil {
+				return tool.StructuredResult{}, err
+			}
+
+			args := []string{"diff", "--name-status", "-z"}
+			if params.Staged {
+				args = append(args, "--cached")
+			}
+			res, err := runGit(ctx, exec, args...)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			if res.ExitCode != 0 {
+				return tool.StructuredResult{}, fmt.Errorf("git diff failed: %s", gitErrText(res))
+			}
+
+			files, truncated := parseNameStatusZ(res.Stdout, gitChangedFilesMaxFile)
+			result := gitChangedFilesResult{
+				Staged:    params.Staged,
+				Files:     files,
+				Truncated: truncated,
+			}
+			return marshalGit(formatGitChangedFiles(result), result, kindGitChangedFiles)
+		},
+	}
+}
+
+// --- git_diff ---
+
+var gitDiffSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"path": {
+			"type": "string",
+			"description": "Optional workspace-relative path to restrict the diff to a single file or directory."
+		},
+		"staged": {
+			"type": "boolean",
+			"description": "When true, diff the staged changes (index vs HEAD). When false or omitted, diff the working tree against the index."
+		}
+	},
+	"additionalProperties": false
+}`)
+
+// GitDiffTool returns a read-only tool producing a bounded unified diff.
+func GitDiffTool(exec executor.Executor) *tool.Tool {
+	return &tool.Tool{
+		Name: "git_diff",
+		Description: "Produce a unified diff of the working tree (or the staged changes when staged is true), optionally restricted to one path. " +
+			"Use this to review the exact line-level changes in a read-only run without enabling run_command. " +
+			"Output is bounded by byte and line caps; a large diff is truncated with a sentinel. " +
+			"Example: {\"path\": \"harness/internal/tool/builtins/git.go\", \"staged\": false}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"path": "harness/internal/tool/builtins/git.go", "staged": false}`)},
+		InputSchema:       gitDiffSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
+			var params struct {
+				Path   string `json:"path"`
+				Staged bool   `json:"staged"`
+			}
+			if len(input) > 0 {
+				if err := json.Unmarshal(input, &params); err != nil {
+					return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
+				}
+			}
+			if err := ensureGitRepo(ctx, exec); err != nil {
+				return tool.StructuredResult{}, err
+			}
+
+			args := []string{"diff"}
+			if params.Staged {
+				args = append(args, "--cached")
+			}
+			if params.Path != "" {
+				p, err := validateGitPath(exec, params.Path)
+				if err != nil {
+					return tool.StructuredResult{}, err
+				}
+				args = append(args, "--", p)
+			}
+			res, err := runGit(ctx, exec, args...)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			if res.ExitCode != 0 {
+				return tool.StructuredResult{}, fmt.Errorf("git diff failed: %s", gitErrText(res))
+			}
+
+			diff, truncated := boundDiff(res.Stdout)
+			result := gitDiffResult{
+				Diff:      diff,
+				Staged:    params.Staged,
+				Path:      params.Path,
+				Truncated: truncated,
+			}
+			return marshalGit(diff, result, kindGitDiff)
+		},
+	}
+}
+
+// --- git_show ---
+
+var gitShowSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"ref": {
+			"type": "string",
+			"description": "The revision to show (commit SHA, tag, branch, or HEAD~N). Required."
+		},
+		"path": {
+			"type": "string",
+			"description": "Optional workspace-relative path to restrict the output to a single file."
+		}
+	},
+	"required": ["ref"],
+	"additionalProperties": false
+}`)
+
+// GitShowTool returns a read-only tool inspecting a specific revision.
+func GitShowTool(exec executor.Executor) *tool.Tool {
+	return &tool.Tool{
+		Name: "git_show",
+		Description: "Show a specific git revision (commit metadata and diff, or a file's content at that revision when path is given). " +
+			"Use this to inspect a commit or a historical file version in a read-only run; ref must name a revision and must not begin with '-'. " +
+			"Output is bounded by byte and line caps; large output is truncated with a sentinel. " +
+			"Example: {\"ref\": \"HEAD\", \"path\": \"README.md\"}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"ref": "HEAD", "path": "README.md"}`)},
+		InputSchema:       gitShowSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
+			var params struct {
+				Ref  string `json:"ref"`
+				Path string `json:"path"`
+			}
+			if err := json.Unmarshal(input, &params); err != nil {
+				return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
+			}
+			if params.Ref == "" {
+				return tool.StructuredResult{}, fmt.Errorf("ref is required")
+			}
+			if err := validateGitRef(params.Ref); err != nil {
+				return tool.StructuredResult{}, err
+			}
+			if err := ensureGitRepo(ctx, exec); err != nil {
+				return tool.StructuredResult{}, err
+			}
+
+			args := []string{"show", params.Ref}
+			if params.Path != "" {
+				p, err := validateGitPath(exec, params.Path)
+				if err != nil {
+					return tool.StructuredResult{}, err
+				}
+				args = append(args, "--", p)
+			}
+			res, err := runGit(ctx, exec, args...)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			if res.ExitCode != 0 {
+				return tool.StructuredResult{}, fmt.Errorf("git show failed: %s", gitErrText(res))
+			}
+
+			out, truncated := boundDiff(res.Stdout)
+			result := gitShowResult{
+				Ref:       params.Ref,
+				Path:      params.Path,
+				Output:    out,
+				Truncated: truncated,
+			}
+			return marshalGit(out, result, kindGitShow)
+		},
+	}
+}
+
+// --- shared helpers ---
+
+// gitErrText returns the most useful error text from a non-zero git result,
+// preferring stderr.
+func gitErrText(res *executor.ExecResult) string {
+	if s := strings.TrimSpace(res.Stderr); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(res.Stdout); s != "" {
+		return s
+	}
+	return fmt.Sprintf("exit code %d", res.ExitCode)
+}
+
+// marshalGit packages the text fallback and a typed structured payload into a
+// StructuredResult, mirroring the run_command/read_file pattern.
+func marshalGit(text string, structured any, kind string) (tool.StructuredResult, error) {
+	payload, err := json.Marshal(structured)
+	if err != nil {
+		return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", err)
+	}
+	return tool.StructuredResult{Text: text, Structured: payload, Kind: kind}, nil
+}
+
+// parsePorcelainZ parses `git status --porcelain=v1 -z` output into entries,
+// capped at max. The porcelain -z format is: two status chars, a space, the
+// path, then NUL. For renames/copies the record is `XY <new>\0<orig>\0`, so a
+// rename consumes two NUL-terminated fields. The bool reports truncation.
+func parsePorcelainZ(out string, max int) ([]gitStatusEntry, bool) {
+	entries := make([]gitStatusEntry, 0)
+	fields := splitNUL(out)
+	for i := 0; i < len(fields); i++ {
+		rec := fields[i]
+		if len(rec) < 4 {
+			// Minimum "XY P" is 4 bytes; skip anything shorter (trailing empty).
+			continue
+		}
+		code := rec[:2]
+		path := rec[3:]
+		entry := gitStatusEntry{
+			Code:     code,
+			Staged:   string(code[0]),
+			Unstaged: string(code[1]),
+			Path:     path,
+		}
+		// A rename or copy in either column carries the original path in the
+		// following NUL-terminated field.
+		if code[0] == 'R' || code[0] == 'C' || code[1] == 'R' || code[1] == 'C' {
+			if i+1 < len(fields) {
+				entry.OrigPath = fields[i+1]
+				i++
+			}
+		}
+		if len(entries) >= max {
+			return entries, true
+		}
+		entries = append(entries, entry)
+	}
+	return entries, false
+}
+
+// parseNameStatusZ parses `git diff --name-status -z` output into changed
+// files, capped at max. Each record is a status letter (possibly with a rename
+// similarity score, e.g. R100) terminated by NUL, followed by the path in the
+// next NUL field; renames/copies carry a second path field. The bool reports
+// truncation.
+func parseNameStatusZ(out string, max int) ([]gitChangedFile, bool) {
+	files := make([]gitChangedFile, 0)
+	fields := splitNUL(out)
+	for i := 0; i < len(fields); i++ {
+		status := fields[i]
+		if status == "" {
+			continue
+		}
+		letter := status[:1]
+		isRenameOrCopy := letter == "R" || letter == "C"
+		if i+1 >= len(fields) {
+			break
+		}
+		i++
+		path := fields[i]
+		file := gitChangedFile{Status: letter, Path: path}
+		if isRenameOrCopy {
+			// name-status -z for R/C is: status\0 <orig>\0 <new>\0. The path
+			// read above is the original; the new path follows.
+			file.OrigPath = path
+			if i+1 < len(fields) {
+				i++
+				file.Path = fields[i]
+			}
+		}
+		if len(files) >= max {
+			return files, true
+		}
+		files = append(files, file)
+	}
+	return files, false
+}
+
+// splitNUL splits a NUL-terminated/-separated stream into fields, dropping a
+// trailing empty field produced by the terminating NUL.
+func splitNUL(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, "\x00")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	return parts
+}
+
+// boundDiff caps diff/show output on both byte and line counts and appends a
+// sentinel when either bound trims the content, so a huge worktree cannot blow
+// up model context. Mirrors list_directory's visible-sentinel truncation.
+func boundDiff(s string) (string, bool) {
+	truncated := false
+	if len(s) > gitDiffMaxBytes {
+		s = s[:gitDiffMaxBytes]
+		truncated = true
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > gitDiffMaxLines {
+		lines = lines[:gitDiffMaxLines]
+		s = strings.Join(lines, "\n")
+		truncated = true
+	}
+	if truncated {
+		s += gitDiffTruncSentinel
+	}
+	return s, truncated
+}
+
+// formatGitStatus renders the canonical text fallback for git_status.
+func formatGitStatus(r gitStatusResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "On branch %s\n", r.Branch)
+	if r.Clean {
+		b.WriteString("working tree clean")
+		return b.String()
+	}
+	for _, e := range r.Entries {
+		if e.OrigPath != "" {
+			fmt.Fprintf(&b, "%s %s -> %s\n", e.Code, e.OrigPath, e.Path)
+		} else {
+			fmt.Fprintf(&b, "%s %s\n", e.Code, e.Path)
+		}
+	}
+	if r.Truncated {
+		fmt.Fprintf(&b, "[status truncated at %d entries]", gitStatusMaxEntries)
+		return b.String()
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatGitChangedFiles renders the canonical text fallback for
+// git_changed_files.
+func formatGitChangedFiles(r gitChangedFilesResult) string {
+	if len(r.Files) == 0 {
+		return "no changed files"
+	}
+	var b strings.Builder
+	for _, f := range r.Files {
+		if f.OrigPath != "" {
+			fmt.Fprintf(&b, "%s\t%s -> %s\n", f.Status, f.OrigPath, f.Path)
+		} else {
+			fmt.Fprintf(&b, "%s\t%s\n", f.Status, f.Path)
+		}
+	}
+	if r.Truncated {
+		fmt.Fprintf(&b, "[changed-file list truncated at %d entries]", gitChangedFilesMaxFile)
+		return b.String()
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/harness/internal/tool/builtins/git_test.go
+++ b/harness/internal/tool/builtins/git_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
 )
@@ -211,6 +212,320 @@ func TestGitDiff_OutputTruncated(t *testing.T) {
 	}
 }
 
+// TestGitDiff_PathLeadingDashRejected covers the option-injection guard on the
+// `path` argument (the ref equivalent is covered by
+// TestValidateGitRef_RejectsOptionInjection). A path like "-p" must be rejected
+// before any git command is issued, so it can never be read as a git flag.
+func TestGitDiff_PathLeadingDashRejected(t *testing.T) {
+	var captured []string
+	mock := captureExec(&captured)
+	tl := GitDiffTool(mock)
+
+	if _, err := tl.StructuredHandler(context.Background(), json.RawMessage(`{"path": "-p"}`)); err == nil {
+		t.Fatalf("handler accepted leading-dash path")
+	}
+	for _, c := range captured {
+		if strings.Contains(c, "'diff'") {
+			t.Errorf("git diff was executed despite hostile path: %q", c)
+		}
+	}
+}
+
+// TestGitShow_ColonRefTraversalRejected covers the colon-ref bypass: a treeish
+// ref of the form `<rev>:<path>` carries its path in the ref string itself,
+// which would otherwise skip validateGitPath. The path portion must still be
+// containment-checked, and git show must not run when it escapes.
+func TestGitShow_ColonRefTraversalRejected(t *testing.T) {
+	var captured []string
+	mock := captureExec(&captured)
+	// Reject any escaping path the way the local executor would.
+	mock.resolvePathFunc = func(p string) (string, error) {
+		if strings.Contains(p, "..") || strings.HasPrefix(p, "/") {
+			return "", os.ErrPermission
+		}
+		return "/workspace/" + p, nil
+	}
+	tl := GitShowTool(mock)
+
+	for _, ref := range []string{"HEAD:../../../etc/passwd", "HEAD:/etc/passwd"} {
+		captured = nil
+		in := json.RawMessage(`{"ref": ` + jsonString(ref) + `}`)
+		if _, err := tl.StructuredHandler(context.Background(), in); err == nil {
+			t.Errorf("colon-ref %q was accepted; want traversal rejection", ref)
+		}
+		for _, c := range captured {
+			if strings.Contains(c, "'show'") {
+				t.Errorf("git show executed despite traversal colon-ref %q: %q", ref, c)
+			}
+		}
+	}
+}
+
+// TestValidateColonRefPath_Branches covers the helper's three arms directly:
+// no colon (no-op), trailing colon with empty path (no-op), and an escaping
+// path (rejected).
+func TestValidateColonRefPath_Branches(t *testing.T) {
+	mock := &mockExecutor{resolvePathFunc: func(p string) (string, error) {
+		if strings.Contains(p, "..") {
+			return "", os.ErrPermission
+		}
+		return "/workspace/" + p, nil
+	}}
+	if err := validateColonRefPath(mock, "HEAD"); err != nil {
+		t.Errorf("no-colon ref rejected: %v", err)
+	}
+	if err := validateColonRefPath(mock, "HEAD:"); err != nil {
+		t.Errorf("empty-path colon-ref rejected: %v", err)
+	}
+	if err := validateColonRefPath(mock, "HEAD:../escape"); err == nil {
+		t.Errorf("escaping colon-ref accepted")
+	}
+}
+
+// TestGitShow_ColonRefInWorkspaceAccepted confirms the colon-ref guard does not
+// reject a legitimate in-workspace path (so the bypass fix is not over-broad).
+func TestGitShow_ColonRefInWorkspaceAccepted(t *testing.T) {
+	var captured []string
+	mock := captureExec(&captured)
+	tl := GitShowTool(mock)
+
+	in := json.RawMessage(`{"ref": "HEAD:README.md"}`)
+	if _, err := tl.StructuredHandler(context.Background(), in); err != nil {
+		t.Fatalf("in-workspace colon-ref rejected: %v", err)
+	}
+	ran := false
+	for _, c := range captured {
+		if strings.Contains(c, "'show'") {
+			ran = true
+		}
+	}
+	if !ran {
+		t.Errorf("git show did not run for a valid colon-ref; captured=%v", captured)
+	}
+}
+
+// TestGitErrText covers the three arms of the error-message surface.
+func TestGitErrText(t *testing.T) {
+	cases := []struct {
+		name string
+		res  executor.ExecResult
+		want string
+	}{
+		{"stderr", executor.ExecResult{ExitCode: 1, Stderr: "fatal: bad revision", Stdout: "ignored"}, "fatal: bad revision"},
+		{"stdout", executor.ExecResult{ExitCode: 1, Stderr: "  \n", Stdout: "some stdout detail"}, "some stdout detail"},
+		{"exitcode", executor.ExecResult{ExitCode: 3}, "exit code 3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gitErrText(&tc.res)
+			if got != tc.want {
+				t.Errorf("gitErrText = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitShow_NonZeroExitSurfacesStderr drives a handler-level non-zero exit
+// (e.g. a non-existent ref) and asserts the stderr text reaches the error.
+func TestGitShow_NonZeroExitSurfacesStderr(t *testing.T) {
+	mock := &mockExecutor{
+		execFunc: func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+			if strings.Contains(command, "is-inside-work-tree") {
+				return &executor.ExecResult{ExitCode: 0, Stdout: "true\n"}, nil
+			}
+			return &executor.ExecResult{ExitCode: 128, Stderr: "fatal: bad revision 'nope'"}, nil
+		},
+	}
+	tl := GitShowTool(mock)
+	_, err := tl.StructuredHandler(context.Background(), json.RawMessage(`{"ref": "nope"}`))
+	if err == nil {
+		t.Fatalf("expected error for non-existent ref")
+	}
+	if !strings.Contains(err.Error(), "bad revision 'nope'") {
+		t.Errorf("error %q does not surface git stderr", err)
+	}
+}
+
+func TestParsePorcelainZ_RenameAndCopy(t *testing.T) {
+	// Rename (R) and copy (C) records each carry the original path in the
+	// following NUL field: `XY <new>\0<orig>\0`. Build a fixture covering a
+	// rename, a copy, and a plain modification.
+	out := "R  new.go\x00old.go\x00C  copy.go\x00src.go\x00 M plain.go\x00"
+	entries, truncated := parsePorcelainZ(out, 100)
+	if truncated {
+		t.Fatalf("unexpected truncation")
+	}
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(entries), entries)
+	}
+	if entries[0].Code != "R " || entries[0].Path != "new.go" || entries[0].OrigPath != "old.go" {
+		t.Errorf("rename entry wrong: %+v", entries[0])
+	}
+	if entries[1].Code != "C " || entries[1].Path != "copy.go" || entries[1].OrigPath != "src.go" {
+		t.Errorf("copy entry wrong: %+v", entries[1])
+	}
+	if entries[2].Code != " M" || entries[2].Path != "plain.go" || entries[2].OrigPath != "" {
+		t.Errorf("plain entry wrong: %+v", entries[2])
+	}
+}
+
+func TestParsePorcelainZ_Truncation(t *testing.T) {
+	out := " M a\x00 M b\x00 M c\x00"
+	entries, truncated := parsePorcelainZ(out, 2)
+	if !truncated {
+		t.Errorf("expected truncation at cap 2")
+	}
+	if len(entries) != 2 {
+		t.Errorf("got %d entries, want 2", len(entries))
+	}
+}
+
+func TestParseNameStatusZ_RenameAndCopy(t *testing.T) {
+	// name-status -z for R/C is: status\0 <orig>\0 <new>\0; M is: status\0 <path>\0.
+	out := "R100\x00old.go\x00new.go\x00M\x00plain.go\x00C75\x00src.go\x00copy.go\x00"
+	files, truncated := parseNameStatusZ(out, 100)
+	if truncated {
+		t.Fatalf("unexpected truncation")
+	}
+	if len(files) != 3 {
+		t.Fatalf("got %d files, want 3: %+v", len(files), files)
+	}
+	if files[0].Status != "R" || files[0].OrigPath != "old.go" || files[0].Path != "new.go" {
+		t.Errorf("rename file wrong: %+v", files[0])
+	}
+	if files[1].Status != "M" || files[1].Path != "plain.go" || files[1].OrigPath != "" {
+		t.Errorf("modify file wrong: %+v", files[1])
+	}
+	if files[2].Status != "C" || files[2].OrigPath != "src.go" || files[2].Path != "copy.go" {
+		t.Errorf("copy file wrong: %+v", files[2])
+	}
+}
+
+func TestParseNameStatusZ_Truncation(t *testing.T) {
+	out := "M\x00a\x00M\x00b\x00M\x00c\x00"
+	files, truncated := parseNameStatusZ(out, 2)
+	if !truncated {
+		t.Errorf("expected truncation at cap 2")
+	}
+	if len(files) != 2 {
+		t.Errorf("got %d files, want 2", len(files))
+	}
+}
+
+func TestFormatGitStatus_RenameRendering(t *testing.T) {
+	r := gitStatusResult{
+		Branch:  "main",
+		Entries: []gitStatusEntry{{Code: "R ", Path: "new.go", OrigPath: "old.go"}},
+	}
+	got := formatGitStatus(r)
+	if !strings.Contains(got, "R  old.go -> new.go") {
+		t.Errorf("rename rendering missing arrow form; got:\n%s", got)
+	}
+}
+
+func TestFormatGitStatus_CleanAndTruncated(t *testing.T) {
+	clean := formatGitStatus(gitStatusResult{Branch: "main", Clean: true})
+	if !strings.Contains(clean, "working tree clean") {
+		t.Errorf("clean rendering wrong: %q", clean)
+	}
+	trunc := formatGitStatus(gitStatusResult{
+		Branch:    "main",
+		Entries:   []gitStatusEntry{{Code: " M", Path: "a"}},
+		Truncated: true,
+	})
+	if !strings.Contains(trunc, "status truncated") {
+		t.Errorf("truncated rendering missing sentinel: %q", trunc)
+	}
+}
+
+func TestFormatGitChangedFiles_RenameAndEmptyAndTruncated(t *testing.T) {
+	empty := formatGitChangedFiles(gitChangedFilesResult{})
+	if empty != "no changed files" {
+		t.Errorf("empty rendering wrong: %q", empty)
+	}
+	rename := formatGitChangedFiles(gitChangedFilesResult{
+		Files: []gitChangedFile{{Status: "R", Path: "new.go", OrigPath: "old.go"}},
+	})
+	if !strings.Contains(rename, "old.go -> new.go") {
+		t.Errorf("rename rendering missing arrow form; got: %q", rename)
+	}
+	trunc := formatGitChangedFiles(gitChangedFilesResult{
+		Files:     []gitChangedFile{{Status: "M", Path: "a"}},
+		Truncated: true,
+	})
+	if !strings.Contains(trunc, "truncated") {
+		t.Errorf("truncated rendering missing sentinel: %q", trunc)
+	}
+}
+
+func TestCurrentBranch_DetachedUnbornUnknown(t *testing.T) {
+	detached := currentBranch(context.Background(), &mockExecutor{
+		execFunc: func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+			return &executor.ExecResult{ExitCode: 0, Stdout: "HEAD\n"}, nil
+		},
+	})
+	if detached != "HEAD (detached)" {
+		t.Errorf("detached = %q, want %q", detached, "HEAD (detached)")
+	}
+	unborn := currentBranch(context.Background(), &mockExecutor{
+		execFunc: func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+			return &executor.ExecResult{ExitCode: 128, Stderr: "no commit yet"}, nil
+		},
+	})
+	if unborn != "(unborn)" {
+		t.Errorf("unborn = %q, want %q", unborn, "(unborn)")
+	}
+	unknown := currentBranch(context.Background(), &mockExecutor{
+		execFunc: func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+			return nil, context.Canceled
+		},
+	})
+	if unknown != "(unknown)" {
+		t.Errorf("unknown = %q, want %q", unknown, "(unknown)")
+	}
+}
+
+// TestBoundDiff_ByteCapTrimsToNewline asserts the byte cap trims back to the
+// last newline so the result is rune-safe and line-complete (no mid-rune slice,
+// no ragged partial final line). Uses a single line longer than the byte cap so
+// only the byte cap fires.
+func TestBoundDiff_ByteCapTrimsToNewline(t *testing.T) {
+	// Two complete lines whose combined length exceeds the byte cap, with the
+	// second line straddling the cap boundary. After the byte cap the output
+	// must end in a newline and contain no partial trailing line.
+	line := strings.Repeat("x", gitDiffMaxBytes-10) + "\n"
+	tail := strings.Repeat("y", 100) + "\n"
+	got, truncated := boundDiff(line + tail)
+	if !truncated {
+		t.Fatalf("expected truncation")
+	}
+	body := strings.TrimSuffix(got, gitDiffTruncSentinel)
+	if !strings.HasSuffix(body, "\n") {
+		t.Errorf("byte-capped body does not end at a line boundary: %q", body[max(0, len(body)-20):])
+	}
+	if strings.Contains(body, "y") {
+		t.Errorf("byte-capped body included the partial straddling line")
+	}
+}
+
+// TestBoundDiff_MidRuneByteCap asserts the byte cap never slices through a
+// multi-byte rune (which would make json.Marshal emit a silent U+FFFD). A line
+// of multi-byte runes longer than the cap, with no newline before the cap,
+// trims to empty rather than to a broken rune.
+func TestBoundDiff_MidRuneByteCap(t *testing.T) {
+	// '€' is 3 bytes; a run with no newline before the cap forces the
+	// no-newline branch, which must yield empty (not a half-rune).
+	huge := strings.Repeat("€", gitDiffMaxBytes) // far exceeds the byte cap
+	got, truncated := boundDiff(huge)
+	if !truncated {
+		t.Fatalf("expected truncation")
+	}
+	body := strings.TrimSuffix(got, gitDiffTruncSentinel)
+	if !utf8.ValidString(body) {
+		t.Errorf("byte cap produced invalid UTF-8")
+	}
+}
+
 // --- end-to-end against a real git repo via the local executor ---
 
 func TestGitTools_RealRepoEndToEnd(t *testing.T) {
@@ -337,6 +652,37 @@ func TestGitTools_RealRepoEndToEnd(t *testing.T) {
 	}
 	if !strings.Contains(showRes.Text, "original") {
 		t.Errorf("git_show missing committed content; got:\n%s", showRes.Text)
+	}
+
+	// Stage the modification last (it empties the unstaged view), then assert
+	// the --cached views report it end to end.
+	runGitCmd("add", "tracked.txt")
+	stagedFiles, err := GitChangedFilesTool(ex).StructuredHandler(ctx, json.RawMessage(`{"staged": true}`))
+	if err != nil {
+		t.Fatalf("git_changed_files staged: %v", err)
+	}
+	var staged gitChangedFilesResult
+	if err := json.Unmarshal(stagedFiles.Structured, &staged); err != nil {
+		t.Fatalf("unmarshal staged: %v", err)
+	}
+	if !staged.Staged {
+		t.Errorf("staged result not flagged staged")
+	}
+	foundStaged := false
+	for _, f := range staged.Files {
+		if f.Path == "tracked.txt" && f.Status == "M" {
+			foundStaged = true
+		}
+	}
+	if !foundStaged {
+		t.Errorf("staged git_changed_files did not report tracked.txt; files=%+v", staged.Files)
+	}
+	stagedDiff, err := GitDiffTool(ex).StructuredHandler(ctx, json.RawMessage(`{"staged": true}`))
+	if err != nil {
+		t.Fatalf("git_diff staged: %v", err)
+	}
+	if !strings.Contains(stagedDiff.Text, "+modified") {
+		t.Errorf("staged git_diff missing the added line; got:\n%s", stagedDiff.Text)
 	}
 }
 

--- a/harness/internal/tool/builtins/git_test.go
+++ b/harness/internal/tool/builtins/git_test.go
@@ -1,0 +1,348 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+)
+
+// --- shellQuote / validation unit tests ---
+
+func TestValidateGitRef_RejectsOptionInjection(t *testing.T) {
+	for _, ref := range []string{"--upload-pack=/bin/sh", "-x", "--output=foo"} {
+		if err := validateGitRef(ref); err == nil {
+			t.Errorf("validateGitRef(%q) = nil, want rejection of leading '-'", ref)
+		}
+	}
+}
+
+func TestValidateGitRef_RejectsShellMetacharacters(t *testing.T) {
+	for _, ref := range []string{"$(rm -rf /)", "foo; echo pwned", "a`id`b", "a|b", "a&b", "a b"} {
+		if err := validateGitRef(ref); err == nil {
+			t.Errorf("validateGitRef(%q) = nil, want rejection of shell metacharacter", ref)
+		}
+	}
+}
+
+func TestValidateGitRef_AcceptsNormalRefs(t *testing.T) {
+	for _, ref := range []string{"HEAD", "HEAD~3", "main", "v1.2.3", "abc123def", "feature/x"} {
+		if err := validateGitRef(ref); err != nil {
+			t.Errorf("validateGitRef(%q) = %v, want nil", ref, err)
+		}
+	}
+}
+
+// --- shell-injection neutralisation via the mock executor ---
+
+// captureExec returns a mock executor that records the command string Exec was
+// invoked with so tests can assert what reached the shell.
+func captureExec(captured *[]string) *mockExecutor {
+	return &mockExecutor{
+		execFunc: func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+			*captured = append(*captured, command)
+			// rev-parse --is-inside-work-tree must report a repo so the
+			// handler proceeds to the data-returning invocation under test.
+			if strings.Contains(command, "rev-parse") && strings.Contains(command, "is-inside-work-tree") {
+				return &executor.ExecResult{ExitCode: 0, Stdout: "true\n"}, nil
+			}
+			if strings.Contains(command, "rev-parse") && strings.Contains(command, "abbrev-ref") {
+				return &executor.ExecResult{ExitCode: 0, Stdout: "main\n"}, nil
+			}
+			return &executor.ExecResult{ExitCode: 0, Stdout: ""}, nil
+		},
+		resolvePathFunc: func(p string) (string, error) {
+			return "/workspace/" + p, nil
+		},
+	}
+}
+
+func TestGitDiff_PathWithShellMetacharactersIsQuoted(t *testing.T) {
+	var captured []string
+	mock := captureExec(&captured)
+	tl := GitDiffTool(mock)
+
+	// A path that, unquoted, would run `rm -rf /` as a second command.
+	in := json.RawMessage(`{"path": "foo; rm -rf /"}`)
+	if _, err := tl.StructuredHandler(context.Background(), in); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	// Find the `git diff` command (not the rev-parse guard) and assert the
+	// hostile path was single-quoted so sh treats it as one literal argument.
+	var diffCmd string
+	for _, c := range captured {
+		if strings.Contains(c, "'diff'") {
+			diffCmd = c
+		}
+	}
+	if diffCmd == "" {
+		t.Fatalf("no `git diff` command was issued; captured=%v", captured)
+	}
+	if !strings.Contains(diffCmd, "'foo; rm -rf /'") {
+		t.Errorf("path was not shell-quoted; command = %q", diffCmd)
+	}
+	// The `;` must be inside the quotes — there must be exactly one command.
+	if strings.Count(diffCmd, ";") != 1 {
+		t.Errorf("unexpected `;` outside quotes; command = %q", diffCmd)
+	}
+}
+
+func TestGitShow_RefWithOptionInjectionIsRejected(t *testing.T) {
+	var captured []string
+	mock := captureExec(&captured)
+	tl := GitShowTool(mock)
+
+	in := json.RawMessage(`{"ref": "--upload-pack=/bin/sh"}`)
+	_, err := tl.StructuredHandler(context.Background(), in)
+	if err == nil {
+		t.Fatalf("handler accepted option-injection ref")
+	}
+	// The rejection must happen before any `git show` reaches the shell.
+	for _, c := range captured {
+		if strings.Contains(c, "'show'") {
+			t.Errorf("git show was executed despite hostile ref: %q", c)
+		}
+	}
+}
+
+func TestGitShow_RefWithCommandSubstitutionIsRejected(t *testing.T) {
+	var captured []string
+	mock := captureExec(&captured)
+	tl := GitShowTool(mock)
+
+	in := json.RawMessage(`{"ref": "$(touch /tmp/pwned)"}`)
+	if _, err := tl.StructuredHandler(context.Background(), in); err == nil {
+		t.Fatalf("handler accepted command-substitution ref")
+	}
+	for _, c := range captured {
+		if strings.Contains(c, "'show'") {
+			t.Errorf("git show executed despite hostile ref: %q", c)
+		}
+	}
+}
+
+// --- non-git workspace ---
+
+func TestGitStatus_NonGitWorkspaceErrorsClearly(t *testing.T) {
+	mock := &mockExecutor{
+		execFunc: func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+			// Simulate git reporting the directory is not a work tree.
+			return &executor.ExecResult{ExitCode: 128, Stderr: "fatal: not a git repository"}, nil
+		},
+	}
+	tl := GitStatusTool(mock)
+	_, err := tl.StructuredHandler(context.Background(), json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatalf("expected error for non-git workspace")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Errorf("error %q does not clearly state the workspace is not a git repository", err)
+	}
+}
+
+// --- path traversal rejection ---
+
+func TestGitDiff_PathTraversalRejected(t *testing.T) {
+	mock := &mockExecutor{
+		execFunc: func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+			if strings.Contains(command, "is-inside-work-tree") {
+				return &executor.ExecResult{ExitCode: 0, Stdout: "true\n"}, nil
+			}
+			return &executor.ExecResult{ExitCode: 0}, nil
+		},
+		resolvePathFunc: func(p string) (string, error) {
+			// Mirror the local executor: a path escaping the workspace fails.
+			if strings.Contains(p, "..") || strings.HasPrefix(p, "/etc") {
+				return "", os.ErrPermission
+			}
+			return "/workspace/" + p, nil
+		},
+	}
+	tl := GitDiffTool(mock)
+	for _, p := range []string{"../etc/passwd", "/etc/passwd"} {
+		in := json.RawMessage(`{"path": ` + jsonString(p) + `}`)
+		if _, err := tl.StructuredHandler(context.Background(), in); err == nil {
+			t.Errorf("path %q was accepted; want traversal rejection", p)
+		}
+	}
+}
+
+// --- bounded output ---
+
+func TestGitDiff_OutputTruncated(t *testing.T) {
+	// Build a diff larger than both caps.
+	var big strings.Builder
+	for i := 0; i < gitDiffMaxLines+1000; i++ {
+		big.WriteString("+a line of diff content that is reasonably long to push bytes up\n")
+	}
+	mock := &mockExecutor{
+		execFunc: func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+			if strings.Contains(command, "is-inside-work-tree") {
+				return &executor.ExecResult{ExitCode: 0, Stdout: "true\n"}, nil
+			}
+			return &executor.ExecResult{ExitCode: 0, Stdout: big.String()}, nil
+		},
+	}
+	tl := GitDiffTool(mock)
+	res, err := tl.StructuredHandler(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !strings.Contains(res.Text, gitDiffTruncSentinel) {
+		t.Errorf("truncation sentinel missing from text output")
+	}
+	var payload gitDiffResult
+	if err := json.Unmarshal(res.Structured, &payload); err != nil {
+		t.Fatalf("unmarshal structured: %v", err)
+	}
+	if !payload.Truncated {
+		t.Errorf("structured payload not marked truncated")
+	}
+	lineCount := strings.Count(payload.Diff, "\n")
+	if lineCount > gitDiffMaxLines+2 { // +sentinel line
+		t.Errorf("diff has %d lines, exceeds line cap %d", lineCount, gitDiffMaxLines)
+	}
+}
+
+// --- end-to-end against a real git repo via the local executor ---
+
+func TestGitTools_RealRepoEndToEnd(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	// EvalSymlinks so the local executor's containment check (which resolves
+	// symlinks) agrees with the workspace root on macOS where TempDir is under
+	// a /var -> /private/var symlink.
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	dir = resolved
+
+	runGitCmd := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		c.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	runGitCmd("init", "-q")
+	runGitCmd("config", "user.email", "test@example.com")
+	runGitCmd("config", "user.name", "test")
+
+	tracked := filepath.Join(dir, "tracked.txt")
+	if err := os.WriteFile(tracked, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("write tracked: %v", err)
+	}
+	runGitCmd("add", "tracked.txt")
+	runGitCmd("commit", "-q", "-m", "initial")
+
+	// Modify the tracked file and add an untracked file.
+	if err := os.WriteFile(tracked, []byte("original\nmodified\n"), 0o644); err != nil {
+		t.Fatalf("modify tracked: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("write untracked: %v", err)
+	}
+
+	ex, err := executor.NewLocalExecutor(dir)
+	if err != nil {
+		t.Fatalf("new local executor: %v", err)
+	}
+	ctx := context.Background()
+
+	// git_status
+	statusRes, err := GitStatusTool(ex).StructuredHandler(ctx, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("git_status: %v", err)
+	}
+	var status gitStatusResult
+	if err := json.Unmarshal(statusRes.Structured, &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if status.Clean {
+		t.Errorf("status reported clean, expected changes")
+	}
+	gotModified, gotUntracked := false, false
+	for _, e := range status.Entries {
+		if e.Path == "tracked.txt" && e.Unstaged == "M" {
+			gotModified = true
+		}
+		if e.Path == "untracked.txt" && e.Code == "??" {
+			gotUntracked = true
+		}
+	}
+	if !gotModified {
+		t.Errorf("git_status did not report modified tracked.txt; entries=%+v", status.Entries)
+	}
+	if !gotUntracked {
+		t.Errorf("git_status did not report untracked.txt; entries=%+v", status.Entries)
+	}
+
+	// git_changed_files (unstaged)
+	cfRes, err := GitChangedFilesTool(ex).StructuredHandler(ctx, json.RawMessage(`{"staged": false}`))
+	if err != nil {
+		t.Fatalf("git_changed_files: %v", err)
+	}
+	var changed gitChangedFilesResult
+	if err := json.Unmarshal(cfRes.Structured, &changed); err != nil {
+		t.Fatalf("unmarshal changed: %v", err)
+	}
+	foundTracked := false
+	for _, f := range changed.Files {
+		if f.Path == "tracked.txt" && f.Status == "M" {
+			foundTracked = true
+		}
+	}
+	if !foundTracked {
+		t.Errorf("git_changed_files did not report modified tracked.txt; files=%+v", changed.Files)
+	}
+
+	// git_diff (whole worktree)
+	diffRes, err := GitDiffTool(ex).StructuredHandler(ctx, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("git_diff: %v", err)
+	}
+	if !strings.Contains(diffRes.Text, "+modified") {
+		t.Errorf("git_diff text missing the added line; got:\n%s", diffRes.Text)
+	}
+
+	// git_diff scoped to a single path.
+	diffPathRes, err := GitDiffTool(ex).StructuredHandler(ctx, json.RawMessage(`{"path": "tracked.txt"}`))
+	if err != nil {
+		t.Fatalf("git_diff path: %v", err)
+	}
+	if !strings.Contains(diffPathRes.Text, "tracked.txt") {
+		t.Errorf("scoped git_diff missing path; got:\n%s", diffPathRes.Text)
+	}
+
+	// git_show on HEAD restricted to the committed file.
+	showRes, err := GitShowTool(ex).StructuredHandler(ctx, json.RawMessage(`{"ref": "HEAD", "path": "tracked.txt"}`))
+	if err != nil {
+		t.Fatalf("git_show: %v", err)
+	}
+	if !strings.Contains(showRes.Text, "original") {
+		t.Errorf("git_show missing committed content; got:\n%s", showRes.Text)
+	}
+}
+
+// jsonString returns a JSON-encoded string literal for use inside hand-built
+// JSON payloads in tests.
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/harness/internal/tool/builtins/register.go
+++ b/harness/internal/tool/builtins/register.go
@@ -23,5 +23,9 @@ func RegisterBuiltins(registry *tool.Registry, exec executor.Executor) {
 	registry.Register(GrepFilesTool(exec))
 	registry.Register(FindFilesTool(exec))
 	registry.Register(RunCommandTool(exec))
+	registry.Register(GitStatusTool(exec))
+	registry.Register(GitChangedFilesTool(exec))
+	registry.Register(GitDiffTool(exec))
+	registry.Register(GitShowTool(exec))
 	registry.Register(WebFetchTool())
 }

--- a/harness/internal/tool/builtins/structured.go
+++ b/harness/internal/tool/builtins/structured.go
@@ -13,10 +13,14 @@ package builtins
 // stable values rather than JSON-sniffing the payload, which would violate the
 // typed-not-`any` rule. Each StructuredHandler returns the matching kind.
 const (
-	kindCommandResult = "command_result"
-	kindSearchResult  = "search_result"
-	kindFindResult    = "find_result"
-	kindFileExcerpt   = "file_excerpt"
+	kindCommandResult   = "command_result"
+	kindSearchResult    = "search_result"
+	kindFindResult      = "find_result"
+	kindFileExcerpt     = "file_excerpt"
+	kindGitStatus       = "git_status"
+	kindGitChangedFiles = "git_changed_files"
+	kindGitDiff         = "git_diff"
+	kindGitShow         = "git_show"
 )
 
 // commandResult is the structured payload for run_command. timedOut reports
@@ -75,4 +79,72 @@ type fileExcerpt struct {
 	Truncated bool     `json:"truncated"`
 	PastEOF   bool     `json:"past_eof,omitempty"`
 	Lines     []string `json:"lines"`
+}
+
+// gitStatusEntry is a single working-tree change from git_status, parsed from
+// `git status --porcelain=v1`. Staged and Unstaged hold the two porcelain XY
+// status letters (a space means unmodified in that column); the raw two-rune
+// code is preserved verbatim in Code so consumers that recognise less common
+// states (copied, type-changed) are not lossy. OrigPath is set only for
+// renames/copies and names the source path.
+type gitStatusEntry struct {
+	Code     string `json:"code"`
+	Staged   string `json:"staged"`
+	Unstaged string `json:"unstaged"`
+	Path     string `json:"path"`
+	OrigPath string `json:"orig_path,omitempty"`
+}
+
+// gitStatusResult is the structured payload for git_status. Branch is the
+// current branch (or a detached-HEAD marker); Entries is the ordered list of
+// working-tree changes, capped at the entry bound. Truncated reports the cap
+// was hit. Clean is true when the working tree had no changes. Entries is a
+// non-nil slice so the JSON always carries an array.
+type gitStatusResult struct {
+	Branch    string           `json:"branch"`
+	Clean     bool             `json:"clean"`
+	Entries   []gitStatusEntry `json:"entries"`
+	Truncated bool             `json:"truncated"`
+}
+
+// gitChangedFile is a single path from git_changed_files with its name-status
+// letter (A/M/D/R/C/T). OrigPath is the rename/copy source when Status is R/C.
+type gitChangedFile struct {
+	Status   string `json:"status"`
+	Path     string `json:"path"`
+	OrigPath string `json:"orig_path,omitempty"`
+}
+
+// gitChangedFilesResult is the structured payload for git_changed_files: the
+// ordered list of changed paths and whether the result was capped. Staged
+// records whether the staged (index vs HEAD) or unstaged (worktree vs index)
+// view was requested. Files is a non-nil slice so the JSON always carries an
+// array.
+type gitChangedFilesResult struct {
+	Staged    bool             `json:"staged"`
+	Files     []gitChangedFile `json:"files"`
+	Truncated bool             `json:"truncated"`
+}
+
+// gitDiffResult is the structured payload for git_diff: the unified diff text,
+// bounded by byte and line caps, and the bounds that produced it. Staged
+// records whether the staged view (--cached) was requested; Path echoes the
+// single-path filter when one was supplied. Truncated reports the diff was cut
+// at a bound.
+type gitDiffResult struct {
+	Diff      string `json:"diff"`
+	Staged    bool   `json:"staged"`
+	Path      string `json:"path,omitempty"`
+	Truncated bool   `json:"truncated"`
+}
+
+// gitShowResult is the structured payload for git_show: the bounded output of
+// `git show <ref>` (optionally restricted to a single path). Ref echoes the
+// requested revision; Path echoes the single-path filter when one was
+// supplied. Truncated reports the output was cut at a bound.
+type gitShowResult struct {
+	Ref       string `json:"ref"`
+	Path      string `json:"path,omitempty"`
+	Output    string `json:"output"`
+	Truncated bool   `json:"truncated"`
 }

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1596,17 +1596,21 @@ const (
 )
 
 var validBuiltInToolNames = map[string]bool{
-	"read_file":      true,
-	"write_file":     true,
-	"search_replace": true,
-	"apply_diff":     true,
-	"edit_file":      true,
-	"list_directory": true,
-	"grep_files":     true,
-	"find_files":     true,
-	"run_command":    true,
-	"web_fetch":      true,
-	"spawn_agent":    true,
+	"read_file":         true,
+	"write_file":        true,
+	"search_replace":    true,
+	"apply_diff":        true,
+	"edit_file":         true,
+	"list_directory":    true,
+	"grep_files":        true,
+	"find_files":        true,
+	"run_command":       true,
+	"web_fetch":         true,
+	"spawn_agent":       true,
+	"git_status":        true,
+	"git_changed_files": true,
+	"git_diff":          true,
+	"git_show":          true,
 }
 
 // validRunModes is the closed set of values accepted on RunConfig.Mode.
@@ -1644,6 +1648,10 @@ func DefaultReadOnlyBuiltInTools() []string {
 		"list_directory",
 		"grep_files",
 		"find_files",
+		"git_status",
+		"git_changed_files",
+		"git_diff",
+		"git_show",
 		"web_fetch",
 		"spawn_agent",
 	}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -587,6 +587,39 @@ func TestValidateRunConfig_ReadOnlyModeWithOnlyReadTools(t *testing.T) {
 	}
 }
 
+// TestValidateRunConfig_ReadOnlyModeAcceptsGitTools proves the #29 invariant
+// that the read-only VCS tools (git_status, git_changed_files, git_diff,
+// git_show) are accepted in every read-only mode, while a config that also
+// lists a write tool is still rejected. The two halves share a fixture so the
+// only difference between accept and reject is the presence of run_command.
+func TestValidateRunConfig_ReadOnlyModeAcceptsGitTools(t *testing.T) {
+	gitTools := []string{"git_status", "git_changed_files", "git_diff", "git_show"}
+	for _, mode := range []string{"planning", "review", "research", "toil"} {
+		t.Run(mode+"/accept", func(t *testing.T) {
+			c := validConfig()
+			c.Mode = mode
+			c.PermissionPolicy = PermissionPolicyConfig{Type: "deny-side-effects"}
+			c.Tools = ToolsConfig{BuiltIn: append([]string{"read_file"}, gitTools...)}
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("read-only mode %q should accept git tools, got: %v", mode, err)
+			}
+		})
+		t.Run(mode+"/reject_with_write", func(t *testing.T) {
+			c := validConfig()
+			c.Mode = mode
+			c.PermissionPolicy = PermissionPolicyConfig{Type: "deny-side-effects"}
+			c.Tools = ToolsConfig{BuiltIn: append(append([]string{"read_file"}, gitTools...), "run_command")}
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("read-only mode %q must still reject run_command alongside git tools", mode)
+			}
+			if !strings.Contains(err.Error(), "read-only mode") || !strings.Contains(err.Error(), "run_command") {
+				t.Errorf("expected rejection mentioning run_command, got: %v", err)
+			}
+		})
+	}
+}
+
 // TestDefaultReadOnlyBuiltInTools_PassesValidation locks in the invariant
 // that DefaultReadOnlyBuiltInTools() is always a valid Tools.BuiltIn list
 // for every read-only mode. Callers (notably the stirrup CLI) rely on


### PR DESCRIPTION
## Summary

Adds four first-class **read-only** VCS/diff built-in tools (issue #29) so `review`, `toil`, `planning`, and `research` modes can inspect the working tree without enabling `run_command` (which read-only modes forbid):

- `git_status` — porcelain working-tree state, parsed into structured entries.
- `git_changed_files` — changed paths with status letters (unstaged or `--cached`/staged).
- `git_diff` — bounded unified diff for the whole worktree or a single path.
- `git_show` — inspect a commit/ref (and optional path) read-only.

All four are `WorkspaceMutating: false` / `RequiresApproval: false`, registered in `RegisterBuiltins`, added to `validBuiltInToolNames` and `DefaultReadOnlyBuiltInTools()`, and deliberately kept out of `mutatingTools`. The read-only validation invariant still rejects `write_file`/`run_command`/`edit_file`. Structured results use concrete typed structs (no `map[string]any`) with `Kind` discriminators. System prompts (review/toil/planning/research) and `docs/architecture.md` + `docs/configuration.md` updated.

## Security model

The injected `executor.Executor.Exec` runs `sh -c <string>` in both the local and container executors, so any interpolated path/ref would be a shell-injection vector. Defences (each with tests):

- Every git argv element is wrapped with `shellQuote`, so a value like `foo; rm -rf /` is literal text to `sh`.
- Paths validated via `exec.ResolvePath` (workspace containment; rejects `..`/absolute escapes); refs reject shell metacharacters and a leading `-` (option injection); `--` separates options from values.
- A `<rev>:<path>` colon-ref has its path portion validated through the same containment gate, so containment does not depend on which API field the path arrives in.
- Output bounded: diffs capped at 256 KB / 4000 lines with a visible `[diff truncated]` sentinel (UTF-8-safe, trimmed to a complete line); status/changed-file lists capped on entry count.
- Non-git workspace yields a clear deterministic error.

## Review

A seven-reviewer wave (security, code, test-coverage, spec-compliance, functionality, consistency, doc-tone). Security verified — under adversarial testing — that shell-injection, option-injection, path-traversal, the read-only invariant, and the 30 s timeout all hold; spec-compliance returned COMPLIANT; functionality drove all four tools end-to-end against a real temp repo. Remediated findings: UTF-8-/line-safe diff truncation; closed a colon-ref path-validation bypass in `git_show`; documented the deliberate validate-resolved/use-relative path handling; and raised `git.go` coverage to ~91% mean (every security helper at 100%) by testing the leading-dash path rejection, `gitErrText`, bad-ref handling, and the rename/copy parser + formatter branches.

## Deferred follow-up (recommended)

The security review noted that `LocalExecutor.Exec` buffers full command output before capping, whereas `ContainerExecutor` drains-on-cap — a `git diff` over a huge file could balloon memory before the timeout. Fixing this means changing the output path for *all* `run_command` calls (and the `OutputTruncated` event's reported size), so it was intentionally **not** bundled here. `boundDiff` carries a comment noting the post-hoc bound. Recommend tracking executor output-streaming hardening as a separate issue.

## Verification

`just build`, `just test` (no failures), `just lint` (0 issues) all green. Driven end-to-end in a real temp git repo: all four tools return correct bounded structured output; `staged:true` exercised; a 5000-line diff shows the truncation sentinel; `HEAD:.env` returns content while `HEAD:../../etc/passwd` and `HEAD:/etc/passwd` are rejected *before* git runs; shell-injection path attempts are neutralised; a non-git directory errors cleanly.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
