### PR TITLE
cli: four-level exit-code scheme across stirrup commands (#253)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,6 +328,27 @@ stdout. The default JSONL trace writes to a file (or to nothing when
 `STIRRUP_RESULT` line. A future JSONL emitter that writes to stdout
 would conflict with `--output=json`.
 
+### Exit codes
+
+The CLI distinguishes failure classes through the process exit code so
+a wrapper script can branch on *why* a command failed without parsing
+stderr. The scheme is uniform across `harness`, `job`, and
+`run-config`:
+
+| Code | Class | Examples |
+|---|---|---|
+| `0` | Success | The command completed; for `harness`, a run reached a terminal outcome. |
+| `1` | Validation / precondition | `ValidateRunConfig` (or `run-config --validate`) rejected the resolved config; a required prompt had no source; `job` ran without `CONTROL_PLANE_ADDR`. Also the default for any failure not in a more specific class. |
+| `2` | Parse error | The JSON in a `--config` file or piped stdin failed to decode (syntax error, unknown field, type mismatch). |
+| `3` | I/O error | A `--config` or `--prompt-file` path could not be opened, read, or stat'd; an empty / oversize input; an `--output-runconfig` write or close failure. |
+
+A failed or cancelled *run* (as opposed to a configuration failure)
+exits non-zero on the same `1` default path; the `RunResult` on stdout
+carries the run's outcome for callers that need finer detail than the
+exit code. The interactive first-contact hints (a bare `stirrup` or a
+bare `stirrup harness` on a terminal) are a success surface and exit
+`0`.
+
 ## Component-selection limits
 
 The CLI deliberately exposes only a subset of each component's

--- a/harness/cmd/stirrup/cmd/exitcode.go
+++ b/harness/cmd/stirrup/cmd/exitcode.go
@@ -1,0 +1,92 @@
+package cmd
+
+import "errors"
+
+// CLI exit-code scheme (issue #253, #240). A single closed set of codes
+// applied across `harness`, `job`, and `run-config` so a wrapper script
+// can branch on the failure class without parsing stderr:
+//
+//	0  success
+//	1  validation failed (ValidateRunConfig / run-config --validate)
+//	2  parse error (malformed JSON on stdin or in --config)
+//	3  I/O error (stdin/stdout/file read/write)
+//
+// Code 0 is never carried by an exitError — a nil error from a command's
+// RunE is the success path, and Execute() exits 0 implicitly. The
+// constants below are the non-zero classes only.
+const (
+	exitValidation = 1
+	exitParse      = 2
+	exitIO         = 3
+)
+
+// exitError wraps a command error with the CLI exit code its failure
+// class maps to. Execute() unwraps it via errors.As and exits with the
+// carried code; any error NOT wrapped in an exitError preserves the
+// historical default-1 behaviour so nothing previously classified
+// silently changes its exit status.
+//
+// The wrapper is transparent: Error() and Unwrap() defer to the
+// underlying error so existing errors.Is / message-matching tests and
+// the stderr text an operator sees are unchanged. Only the process exit
+// code is affected.
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+
+func (e *exitError) Unwrap() error { return e.err }
+
+// parseError tags err as a malformed-input failure (exit 2): JSON that
+// failed to decode from --config or piped stdin. A nil err returns nil
+// so call sites can wrap unconditionally without manufacturing a
+// phantom failure.
+func parseError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &exitError{code: exitParse, err: err}
+}
+
+// ioError tags err as an I/O failure (exit 3): a --config / --prompt-file
+// path that could not be opened, stat'd, or read, or an output write
+// that failed. A nil err returns nil.
+func ioError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &exitError{code: exitIO, err: err}
+}
+
+// validationError tags err as a configuration-validation failure
+// (exit 1): a RunConfig that parsed cleanly but failed
+// ValidateRunConfig (or run-config --validate). A nil err returns nil.
+//
+// Exit 1 is also the untyped-error default, so wrapping here is mostly
+// documentary today; it keeps the validation class explicit so a future
+// renumbering of the scheme touches one site rather than relying on the
+// default.
+func validationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &exitError{code: exitValidation, err: err}
+}
+
+// classifyExitCode maps a command error to its process exit code. It is
+// the testable core of Execute()'s os.Exit decision: a nil error is the
+// success path (0), an error that unwraps to an *exitError carries its
+// code, and any other error preserves the historical default of 1 so
+// no previously-unclassified failure changes its exit status.
+func classifyExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee *exitError
+	if errors.As(err, &ee) {
+		return ee.code
+	}
+	return 1
+}

--- a/harness/cmd/stirrup/cmd/exitcode_test.go
+++ b/harness/cmd/stirrup/cmd/exitcode_test.go
@@ -1,0 +1,367 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClassifyExitCode pins the core mapping Execute() relies on: a nil
+// error is success (0), an *exitError carries its class code, an
+// *exitError reached through a wrapping fmt.Errorf chain is still found
+// via errors.As, and any other error preserves the historical default
+// of 1 so nothing previously unclassified changes its exit status.
+func TestClassifyExitCode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil is success", err: nil, want: 0},
+		{name: "validation", err: validationError(errors.New("bad config")), want: exitValidation},
+		{name: "parse", err: parseError(errors.New("bad json")), want: exitParse},
+		{name: "io", err: ioError(errors.New("no such file")), want: exitIO},
+		{
+			name: "wrapped exitError still classified",
+			err:  errors.New("outer: " + parseError(errors.New("inner")).Error()),
+			want: 1, // a plain re-string loses the wrapper; default applies
+		},
+		{
+			name: "fmt.Errorf %w preserves the class",
+			want: exitIO,
+			err: func() error {
+				return errors.Join(errors.New("context"), ioError(errors.New("disk full")))
+			}(),
+		},
+		{name: "untyped error defaults to 1", err: errors.New("something else"), want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyExitCode(tc.err); got != tc.want {
+				t.Errorf("classifyExitCode(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExitErrorWrappersAreTransparent pins that the wrapper does not
+// change the operator-facing message or break errors.Is on the wrapped
+// sentinel. Only the carried exit code is new behaviour.
+func TestExitErrorWrappersAreTransparent(t *testing.T) {
+	sentinel := errors.New("the underlying failure")
+	for _, wrap := range []func(error) error{parseError, ioError, validationError} {
+		got := wrap(sentinel)
+		if got.Error() != sentinel.Error() {
+			t.Errorf("wrapped Error() = %q, want %q", got.Error(), sentinel.Error())
+		}
+		if !errors.Is(got, sentinel) {
+			t.Errorf("errors.Is should match the wrapped sentinel through the exitError")
+		}
+	}
+}
+
+// TestExitErrorWrappersNilPassthrough pins that wrapping a nil error
+// returns nil rather than a non-nil exitError around nothing, so a call
+// site can wrap unconditionally without inventing a phantom failure.
+func TestExitErrorWrappersNilPassthrough(t *testing.T) {
+	for _, wrap := range []func(error) error{parseError, ioError, validationError} {
+		if got := wrap(nil); got != nil {
+			t.Errorf("wrap(nil) = %v, want nil", got)
+		}
+	}
+}
+
+// TestLoadRunConfigFile_ExitClasses pins the file-loader's
+// classification: a missing file is I/O (exit 3) and malformed JSON is
+// a parse error (exit 2). The class is asserted via classifyExitCode so
+// the test follows the same path Execute() does.
+func TestLoadRunConfigFile_ExitClasses(t *testing.T) {
+	t.Run("missing file is I/O", func(t *testing.T) {
+		_, err := loadRunConfigFile(filepath.Join(t.TempDir(), "absent.json"))
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
+	t.Run("malformed JSON is parse", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.json")
+		if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_, err := loadRunConfigFile(path)
+		if got := classifyExitCode(err); got != exitParse {
+			t.Errorf("classifyExitCode = %d, want %d (parse); err=%v", got, exitParse, err)
+		}
+	})
+	t.Run("empty file is I/O", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.json")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_, err := loadRunConfigFile(path)
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
+}
+
+// TestReadRunConfigFromReader_ExitClasses pins the stdin reader's
+// classification: malformed piped JSON is a parse error (exit 2) and an
+// empty stream is an I/O error (exit 3). A non-*os.File reader forces
+// the piped path without a real pipe (see isStdinPiped).
+func TestReadRunConfigFromReader_ExitClasses(t *testing.T) {
+	t.Run("malformed piped JSON is parse", func(t *testing.T) {
+		_, err := readRunConfigFromReader(strings.NewReader("{bad"), "<stdin>")
+		if got := classifyExitCode(err); got != exitParse {
+			t.Errorf("classifyExitCode = %d, want %d (parse); err=%v", got, exitParse, err)
+		}
+	})
+	t.Run("empty stream is I/O", func(t *testing.T) {
+		_, err := readRunConfigFromReader(strings.NewReader(""), "<stdin>")
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
+}
+
+// TestReadPromptFile_ExitClassIsIO pins that every --prompt-file failure
+// classifies as I/O (exit 3): the file is plain text so no path can be a
+// JSON parse failure.
+func TestReadPromptFile_ExitClassIsIO(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := readPromptFile(filepath.Join(t.TempDir(), "absent.txt"))
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
+	t.Run("empty file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.txt")
+		if err := os.WriteFile(path, []byte("\n"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_, err := readPromptFile(path)
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
+}
+
+// TestBuildRunConfig_ValidationExitClass pins that a read-only mode with
+// an allow-all policy — a config that parses cleanly but fails
+// ValidateRunConfig — classifies as validation (exit 1) when resolved
+// through the ResolveAll path the harness uses.
+func TestBuildRunConfig_ValidationExitClass(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	// planning is read-only; allow-all on a read-only mode is the hard
+	// invariant ValidateRunConfig rejects (see CLAUDE.md). The prompt is
+	// present so resolution reaches the validator rather than the
+	// prompt-required gate.
+	body := `{"runId":"r","mode":"planning","prompt":"do a thing",` +
+		`"maxTurns":10,"timeout":600,` +
+		`"permissionPolicy":{"type":"allow-all"},` +
+		`"provider":{"type":"anthropic","apiKeyRef":"secret://ANTHROPIC_API_KEY"},` +
+		`"modelRouter":{"type":"static","provider":"anthropic","model":"claude-x"}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cmd := newTestHarnessCommand()
+	_, err := BuildRunConfig(RunConfigSources{
+		ConfigPath: path,
+		Cmd:        cmd,
+		Resolve:    ResolveAll,
+	})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if got := classifyExitCode(err); got != exitValidation {
+		t.Errorf("classifyExitCode = %d, want %d (validation); err=%v", got, exitValidation, err)
+	}
+}
+
+// TestRunRunConfig_PromptRequiredExitClass pins that `run-config
+// --validate` with no prompt on a non-TTY surface classifies as
+// validation (exit 1). The stderrIsInteractive seam is pinned to false
+// so the test does not depend on whether the test runner has a TTY.
+func TestRunRunConfig_PromptRequiredExitClass(t *testing.T) {
+	orig := stderrIsInteractive
+	stderrIsInteractive = func() bool { return false }
+	defer func() { stderrIsInteractive = orig }()
+
+	cmd := newTestRunConfigCommand()
+	_ = cmd.Flags().Set("validate", "true")
+
+	// nil stdin (not an empty reader): a non-nil reader is treated as
+	// piped by isStdinPiped and would trip the "input is empty" I/O
+	// error before resolution reaches the prompt-required gate.
+	var out bytes.Buffer
+	err := runRunConfigWithIO(cmd, nil, nil, &out)
+	if err == nil {
+		t.Fatal("expected prompt-required error, got nil")
+	}
+	if !errors.Is(err, errPromptRequired) {
+		t.Errorf("error should wrap errPromptRequired, got: %v", err)
+	}
+	if got := classifyExitCode(err); got != exitValidation {
+		t.Errorf("classifyExitCode = %d, want %d (validation); err=%v", got, exitValidation, err)
+	}
+}
+
+// TestCLIExitCodes_EndToEnd pins the real os.Exit codes the built binary
+// produces for each failure class. A type-check pass does not prove the
+// Execute() → classifyExitCode → os.Exit wiring fires, so this builds
+// the binary once and execs it with stdin attached to a pipe (never a
+// TTY under `go test`), exercising harness and run-config:
+//
+//	success            -> 0
+//	validation failure -> 1
+//	malformed --config -> 2
+//	missing  --config  -> 3
+func TestCLIExitCodes_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping binary build + exec in -short mode")
+	}
+	bin := buildStirrupBinary(t)
+	dir := t.TempDir()
+
+	validConfig := filepath.Join(dir, "valid.json")
+	// maxTurns + timeout are required by ValidateRunConfig and have no
+	// file-side defaults (the flag-only path gets them from cobra
+	// DefValues), so a from-file config must set them explicitly.
+	writeFile(t, validConfig, `{"runId":"r","mode":"planning","prompt":"hi",`+
+		`"maxTurns":10,"timeout":600,`+
+		`"provider":{"type":"anthropic","apiKeyRef":"secret://ANTHROPIC_API_KEY"},`+
+		`"modelRouter":{"type":"static","provider":"anthropic","model":"claude-x"}}`)
+
+	invalidConfig := filepath.Join(dir, "invalid.json")
+	// allow-all on the read-only planning mode is the sole reason this
+	// fails ValidateRunConfig — every other required field is present so
+	// the failure is unambiguously the read-only-mode invariant.
+	writeFile(t, invalidConfig, `{"runId":"r","mode":"planning","prompt":"hi",`+
+		`"maxTurns":10,"timeout":600,`+
+		`"permissionPolicy":{"type":"allow-all"},`+
+		`"provider":{"type":"anthropic","apiKeyRef":"secret://ANTHROPIC_API_KEY"},`+
+		`"modelRouter":{"type":"static","provider":"anthropic","model":"claude-x"}}`)
+
+	malformedConfig := filepath.Join(dir, "malformed.json")
+	writeFile(t, malformedConfig, `{not json`)
+
+	missingConfig := filepath.Join(dir, "does-not-exist.json")
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{
+			name: "run-config valid succeeds",
+			args: []string{"run-config", "--validate", "--config", validConfig},
+			want: 0,
+		},
+		{
+			name: "run-config validation failure",
+			args: []string{"run-config", "--validate", "--config", invalidConfig},
+			want: exitValidation,
+		},
+		{
+			name: "run-config malformed JSON",
+			args: []string{"run-config", "--config", malformedConfig},
+			want: exitParse,
+		},
+		{
+			name: "run-config missing file",
+			args: []string{"run-config", "--config", missingConfig},
+			want: exitIO,
+		},
+		{
+			name: "harness validation failure",
+			args: []string{"harness", "--config", invalidConfig},
+			want: exitValidation,
+		},
+		{
+			name: "harness malformed JSON",
+			args: []string{"harness", "--config", malformedConfig},
+			want: exitParse,
+		},
+		{
+			name: "harness missing file",
+			args: []string{"harness", "--config", missingConfig},
+			want: exitIO,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runExit(t, bin, tc.args)
+			if got != tc.want {
+				t.Errorf("exit code = %d, want %d (args: %v)", got, tc.want, tc.args)
+			}
+		})
+	}
+}
+
+// TestCLIExitCodes_BareInvocationsStayZero pins that the #249 success
+// paths are not regressed by the exit-code mapping: a bare `stirrup`
+// prints the orientation hint and exits 0. (`stirrup harness` with no
+// prompt exits non-zero under the non-TTY `go test` subprocess — its
+// interactive hint exit-0 path needs a PTY and is covered by the #249
+// suite plus the manual verification in the task report.)
+func TestCLIExitCodes_BareInvocationsStayZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping binary build + exec in -short mode")
+	}
+	bin := buildStirrupBinary(t)
+	if got := runExit(t, bin, []string{}); got != 0 {
+		t.Errorf("bare `stirrup` exit code = %d, want 0", got)
+	}
+}
+
+// buildStirrupBinary compiles the stirrup CLI into the test's temp dir
+// and returns its path. Building once per test keeps the subprocess
+// exec hermetic (no dependency on a stale ./stirrup in the worktree).
+func buildStirrupBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "stirrup-exitcode-test")
+	cmd := exec.Command("go", "build", "-o", bin, "github.com/rxbynerd/stirrup/harness/cmd/stirrup")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// runExit execs the binary with the given args and returns the process
+// exit code. Stdin is /dev/null — a character device, which isStdinPiped
+// treats as "not piped" (issue #249), so a --config <path> argument is
+// not rejected as ambiguous against a phantom piped base. A non-ExitError
+// failure (binary missing, signal) fails the test.
+func runExit(t *testing.T, bin string, args []string) int {
+	t.Helper()
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	defer func() { _ = devNull.Close() }()
+
+	cmd := exec.Command(bin, args...) //nolint:gosec // bin is the test-built binary, args are test-controlled
+	cmd.Stdin = devNull
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	runErr := cmd.Run()
+	if runErr == nil {
+		return 0
+	}
+	var ee *exec.ExitError
+	if errors.As(runErr, &ee) {
+		return ee.ExitCode()
+	}
+	t.Fatalf("running %s %v: non-exit error: %v", bin, args, runErr)
+	return -1
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/harness/cmd/stirrup/cmd/exitcode_test.go
+++ b/harness/cmd/stirrup/cmd/exitcode_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,11 +32,16 @@ func TestClassifyExitCode(t *testing.T) {
 			want: 1, // a plain re-string loses the wrapper; default applies
 		},
 		{
-			name: "fmt.Errorf %w preserves the class",
+			name: "errors.Join wrapping preserves the class",
 			want: exitIO,
 			err: func() error {
 				return errors.Join(errors.New("context"), ioError(errors.New("disk full")))
 			}(),
+		},
+		{
+			name: "fmt.Errorf %w preserves the class",
+			want: exitIO,
+			err:  fmt.Errorf("context: %w", ioError(errors.New("disk full"))),
 		},
 		{name: "untyped error defaults to 1", err: errors.New("something else"), want: 1},
 	} {
@@ -105,6 +111,33 @@ func TestLoadRunConfigFile_ExitClasses(t *testing.T) {
 			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
 		}
 	})
+	t.Run("directory path is I/O", func(t *testing.T) {
+		_, err := loadRunConfigFile(t.TempDir())
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
+	t.Run("oversize file is I/O", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "big.json")
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		// A sparse file one byte over the cap trips the size guard without
+		// writing a megabyte to disk: Truncate extends the file to the
+		// length, which os.Stat reports as Size() > maxConfigFileBytes.
+		if err := f.Truncate(maxConfigFileBytes + 1); err != nil {
+			_ = f.Close()
+			t.Fatalf("truncate: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		_, err = loadRunConfigFile(path)
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
 }
 
 // TestReadRunConfigFromReader_ExitClasses pins the stdin reader's
@@ -124,6 +157,26 @@ func TestReadRunConfigFromReader_ExitClasses(t *testing.T) {
 			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
 		}
 	})
+	t.Run("read failure is I/O", func(t *testing.T) {
+		// The io.ReadAll-failure branch is unreachable via strings.Reader
+		// (it never errors), so inject a reader that fails on first Read.
+		_, err := readRunConfigFromReader(&errReader{err: errors.New("broken pipe")}, "<stdin>")
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
+	})
+}
+
+// errReader is an io.Reader that returns a configured error on the first
+// Read. It exercises the readRunConfigFromReader io.ReadAll-failure
+// branch, which no in-memory reader (strings.Reader, bytes.Reader) can
+// reach because those never error.
+type errReader struct {
+	err error
+}
+
+func (r *errReader) Read([]byte) (int, error) {
+	return 0, r.err
 }
 
 // TestReadPromptFile_ExitClassIsIO pins that every --prompt-file failure
@@ -146,6 +199,31 @@ func TestReadPromptFile_ExitClassIsIO(t *testing.T) {
 			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
 		}
 	})
+}
+
+// TestBuildRunConfig_MissingPromptFileExitClass pins the I/O class for
+// the longest --prompt-file propagation chain in process: readPromptFile
+// → resolvePromptForRun → BuildRunConfig. A nonexistent --prompt-file
+// must classify as I/O (exit 3), not be flattened to the validation
+// default by a stray wrapper anywhere on that chain. ResolveAll is used
+// because resolvePromptForRun only runs on the loop-ready path.
+func TestBuildRunConfig_MissingPromptFileExitClass(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	missing := filepath.Join(t.TempDir(), "absent-brief.txt")
+	if err := cmd.Flags().Set("prompt-file", missing); err != nil {
+		t.Fatalf("set --prompt-file: %v", err)
+	}
+
+	_, err := BuildRunConfig(RunConfigSources{
+		Cmd:     cmd,
+		Resolve: ResolveAll,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a missing --prompt-file, got nil")
+	}
+	if got := classifyExitCode(err); got != exitIO {
+		t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+	}
 }
 
 // TestBuildRunConfig_ValidationExitClass pins that a read-only mode with
@@ -213,13 +291,14 @@ func TestRunRunConfig_PromptRequiredExitClass(t *testing.T) {
 // TestCLIExitCodes_EndToEnd pins the real os.Exit codes the built binary
 // produces for each failure class. A type-check pass does not prove the
 // Execute() → classifyExitCode → os.Exit wiring fires, so this builds
-// the binary once and execs it with stdin attached to a pipe (never a
+// the binary once and execs it with stdin attached to /dev/null (never a
 // TTY under `go test`), exercising harness and run-config:
 //
-//	success            -> 0
-//	validation failure -> 1
-//	malformed --config -> 2
-//	missing  --config  -> 3
+//	success                 -> 0
+//	validation failure       -> 1
+//	malformed --config        -> 2
+//	missing --config          -> 3
+//	missing --prompt-file     -> 3 (the longest I/O propagation chain)
 func TestCLIExitCodes_EndToEnd(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping binary build + exec in -short mode")
@@ -251,6 +330,18 @@ func TestCLIExitCodes_EndToEnd(t *testing.T) {
 
 	missingConfig := filepath.Join(dir, "does-not-exist.json")
 
+	// A config that parses and would validate, but supplies no prompt —
+	// so resolution reaches the --prompt-file gate. Paired with a missing
+	// --prompt-file it exercises the longest I/O chain end-to-end:
+	// readPromptFile → resolvePromptForRun → BuildRunConfig → runHarness
+	// → Execute → classifyExitCode.
+	noPromptConfig := filepath.Join(dir, "no-prompt.json")
+	writeFile(t, noPromptConfig, `{"runId":"r","mode":"planning",`+
+		`"maxTurns":10,"timeout":600,`+
+		`"provider":{"type":"anthropic","apiKeyRef":"secret://ANTHROPIC_API_KEY"},`+
+		`"modelRouter":{"type":"static","provider":"anthropic","model":"claude-x"}}`)
+	missingPromptFile := filepath.Join(dir, "absent-brief.txt")
+
 	for _, tc := range []struct {
 		name string
 		args []string
@@ -259,6 +350,15 @@ func TestCLIExitCodes_EndToEnd(t *testing.T) {
 		{
 			name: "run-config valid succeeds",
 			args: []string{"run-config", "--validate", "--config", validConfig},
+			want: 0,
+		},
+		{
+			// Cheap regression guard for the harness success path; the
+			// only other e2e zero-case is run-config above. dry-run via
+			// --output-runconfig=- so the loop never starts (no provider
+			// call, no network) yet Execute() still returns nil → exit 0.
+			name: "harness valid succeeds",
+			args: []string{"harness", "--config", validConfig, "--output-runconfig", "-"},
 			want: 0,
 		},
 		{
@@ -289,6 +389,16 @@ func TestCLIExitCodes_EndToEnd(t *testing.T) {
 		{
 			name: "harness missing file",
 			args: []string{"harness", "--config", missingConfig},
+			want: exitIO,
+		},
+		{
+			// Longest I/O chain: a valid no-prompt config + a missing
+			// --prompt-file. readPromptFile fails before validation runs,
+			// so the failure must surface as I/O (3), not the validation
+			// default — a stray validationError wrapper anywhere on the
+			// chain would flip this to 1 and only this case would catch it.
+			name: "harness missing prompt-file",
+			args: []string{"harness", "--config", noPromptConfig, "--prompt-file", missingPromptFile},
 			want: exitIO,
 		},
 	} {

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -667,9 +667,9 @@ const maxConfigFileBytes int64 = 1 << 20 // 1 MiB
 func loadRunConfigFile(path string) (*types.RunConfig, error) {
 	// A missing / unreadable / oversize / empty file is an I/O failure
 	// (exit 3): the bytes never reached the JSON decoder. Only the decode
-	// step below is a parse failure (exit 2). The two classes share the
-	// "reading config file" / "parsing config file" message prefixes so
-	// the operator-facing text is unchanged.
+	// step below is a parse failure (exit 2). I/O-class errors use the
+	// "reading config file" prefix and parse-class errors use "parsing
+	// config file" so the operator-facing wording matches the exit code.
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, ioError(fmt.Errorf("reading config file %q: %w", path, err))
@@ -685,7 +685,11 @@ func loadRunConfigFile(path string) (*types.RunConfig, error) {
 		return nil, ioError(fmt.Errorf("reading config file %q: %w", path, err))
 	}
 	if len(data) == 0 {
-		return nil, ioError(fmt.Errorf("parsing config file %q: file is empty", path))
+		// "reading", not "parsing": an empty file never reached the JSON
+		// decoder, so the I/O exit class (3) and the wording agree. The
+		// parallel readRunConfigFromReader empty-stdin path already says
+		// "reading", so this aligns the two.
+		return nil, ioError(fmt.Errorf("reading config file %q: file is empty", path))
 	}
 	var cfg types.RunConfig
 	dec := json.NewDecoder(bytes.NewReader(data))

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -43,13 +43,18 @@ const maxPromptFileBytes int64 = 10 * 1024 * 1024 // matches local.go maxFileSiz
 // --prompt-file ./brief.txt` from their checkout gets the file next
 // to them, not next to a possibly-remote workspace.
 func readPromptFile(path string) (string, error) {
+	// Every failure here is an I/O error (exit 3): a --prompt-file the
+	// harness could not stat, open, or read, or one whose contents
+	// failed a pre-read precondition (directory, non-regular, oversize,
+	// empty). None is a JSON parse failure — the prompt file is plain
+	// text — so they all classify as I/O.
 	clean := filepath.Clean(path)
 	info, err := os.Stat(clean)
 	if err != nil {
-		return "", fmt.Errorf("reading --prompt-file %q: %w", path, err)
+		return "", ioError(fmt.Errorf("reading --prompt-file %q: %w", path, err))
 	}
 	if info.IsDir() {
-		return "", fmt.Errorf("reading --prompt-file %q: is a directory", path)
+		return "", ioError(fmt.Errorf("reading --prompt-file %q: is a directory", path))
 	}
 	// Reject character devices, named pipes (FIFOs), Unix sockets, and
 	// every other non-regular file type. `os.Stat` reports Size()==0
@@ -63,10 +68,10 @@ func readPromptFile(path string) (string, error) {
 	// The IsDir() guard above does not cover these; IsDir() is false
 	// for devices and FIFOs.
 	if !info.Mode().IsRegular() {
-		return "", fmt.Errorf("reading --prompt-file %q: not a regular file", path)
+		return "", ioError(fmt.Errorf("reading --prompt-file %q: not a regular file", path))
 	}
 	if info.Size() > maxPromptFileBytes {
-		return "", fmt.Errorf("reading --prompt-file %q: %d bytes exceeds %d byte cap", path, info.Size(), maxPromptFileBytes)
+		return "", ioError(fmt.Errorf("reading --prompt-file %q: %d bytes exceeds %d byte cap", path, info.Size(), maxPromptFileBytes))
 	}
 	// Bounded read via io.LimitReader. Belt-and-braces alongside the
 	// stat-time size check above: closes the TOCTOU window where the
@@ -77,15 +82,15 @@ func readPromptFile(path string) (string, error) {
 	// the operator-facing error is accurate.
 	f, err := os.Open(clean)
 	if err != nil {
-		return "", fmt.Errorf("reading --prompt-file %q: %w", path, err)
+		return "", ioError(fmt.Errorf("reading --prompt-file %q: %w", path, err))
 	}
 	defer func() { _ = f.Close() }()
 	data, err := io.ReadAll(io.LimitReader(f, maxPromptFileBytes+1))
 	if err != nil {
-		return "", fmt.Errorf("reading --prompt-file %q: %w", path, err)
+		return "", ioError(fmt.Errorf("reading --prompt-file %q: %w", path, err))
 	}
 	if int64(len(data)) > maxPromptFileBytes {
-		return "", fmt.Errorf("reading --prompt-file %q: exceeds %d byte cap", path, maxPromptFileBytes)
+		return "", ioError(fmt.Errorf("reading --prompt-file %q: exceeds %d byte cap", path, maxPromptFileBytes))
 	}
 	// Trim only trailing CR/LF so `echo "prompt" > file` and
 	// `printf 'prompt\n' > file` both produce the same string. Leading
@@ -93,7 +98,7 @@ func readPromptFile(path string) (string, error) {
 	// indentation (e.g. a code block) should round-trip unchanged.
 	trimmed := strings.TrimRight(string(data), "\r\n")
 	if trimmed == "" {
-		return "", fmt.Errorf("--prompt-file %q is empty", path)
+		return "", ioError(fmt.Errorf("--prompt-file %q is empty", path))
 	}
 	return trimmed, nil
 }
@@ -660,28 +665,33 @@ const maxConfigFileBytes int64 = 1 << 20 // 1 MiB
 // JSON fields are rejected so that typos in the config file surface as
 // errors rather than being silently ignored.
 func loadRunConfigFile(path string) (*types.RunConfig, error) {
+	// A missing / unreadable / oversize / empty file is an I/O failure
+	// (exit 3): the bytes never reached the JSON decoder. Only the decode
+	// step below is a parse failure (exit 2). The two classes share the
+	// "reading config file" / "parsing config file" message prefixes so
+	// the operator-facing text is unchanged.
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading config file %q: %w", path, err)
+		return nil, ioError(fmt.Errorf("reading config file %q: %w", path, err))
 	}
 	if info.IsDir() {
-		return nil, fmt.Errorf("reading config file %q: is a directory", path)
+		return nil, ioError(fmt.Errorf("reading config file %q: is a directory", path))
 	}
 	if info.Size() > maxConfigFileBytes {
-		return nil, fmt.Errorf("reading config file %q: %d bytes exceeds %d byte cap", path, info.Size(), maxConfigFileBytes)
+		return nil, ioError(fmt.Errorf("reading config file %q: %d bytes exceeds %d byte cap", path, info.Size(), maxConfigFileBytes))
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading config file %q: %w", path, err)
+		return nil, ioError(fmt.Errorf("reading config file %q: %w", path, err))
 	}
 	if len(data) == 0 {
-		return nil, fmt.Errorf("parsing config file %q: file is empty", path)
+		return nil, ioError(fmt.Errorf("parsing config file %q: file is empty", path))
 	}
 	var cfg types.RunConfig
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("parsing config file %q: %w", path, err)
+		return nil, parseError(fmt.Errorf("parsing config file %q: %w", path, err))
 	}
 	return &cfg, nil
 }
@@ -1316,7 +1326,7 @@ func writeOutputRunConfig(path string, cfg *types.RunConfig) error {
 	// a replay file.
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return fmt.Errorf("opening --output-runconfig %q: %w", path, err)
+		return ioError(fmt.Errorf("opening --output-runconfig %q: %w", path, err))
 	}
 	return writeAndCloseRunConfig(f, path, cfg)
 }
@@ -1335,7 +1345,7 @@ func writeOutputRunConfig(path string, cfg *types.RunConfig) error {
 func writeAndCloseRunConfig(wc io.WriteCloser, path string, cfg *types.RunConfig) error {
 	writeErr := writeRunConfigJSON(wc, cfg, false)
 	if cerr := wc.Close(); cerr != nil && writeErr == nil {
-		return fmt.Errorf("closing --output-runconfig %q: %w", path, cerr)
+		return ioError(fmt.Errorf("closing --output-runconfig %q: %w", path, cerr))
 	}
 	return writeErr
 }

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -1591,8 +1591,10 @@ func TestRunHarness_ConfigValidationFailurePropagates(t *testing.T) {
 
 // TestLoadRunConfigFile_EmptyFile pins the error path for an empty (zero-
 // byte) file. encoding/json would otherwise return io.EOF, which is
-// unhelpful out of context — we want a message that names the path and
-// the parsing stage so the user can find the typo.
+// unhelpful out of context — we want a message that names the path so
+// the user can find the mistake. The prefix is "reading" (not
+// "parsing"): an empty file never reached the decoder, so the wording
+// matches its I/O exit class (3).
 func TestLoadRunConfigFile_EmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "empty.json")
@@ -1603,7 +1605,7 @@ func TestLoadRunConfigFile_EmptyFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty file, got nil")
 	}
-	if !strings.Contains(err.Error(), "parsing config file") || !strings.Contains(err.Error(), "empty") {
+	if !strings.Contains(err.Error(), "reading config file") || !strings.Contains(err.Error(), "empty") {
 		t.Errorf("error should describe empty file, got: %v", err)
 	}
 }

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -39,9 +39,26 @@ var rootCmd = &cobra.Command{
 }
 
 // Execute runs the root command. Called from main().
+//
+// SilenceErrors + SilenceUsage are set so a RunE failure prints the
+// error message alone — Execute() owns the stderr line below, and the
+// 80-flag usage block Cobra would otherwise append on every error is
+// noise on a one-line "prompt is required" or "invalid config" failure
+// (the #249 review called this out). --help still prints the full usage
+// because SilenceUsage only suppresses the usage-on-error path, not an
+// explicit help request.
+//
+// The exit code follows the four-level CLI scheme (issue #253): an
+// error wrapped in an *exitError carries its class code (1 validation /
+// 2 parse / 3 I/O); any other error preserves the historical default of
+// 1. classifyExitCode encodes the mapping so it is unit-testable without
+// reaching os.Exit.
 func Execute() {
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(classifyExitCode(err))
 	}
 }
 

--- a/harness/cmd/stirrup/cmd/runconfig.go
+++ b/harness/cmd/stirrup/cmd/runconfig.go
@@ -86,7 +86,12 @@ func runRunConfigWithIO(cmd *cobra.Command, args []string, stdin io.Reader, stdo
 		// cobra (which would print "Error: stirrup: interactive prompt
 		// hint requested" and exit non-zero).
 		if errors.Is(err, errPromptHintRequested) {
-			return errPromptRequired
+			// A missing prompt is a precondition / validation-class
+			// failure (exit 1, issue #253): the config could not be
+			// completed because a required field had no source. The plain
+			// errPromptRequired message replaces the internal sentinel
+			// string so the operator sees an actionable error.
+			return validationError(errPromptRequired)
 		}
 		return err
 	}

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -149,7 +149,7 @@ func BuildRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 	}
 
 	if err := types.ValidateRunConfig(cfg); err != nil {
-		return nil, fmt.Errorf("invalid config: %w", err)
+		return nil, validationError(fmt.Errorf("invalid config: %w", err))
 	}
 	return cfg, nil
 }
@@ -301,19 +301,24 @@ func readRunConfigFromReader(r io.Reader, source string) (*types.RunConfig, erro
 	// readPromptFile helper above.
 	data, err := io.ReadAll(io.LimitReader(r, maxConfigFileBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("reading config from %s: %w", source, err)
+		// Read failure on the stream itself (a broken pipe, a flaky
+		// redirected file) is an I/O error (exit 3), not a parse error:
+		// the bytes never reached the decoder.
+		return nil, ioError(fmt.Errorf("reading config from %s: %w", source, err))
 	}
 	if int64(len(data)) > maxConfigFileBytes {
-		return nil, fmt.Errorf("reading config from %s: exceeds %d byte cap", source, maxConfigFileBytes)
+		return nil, ioError(fmt.Errorf("reading config from %s: exceeds %d byte cap", source, maxConfigFileBytes))
 	}
 	if len(data) == 0 {
-		return nil, fmt.Errorf("reading config from %s: input is empty; pass --config <path> or remove the redirection", source)
+		return nil, ioError(fmt.Errorf("reading config from %s: input is empty; pass --config <path> or remove the redirection", source))
 	}
 	var cfg types.RunConfig
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("parsing config from %s: %w", source, err)
+		// Malformed JSON (syntax error, unknown field, type mismatch) is
+		// a parse error (exit 2): the input was read but did not decode.
+		return nil, parseError(fmt.Errorf("parsing config from %s: %w", source, err))
 	}
 	return &cfg, nil
 }
@@ -537,9 +542,20 @@ func resolvePromptForRun(cmd *cobra.Command, cfg *types.RunConfig) error {
 	}
 	if cfg.Prompt == "" {
 		if stderrIsInteractive() {
+			// errPromptHintRequested is intercepted by runHarness (prints
+			// the grouped hint, exits 0) and by run-config (remapped to
+			// the plain errPromptRequired). It is NEVER classified here:
+			// wrapping it in an exitError would let it reach
+			// classifyExitCode as a non-zero failure on the interactive
+			// success path. Return the bare sentinel.
 			return errPromptHintRequested
 		}
-		return errPromptRequired
+		// A scripted (non-TTY) run with no prompt anywhere is a
+		// precondition / validation-class failure (exit 1, issue #253).
+		// errors.Is still matches the sentinel through the exitError
+		// wrapper, so the run-config remap and existing fixtures are
+		// unaffected.
+		return validationError(errPromptRequired)
 	}
 	return nil
 }
@@ -560,13 +576,16 @@ func writeRunConfigJSON(w io.Writer, cfg *types.RunConfig, compact bool) error {
 		data, err = json.MarshalIndent(cfg, "", "  ")
 	}
 	if err != nil {
+		// A RunConfig that fails to marshal is an internal bug, not an
+		// operator-facing I/O or input failure; leave it untyped so it
+		// takes the default exit 1 rather than masquerading as exit 3.
 		return fmt.Errorf("marshal RunConfig: %w", err)
 	}
 	if _, err := w.Write(data); err != nil {
-		return fmt.Errorf("write RunConfig: %w", err)
+		return ioError(fmt.Errorf("write RunConfig: %w", err))
 	}
 	if _, err := w.Write([]byte("\n")); err != nil {
-		return fmt.Errorf("write RunConfig: %w", err)
+		return ioError(fmt.Errorf("write RunConfig: %w", err))
 	}
 	return nil
 }

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -195,11 +195,18 @@ func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 		}
 	}
 
+	// The base-source preconditions below are configuration mistakes the
+	// operator must resolve before any input is read — ambiguous sources,
+	// or --config -/STIRRUP_CONFIG=- without a usable piped stdin. They
+	// are validation-class (exit 1): nothing was parsed and no I/O
+	// failed. Declaring the class explicitly keeps every validation-class
+	// error in this package self-describing rather than relying on the
+	// classifyExitCode default.
 	if filePath != "" && stdinPiped {
 		if envConfigSourced {
-			return nil, fmt.Errorf("ambiguous config sources: both env var STIRRUP_CONFIG=%q and piped stdin specify a base config; pick one", filePath)
+			return nil, validationError(fmt.Errorf("ambiguous config sources: both env var STIRRUP_CONFIG=%q and piped stdin specify a base config; pick one", filePath))
 		}
-		return nil, fmt.Errorf("ambiguous config sources: --config %q and piped stdin are both present; pick one", filePath)
+		return nil, validationError(fmt.Errorf("ambiguous config sources: --config %q and piped stdin are both present; pick one", filePath))
 	}
 
 	switch {
@@ -207,11 +214,11 @@ func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 		if !stdinPiped {
 			if envConfigSourced {
 				if sources.Stdin == nil {
-					return nil, fmt.Errorf("STIRRUP_CONFIG=- requires piped stdin but no stdin reader was provided")
+					return nil, validationError(fmt.Errorf("STIRRUP_CONFIG=- requires piped stdin but no stdin reader was provided"))
 				}
-				return nil, fmt.Errorf("STIRRUP_CONFIG=- requires piped stdin but stdin is a terminal")
+				return nil, validationError(fmt.Errorf("STIRRUP_CONFIG=- requires piped stdin but stdin is a terminal"))
 			}
-			return nil, fmt.Errorf("--config - requires piped stdin but stdin is a terminal")
+			return nil, validationError(fmt.Errorf("--config - requires piped stdin but stdin is a terminal"))
 		}
 		if envConfigSourced {
 			slog.Debug("using STIRRUP_CONFIG as base RunConfig source", "path", "-")
@@ -552,9 +559,11 @@ func resolvePromptForRun(cmd *cobra.Command, cfg *types.RunConfig) error {
 		}
 		// A scripted (non-TTY) run with no prompt anywhere is a
 		// precondition / validation-class failure (exit 1, issue #253).
-		// errors.Is still matches the sentinel through the exitError
-		// wrapper, so the run-config remap and existing fixtures are
-		// unaffected.
+		// errors.Is still matches errPromptRequired through the exitError
+		// wrapper (the wrapper is transparent via Unwrap), so the
+		// run-config remap and existing fixtures are unaffected. Note this
+		// wraps errPromptRequired, NOT the errPromptHintRequested sentinel
+		// above — that one is returned bare on purpose.
 		return validationError(errPromptRequired)
 	}
 	return nil

--- a/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder_test.go
@@ -724,6 +724,11 @@ func TestWriteRunConfigJSON_WriteError(t *testing.T) {
 		if !strings.Contains(err.Error(), "write RunConfig") {
 			t.Errorf("error should describe the write failure, got: %v", err)
 		}
+		// A write failure is an I/O error (exit 3): the marshal succeeded
+		// but the bytes did not reach the sink.
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
+		}
 	})
 
 	t.Run("second write (newline) fails", func(t *testing.T) {
@@ -734,6 +739,9 @@ func TestWriteRunConfigJSON_WriteError(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "write RunConfig") {
 			t.Errorf("error should describe the newline write failure, got: %v", err)
+		}
+		if got := classifyExitCode(err); got != exitIO {
+			t.Errorf("classifyExitCode = %d, want %d (I/O); err=%v", got, exitIO, err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Implements the #240-derived four-level CLI exit-code scheme (issue #253), CLI-wide:

```
0  success
1  validation failed (ValidateRunConfig / run-config --validate / preconditions)
2  parse error (malformed JSON on stdin or in --config)
3  I/O error (file/stdin/stdout read/write)
```

Targets `main` (the #249 work this was developed on top of merged in #334; this PR's diff is the four exit-code commits). Merges cleanly alongside the #29 tools merged in #335 — verified via a 3-way trial merge (the git tools and `exitcode.go` both survive).

## Approach

A transparent `exitError` wrapper (`harness/cmd/stirrup/cmd/exitcode.go`) carries a closed code set (`exitValidation=1`, `exitParse=2`, `exitIO=3`) with nil-passthrough `parseError`/`ioError`/`validationError` helpers and a unit-testable `classifyExitCode(err) int`. `Execute()` (`root.go`) sets `SilenceErrors`+`SilenceUsage`, prints the error line itself, and exits `classifyExitCode(err)`. Untyped errors keep the historical exit 1 — no regression — and `Execute()` is the sole `os.Exit` decision point.

Classification is applied at the existing error sites: JSON decode → parse (2); file open/stat/read/empty/oversize, `--prompt-file`, `--output-runconfig`, and stdin/stream failures → I/O (3); `ValidateRunConfig`, `run-config --validate`, and base-source preconditions → validation (1). Applied across `harness` and `run-config`; `job` keeps its plain-text errors on the default-1 path (documented in the exit-codes table). The #249 usage-hint paths still return nil → exit 0. `SilenceUsage` also removes the trailing flag-block from the non-TTY prompt-required error (a follow-up the #249 review deferred here).

## Review

code-reviewer (sound, NITs only), spec-compliance-reviewer (COMPLIANT — all four codes, exact meanings, CLI-wide single source of truth), test-coverage-auditor. Remediated: closed the end-to-end gap on the longest I/O propagation chain (`--prompt-file <missing>` → exit 3); fixed an operator-visible message that said "parsing" on an I/O-class empty-file error; made base-source preconditions classify validation explicitly; added exit-class assertions for the reader-error, write-error, directory, and oversize branches.

## Verification

`just build`, `just test`, `just lint` (0 issues) green. Observed against the built binary: success → 0; validation failure (`--max-turns 9999`) → 1; malformed `--config` → 2; missing/empty `--config` and missing `--prompt-file` → 3 (with "reading…" wording); `job` without `CONTROL_PLANE_ADDR` → 1 plain/no-ANSI; bare `stirrup` → 0; `--help` still prints full usage; error output no longer trails a usage block.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
