### PR TITLE
cli: --dry-run preflight with per-component probes (#245)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,86 @@ any subsequent control-event input. This matches the batch shape the
 pipeline pattern targets — operators who need interactive control
 should use `--transport grpc`.
 
+## Dry-run preflight
+
+`--output-runconfig` answers "what *would* run?"; `--dry-run` answers
+"*could* it run?". A dry-run takes the resolved `RunConfig` through every
+initialisation step short of the first agentic turn — validate the
+config, construct every component, resolve every credential, and probe
+the reachability of the provider, MCP servers, trace backend, and egress
+allowlist — then prints a per-step report and exits. It is the
+preflight check for the side-channel concerns `ValidateRunConfig` cannot
+see: a missing API key, an unreachable MCP server, a Cedar policy that
+will not parse, a container image that is not pulled, a trace collector
+that is down.
+
+```sh
+stirrup harness --config run.json --dry-run
+```
+
+A dry-run **never spends provider tokens**. Provider probes hit only a
+metadata endpoint — Anthropic and OpenAI `GET /v1/models`, the
+publisher-model list for Vertex AI — and never a completion endpoint.
+The Bedrock probe validates the AWS credential chain rather than calling
+a billable runtime operation.
+
+The report lists each step with one of three statuses:
+
+- `ok` — the component constructed and (where applicable) its probe
+  succeeded.
+- `skip` — the step was intentionally not run: the component has no
+  network probe (a local executor, a `jsonl` trace file), the feature is
+  not configured (no MCP servers, no workspace export), or a
+  `--no-probe-*` gate suppressed it.
+- `fail` — construction or a probe failed. The step names the component,
+  carries the underlying error, and — where a concrete next step is
+  known — a remediation hint.
+
+The human-readable report goes to **stderr**; `--output=json` emits the
+structured report (a `PreflightReport`: a `steps` array plus an `ok`
+boolean) to **stdout** instead, so it can be parsed or stored. Routing
+the report to stderr keeps stdout free for a captured config when
+`--dry-run` is combined with `--output-runconfig`.
+
+### Probe gates
+
+Each network-touching probe can be suppressed for cost-controlled or
+air-gapped environments. A suppressed probe records `skip` and does not
+fail the run:
+
+| Flag | Skips |
+|---|---|
+| `--no-probe-provider` | The provider metadata probe (all configured providers). |
+| `--no-probe-mcp` | The MCP `initialize` / `tools/list` handshake for every configured server. |
+| `--no-probe-trace` | The trace-emitter reachability probe (`otel` flush, `gcs` bucket check). |
+| `--no-probe-egress` | The egress-allowlist DNS resolution (container executor in `allowlist` network mode). |
+| `--dry-run-timeout` | Not a gate — bounds the total preflight wall-clock. Defaults to `30s`. |
+
+A `--no-probe-*` gate or `--dry-run-timeout` supplied **without**
+`--dry-run` is an invalid flag combination and exits `4` (see
+[Exit codes](#exit-codes)). Silently ignoring them would hide an
+operator typo — for example, `--no-probe-provider` on a real run that
+then contacts the provider anyway.
+
+MCP probe failures are treated like every other probe: a configured
+server that does not answer the handshake fails the dry-run. An operator
+who expects a server to be unavailable suppresses its probe with
+`--no-probe-mcp`.
+
+### Exit codes and composition
+
+| Outcome | Exit code |
+|---|---|
+| Every step `ok` or `skip` | `0` |
+| One or more steps `fail` | `1` |
+| Invalid flag combination | `4` |
+
+`--dry-run` composes with `--output-runconfig`: both run. The order is
+validate → preflight → write the captured config → exit, so the resolved
+config is captured alongside the report even when a probe fails (a
+failed `--output-runconfig` write still takes precedence as an I/O error,
+exit `3`).
+
 ## CLI flags
 
 `stirrup harness --help` is authoritative. The table below documents
@@ -328,6 +408,23 @@ stdout. The default JSONL trace writes to a file (or to nothing when
 `STIRRUP_RESULT` line. A future JSONL emitter that writes to stdout
 would conflict with `--output=json`.
 
+### Dry-run
+
+The preflight flags. See [Dry-run preflight](#dry-run-preflight) for the
+full workflow, the per-step report, and how the flags compose.
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--dry-run` | `false` | Run every initialisation step short of the first agentic turn, print a per-step preflight report, then exit. Spends no provider tokens. |
+| `--no-probe-provider` | `false` | Skip the provider metadata probe. Meaningless without `--dry-run` (exit `4`). |
+| `--no-probe-mcp` | `false` | Skip the MCP server handshake probe. Meaningless without `--dry-run` (exit `4`). |
+| `--no-probe-trace` | `false` | Skip the trace-emitter reachability probe. Meaningless without `--dry-run` (exit `4`). |
+| `--no-probe-egress` | `false` | Skip the egress-allowlist DNS probe. Meaningless without `--dry-run` (exit `4`). |
+| `--dry-run-timeout` | `30s` | Total wall-clock budget for the preflight. Meaningless without `--dry-run` (exit `4`). |
+
+`--output=json` (above) emits the `PreflightReport` to stdout when paired
+with `--dry-run`; otherwise the report goes to stderr.
+
 ### Exit codes
 
 The CLI distinguishes failure classes through the process exit code so
@@ -341,6 +438,12 @@ stderr. The scheme is uniform across `harness`, `job`, and
 | `1` | Validation / precondition | `ValidateRunConfig` (or `run-config --validate`) rejected the resolved config; a required prompt had no source; `job` ran without `CONTROL_PLANE_ADDR`. Also the default for any failure not in a more specific class. |
 | `2` | Parse error | The JSON in a `--config` file or piped stdin failed to decode (syntax error, unknown field, type mismatch). |
 | `3` | I/O error | A `--config` or `--prompt-file` path could not be opened, read, or stat'd; an empty / oversize input; an `--output-runconfig` write or close failure. |
+| `4` | Usage error | An invalid flag combination — currently a `--dry-run` probe gate (`--no-probe-provider`/`--no-probe-mcp`/`--no-probe-trace`/`--no-probe-egress`) or `--dry-run-timeout` supplied without `--dry-run`. See [Dry-run preflight](#dry-run-preflight). |
+
+A failed `--dry-run` (one or more probes reported `fail`) exits `1` on
+the default path, not `4`: code `4` is reserved for the command-line
+combination itself being incoherent, not for a probe finding a real
+misconfiguration.
 
 A failed or cancelled *run* (as opposed to a configuration failure)
 exits non-zero on the same `1` default path; the `RunResult` on stdout

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,7 +161,21 @@ A dry-run **never spends provider tokens**. Provider probes hit only a
 metadata endpoint — Anthropic and OpenAI `GET /v1/models`, the
 publisher-model list for Vertex AI — and never a completion endpoint.
 The Bedrock probe validates the AWS credential chain rather than calling
-a billable runtime operation.
+a billable runtime operation (so it confirms credentials resolve, not
+that the Bedrock endpoint is reachable). A container-executor dry-run is
+read-only: it pings the engine socket and checks the image is present
+locally without creating a container, starting the egress proxy, or
+pulling the image.
+
+The trace probe is the one step that reaches a live backend: for
+`traceEmitter.type=otel` it exports a single throwaway span (tagged
+`stirrup.preflight=true` so dashboards and alert rules can filter it) to
+confirm the collector is reachable. Pass `--no-probe-trace` to suppress
+all collector contact. The workspace-export probe (`gs://` destinations)
+and the `gcs` trace probe authenticate via the same
+`gcp-workload-identity` default the real run uses, so both fail outside a
+GCP runtime that provides a metadata server unless an explicit credential
+is configured.
 
 The report lists each step with one of three statuses:
 

--- a/harness/cmd/stirrup/cmd/dryrun_test.go
+++ b/harness/cmd/stirrup/cmd/dryrun_test.go
@@ -2,12 +2,126 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/rxbynerd/stirrup/harness/internal/core"
+	"github.com/rxbynerd/stirrup/types"
 )
+
+// stubPreflight swaps preflightFn for the duration of a test so runDryRun's
+// dispatch/output/exit branches are exercised against a canned report
+// without a live config or network. It restores the original on cleanup.
+func stubPreflight(t *testing.T, report *core.PreflightReport) {
+	t.Helper()
+	orig := preflightFn
+	preflightFn = func(_ context.Context, _ *types.RunConfig, _ core.PreflightOptions) (*core.PreflightReport, error) {
+		return report, nil
+	}
+	t.Cleanup(func() { preflightFn = orig })
+}
+
+// dryRunTestCmd returns a harness command with stdout/stderr captured.
+func dryRunTestCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := newTestHarnessCommand()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	return cmd, &out, &errBuf
+}
+
+func okReport() *core.PreflightReport {
+	return &core.PreflightReport{
+		Steps: []core.PreflightStep{{Name: "config-validation", Status: core.PreflightOK, Detail: "ok"}},
+		OK:    true,
+	}
+}
+
+func failReport() *core.PreflightReport {
+	return &core.PreflightReport{
+		Steps: []core.PreflightStep{{Name: "credentials", Status: core.PreflightFail, Detail: "no key"}},
+		OK:    false,
+	}
+}
+
+func TestRunDryRun_TextToStderr(t *testing.T) {
+	stubPreflight(t, okReport())
+	cmd, out, errBuf := dryRunTestCmd()
+
+	if err := runDryRun(cmd, baseFileConfig(), core.PreflightOptions{}, "text", ""); err != nil {
+		t.Fatalf("runDryRun: %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "config-validation") {
+		t.Errorf("text report should go to stderr, got: %q", errBuf.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout should be empty for text mode, got: %q", out.String())
+	}
+}
+
+func TestRunDryRun_JSONToStdout(t *testing.T) {
+	stubPreflight(t, okReport())
+	cmd, out, _ := dryRunTestCmd()
+
+	if err := runDryRun(cmd, baseFileConfig(), core.PreflightOptions{}, "json", ""); err != nil {
+		t.Fatalf("runDryRun: %v", err)
+	}
+	var decoded core.PreflightReport
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout should carry a PreflightReport JSON, got %q: %v", out.String(), err)
+	}
+	if !decoded.OK {
+		t.Error("decoded report should preserve OK=true")
+	}
+}
+
+func TestRunDryRun_FailReportExit1(t *testing.T) {
+	stubPreflight(t, failReport())
+	cmd, _, _ := dryRunTestCmd()
+
+	err := runDryRun(cmd, baseFileConfig(), core.PreflightOptions{}, "text", "")
+	if err == nil {
+		t.Fatal("a failing report must return a non-nil error")
+	}
+	if got := classifyExitCode(err); got != 1 {
+		t.Errorf("classifyExitCode = %d, want 1 (probe failure is the untyped default)", got)
+	}
+}
+
+// TestRunDryRun_ComposeWithOutputRunConfig is the explicit AC4 check:
+// --dry-run --output-runconfig=<path> BOTH renders the report AND writes
+// the captured config in one success run.
+func TestRunDryRun_ComposeWithOutputRunConfig(t *testing.T) {
+	stubPreflight(t, okReport())
+	cmd, _, errBuf := dryRunTestCmd()
+	outPath := filepath.Join(t.TempDir(), "captured.json")
+
+	if err := runDryRun(cmd, baseFileConfig(), core.PreflightOptions{}, "text", outPath); err != nil {
+		t.Fatalf("runDryRun: %v", err)
+	}
+	// Report rendered...
+	if !strings.Contains(errBuf.String(), "Dry-run preflight") {
+		t.Errorf("report should have been rendered to stderr, got: %q", errBuf.String())
+	}
+	// ...AND the config captured.
+	data, rerr := os.ReadFile(outPath)
+	if rerr != nil {
+		t.Fatalf("captured config not written: %v", rerr)
+	}
+	var captured types.RunConfig
+	if err := json.Unmarshal(data, &captured); err != nil {
+		t.Fatalf("captured file is not valid RunConfig JSON: %v\n%s", err, data)
+	}
+	if captured.RunID != "from-file" {
+		t.Errorf("captured config RunID = %q, want the config that was probed", captured.RunID)
+	}
+}
 
 // TestUsageErrorClass pins usageError to exit code 4 and the nil
 // passthrough / transparency contract the other wrappers also honour.

--- a/harness/cmd/stirrup/cmd/dryrun_test.go
+++ b/harness/cmd/stirrup/cmd/dryrun_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/core"
+)
+
+// TestUsageErrorClass pins usageError to exit code 4 and the nil
+// passthrough / transparency contract the other wrappers also honour.
+func TestUsageErrorClass(t *testing.T) {
+	if got := usageError(nil); got != nil {
+		t.Errorf("usageError(nil) = %v, want nil", got)
+	}
+	err := usageError(errStub("bad combo"))
+	if got := classifyExitCode(err); got != exitUsage {
+		t.Errorf("classifyExitCode(usageError) = %d, want %d", got, exitUsage)
+	}
+	if err.Error() != "bad combo" {
+		t.Errorf("usageError Error() = %q, want transparent passthrough", err.Error())
+	}
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }
+
+// TestValidateDryRunFlags pins that a probe gate or --dry-run-timeout
+// without --dry-run classifies as usage (exit 4), while the same flags
+// alongside --dry-run are accepted.
+func TestValidateDryRunFlags(t *testing.T) {
+	for _, gate := range dryRunProbeGates {
+		t.Run(gate+" without dry-run is exit 4", func(t *testing.T) {
+			cmd := newTestHarnessCommand()
+			if err := cmd.Flags().Set(gate, gateSetValue(gate)); err != nil {
+				t.Fatalf("set %s: %v", gate, err)
+			}
+			err := validateDryRunFlags(cmd.Flags(), false)
+			if err == nil {
+				t.Fatalf("expected usage error for %s without --dry-run", gate)
+			}
+			if got := classifyExitCode(err); got != exitUsage {
+				t.Errorf("classifyExitCode = %d, want %d (usage)", got, exitUsage)
+			}
+			if !strings.Contains(err.Error(), gate) {
+				t.Errorf("error should name the offending flag %q, got: %v", gate, err)
+			}
+		})
+		t.Run(gate+" with dry-run is accepted", func(t *testing.T) {
+			cmd := newTestHarnessCommand()
+			if err := cmd.Flags().Set(gate, gateSetValue(gate)); err != nil {
+				t.Fatalf("set %s: %v", gate, err)
+			}
+			if err := validateDryRunFlags(cmd.Flags(), true); err != nil {
+				t.Errorf("expected no error with --dry-run, got: %v", err)
+			}
+		})
+	}
+}
+
+// gateSetValue returns a valid pflag string for the probe gate (bools take
+// "true", the duration takes a parseable value).
+func gateSetValue(gate string) string {
+	if gate == "dry-run-timeout" {
+		return "10s"
+	}
+	return "true"
+}
+
+func TestDryRunOptionsFromFlags(t *testing.T) {
+	cmd := newTestHarnessCommand()
+	f := cmd.Flags()
+	_ = f.Set("no-probe-provider", "true")
+	_ = f.Set("no-probe-egress", "true")
+	_ = f.Set("dry-run-timeout", "12s")
+
+	opts := dryRunOptionsFromFlags(f)
+	if !opts.SkipProvider {
+		t.Error("SkipProvider should be true")
+	}
+	if opts.SkipMCP {
+		t.Error("SkipMCP should default false")
+	}
+	if !opts.SkipEgress {
+		t.Error("SkipEgress should be true")
+	}
+	if opts.Timeout.String() != "12s" {
+		t.Errorf("Timeout = %v, want 12s", opts.Timeout)
+	}
+}
+
+func TestWritePreflightJSON(t *testing.T) {
+	report := &core.PreflightReport{
+		Steps: []core.PreflightStep{
+			{Name: "config-validation", Status: core.PreflightOK, Detail: "ok"},
+			{Name: "credentials", Status: core.PreflightFail, Detail: "no key", Hint: "set the env var"},
+		},
+		OK: false,
+	}
+	var buf bytes.Buffer
+	if err := writePreflightJSON(&buf, report); err != nil {
+		t.Fatalf("writePreflightJSON: %v", err)
+	}
+	var decoded core.PreflightReport
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("emitted JSON does not round-trip: %v\n%s", err, buf.String())
+	}
+	if decoded.OK {
+		t.Error("decoded report should preserve OK=false")
+	}
+	if len(decoded.Steps) != 2 {
+		t.Fatalf("decoded %d steps, want 2", len(decoded.Steps))
+	}
+	if decoded.Steps[1].Hint != "set the env var" {
+		t.Errorf("hint not preserved through JSON: %+v", decoded.Steps[1])
+	}
+}
+
+func TestWritePreflightText(t *testing.T) {
+	report := &core.PreflightReport{
+		Steps: []core.PreflightStep{
+			{Name: "credentials", Status: core.PreflightFail, Detail: "no key", Hint: "set the env var"},
+			{Name: "mcp", Status: core.PreflightSkip, Detail: "none configured"},
+		},
+		OK: false,
+	}
+	var buf bytes.Buffer
+	writePreflightText(&buf, report)
+	out := buf.String()
+	if !strings.Contains(out, "FAIL") || !strings.Contains(out, "credentials") {
+		t.Errorf("text output should flag the failing step, got:\n%s", out)
+	}
+	if !strings.Contains(out, "hint: set the env var") {
+		t.Errorf("text output should render the hint, got:\n%s", out)
+	}
+	if !strings.Contains(out, "SKIP") {
+		t.Errorf("text output should render the skipped step, got:\n%s", out)
+	}
+}

--- a/harness/cmd/stirrup/cmd/exitcode.go
+++ b/harness/cmd/stirrup/cmd/exitcode.go
@@ -10,6 +10,8 @@ import "errors"
 //	1  validation failed (ValidateRunConfig / run-config --validate)
 //	2  parse error (malformed JSON on stdin or in --config)
 //	3  I/O error (stdin/stdout/file read/write)
+//	4  usage error (an invalid flag combination — e.g. a --dry-run probe
+//	   gate supplied without --dry-run)
 //
 // Code 0 is never carried by an exitError — a nil error from a command's
 // RunE is the success path, and Execute() exits 0 implicitly. The
@@ -18,6 +20,7 @@ const (
 	exitValidation = 1
 	exitParse      = 2
 	exitIO         = 3
+	exitUsage      = 4
 )
 
 // exitError wraps a command error with the CLI exit code its failure
@@ -73,6 +76,20 @@ func validationError(err error) error {
 		return nil
 	}
 	return &exitError{code: exitValidation, err: err}
+}
+
+// usageError tags err as an invalid flag-combination failure (exit 4):
+// a flag was supplied in a context where it has no meaning — e.g. a
+// --dry-run probe gate (--no-probe-provider) or --dry-run-timeout
+// without --dry-run. A nil err returns nil so call sites can wrap
+// unconditionally. Distinct from validationError (exit 1, a structurally
+// invalid RunConfig) because the config itself is fine; only the
+// command-line combination is incoherent.
+func usageError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &exitError{code: exitUsage, err: err}
 }
 
 // classifyExitCode maps a command error to its process exit code. It is

--- a/harness/cmd/stirrup/cmd/exitcode_test.go
+++ b/harness/cmd/stirrup/cmd/exitcode_test.go
@@ -346,6 +346,7 @@ func TestCLIExitCodes_EndToEnd(t *testing.T) {
 		name string
 		args []string
 		want int
+		env  []string // extra environment for the subprocess
 	}{
 		{
 			name: "run-config valid succeeds",
@@ -401,9 +402,32 @@ func TestCLIExitCodes_EndToEnd(t *testing.T) {
 			args: []string{"harness", "--config", noPromptConfig, "--prompt-file", missingPromptFile},
 			want: exitIO,
 		},
+		{
+			// #245 dry-run success: every component constructs and the only
+			// network-touching probe (provider) is suppressed, so all steps
+			// are ok/skip and Execute() returns nil → exit 0. Provider creds
+			// come from the secret:// env ref, which is unset here but never
+			// resolved on the --no-probe-provider path because credential
+			// resolution happens during provider construction... which still
+			// runs. So set the env var via the config's static ref instead:
+			// validConfig references ANTHROPIC_API_KEY; export it for the run.
+			name: "harness dry-run all-ok",
+			args: []string{"harness", "--config", validConfig, "--dry-run", "--no-probe-provider"},
+			want: 0,
+			env:  []string{"ANTHROPIC_API_KEY=sk-ant-test"},
+		},
+		{
+			// #245 invalid flag combination: a probe gate without --dry-run
+			// is meaningless and must classify as usage (exit 4), not be
+			// silently ignored.
+			name: "harness probe gate without dry-run",
+			args: []string{"harness", "--config", validConfig, "--no-probe-provider"},
+			want: exitUsage,
+			env:  []string{"ANTHROPIC_API_KEY=sk-ant-test"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := runExit(t, bin, tc.args)
+			got := runExit(t, bin, tc.args, tc.env...)
 			if got != tc.want {
 				t.Errorf("exit code = %d, want %d (args: %v)", got, tc.want, tc.args)
 			}
@@ -445,7 +469,7 @@ func buildStirrupBinary(t *testing.T) string {
 // treats as "not piped" (issue #249), so a --config <path> argument is
 // not rejected as ambiguous against a phantom piped base. A non-ExitError
 // failure (binary missing, signal) fails the test.
-func runExit(t *testing.T, bin string, args []string) int {
+func runExit(t *testing.T, bin string, args []string, extraEnv ...string) int {
 	t.Helper()
 	devNull, err := os.Open(os.DevNull)
 	if err != nil {
@@ -457,6 +481,9 @@ func runExit(t *testing.T, bin string, args []string) int {
 	cmd.Stdin = devNull
 	cmd.Stdout = nil
 	cmd.Stderr = nil
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	runErr := cmd.Run()
 	if runErr == nil {
 		return 0

--- a/harness/cmd/stirrup/cmd/exitcode_test.go
+++ b/harness/cmd/stirrup/cmd/exitcode_test.go
@@ -342,6 +342,17 @@ func TestCLIExitCodes_EndToEnd(t *testing.T) {
 		`"modelRouter":{"type":"static","provider":"anthropic","model":"claude-x"}}`)
 	missingPromptFile := filepath.Join(dir, "absent-brief.txt")
 
+	// A config whose openai-compatible provider points at a refused port,
+	// so a --dry-run provider probe (no --no-probe-provider) fails and the
+	// process exits 1. Port 1 is privileged and never listening, giving a
+	// deterministic connection-refused without depending on DNS or a real
+	// server. execution mode so deny-side-effects (not allow-all) is fine.
+	refusedProviderConfig := filepath.Join(dir, "refused-provider.json")
+	writeFile(t, refusedProviderConfig, `{"runId":"r","mode":"execution","prompt":"hi",`+
+		`"maxTurns":10,"timeout":600,`+
+		`"provider":{"type":"openai-compatible","apiKeyRef":"secret://OPENAI_KEY","baseURL":"http://127.0.0.1:1/v1"},`+
+		`"modelRouter":{"type":"static","provider":"openai-compatible","model":"x"}}`)
+
 	for _, tc := range []struct {
 		name string
 		args []string
@@ -424,6 +435,15 @@ func TestCLIExitCodes_EndToEnd(t *testing.T) {
 			args: []string{"harness", "--config", validConfig, "--no-probe-provider"},
 			want: exitUsage,
 			env:  []string{"ANTHROPIC_API_KEY=sk-ant-test"},
+		},
+		{
+			// #245 dry-run probe failure: the provider probe hits a refused
+			// port, so one step fails and the process exits 1 (not 4 — the
+			// flags are valid; a probe found a real problem).
+			name: "harness dry-run probe failure",
+			args: []string{"harness", "--config", refusedProviderConfig, "--dry-run", "--dry-run-timeout", "5s"},
+			want: 1,
+			env:  []string{"OPENAI_KEY=sk-test"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1447,8 +1447,10 @@ func runDryRun(cmd *cobra.Command, cfg *types.RunConfig, opts core.PreflightOpti
 	// the context and lets in-flight probes (and any owned resource
 	// cleanup inside Preflight) unwind, matching runWithConfig. Without
 	// this a Cloud Run job cancellation during a dry-run would not
-	// propagate to the probe context.
-	ctx, cancel := context.WithCancel(cmd.Context())
+	// propagate to the probe context. Rooted at context.Background() (as
+	// runWithConfig and job.go are) rather than cmd.Context(), which is
+	// nil for a command constructed outside Cobra's Execute path.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	setupSignalHandler(cancel)
 

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 
 	"github.com/rxbynerd/stirrup/harness/internal/core"
 	"github.com/rxbynerd/stirrup/types"
@@ -762,6 +763,12 @@ func init() {
 	f := harnessCmd.Flags()
 	f.Bool("export-workspace-required", false, "When true, a failed workspace export exits the run non-zero. When false (default), failures are logged and the run's exit code is unchanged.")
 	f.String("output-runconfig", "", "Write the resolved RunConfig as JSON to <path> (use '-' for stdout) and exit without running. Useful for capturing the exact config a flag-only invocation would have used. Validation must pass first; the path is not written on a validator error.")
+	f.Bool("dry-run", false, "Run every initialisation step short of the first agentic turn (validate, construct components, resolve credentials, probe provider/MCP/trace/egress reachability), print a per-step preflight report, then exit. No provider tokens are spent. Exit 0 when all steps pass, 1 when any probe fails, 4 for an invalid flag combination. Composes with --output-runconfig (both run) and --output=json (emits the report as JSON).")
+	f.Bool("no-probe-provider", false, "With --dry-run, skip the provider reachability probe (for cost-controlled environments that do not want any provider contact). Meaningless without --dry-run (exit 4).")
+	f.Bool("no-probe-mcp", false, "With --dry-run, skip the MCP server reachability probe. Meaningless without --dry-run (exit 4).")
+	f.Bool("no-probe-trace", false, "With --dry-run, skip the trace-emitter reachability probe. Meaningless without --dry-run (exit 4).")
+	f.Bool("no-probe-egress", false, "With --dry-run, skip the egress-allowlist DNS probe. Meaningless without --dry-run (exit 4).")
+	f.Duration("dry-run-timeout", core.DefaultPreflightTimeout, "With --dry-run, the total wall-clock budget for the preflight. Meaningless without --dry-run (exit 4).")
 	f.StringP("output", "o", "text", "Post-run summary format: text (default human-readable summary on stderr), json (structured RunResult JSON on stdout, suppresses stderr summary), none (suppresses both). When json is set together with resultSink.type=stdout-json the line is emitted once (the flag wins); pair json with a trace emitter that does not target stdout (the default jsonl file path is fine).")
 
 	// --output-runconfig accepts a path or "-" for stdout. The .json
@@ -1296,7 +1303,21 @@ func runHarness(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// --output-runconfig is a dry-run capture: write the validated
+	// --dry-run preflight (issue #245). The probe gates and the timeout
+	// only make sense alongside --dry-run; supplying one without --dry-run
+	// is an invalid flag combination (exit 4) rather than a silent no-op.
+	// This check runs after BuildRunConfig so a bad config still surfaces
+	// its own (exit 1/2/3) class first.
+	dryRun, _ := f.GetBool("dry-run")
+	if err := validateDryRunFlags(f, dryRun); err != nil {
+		return err
+	}
+	if dryRun {
+		outPath, _ := f.GetString("output-runconfig")
+		return runDryRun(cmd, cfg, dryRunOptionsFromFlags(f), outputMode, outPath)
+	}
+
+	// --output-runconfig is a config capture: write the validated
 	// RunConfig to the named path (or stdout) and exit without
 	// invoking the loop. The validator has already run inside
 	// BuildRunConfig, so reaching this branch with an invalid config
@@ -1352,6 +1373,144 @@ func writeAndCloseRunConfig(wc io.WriteCloser, path string, cfg *types.RunConfig
 		return ioError(fmt.Errorf("closing --output-runconfig %q: %w", path, cerr))
 	}
 	return writeErr
+}
+
+// dryRunProbeGates lists the flags whose only meaning is to gate a
+// --dry-run probe. Supplying any of them without --dry-run is an invalid
+// combination (exit 4). Kept as a table so the error names the offending
+// flag and a future probe gate is one append away.
+var dryRunProbeGates = []string{
+	"no-probe-provider",
+	"no-probe-mcp",
+	"no-probe-trace",
+	"no-probe-egress",
+	"dry-run-timeout",
+}
+
+// validateDryRunFlags rejects a --dry-run probe gate or --dry-run-timeout
+// supplied without --dry-run. Those flags are inert outside a dry-run, so
+// rather than silently ignoring them (which would hide an operator typo
+// such as `--no-probe-provider` on a real run that then contacts the
+// provider anyway) the harness fails with the usage class (exit 4).
+func validateDryRunFlags(f *flag.FlagSet, dryRun bool) error {
+	if dryRun {
+		return nil
+	}
+	for _, name := range dryRunProbeGates {
+		if f.Changed(name) {
+			return usageError(fmt.Errorf("--%s has no effect without --dry-run", name))
+		}
+	}
+	return nil
+}
+
+// dryRunOptionsFromFlags maps the --no-probe-* gates and --dry-run-timeout
+// onto core.PreflightOptions.
+func dryRunOptionsFromFlags(f *flag.FlagSet) core.PreflightOptions {
+	skipProvider, _ := f.GetBool("no-probe-provider")
+	skipMCP, _ := f.GetBool("no-probe-mcp")
+	skipTrace, _ := f.GetBool("no-probe-trace")
+	skipEgress, _ := f.GetBool("no-probe-egress")
+	timeout, _ := f.GetDuration("dry-run-timeout")
+	return core.PreflightOptions{
+		SkipProvider: skipProvider,
+		SkipMCP:      skipMCP,
+		SkipTrace:    skipTrace,
+		SkipEgress:   skipEgress,
+		Timeout:      timeout,
+	}
+}
+
+// runDryRun executes the preflight, renders the report, optionally writes
+// the captured RunConfig (when --output-runconfig is also set, per the
+// issue's compose edge case), and maps the aggregate to an exit code:
+//
+//	all steps ok/skip -> nil (exit 0)
+//	any step failed   -> a plain error (exit 1, the untyped default)
+//
+// Order matches the spec: validate -> preflight -> write config (if
+// requested) -> exit. The config write happens only when the report
+// itself did not fail to produce, so a dry-run that surfaces a
+// misconfiguration still captures the config the operator was probing.
+//
+// outputMode "json" emits the structured report to stdout; otherwise a
+// human-readable per-step report goes to stderr (so it does not collide
+// with a captured config on stdout).
+func runDryRun(cmd *cobra.Command, cfg *types.RunConfig, opts core.PreflightOptions, outputMode, outputRunConfigPath string) error {
+	report, err := core.Preflight(cmd.Context(), cfg, opts)
+	if err != nil {
+		return err
+	}
+
+	if outputMode == "json" {
+		if err := writePreflightJSON(cmd.OutOrStdout(), report); err != nil {
+			return ioError(err)
+		}
+	} else if outputMode != "none" {
+		writePreflightText(cmd.ErrOrStderr(), report)
+	}
+
+	// Compose with --output-runconfig: capture the config too. A write
+	// failure (exit 3) takes precedence over the probe-failure exit so a
+	// broken capture path is not masked by a soft probe failure.
+	if outputRunConfigPath != "" {
+		if werr := writeOutputRunConfig(outputRunConfigPath, cfg); werr != nil {
+			return werr
+		}
+	}
+
+	if !report.OK {
+		return fmt.Errorf("dry-run preflight failed: %d of %d step(s) did not pass", failedStepCount(report), len(report.Steps))
+	}
+	return nil
+}
+
+// failedStepCount counts the failed steps in a report for the summary
+// error message.
+func failedStepCount(report *core.PreflightReport) int {
+	n := 0
+	for _, s := range report.Steps {
+		if s.Status == core.PreflightFail {
+			n++
+		}
+	}
+	return n
+}
+
+// writePreflightJSON emits the report as indented JSON. The report is
+// already secret-free: it carries step names, statuses, and error text
+// (provider/MCP diagnostics), never resolved credentials.
+func writePreflightJSON(w io.Writer, report *core.PreflightReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("encode preflight report: %w", err)
+	}
+	return nil
+}
+
+// writePreflightText renders a human-readable per-step report to w. Each
+// line leads with the status so an operator scanning the output spots a
+// FAIL immediately; the remediation hint (when present) is indented under
+// the failing step.
+func writePreflightText(w io.Writer, report *core.PreflightReport) {
+	fmt.Fprintln(w, "Dry-run preflight:")
+	for _, s := range report.Steps {
+		label := strings.ToUpper(string(s.Status))
+		if s.Detail != "" {
+			fmt.Fprintf(w, "  [%-4s] %s: %s\n", label, s.Name, s.Detail)
+		} else {
+			fmt.Fprintf(w, "  [%-4s] %s\n", label, s.Name)
+		}
+		if s.Status == core.PreflightFail && s.Hint != "" {
+			fmt.Fprintf(w, "         hint: %s\n", s.Hint)
+		}
+	}
+	if report.OK {
+		fmt.Fprintln(w, "Result: OK (all steps ok or skipped)")
+	} else {
+		fmt.Fprintf(w, "Result: FAIL (%d of %d step(s) did not pass)\n", failedStepCount(report), len(report.Steps))
+	}
 }
 
 // applyAnthropicWIFOverrides folds the Anthropic-WIF flag surface and

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1492,25 +1492,29 @@ func writePreflightJSON(w io.Writer, report *core.PreflightReport) error {
 // writePreflightText renders a human-readable per-step report to w. Each
 // line leads with the status so an operator scanning the output spots a
 // FAIL immediately; the remediation hint (when present) is indented under
-// the failing step.
+// the failing step. Built into a strings.Builder and written once,
+// matching printHarnessUsageHint — the report is a best-effort stderr
+// surface, so a write failure to stderr is not propagated.
 func writePreflightText(w io.Writer, report *core.PreflightReport) {
-	fmt.Fprintln(w, "Dry-run preflight:")
+	var b strings.Builder
+	b.WriteString("Dry-run preflight:\n")
 	for _, s := range report.Steps {
 		label := strings.ToUpper(string(s.Status))
 		if s.Detail != "" {
-			fmt.Fprintf(w, "  [%-4s] %s: %s\n", label, s.Name, s.Detail)
+			fmt.Fprintf(&b, "  [%-4s] %s: %s\n", label, s.Name, s.Detail)
 		} else {
-			fmt.Fprintf(w, "  [%-4s] %s\n", label, s.Name)
+			fmt.Fprintf(&b, "  [%-4s] %s\n", label, s.Name)
 		}
 		if s.Status == core.PreflightFail && s.Hint != "" {
-			fmt.Fprintf(w, "         hint: %s\n", s.Hint)
+			fmt.Fprintf(&b, "         hint: %s\n", s.Hint)
 		}
 	}
 	if report.OK {
-		fmt.Fprintln(w, "Result: OK (all steps ok or skipped)")
+		b.WriteString("Result: OK (all steps ok or skipped)\n")
 	} else {
-		fmt.Fprintf(w, "Result: FAIL (%d of %d step(s) did not pass)\n", failedStepCount(report), len(report.Steps))
+		fmt.Fprintf(&b, "Result: FAIL (%d of %d step(s) did not pass)\n", failedStepCount(report), len(report.Steps))
 	}
+	_, _ = io.WriteString(w, b.String())
 }
 
 // applyAnthropicWIFOverrides folds the Anthropic-WIF flag surface and

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1436,12 +1436,37 @@ func dryRunOptionsFromFlags(f *flag.FlagSet) core.PreflightOptions {
 // outputMode "json" emits the structured report to stdout; otherwise a
 // human-readable per-step report goes to stderr (so it does not collide
 // with a captured config on stdout).
+// preflightFn is the seam through which runDryRun invokes the preflight.
+// Production points it at core.Preflight; tests substitute a stub that
+// returns a canned report so the dispatch/output/exit-code branches of
+// runDryRun can be exercised without a live config or network.
+var preflightFn = core.Preflight
+
 func runDryRun(cmd *cobra.Command, cfg *types.RunConfig, opts core.PreflightOptions, outputMode, outputRunConfigPath string) error {
-	report, err := core.Preflight(cmd.Context(), cfg, opts)
+	// Wire signal cancellation so a SIGINT/SIGTERM mid-preflight cancels
+	// the context and lets in-flight probes (and any owned resource
+	// cleanup inside Preflight) unwind, matching runWithConfig. Without
+	// this a Cloud Run job cancellation during a dry-run would not
+	// propagate to the probe context.
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+	setupSignalHandler(cancel)
+
+	report, err := preflightFn(ctx, cfg, opts)
 	if err != nil {
 		return err
 	}
+	return renderAndDispatchPreflight(cmd, report, cfg, outputMode, outputRunConfigPath)
+}
 
+// renderAndDispatchPreflight writes the report (JSON to stdout for
+// --output=json, the human report to stderr otherwise), composes with
+// --output-runconfig when requested, and maps the aggregate to an exit
+// code: a failed --output-runconfig write (exit 3) takes precedence over a
+// probe failure (exit 1) so a broken capture path is not masked by a soft
+// probe failure. Split out from runDryRun so the output/compose/exit
+// branches are unit-testable without invoking the real preflight.
+func renderAndDispatchPreflight(cmd *cobra.Command, report *core.PreflightReport, cfg *types.RunConfig, outputMode, outputRunConfigPath string) error {
 	if outputMode == "json" {
 		if err := writePreflightJSON(cmd.OutOrStdout(), report); err != nil {
 			return ioError(err)
@@ -1450,9 +1475,6 @@ func runDryRun(cmd *cobra.Command, cfg *types.RunConfig, opts core.PreflightOpti
 		writePreflightText(cmd.ErrOrStderr(), report)
 	}
 
-	// Compose with --output-runconfig: capture the config too. A write
-	// failure (exit 3) takes precedence over the probe-failure exit so a
-	// broken capture path is not masked by a soft probe failure.
 	if outputRunConfigPath != "" {
 		if werr := writeOutputRunConfig(outputRunConfigPath, cfg); werr != nil {
 			return werr

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rxbynerd/stirrup/harness/internal/core"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/resultsink"
 	"github.com/rxbynerd/stirrup/types"
@@ -595,6 +596,14 @@ func newTestHarnessCommand() *cobra.Command {
 	f.Bool("export-workspace-required", false, "")
 	f.String("output-runconfig", "", "")
 	f.StringP("output", "o", "text", "")
+	// Dry-run flags (issue #245). Mirrors the registration in harness.go
+	// init() so flag-combination tests can exercise validateDryRunFlags.
+	f.Bool("dry-run", false, "")
+	f.Bool("no-probe-provider", false, "")
+	f.Bool("no-probe-mcp", false, "")
+	f.Bool("no-probe-trace", false, "")
+	f.Bool("no-probe-egress", false, "")
+	f.Duration("dry-run-timeout", core.DefaultPreflightTimeout, "")
 	return cmd
 }
 

--- a/harness/internal/core/preflight.go
+++ b/harness/internal/core/preflight.go
@@ -1,0 +1,440 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/credential"
+	"github.com/rxbynerd/stirrup/harness/internal/executor/egressproxy"
+	"github.com/rxbynerd/stirrup/harness/internal/mcp"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/provider"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/workspaceexport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// Preflighter is the structural interface a component implements to opt
+// into a dry-run reachability/authentication probe. Components satisfy it
+// WITHOUT importing core — Preflight type-asserts each constructed
+// component to this interface and calls Probe when present, or records a
+// skip when absent. This keeps the dependency direction one-way (core ->
+// components) and preserves the invariant that the agentic loop is a pure
+// function of its interfaces: Preflight is a separate entry point that
+// never touches loop.go.
+//
+// Probe must be side-effect-free with respect to the run: it may open a
+// network connection or read a file, but it must not spend provider
+// tokens, mutate the workspace, or register tools. A nil return means the
+// component is reachable and authenticated; a non-nil error becomes a
+// failed preflight step carrying the error text.
+type Preflighter interface {
+	Probe(ctx context.Context) error
+}
+
+// PreflightStatus is the outcome of a single preflight step.
+type PreflightStatus string
+
+const (
+	// PreflightOK marks a step whose probe (or construction) succeeded.
+	PreflightOK PreflightStatus = "ok"
+	// PreflightSkip marks a step intentionally not run: a component that
+	// implements no Probe, or one gated off by a --no-probe-* flag.
+	PreflightSkip PreflightStatus = "skip"
+	// PreflightFail marks a step whose construction or probe failed.
+	PreflightFail PreflightStatus = "fail"
+)
+
+// PreflightStep is one line of the preflight report.
+type PreflightStep struct {
+	Name   string          `json:"name"`
+	Status PreflightStatus `json:"status"`
+	// Detail carries the success note or the failure's error text.
+	Detail string `json:"detail,omitempty"`
+	// Hint is an operator-facing remediation suggestion, set only on
+	// failures where a concrete next step is known.
+	Hint string `json:"hint,omitempty"`
+}
+
+// PreflightReport is the structured result of a dry-run. It is
+// JSON-serialisable for --output=json. OK is true when no step failed
+// (skips do not fail the run).
+type PreflightReport struct {
+	Steps []PreflightStep `json:"steps"`
+	OK    bool            `json:"ok"`
+}
+
+// PreflightOptions gates which network-touching probes run. A true Skip*
+// flag records the corresponding step as a skip instead of probing — used
+// by the --no-probe-* CLI flags for cost-controlled or air-gapped
+// environments. Timeout bounds the entire preflight wall-clock.
+type PreflightOptions struct {
+	SkipProvider bool
+	SkipMCP      bool
+	SkipTrace    bool
+	SkipEgress   bool
+	Timeout      time.Duration
+}
+
+// DefaultPreflightTimeout is the wall-clock budget for a dry-run when the
+// caller does not set PreflightOptions.Timeout. Matches the 30s default
+// documented for --dry-run-timeout.
+const DefaultPreflightTimeout = 30 * time.Second
+
+// Preflight runs every initialisation step short of the first agentic
+// turn and returns a per-step report. It mirrors BuildLoop's construction
+// sequence but stops before assembling the AgenticLoop: it validates the
+// config, constructs each component (a construction failure becomes a
+// failed step naming the component — this is where credential resolution,
+// which BuildLoop performs inline during provider construction, surfaces),
+// then probes each constructed component that implements Preflighter and
+// is not gated off by opts.
+//
+// The whole sequence runs under a context.WithTimeout(ctx, opts.Timeout)
+// so a wedged endpoint cannot hang the dry-run past the operator's budget.
+// Owned resources (the executor's container, trace exporters) are closed
+// before returning so a dry-run leaves nothing running.
+//
+// Preflight returns a non-nil error only for an internal failure that
+// prevents producing a report at all; a report with failed steps is
+// returned with a nil error and report.OK == false so the caller can
+// render every step and map the aggregate to an exit code.
+func Preflight(ctx context.Context, config *types.RunConfig, opts PreflightOptions) (*PreflightReport, error) {
+	if config == nil {
+		return nil, fmt.Errorf("preflight: nil RunConfig")
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultPreflightTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	report := &PreflightReport{}
+	add := func(step PreflightStep) { report.Steps = append(report.Steps, step) }
+	ok := func(name, detail string) { add(PreflightStep{Name: name, Status: PreflightOK, Detail: detail}) }
+	skip := func(name, detail string) { add(PreflightStep{Name: name, Status: PreflightSkip, Detail: detail}) }
+	fail := func(name string, err error, hint string) {
+		add(PreflightStep{Name: name, Status: PreflightFail, Detail: err.Error(), Hint: hint})
+	}
+
+	// 1. Config validation — the same fast invariant check BuildLoop runs.
+	if err := types.ValidateRunConfig(config); err != nil {
+		fail("config-validation", err, "fix the RunConfig shape; see `stirrup run-config --validate`")
+		report.finalise()
+		return report, nil
+	}
+	ok("config-validation", "RunConfig invariants satisfied")
+
+	// Preflight constructs components that take a SecurityLogger, but a
+	// dry-run must not emit security events to the operator's stderr (those
+	// belong to a real run's audit trail). Discard them.
+	secLogger := security.NewSecurityLogger(io.Discard, config.RunID)
+
+	// 2. Secret store.
+	secrets, err := security.NewAutoSecretStore(ctx, config)
+	if err != nil {
+		fail("secret-store", err, "check the secret backend (env/file/SSM) for the referenced secret:// paths")
+		report.finalise()
+		return report, nil
+	}
+	ok("secret-store", "secret store constructed")
+
+	// 3. Providers + credential resolution. buildProviders resolves the
+	// credential source for every provider (default + named) inline, so a
+	// failure here is the credential/auth-config surface. Reported as a
+	// "credentials" step to match the issue's step naming. Provider
+	// reachability probes follow only if construction succeeded.
+	prov, providers, err := buildProviders(ctx, config, secrets)
+	if err != nil {
+		fail("credentials", err, "verify the credential source resolves (env var set, federation rule valid, key present)")
+	} else {
+		ok("credentials", "all provider credentials resolved")
+		preflightProviders(ctx, config, providers, opts, ok, skip, fail)
+	}
+
+	// 4. Executor. Container construction creates and starts a container,
+	// so a failure here already proves the engine is unreachable or the
+	// image is absent; the ContainerExecutor.Probe step that follows is a
+	// secondary socket+image confirmation. local/api executors implement
+	// no Probe and record a skip.
+	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
+	if err != nil {
+		fail("executor", err, executorHint(config.Executor.Type))
+	} else {
+		ok("executor", fmt.Sprintf("%s executor constructed", executorTypeName(config.Executor.Type)))
+		probeComponent(ctx, "executor-probe", exec, false, "", ok, skip, fail)
+		if closer, isCloser := exec.(interface{ Close() error }); isCloser {
+			defer func() { _ = closer.Close() }()
+		}
+	}
+
+	// 5. Permission policy. The policy-engine arm loads + parses the Cedar
+	// file at construction, so a malformed policy fails here; its Probe
+	// then smoke-tests evaluation. Other policy types implement no Probe.
+	pp, err := buildPermissionPolicy(config, tool.NewRegistry(), nil, secLogger)
+	if err != nil {
+		fail("permission-policy", err, "check permissionPolicy.policyFile parses as Cedar")
+	} else {
+		ok("permission-policy", fmt.Sprintf("%s policy constructed", config.PermissionPolicy.Type))
+		probeComponent(ctx, "permission-policy-probe", pp, false, "", ok, skip, fail)
+	}
+
+	// 6. Trace emitter. otel/gcs probe network reachability; jsonl opens
+	// its file at construction and implements no Probe (skip). Gated by
+	// --no-probe-trace. Built via the same buildTraceEmitter path BuildLoop
+	// uses so the preflight exercises the real construction (secret://
+	// header resolution included).
+	resolvedHeaders, hdrErr := observability.ResolveHeaders(ctx, secrets, config.TraceEmitter.Headers)
+	if hdrErr != nil {
+		fail("trace-emitter", hdrErr, "resolve secret:// references in traceEmitter.headers")
+	} else {
+		te, err := buildTraceEmitter(ctx, config.TraceEmitter, resolvedHeaders, resourceOptionsFromConfig(config))
+		if err != nil {
+			fail("trace-emitter", err, traceHint(config.TraceEmitter.Type))
+		} else {
+			ok("trace-emitter", fmt.Sprintf("%s trace emitter constructed", traceTypeName(config.TraceEmitter.Type)))
+			probeComponent(ctx, "trace-emitter-probe", te, opts.SkipTrace, "--no-probe-trace set", ok, skip, fail)
+			if closer, isCloser := te.(interface{ Close() error }); isCloser {
+				defer func() { _ = closer.Close() }()
+			}
+		}
+	}
+
+	// 7. MCP servers. Probed per-server with a tools/list handshake that
+	// does not register tools. Gated by --no-probe-mcp.
+	preflightMCP(ctx, config, secrets, opts, ok, skip, fail)
+
+	// 8. Egress allowlist. Only relevant for the container executor in
+	// allowlist network mode. Gated by --no-probe-egress.
+	preflightEgress(ctx, config, opts, ok, skip, fail)
+
+	// 9. Workspace export destination. Only when a gs:// export URI is
+	// configured. It has no dedicated --no-probe gate: the probe is a
+	// read-only bucket-metadata GET that spends nothing, so it always runs
+	// when an export destination is set.
+	preflightWorkspaceExport(ctx, config, ok, skip, fail)
+
+	// prov is the default provider adapter; it was probed via the
+	// providers map above (which keys the default by its type), so the
+	// value is not needed again here. Retained from buildProviders' return
+	// for parity with BuildLoop's signature.
+	_ = prov
+
+	report.finalise()
+	return report, nil
+}
+
+// finalise sets report.OK to true iff no step failed.
+func (r *PreflightReport) finalise() {
+	r.OK = true
+	for _, s := range r.Steps {
+		if s.Status == PreflightFail {
+			r.OK = false
+			return
+		}
+	}
+}
+
+// probeComponent type-asserts component to Preflighter and records the
+// outcome. A component implementing no Probe records a skip with a
+// generic note; a gated component (skipGate true) records a skip with
+// gateNote. The name is the step name (distinct from the construction
+// step so the report shows both construction and probe outcomes).
+func probeComponent(
+	ctx context.Context,
+	name string,
+	component any,
+	skipGate bool,
+	gateNote string,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	probe, isProbe := component.(Preflighter)
+	if !isProbe {
+		skip(name, "component exposes no probe")
+		return
+	}
+	if skipGate {
+		skip(name, gateNote)
+		return
+	}
+	if err := probe.Probe(ctx); err != nil {
+		fail(name, err, "")
+		return
+	}
+	ok(name, "probe succeeded")
+}
+
+// preflightProviders probes the default and every named provider adapter
+// for metadata-endpoint reachability. Gated by --no-probe-provider. Each
+// adapter is the raw streaming adapter (the normalizer/batch wrappers are
+// not applied in preflight), so the Probe methods on the concrete adapter
+// types are reached directly.
+func preflightProviders(
+	ctx context.Context,
+	config *types.RunConfig,
+	providers map[string]provider.ProviderAdapter,
+	opts PreflightOptions,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	for name, p := range providers {
+		step := "provider-probe:" + name
+		if opts.SkipProvider {
+			skip(step, "--no-probe-provider set")
+			continue
+		}
+		probe, isProbe := p.(Preflighter)
+		if !isProbe {
+			skip(step, "provider exposes no probe")
+			continue
+		}
+		if err := probe.Probe(ctx); err != nil {
+			fail(step, err, "verify the API key/credential and base URL for this provider")
+			continue
+		}
+		ok(step, "metadata endpoint reachable")
+	}
+}
+
+// preflightMCP probes every configured MCP server. Gated by
+// --no-probe-mcp. An MCP probe failure is recorded as a fail (consistent
+// with every other probe), which fails the dry-run. The issue notes MCP
+// failures are non-fatal unless --strict is set; --strict is out of scope
+// for this change, so the simpler consistent behaviour is chosen and
+// documented: a configured MCP server that does not answer the
+// tools/list handshake fails the dry-run, and an operator who expects an
+// MCP server to be down can suppress the probe with --no-probe-mcp.
+func preflightMCP(
+	ctx context.Context,
+	config *types.RunConfig,
+	secrets security.SecretStore,
+	opts PreflightOptions,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	if len(config.Tools.MCPServers) == 0 {
+		skip("mcp", "no MCP servers configured")
+		return
+	}
+	client := mcp.NewClient(tool.NewRegistry(), nil)
+	for _, srv := range config.Tools.MCPServers {
+		step := "mcp:" + srv.Name
+		if opts.SkipMCP {
+			skip(step, "--no-probe-mcp set")
+			continue
+		}
+		if err := client.Probe(ctx, srv, secrets); err != nil {
+			fail(step, err, "check the MCP server URI is reachable and the auth ref resolves (or pass --no-probe-mcp)")
+			continue
+		}
+		ok(step, "initialize/tools/list handshake succeeded")
+	}
+}
+
+// preflightEgress probes the egress allowlist by resolving each
+// destination via DNS. Only relevant when the container executor is in
+// allowlist network mode. Gated by --no-probe-egress.
+func preflightEgress(
+	ctx context.Context,
+	config *types.RunConfig,
+	opts PreflightOptions,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	net := config.Executor.Network
+	if config.Executor.Type != "container" || net == nil || net.Mode != "allowlist" {
+		skip("egress", "executor is not a container in allowlist network mode")
+		return
+	}
+	if opts.SkipEgress {
+		skip("egress", "--no-probe-egress set")
+		return
+	}
+	if err := egressproxy.ProbeAllowlist(ctx, net.Allowlist, nil); err != nil {
+		fail("egress", err, "check the allowlist entries resolve via DNS (or pass --no-probe-egress)")
+		return
+	}
+	ok("egress", "all allowlist destinations resolve")
+}
+
+// preflightWorkspaceExport probes the gs:// workspace-export destination
+// when one is configured. It constructs a GCSExporter with the default
+// workload-identity credential source (matching the CLI's
+// newWorkspaceExporter default) and performs a read-only bucket check.
+func preflightWorkspaceExport(
+	ctx context.Context,
+	config *types.RunConfig,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	dest := config.Executor.WorkspaceExportTo
+	if dest == "" {
+		skip("workspace-export", "no workspace export destination configured")
+		return
+	}
+	exporter, err := workspaceexport.NewGCSExporter(workspaceexport.GCSExporterOptions{
+		CredentialSource: credential.NewGoogleWorkloadIdentitySource(),
+	})
+	if err != nil {
+		fail("workspace-export", err, "")
+		return
+	}
+	if err := exporter.Probe(ctx, dest); err != nil {
+		fail("workspace-export", err, "verify the export bucket exists and the run's credential can access it")
+		return
+	}
+	ok("workspace-export", "export bucket accessible")
+}
+
+// executorTypeName renders the configured executor type for the report,
+// defaulting an empty type to "local" to match buildExecutor's default.
+func executorTypeName(t string) string {
+	if t == "" {
+		return "local"
+	}
+	return t
+}
+
+// executorHint returns a remediation hint for an executor construction
+// failure, tailored to the container path where the common causes
+// (daemon down, image absent) have concrete operator actions.
+func executorHint(t string) string {
+	if t == "container" {
+		return "check the Docker/Podman daemon is running and the image is present (pull it first)"
+	}
+	return ""
+}
+
+// traceTypeName renders the configured trace emitter type, defaulting an
+// empty type to "jsonl" to match buildTraceEmitter's default.
+func traceTypeName(t string) string {
+	if t == "" {
+		return "jsonl"
+	}
+	return t
+}
+
+// traceHint returns a remediation hint for a trace-emitter construction
+// failure keyed on the configured type.
+func traceHint(t string) string {
+	switch t {
+	case "otel":
+		return "check traceEmitter.endpoint and protocol point at a reachable OTLP collector"
+	case "gcs":
+		return "check traceEmitter.bucket exists and the credential can access it"
+	case "jsonl", "":
+		return "check traceEmitter.filePath is in a writable directory"
+	default:
+		return ""
+	}
+}

--- a/harness/internal/core/preflight.go
+++ b/harness/internal/core/preflight.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"time"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
 	"github.com/rxbynerd/stirrup/harness/internal/executor/egressproxy"
 	"github.com/rxbynerd/stirrup/harness/internal/mcp"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
@@ -93,6 +95,14 @@ const DefaultPreflightTimeout = 30 * time.Second
 // then probes each constructed component that implements Preflighter and
 // is not gated off by opts.
 //
+// MAINTENANCE INVARIANT: this construction sequence intentionally mirrors
+// BuildLoopWithTransport in factory.go and MUST be updated in lockstep
+// with it. There is no shared construction helper today (a refactor to
+// extract one is a deferred follow-up), so a new component added to
+// BuildLoop that resolves credentials or validates connectivity will be
+// silently ABSENT from the dry-run — giving a false "all OK" — unless a
+// corresponding step is added here. See factory.go:BuildLoopWithTransport.
+//
 // The whole sequence runs under a context.WithTimeout(ctx, opts.Timeout)
 // so a wedged endpoint cannot hang the dry-run past the operator's budget.
 // Owned resources (the executor's container, trace exporters) are closed
@@ -156,21 +166,8 @@ func Preflight(ctx context.Context, config *types.RunConfig, opts PreflightOptio
 		preflightProviders(ctx, config, providers, opts, ok, skip, fail)
 	}
 
-	// 4. Executor. Container construction creates and starts a container,
-	// so a failure here already proves the engine is unreachable or the
-	// image is absent; the ContainerExecutor.Probe step that follows is a
-	// secondary socket+image confirmation. local/api executors implement
-	// no Probe and record a skip.
-	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
-	if err != nil {
-		fail("executor", err, executorHint(config.Executor.Type))
-	} else {
-		ok("executor", fmt.Sprintf("%s executor constructed", executorTypeName(config.Executor.Type)))
-		probeComponent(ctx, "executor-probe", exec, false, "", ok, skip, fail)
-		if closer, isCloser := exec.(interface{ Close() error }); isCloser {
-			defer func() { _ = closer.Close() }()
-		}
-	}
+	// 4. Executor.
+	preflightExecutor(ctx, config, secrets, secLogger, ok, skip, fail)
 
 	// 5. Permission policy. The policy-engine arm loads + parses the Cedar
 	// file at construction, so a malformed policy fails here; its Probe
@@ -270,11 +267,65 @@ func probeComponent(
 	ok(name, "probe succeeded")
 }
 
+// preflightExecutor checks the configured executor. The container path is
+// deliberately NOT routed through buildExecutor: constructing a
+// ContainerExecutor creates and STARTS a real container (and the egress
+// proxy in allowlist mode) as a side effect, which contradicts the
+// read-only intent of a dry-run (issue #245 step 7). Instead it calls
+// executor.ProbeContainerEngine, which only pings the engine socket and
+// inspects the requested image (no pull, no container, no proxy). local
+// and api executors are cheap to construct and have no live side effects,
+// so they keep the construction path; neither implements a Probe, so the
+// probe step records a skip.
+func preflightExecutor(
+	ctx context.Context,
+	config *types.RunConfig,
+	secrets security.SecretStore,
+	secLogger *security.SecurityLogger,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	if config.Executor.Type == "container" {
+		if err := executor.ProbeContainerEngine(ctx, containerProbeConfig(config.Executor)); err != nil {
+			fail("executor", err, executorHint("container"))
+			return
+		}
+		ok("executor", "container engine reachable and image present")
+		return
+	}
+
+	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
+	if err != nil {
+		fail("executor", err, executorHint(config.Executor.Type))
+		return
+	}
+	ok("executor", fmt.Sprintf("%s executor constructed", executorTypeName(config.Executor.Type)))
+	probeComponent(ctx, "executor-probe", exec, false, "", ok, skip, fail)
+	if closer, isCloser := exec.(interface{ Close() error }); isCloser {
+		_ = closer.Close()
+	}
+}
+
+// containerProbeConfig projects the RunConfig's executor block onto the
+// subset ProbeContainerEngine needs. The socket is left empty so
+// ProbeContainerEngine auto-detects it (RunConfig has no socket override;
+// that field exists only on the test-facing ContainerExecutorConfig).
+func containerProbeConfig(cfg types.ExecutorConfig) executor.ContainerExecutorConfig {
+	return executor.ContainerExecutorConfig{
+		Image:   cfg.Image,
+		Network: cfg.Network,
+		Runtime: cfg.Runtime,
+	}
+}
+
 // preflightProviders probes the default and every named provider adapter
 // for metadata-endpoint reachability. Gated by --no-probe-provider. Each
 // adapter is the raw streaming adapter (the normalizer/batch wrappers are
 // not applied in preflight), so the Probe methods on the concrete adapter
-// types are reached directly.
+// types are reached directly. Provider names are sorted so the report's
+// step order is deterministic for a multi-provider config (reproducible
+// --output=json).
 func preflightProviders(
 	ctx context.Context,
 	config *types.RunConfig,
@@ -284,7 +335,14 @@ func preflightProviders(
 	skip func(string, string),
 	fail func(string, error, string),
 ) {
-	for name, p := range providers {
+	names := make([]string, 0, len(providers))
+	for name := range providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		p := providers[name]
 		step := "provider-probe:" + name
 		if opts.SkipProvider {
 			skip(step, "--no-probe-provider set")
@@ -299,8 +357,30 @@ func preflightProviders(
 			fail(step, err, "verify the API key/credential and base URL for this provider")
 			continue
 		}
-		ok(step, "metadata endpoint reachable")
+		ok(step, providerProbeDetail(providerTypeFor(config, name)))
 	}
+}
+
+// providerTypeFor resolves the provider TYPE for a providers-map key. The
+// default provider is keyed by its type; a named entry in
+// config.Providers is keyed by its map name but carries its own Type.
+func providerTypeFor(config *types.RunConfig, name string) string {
+	if cfg, ok := config.Providers[name]; ok {
+		return cfg.Type
+	}
+	return name
+}
+
+// providerProbeDetail returns the success detail for a provider probe.
+// Bedrock is special-cased: its probe resolves the AWS credential chain
+// but contacts no endpoint (bedrockruntime has no zero-cost reachability
+// op), so claiming "metadata endpoint reachable" would mislead an operator
+// diagnosing a Bedrock network/VPC issue.
+func providerProbeDetail(providerType string) string {
+	if providerType == "bedrock" {
+		return "AWS credentials resolved (network reachability not probed — no zero-cost Bedrock metadata endpoint)"
+	}
+	return "metadata endpoint reachable"
 }
 
 // preflightMCP probes every configured MCP server. Gated by

--- a/harness/internal/core/preflight_test.go
+++ b/harness/internal/core/preflight_test.go
@@ -1,0 +1,189 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// preflightTestConfig returns a minimal, validator-clean RunConfig
+// pointing its openai-compatible provider at baseURL. mode=execution so
+// the read-only-mode tool/permission invariants do not constrain the
+// permission policy choice.
+func preflightTestConfig(t *testing.T, baseURL string) *types.RunConfig {
+	t.Helper()
+	timeout := 30
+	return &types.RunConfig{
+		RunID:            "preflight-test",
+		Mode:             "execution",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_PREFLIGHT_KEY", BaseURL: baseURL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+}
+
+// metadataOnlyServer serves GET /v1/models (the probe target) and records
+// any hit to /chat/completions so the no-completion-endpoint invariant can
+// be asserted at the integration level.
+func metadataOnlyServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var completionHits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/models"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/chat/completions"):
+			completionHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return srv, &completionHits
+}
+
+func stepStatus(report *PreflightReport, name string) (PreflightStatus, bool) {
+	for _, s := range report.Steps {
+		if s.Name == name {
+			return s.Status, true
+		}
+	}
+	return "", false
+}
+
+func TestPreflight_AllOK_NoCompletionRequest(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, completionHits := metadataOnlyServer(t)
+	defer srv.Close()
+
+	report, err := Preflight(context.Background(), preflightTestConfig(t, srv.URL+"/v1"), PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if !report.OK {
+		t.Fatalf("expected report.OK; steps: %+v", report.Steps)
+	}
+	if got := completionHits.Load(); got != 0 {
+		t.Errorf("completion endpoint hit %d times; a dry-run must never call it", got)
+	}
+	if st, ok := stepStatus(report, "provider-probe:openai-compatible"); !ok || st != PreflightOK {
+		t.Errorf("provider probe step status = %v (ok=%v), want ok", st, ok)
+	}
+	if st, _ := stepStatus(report, "credentials"); st != PreflightOK {
+		t.Errorf("credentials step = %v, want ok", st)
+	}
+}
+
+func TestPreflight_BadCredentialFails(t *testing.T) {
+	// No env var set -> credential resolution fails during provider build.
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	report, err := Preflight(context.Background(), preflightTestConfig(t, srv.URL+"/v1"), PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if report.OK {
+		t.Fatal("expected report.OK == false for missing credential")
+	}
+	st, ok := stepStatus(report, "credentials")
+	if !ok || st != PreflightFail {
+		t.Errorf("credentials step status = %v (found=%v), want fail", st, ok)
+	}
+}
+
+func TestPreflight_SkipProvider(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	report, err := Preflight(context.Background(), preflightTestConfig(t, srv.URL+"/v1"), PreflightOptions{SkipProvider: true})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "provider-probe:openai-compatible")
+	if !ok || st != PreflightSkip {
+		t.Errorf("provider probe step = %v (found=%v), want skip", st, ok)
+	}
+	if !report.OK {
+		t.Errorf("a skipped probe must not fail the report; steps: %+v", report.Steps)
+	}
+}
+
+func TestPreflight_ProviderProbeFailure(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad key"}}`))
+	}))
+	defer srv.Close()
+
+	report, err := Preflight(context.Background(), preflightTestConfig(t, srv.URL+"/v1"), PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if report.OK {
+		t.Fatal("expected report.OK == false for a 401 provider probe")
+	}
+	st, _ := stepStatus(report, "provider-probe:openai-compatible")
+	if st != PreflightFail {
+		t.Errorf("provider probe step = %v, want fail", st)
+	}
+}
+
+func TestPreflight_ValidationFailureStopsEarly(t *testing.T) {
+	cfg := preflightTestConfig(t, "http://127.0.0.1:1/v1")
+	cfg.MaxTurns = 0 // invalid
+
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if report.OK {
+		t.Fatal("expected report.OK == false for invalid config")
+	}
+	if st, _ := stepStatus(report, "config-validation"); st != PreflightFail {
+		t.Errorf("config-validation step = %v, want fail", st)
+	}
+	// Validation failure short-circuits, so no later steps run.
+	if _, ok := stepStatus(report, "credentials"); ok {
+		t.Error("credentials step should not run after a validation failure")
+	}
+}
+
+func TestPreflight_TimeoutDefaulted(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	// A zero Timeout must fall back to DefaultPreflightTimeout rather than
+	// producing an already-expired context.
+	start := time.Now()
+	report, err := Preflight(context.Background(), preflightTestConfig(t, srv.URL+"/v1"), PreflightOptions{Timeout: 0})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if !report.OK {
+		t.Fatalf("expected OK with defaulted timeout; steps: %+v", report.Steps)
+	}
+	if time.Since(start) > DefaultPreflightTimeout {
+		t.Errorf("preflight exceeded the default timeout budget")
+	}
+}

--- a/harness/internal/core/preflight_test.go
+++ b/harness/internal/core/preflight_test.go
@@ -168,6 +168,172 @@ func TestPreflight_ValidationFailureStopsEarly(t *testing.T) {
 	}
 }
 
+// mcpProbeServer answers MCP tools/list with an empty list (ok) or a 500
+// (fail), so MCP probe paths can be exercised through core.Preflight.
+func mcpProbeServer(t *testing.T, fail bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`))
+	}))
+}
+
+func TestPreflight_MCP_Skip(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+	mcpSrv := mcpProbeServer(t, false)
+	defer mcpSrv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1")
+	cfg.Tools.MCPServers = []types.MCPServerConfig{{Name: "docs", URI: mcpSrv.URL}}
+
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{SkipMCP: true})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "mcp:docs")
+	if !ok || st != PreflightSkip {
+		t.Errorf("mcp step = %v (found=%v), want skip", st, ok)
+	}
+}
+
+func TestPreflight_MCP_OK(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+	mcpSrv := mcpProbeServer(t, false)
+	defer mcpSrv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1")
+	cfg.Tools.MCPServers = []types.MCPServerConfig{{Name: "docs", URI: mcpSrv.URL}}
+
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "mcp:docs")
+	if !ok || st != PreflightOK {
+		t.Errorf("mcp step = %v (found=%v), want ok; steps: %+v", st, ok, report.Steps)
+	}
+}
+
+func TestPreflight_MCP_Fail(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+	mcpSrv := mcpProbeServer(t, true)
+	defer mcpSrv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1")
+	cfg.Tools.MCPServers = []types.MCPServerConfig{{Name: "docs", URI: mcpSrv.URL}}
+
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if report.OK {
+		t.Fatal("a failing MCP probe must fail the report")
+	}
+	st, _ := stepStatus(report, "mcp:docs")
+	if st != PreflightFail {
+		t.Errorf("mcp step = %v, want fail", st)
+	}
+}
+
+func TestPreflight_Egress_Skip(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1")
+	cfg.Executor = types.ExecutorConfig{
+		Type:    "container",
+		Image:   "ubuntu:26.04",
+		Network: &types.NetworkConfig{Mode: "allowlist", Allowlist: []string{"example.com"}},
+	}
+
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{SkipEgress: true})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "egress")
+	if !ok || st != PreflightSkip {
+		t.Errorf("egress step = %v (found=%v), want skip", st, ok)
+	}
+}
+
+func TestPreflight_Egress_Fail_MalformedAllowlist(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1")
+	// A malformed allowlist entry fails the egress probe deterministically
+	// (a parse error, no DNS) without depending on network resolution.
+	cfg.Executor = types.ExecutorConfig{
+		Type:    "container",
+		Image:   "ubuntu:26.04",
+		Network: &types.NetworkConfig{Mode: "allowlist", Allowlist: []string{"bad host with spaces"}},
+	}
+
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "egress")
+	if !ok || st != PreflightFail {
+		t.Errorf("egress step = %v (found=%v), want fail", st, ok)
+	}
+}
+
+func TestPreflight_WorkspaceExport_Skip(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1") // no WorkspaceExportTo
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "workspace-export")
+	if !ok || st != PreflightSkip {
+		t.Errorf("workspace-export step = %v (found=%v), want skip", st, ok)
+	}
+}
+
+func TestPreflight_NilConfig(t *testing.T) {
+	if _, err := Preflight(context.Background(), nil, PreflightOptions{}); err == nil {
+		t.Fatal("Preflight(nil) should error")
+	}
+}
+
+func TestPreflight_ShortTimeoutSurfacesAsFail(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	// A server that sleeps past a 1ns deadline so the provider probe's
+	// context is already expired — the step must surface a clear fail, not
+	// panic or hang.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	report, err := Preflight(context.Background(), preflightTestConfig(t, srv.URL+"/v1"), PreflightOptions{Timeout: time.Nanosecond})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if report.OK {
+		t.Fatal("a deadline-exceeded probe must not report OK")
+	}
+}
+
 func TestPreflight_TimeoutDefaulted(t *testing.T) {
 	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
 	srv, _ := metadataOnlyServer(t)

--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -58,10 +58,34 @@ type ContainerExecutor struct {
 	workspace   string // always containerWorkspace ("/workspace")
 	hostDir     string
 	networkMode string
+	image       string // requested image, retained for the dry-run probe
 	Security    SecurityEventEmitter
 	// proxy, when non-nil, is the in-process egress proxy started for the
 	// allowlist network mode. Close() stops it.
 	proxy *egressproxy.Proxy
+}
+
+// Probe checks the container runtime for a dry-run preflight: it pings
+// the engine socket (GET /_ping) and verifies the requested image is
+// present locally (GET /images/{image}/json) without pulling. An absent
+// image is reported as an error carrying a remediation hint rather than
+// silently pulling at run time, which would burn the run's wall-clock on
+// a multi-hundred-megabyte download the operator did not anticipate.
+func (e *ContainerExecutor) Probe(ctx context.Context) error {
+	if err := e.api.ping(ctx); err != nil {
+		return fmt.Errorf("container engine unreachable: %w", err)
+	}
+	if e.image == "" {
+		return nil
+	}
+	present, err := e.api.imageExistsLocally(ctx, e.image)
+	if err != nil {
+		return fmt.Errorf("inspect image %q: %w", e.image, err)
+	}
+	if !present {
+		return fmt.Errorf("image %q is not present locally; pull it before the run (e.g. `docker pull %s`)", e.image, e.image)
+	}
+	return nil
 }
 
 // NewContainerExecutor creates and starts a container, returning an executor
@@ -194,6 +218,7 @@ func NewContainerExecutorWithContext(ctx context.Context, cfg ContainerExecutorC
 		workspace:   containerWorkspace,
 		hostDir:     cfg.HostDir,
 		networkMode: hc.NetworkMode,
+		image:       cfg.Image,
 		Security:    nil,
 		proxy:       proxy,
 	}, nil

--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -72,18 +72,48 @@ type ContainerExecutor struct {
 // silently pulling at run time, which would burn the run's wall-clock on
 // a multi-hundred-megabyte download the operator did not anticipate.
 func (e *ContainerExecutor) Probe(ctx context.Context) error {
-	if err := e.api.ping(ctx); err != nil {
+	return probeContainerEngine(ctx, e.api, e.image)
+}
+
+// ProbeContainerEngine performs the dry-run preflight check for a
+// container executor WITHOUT constructing or starting a container. It
+// builds only the Engine API client (honouring cfg.SocketPath or
+// auto-detecting the socket), pings the daemon, and verifies the image is
+// present locally. Crucially it never calls createContainer/startContainer
+// and never starts the egress proxy, so a `--dry-run` of a container
+// config is truly read-only — unlike NewContainerExecutorWithContext,
+// which creates a live container as a construction side effect. The
+// preflight path (core.Preflight) uses this instead of building a full
+// ContainerExecutor (issue #245 step 7).
+func ProbeContainerEngine(ctx context.Context, cfg ContainerExecutorConfig) error {
+	socketPath := cfg.SocketPath
+	if socketPath == "" {
+		var err error
+		socketPath, err = detectSocket()
+		if err != nil {
+			return fmt.Errorf("detect container socket: %w", err)
+		}
+	}
+	return probeContainerEngine(ctx, newContainerAPIClient(socketPath), cfg.Image)
+}
+
+// probeContainerEngine is the shared ping + image-presence check used by
+// both ContainerExecutor.Probe (already-constructed executor) and
+// ProbeContainerEngine (preflight, no container). An empty image skips the
+// image check — the engine ping alone still confirms reachability.
+func probeContainerEngine(ctx context.Context, api *containerAPIClient, image string) error {
+	if err := api.ping(ctx); err != nil {
 		return fmt.Errorf("container engine unreachable: %w", err)
 	}
-	if e.image == "" {
+	if image == "" {
 		return nil
 	}
-	present, err := e.api.imageExistsLocally(ctx, e.image)
+	present, err := api.imageExistsLocally(ctx, image)
 	if err != nil {
-		return fmt.Errorf("inspect image %q: %w", e.image, err)
+		return fmt.Errorf("inspect image %q: %w", image, err)
 	}
 	if !present {
-		return fmt.Errorf("image %q is not present locally; pull it before the run (e.g. `docker pull %s`)", e.image, e.image)
+		return fmt.Errorf("image %q is not present locally; pull it before the run (e.g. `docker pull %q`)", image, image)
 	}
 	return nil
 }

--- a/harness/internal/executor/container_api.go
+++ b/harness/internal/executor/container_api.go
@@ -192,7 +192,7 @@ func (c *containerAPIClient) imageExistsLocally(ctx context.Context, image strin
 	}
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return false, fmt.Errorf("docker API request GET /images/%s/json: %w", image, err)
+		return false, fmt.Errorf("docker API request GET /images/%q/json: %w", image, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	switch {
@@ -202,9 +202,9 @@ func (c *containerAPIClient) imageExistsLocally(ctx context.Context, image strin
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		var apiErr apiError
 		if json.Unmarshal(body, &apiErr) == nil && apiErr.Message != "" {
-			return false, fmt.Errorf("docker API GET /images/%s/json: %s (HTTP %d)", image, apiErr.Message, resp.StatusCode)
+			return false, fmt.Errorf("docker API GET /images/%q/json: %s (HTTP %d)", image, apiErr.Message, resp.StatusCode)
 		}
-		return false, fmt.Errorf("docker API GET /images/%s/json: HTTP %d", image, resp.StatusCode)
+		return false, fmt.Errorf("docker API GET /images/%q/json: HTTP %d", image, resp.StatusCode)
 	default:
 		return true, nil
 	}

--- a/harness/internal/executor/container_api.go
+++ b/harness/internal/executor/container_api.go
@@ -159,6 +159,57 @@ func (c *containerAPIClient) createContainer(ctx context.Context, cfg containerC
 	return result.ID, nil
 }
 
+// ping issues GET /_ping against the engine socket. A 2xx (the engine
+// answers "OK") confirms the daemon is reachable; doRequest turns any
+// >=400 into an error. Used by the dry-run preflight probe so an
+// unreachable or stopped daemon surfaces before the run commits to
+// creating a container.
+func (c *containerAPIClient) ping(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url("/_ping"), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+// imageExistsLocally reports whether the named image is present in the
+// engine's local store via GET /images/{name}/json. A 404 is translated
+// to (false, nil) — the image is simply not pulled — so the preflight can
+// distinguish "engine unreachable" (an error) from "image absent" (a
+// warning the operator can act on without a failed run). The probe never
+// pulls: that is a deliberate cost/latency decision left to the run
+// itself. The image reference is path-escaped because it may contain a
+// registry host, a tag, or an "@sha256:" digest with reserved bytes.
+func (c *containerAPIClient) imageExistsLocally(ctx context.Context, image string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url("/images/"+url.PathEscape(image)+"/json"), nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("docker API request GET /images/%s/json: %w", image, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return false, nil
+	case resp.StatusCode >= 400:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		var apiErr apiError
+		if json.Unmarshal(body, &apiErr) == nil && apiErr.Message != "" {
+			return false, fmt.Errorf("docker API GET /images/%s/json: %s (HTTP %d)", image, apiErr.Message, resp.StatusCode)
+		}
+		return false, fmt.Errorf("docker API GET /images/%s/json: HTTP %d", image, resp.StatusCode)
+	default:
+		return true, nil
+	}
+}
+
 func (c *containerAPIClient) startContainer(ctx context.Context, id string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(fmt.Sprintf("/containers/%s/start", id)), nil)
 	if err != nil {

--- a/harness/internal/executor/egressproxy/probe.go
+++ b/harness/internal/executor/egressproxy/probe.go
@@ -1,0 +1,68 @@
+package egressproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// ProbeAllowlist performs a dry-run preflight reachability check of an
+// egress allowlist. For each entry it resolves the destination hostname
+// via DNS (using the supplied resolver, defaulting to net.DefaultResolver
+// when nil) so an operator catches a typo'd or NXDOMAIN destination before
+// the run starts. A wildcard entry ("*.example.com") has no single
+// resolvable host, so its base domain ("example.com") is resolved as a
+// best-effort signal that the zone exists.
+//
+// The probe is DNS-only by design: it never opens a TCP connection to the
+// destination. A TCP dial would be a stronger signal but turns a cheap
+// dry-run into a fan-out of outbound connections to every allowlisted
+// host, which is both slow and surprising for a "check my config" command.
+// DNS resolution catches the common misconfiguration (a bad hostname)
+// without that cost.
+//
+// The allowlist is parsed with the same NewMatcher rules the proxy
+// enforces, so a malformed entry fails the probe identically to how it
+// would fail the proxy at run time. An empty allowlist is a no-op (nil):
+// allowlist network mode with no entries denies all egress, which is a
+// valid — if restrictive — configuration the probe should not flag.
+func ProbeAllowlist(ctx context.Context, allowlist []string, resolver *net.Resolver) error {
+	matcher, err := NewMatcher(allowlist)
+	if err != nil {
+		return fmt.Errorf("egress allowlist parse: %w", err)
+	}
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+
+	var failures []string
+	for _, entry := range matcher.Entries() {
+		host := probeHost(entry)
+		if host == "" {
+			continue
+		}
+		if _, err := resolver.LookupHost(ctx, host); err != nil {
+			failures = append(failures, fmt.Sprintf("%s (%v)", entry, err))
+		}
+	}
+	if len(failures) > 0 {
+		return errors.New("egress allowlist destinations unresolvable: " + strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// probeHost extracts the resolvable hostname from a matcher entry of the
+// form "host:port" or "*.host:port". The wildcard prefix is stripped so
+// the base zone is resolved. Returns "" when the entry has no host
+// component (which NewMatcher would already have rejected, so this is
+// defence-in-depth).
+func probeHost(entry string) string {
+	host := entry
+	if idx := strings.LastIndex(entry, ":"); idx >= 0 {
+		host = entry[:idx]
+	}
+	host = strings.TrimPrefix(host, "*.")
+	return host
+}

--- a/harness/internal/executor/egressproxy/probe_test.go
+++ b/harness/internal/executor/egressproxy/probe_test.go
@@ -1,0 +1,65 @@
+package egressproxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProbeAllowlist_EmptyIsNoop(t *testing.T) {
+	if err := ProbeAllowlist(context.Background(), nil, net.DefaultResolver); err != nil {
+		t.Fatalf("empty allowlist should be a no-op, got: %v", err)
+	}
+}
+
+func TestProbeAllowlist_MalformedEntry(t *testing.T) {
+	err := ProbeAllowlist(context.Background(), []string{"bad host with spaces"}, net.DefaultResolver)
+	if err == nil {
+		t.Fatal("expected parse error for malformed allowlist entry")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error should mention parse failure, got: %v", err)
+	}
+}
+
+func TestProbeAllowlist_Unresolvable(t *testing.T) {
+	// A custom resolver whose Dial always errors makes every lookup fail,
+	// standing in for an NXDOMAIN/unreachable destination without depending
+	// on a hostname that is guaranteed not to resolve in CI.
+	failing := &net.Resolver{
+		PreferGo: true,
+		Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return nil, fmt.Errorf("no DNS")
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := ProbeAllowlist(ctx, []string{"example.com", "*.api.example.com:8443"}, failing)
+	if err == nil {
+		t.Fatal("expected error when destinations do not resolve")
+	}
+	if !strings.Contains(err.Error(), "unresolvable") {
+		t.Errorf("error should report unresolvable destinations, got: %v", err)
+	}
+	// Both the exact host and the wildcard base zone should be reported.
+	if !strings.Contains(err.Error(), "example.com") {
+		t.Errorf("error should name the failing destinations, got: %v", err)
+	}
+}
+
+func TestProbeHost(t *testing.T) {
+	cases := map[string]string{
+		"example.com:443":        "example.com",
+		"*.api.example.com:8443": "api.example.com",
+		"host:80":                "host",
+	}
+	for in, want := range cases {
+		if got := probeHost(in); got != want {
+			t.Errorf("probeHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/harness/internal/executor/probe_test.go
+++ b/harness/internal/executor/probe_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -45,6 +46,72 @@ func TestContainerExecutor_Probe_ImageAbsent(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not present locally") || !strings.Contains(err.Error(), "missing:latest") {
 		t.Errorf("error should name the missing image with a pull hint, got: %v", err)
+	}
+}
+
+// TestProbeContainerEngine_NoContainerCreated is the load-bearing R1
+// regression: a container dry-run must ping + inspect the image but never
+// create or start a container, and never touch the egress proxy. The mock
+// engine fails the test if it sees a create/start request.
+func TestProbeContainerEngine_NoContainerCreated(t *testing.T) {
+	var createHits, startHits atomic.Int64
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		},
+		"GET /images/*/json": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"sha256:abc"}`))
+		},
+		"POST /containers/create": func(w http.ResponseWriter, _ *http.Request) {
+			createHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"should-not-happen"}`))
+		},
+		"POST /containers/*/start": func(w http.ResponseWriter, _ *http.Request) {
+			startHits.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer cleanup()
+
+	err := ProbeContainerEngine(context.Background(), ContainerExecutorConfig{
+		Image:      "ubuntu:26.04",
+		SocketPath: sock,
+	})
+	if err != nil {
+		t.Fatalf("ProbeContainerEngine: unexpected error: %v", err)
+	}
+	if got := createHits.Load(); got != 0 {
+		t.Errorf("container create hit %d times; a dry-run must not create a container", got)
+	}
+	if got := startHits.Load(); got != 0 {
+		t.Errorf("container start hit %d times; a dry-run must not start a container", got)
+	}
+}
+
+func TestProbeContainerEngine_ImageAbsent(t *testing.T) {
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+		"GET /images/*/json": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"no such image"}`))
+		},
+	})
+	defer cleanup()
+
+	err := ProbeContainerEngine(context.Background(), ContainerExecutorConfig{
+		Image:      "missing:latest",
+		SocketPath: sock,
+	})
+	if err == nil {
+		t.Fatal("ProbeContainerEngine: expected error for absent image")
+	}
+	if !strings.Contains(err.Error(), "not present locally") {
+		t.Errorf("error should report the absent image, got: %v", err)
 	}
 }
 

--- a/harness/internal/executor/probe_test.go
+++ b/harness/internal/executor/probe_test.go
@@ -1,0 +1,68 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestContainerExecutor_Probe_OK(t *testing.T) {
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		},
+		"GET /images/*/json": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"sha256:abc"}`))
+		},
+	})
+	defer cleanup()
+
+	exec := &ContainerExecutor{api: newContainerAPIClient(sock), image: "ubuntu:26.04"}
+	if err := exec.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+}
+
+func TestContainerExecutor_Probe_ImageAbsent(t *testing.T) {
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+		"GET /images/*/json": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"no such image"}`))
+		},
+	})
+	defer cleanup()
+
+	exec := &ContainerExecutor{api: newContainerAPIClient(sock), image: "missing:latest"}
+	err := exec.Probe(context.Background())
+	if err == nil {
+		t.Fatal("Probe: expected error for absent image, got nil")
+	}
+	if !strings.Contains(err.Error(), "not present locally") || !strings.Contains(err.Error(), "missing:latest") {
+		t.Errorf("error should name the missing image with a pull hint, got: %v", err)
+	}
+}
+
+func TestContainerExecutor_Probe_EngineUnreachable(t *testing.T) {
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"daemon error"}`))
+		},
+	})
+	defer cleanup()
+
+	exec := &ContainerExecutor{api: newContainerAPIClient(sock), image: "ubuntu:26.04"}
+	err := exec.Probe(context.Background())
+	if err == nil {
+		t.Fatal("Probe: expected error for unreachable engine, got nil")
+	}
+	if !strings.Contains(err.Error(), "unreachable") {
+		t.Errorf("error should mention engine unreachable, got: %v", err)
+	}
+}

--- a/harness/internal/gcs/bucket_test.go
+++ b/harness/internal/gcs/bucket_test.go
@@ -1,0 +1,66 @@
+package gcs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBucketAccessible_OK(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"my-bucket"}`))
+	}))
+	defer srv.Close()
+
+	err := BucketAccessible(context.Background(), srv.Client(), BucketProbeOptions{
+		Bucket:          "my-bucket",
+		Bearer:          staticBearer("tok"),
+		EndpointBaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("BucketAccessible: unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET (read-only)", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/storage/v1/b/my-bucket") {
+		t.Errorf("path = %q, want bucket-metadata route", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth = %q, want bearer token applied", gotAuth)
+	}
+}
+
+func TestBucketAccessible_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+	}))
+	defer srv.Close()
+
+	err := BucketAccessible(context.Background(), srv.Client(), BucketProbeOptions{
+		Bucket:          "missing",
+		Bearer:          staticBearer("tok"),
+		EndpointBaseURL: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("BucketAccessible: expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "404") || !strings.Contains(err.Error(), "missing") {
+		t.Errorf("error should carry status and bucket name, got: %v", err)
+	}
+}
+
+func TestBucketAccessible_RequiresBearer(t *testing.T) {
+	err := BucketAccessible(context.Background(), http.DefaultClient, BucketProbeOptions{Bucket: "b"})
+	if err == nil {
+		t.Fatal("expected error when bearer is nil")
+	}
+}

--- a/harness/internal/gcs/upload.go
+++ b/harness/internal/gcs/upload.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
@@ -172,8 +173,12 @@ func BucketAccessible(ctx context.Context, client *http.Client, opts BucketProbe
 		return fmt.Errorf("acquire bearer token: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/storage/v1/b/%s", strings.TrimRight(endpoint, "/"), opts.Bucket)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	// PathEscape the bucket so a name carrying reserved bytes cannot
+	// rewrite the request path. TraceEmitter.Bucket is regex-validated, but
+	// WorkspaceExportTo's bucket has weaker validation, so escape here as
+	// defence-in-depth rather than relying on the caller having checked.
+	reqURL := fmt.Sprintf("%s/storage/v1/b/%s", strings.TrimRight(endpoint, "/"), url.PathEscape(opts.Bucket))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}

--- a/harness/internal/gcs/upload.go
+++ b/harness/internal/gcs/upload.go
@@ -132,6 +132,68 @@ func UploadObject(ctx context.Context, client *http.Client, opts UploadOptions) 
 	return fmt.Errorf("gcs upload returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
 }
 
+// BucketProbeOptions configures a single bucket-access probe.
+type BucketProbeOptions struct {
+	// Bucket is the GCS bucket name to check.
+	Bucket string
+
+	// Bearer returns the current bearer token. Required.
+	Bearer credential.BearerTokenFunc
+
+	// EndpointBaseURL overrides the GCS JSON-API host. Empty means use
+	// DefaultEndpointBaseURL. Tests set this to an httptest.NewServer.
+	EndpointBaseURL string
+}
+
+// BucketAccessible performs a read-only bucket-metadata GET
+// (GET /storage/v1/b/{bucket}) to verify the credential can see the
+// bucket, for a dry-run preflight. A 2xx confirms access without
+// uploading anything; a non-2xx (404 missing bucket, 403 denied, 401 bad
+// credential) is surfaced as an error carrying the GCS diagnostic. This
+// is the cheapest authenticated bucket check the JSON API offers and is
+// shared by the gcs trace emitter and the workspace exporter so both
+// report bucket access identically.
+func BucketAccessible(ctx context.Context, client *http.Client, opts BucketProbeOptions) error {
+	if client == nil {
+		return fmt.Errorf("gcs: http client is required")
+	}
+	if opts.Bucket == "" {
+		return fmt.Errorf("gcs: bucket is required")
+	}
+	if opts.Bearer == nil {
+		return fmt.Errorf("gcs: bearer is required")
+	}
+	endpoint := opts.EndpointBaseURL
+	if endpoint == "" {
+		endpoint = DefaultEndpointBaseURL
+	}
+	token, err := opts.Bearer(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire bearer token: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/storage/v1/b/%s", strings.TrimRight(endpoint, "/"), opts.Bucket)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("get gcs bucket metadata: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	const maxErrBody = 4 * 1024
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
+	return fmt.Errorf("gcs bucket %q access returned HTTP %d: %s", opts.Bucket, resp.StatusCode, strings.TrimSpace(string(msg)))
+}
+
 // urlPathEscape escapes an object name for use in the name= query
 // parameter. GCS allows '/' unescaped in this position (the value goes
 // into the bucket as the object key, '/'-separators preserved). Other

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -365,6 +365,48 @@ func (c *Client) Connect(ctx context.Context, config types.MCPServerConfig, secr
 	return nil
 }
 
+// Probe performs a read-only reachability and authentication handshake
+// against a single MCP server for a dry-run preflight: it validates the
+// URI shape, resolves the configured bearer token, and issues the same
+// tools/list request Connect uses — but it does NOT register the
+// discovered tools into the registry. This keeps the probe a pure
+// side-effect-free check that can run before (or instead of) the real
+// Connect, and avoids mutating a registry a non-dry-run path may also be
+// populating.
+//
+// A returned error names the server so the preflight step can point the
+// operator at the specific misconfigured entry.
+func (c *Client) Probe(ctx context.Context, config types.MCPServerConfig, secrets security.SecretStore) error {
+	if config.Name == "" {
+		return fmt.Errorf("mcp: server config missing required Name field")
+	}
+	if config.URI == "" {
+		return fmt.Errorf("mcp: server %q missing required URI field", config.Name)
+	}
+
+	parsed, err := url.Parse(config.URI)
+	if err != nil {
+		return fmt.Errorf("mcp: invalid URI for server %q: %w", config.Name, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("mcp: server %q URI scheme %q not allowed (must be http or https)", config.Name, parsed.Scheme)
+	}
+
+	var token string
+	if config.APIKeyRef != "" {
+		token, err = secrets.Resolve(ctx, config.APIKeyRef)
+		if err != nil {
+			return fmt.Errorf("mcp: resolve auth for server %q: %w", config.Name, err)
+		}
+	}
+
+	sess := &serverSession{uri: config.URI, token: token}
+	if _, err := c.listTools(ctx, sess); err != nil {
+		return fmt.Errorf("mcp: list tools from server %q: %w", config.Name, err)
+	}
+	return nil
+}
+
 // Close releases resources held by the client. Currently a no-op since
 // Streamable HTTP is stateless on the client side, but provides a clean
 // lifecycle boundary for future session teardown (e.g. DELETE request).

--- a/harness/internal/mcp/probe_test.go
+++ b/harness/internal/mcp/probe_test.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func TestProbe_HandshakeSucceedsWithoutRegistering(t *testing.T) {
+	tools := []mcpTool{
+		{Name: "search", Description: "Search", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	srv, _ := fakeMCPServer(t, tools, "")
+	registry := tool.NewRegistry()
+	client := NewClient(registry, srv.Client())
+
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+	config := types.MCPServerConfig{Name: "docs", URI: srv.URL}
+
+	if err := client.Probe(context.Background(), config, secrets); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+
+	// A probe must NOT register tools — that is the contract difference
+	// from Connect.
+	if defs := registry.List(); len(defs) != 0 {
+		t.Errorf("Probe registered %d tools; expected 0 (probe must not mutate the registry)", len(defs))
+	}
+}
+
+func TestProbe_BadScheme(t *testing.T) {
+	client := NewClient(tool.NewRegistry(), nil)
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+	config := types.MCPServerConfig{Name: "bad", URI: "file:///etc/passwd"}
+
+	err := client.Probe(context.Background(), config, secrets)
+	if err == nil {
+		t.Fatal("Probe: expected error for non-http scheme")
+	}
+	if !strings.Contains(err.Error(), "scheme") {
+		t.Errorf("error should mention the rejected scheme, got: %v", err)
+	}
+}
+
+func TestProbe_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(tool.NewRegistry(), srv.Client())
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+	config := types.MCPServerConfig{Name: "down", URI: srv.URL}
+
+	err := client.Probe(context.Background(), config, secrets)
+	if err == nil {
+		t.Fatal("Probe: expected error for 5xx server")
+	}
+	if !strings.Contains(err.Error(), "down") {
+		t.Errorf("error should name the server, got: %v", err)
+	}
+}

--- a/harness/internal/permission/policyengine.go
+++ b/harness/internal/permission/policyengine.go
@@ -210,6 +210,33 @@ func (p *PolicyEnginePolicy) Check(ctx context.Context, tool types.ToolDefinitio
 	}
 }
 
+// Probe validates the loaded Cedar policy set for a dry-run preflight.
+// The file was already read and parsed at construction (a malformed file
+// fails the build), so this confirms the parsed set is present and
+// exercises one cedar.Authorize evaluation against a synthetic request to
+// smoke-test the decision path. It deliberately calls cedar.Authorize
+// directly rather than Check: Check would delegate an unmatched decision
+// to the fallback policy, and for an ask-upstream fallback that means a
+// live transport approval prompt — a side effect a probe must never
+// trigger. A nil set (impossible via the normal constructor but reachable
+// for a hand-built policy) is reported so the preflight does not silently
+// pass a policy that would deny every call at run time.
+func (p *PolicyEnginePolicy) Probe(_ context.Context) error {
+	if p == nil || p.cedar == nil {
+		return errors.New("policy-engine: no Cedar policy set loaded")
+	}
+	probeTool := types.ToolDefinition{Name: "preflight_probe"}
+	req, entities, err := p.buildRequest(probeTool, json.RawMessage(`{}`))
+	if err != nil {
+		return fmt.Errorf("policy-engine: build probe request: %w", err)
+	}
+	// The decision itself is irrelevant — the probe only confirms the
+	// policy set evaluates without panicking or erroring on a well-formed
+	// request.
+	cedar.Authorize(p.cedar, entities, req)
+	return nil
+}
+
 // ForChildRun returns a shallow clone of the receiver bound to a new
 // child run identity. The Cedar policy set, fallback policy, and
 // security emitter are reused unchanged; runID is replaced with the

--- a/harness/internal/permission/probe_test.go
+++ b/harness/internal/permission/probe_test.go
@@ -1,0 +1,63 @@
+package permission
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func TestPolicyEnginePolicy_Probe_OK(t *testing.T) {
+	policy := `permit (
+		principal,
+		action == Action::"tool:web_fetch",
+		resource
+	);`
+	p := newTestPolicy(t, PolicyEngineConfig{
+		PolicySet: mustParse(t, policy),
+		Fallback:  NewDenySideEffects(map[string]bool{"write_file": true}),
+	})
+	if err := p.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+}
+
+func TestPolicyEnginePolicy_Probe_DoesNotTriggerFallback(t *testing.T) {
+	// The synthetic probe tool matches no policy, so a Check() would
+	// delegate to the fallback. Probe must NOT do that — it evaluates the
+	// Cedar set directly. Use a fallback that records whether it was
+	// consulted to pin the no-side-effect guarantee.
+	policy := `permit (
+		principal,
+		action == Action::"tool:web_fetch",
+		resource
+	);`
+	fb := &recordingFallback{}
+	p := newTestPolicy(t, PolicyEngineConfig{
+		PolicySet: mustParse(t, policy),
+		Fallback:  fb,
+	})
+	if err := p.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+	if fb.called {
+		t.Error("Probe consulted the fallback policy; it must evaluate Cedar directly to avoid a live ask-upstream prompt")
+	}
+}
+
+func TestPolicyEnginePolicy_Probe_NilSet(t *testing.T) {
+	var p *PolicyEnginePolicy
+	if err := p.Probe(context.Background()); err == nil {
+		t.Fatal("Probe on nil policy should error")
+	}
+}
+
+// recordingFallback records whether Check was called, standing in for a
+// fallback policy whose evaluation would be an observable side effect.
+type recordingFallback struct{ called bool }
+
+func (r *recordingFallback) Check(_ context.Context, _ types.ToolDefinition, _ json.RawMessage) (*PermissionResult, error) {
+	r.called = true
+	return &PermissionResult{Allowed: true}, nil
+}

--- a/harness/internal/provider/bedrock.go
+++ b/harness/internal/provider/bedrock.go
@@ -39,6 +39,13 @@ type BedrockAdapter struct {
 	client  bedrockConverseStreamer
 	Tracer  oteltrace.Tracer       // optional, set by factory for span instrumentation
 	Metrics *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
+
+	// credentials and region are captured from the resolved AWS config so
+	// Probe can validate the credential chain without issuing a billable
+	// request. Both are nil/empty for the test-injected mock-client path
+	// (newBedrockAdapterWithClient), which leaves Probe a no-op skip.
+	credentials aws.CredentialsProvider
+	region      string
 }
 
 // NewBedrockAdapter creates an adapter that uses the ConverseStream API.
@@ -64,7 +71,35 @@ func NewBedrockAdapter(region, profile string, credProvider aws.CredentialsProvi
 	}
 
 	client := bedrockruntime.NewFromConfig(cfg)
-	return &BedrockAdapter{client: client}, nil
+	return &BedrockAdapter{
+		client:      client,
+		credentials: cfg.Credentials,
+		region:      cfg.Region,
+	}, nil
+}
+
+// Probe validates that the AWS credential chain resolves, as a cheap
+// control-plane reachability check for a dry-run. It deliberately does
+// NOT call a Bedrock API: ConverseStream is billable, and the
+// bedrockruntime client carries no zero-cost reachability operation.
+// Pulling in aws-sdk-go-v2/service/bedrock purely for ListFoundationModels
+// would add a second SDK module to satisfy a preflight check, so the probe
+// settles for credential resolution — the failure mode operators most
+// often hit (missing/expired keys, an unconfigured federation role)
+// surfaces here, while a region typo or a revoked Bedrock-invoke IAM
+// permission would only surface on the first real turn. This limitation
+// is documented for the dry-run report's "skip"/"ok" semantics.
+//
+// A nil credentials provider (the mock-client test path) returns nil so
+// the preflight records the step without a spurious failure.
+func (b *BedrockAdapter) Probe(ctx context.Context) error {
+	if b.credentials == nil {
+		return nil
+	}
+	if _, err := b.credentials.Retrieve(ctx); err != nil {
+		return fmt.Errorf("resolve AWS credentials (region %q): %w", b.region, err)
+	}
+	return nil
 }
 
 // Stream sends a ConverseStream request to Bedrock and returns a channel of

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -31,6 +31,11 @@ const (
 	geminiAPIRegionalHost = "%s-aiplatform.googleapis.com"
 	geminiAPIGlobalHost   = "aiplatform.googleapis.com"
 	geminiAPIPathTemplate = "/v1/projects/%s/locations/%s/publishers/google/models/%s:streamGenerateContent?alt=sse"
+	// geminiModelsPathTemplate is the publisher-model collection route used
+	// only by the preflight probe (GeminiAdapter.Probe). It has no model
+	// segment and no :streamGenerateContent action, so a probe GET is a
+	// metadata read that never triggers a completion.
+	geminiModelsPathTemplate = "/v1/projects/%s/locations/%s/publishers/google/models"
 
 	// maxScannerBuffer caps the per-line buffer used for the SSE scanner.
 	// Vertex chunks are typically small, but a final chunk that bundles
@@ -143,6 +148,27 @@ func (g *GeminiAdapter) buildURL(model string) string {
 		host = fmt.Sprintf(geminiAPIRegionalHost, g.location)
 	}
 	path := fmt.Sprintf(geminiAPIPathTemplate, projID, loc, mdl)
+	return "https://" + host + path
+}
+
+// modelsURL renders the publisher-model collection URL for a preflight
+// probe. It mirrors buildURL's host derivation (baseURLOverride for
+// tests, global vs regional subdomain otherwise) but targets the
+// list-models route .../publishers/google/models with no model segment
+// and no :streamGenerateContent action — a metadata GET that spends no
+// tokens.
+func (g *GeminiAdapter) modelsURL() string {
+	projID := url.PathEscape(g.projectID)
+	loc := url.PathEscape(g.location)
+	path := fmt.Sprintf(geminiModelsPathTemplate, projID, loc)
+
+	if g.baseURLOverride != "" {
+		return strings.TrimRight(g.baseURLOverride, "/") + path
+	}
+	host := geminiAPIGlobalHost
+	if g.location != "global" {
+		host = fmt.Sprintf(geminiAPIRegionalHost, g.location)
+	}
 	return "https://" + host + path
 }
 

--- a/harness/internal/provider/probe.go
+++ b/harness/internal/provider/probe.go
@@ -6,27 +6,22 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/rxbynerd/stirrup/harness/internal/credential"
 )
 
 // probeBodyLimit caps how much of a non-2xx probe response body is read
-// into the returned error. A metadata endpoint should answer in a few
-// hundred bytes; 4 KiB is generous headroom without letting a hostile or
-// misconfigured intermediary pin a large buffer.
+// into the returned error so a hostile or misconfigured intermediary
+// cannot pin a large buffer just to construct the error message.
 const probeBodyLimit = 4096
 
-// Probe issues a cheap, read-only reachability and authentication check
-// against the Anthropic API. It hits the models metadata endpoint
-// (GET /v1/models) and never the completion path (/v1/messages), so a
-// dry-run cannot spend tokens. A non-2xx status (notably 401 for a bad
-// key) is surfaced as an error; the caller turns that into a failed
-// preflight step.
-//
-// The same httpClient and auth-header selection the Stream path uses are
-// reused so the probe authenticates identically to a real request.
+// Probe hits the models metadata endpoint, never the completion path, so
+// a dry-run cannot spend tokens (issue #245 AC). Auth-header selection
+// mirrors Stream so the probe authenticates identically.
 func (a *AnthropicAdapter) Probe(ctx context.Context) error {
-	apiKey, err := a.bearer(ctx)
+	apiKey, err := resolveBearer(ctx, a.bearer)
 	if err != nil {
-		return fmt.Errorf("resolve bearer token: %w", err)
+		return err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, anthropicModelsURL(a.baseURL), nil)
@@ -48,11 +43,10 @@ func (a *AnthropicAdapter) Probe(ctx context.Context) error {
 	return checkProbeStatus("anthropic", resp)
 }
 
-// anthropicModelsURL derives the models metadata URL from the configured
-// messages base URL by swapping the trailing "/messages" path for
-// "/models". A custom baseURL without that suffix falls back to joining
-// "/models" onto its API root so test servers and gateways still resolve
-// to a metadata path rather than the completion path.
+// anthropicModelsURL derives the models metadata URL from the messages
+// base URL by swapping a trailing "/messages" for "/models", so the probe
+// targets a metadata path rather than the completion path. A custom
+// baseURL without that suffix joins "/models" onto its API root.
 func anthropicModelsURL(baseURL string) string {
 	if strings.HasSuffix(baseURL, "/messages") {
 		return strings.TrimSuffix(baseURL, "/messages") + "/models"
@@ -60,43 +54,35 @@ func anthropicModelsURL(baseURL string) string {
 	return strings.TrimRight(baseURL, "/") + "/models"
 }
 
-// Probe issues a read-only reachability and authentication check against
-// the OpenAI-compatible Chat Completions endpoint. It hits the models
-// metadata endpoint (GET {baseURL}/models) and never /chat/completions,
-// so a dry-run cannot spend tokens. The configured auth header and query
-// parameters are applied exactly as on the Stream path.
+// Probe hits GET {baseURL}/models, never /chat/completions, so a dry-run
+// spends no tokens.
 func (o *OpenAICompatibleAdapter) Probe(ctx context.Context) error {
-	apiKey, err := resolveBearer(ctx, o.bearer)
-	if err != nil {
-		return err
-	}
-	requestURL, err := composeOpenAIURL(o.baseURL, "/models", o.queryParams)
-	if err != nil {
-		return fmt.Errorf("compose request URL: %w", err)
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	setOpenAIAuthHeader(req, apiKey, o.apiKeyHeader)
-
-	resp, err := o.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("execute request: %w", err)
-	}
-	return checkProbeStatus("openai-compatible", resp)
+	return probeOpenAIModels(ctx, "openai-compatible", o.httpClient, o.bearer, o.baseURL, o.apiKeyHeader, o.queryParams)
 }
 
-// Probe issues a read-only reachability and authentication check against
-// the OpenAI Responses endpoint. The Responses API shares the same
-// /models metadata route as Chat Completions, so the probe hits
-// GET {baseURL}/models and never /responses.
+// Probe hits GET {baseURL}/models — the Responses API shares the Chat
+// Completions metadata route — and never /responses, so a dry-run spends
+// no tokens.
 func (o *OpenAIResponsesAdapter) Probe(ctx context.Context) error {
-	apiKey, err := resolveBearer(ctx, o.bearer)
+	return probeOpenAIModels(ctx, "openai-responses", o.httpClient, o.bearer, o.baseURL, o.apiKeyHeader, o.queryParams)
+}
+
+// probeOpenAIModels is the shared models-metadata GET for the two OpenAI
+// dialects: identical auth/URL composition, differing only in the
+// provider label carried into the error.
+func probeOpenAIModels(
+	ctx context.Context,
+	providerLabel string,
+	httpClient *http.Client,
+	bearer credential.BearerTokenFunc,
+	baseURL, apiKeyHeader string,
+	queryParams map[string]string,
+) error {
+	apiKey, err := resolveBearer(ctx, bearer)
 	if err != nil {
 		return err
 	}
-	requestURL, err := composeOpenAIURL(o.baseURL, "/models", o.queryParams)
+	requestURL, err := composeOpenAIURL(baseURL, "/models", queryParams)
 	if err != nil {
 		return fmt.Errorf("compose request URL: %w", err)
 	}
@@ -104,25 +90,22 @@ func (o *OpenAIResponsesAdapter) Probe(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
-	setOpenAIAuthHeader(req, apiKey, o.apiKeyHeader)
+	setOpenAIAuthHeader(req, apiKey, apiKeyHeader)
 
-	resp, err := o.httpClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("execute request: %w", err)
 	}
-	return checkProbeStatus("openai-responses", resp)
+	return checkProbeStatus(providerLabel, resp)
 }
 
-// Probe issues a read-only reachability and authentication check against
-// Vertex AI. It performs a GET on the publisher-model resource
-// (.../publishers/google/models) — the list-models route — rather than
-// the :streamGenerateContent action, so no completion is requested and no
-// tokens are spent. The OAuth2 bearer is acquired through the same
-// closure the Stream path uses.
+// Probe GETs the publisher-model collection rather than the
+// :streamGenerateContent action, so no completion is requested and no
+// tokens are spent.
 func (g *GeminiAdapter) Probe(ctx context.Context) error {
-	token, err := g.bearer(ctx)
+	token, err := resolveBearer(ctx, g.bearer)
 	if err != nil {
-		return fmt.Errorf("resolve bearer token: %w", err)
+		return err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.modelsURL(), nil)
@@ -138,13 +121,15 @@ func (g *GeminiAdapter) Probe(ctx context.Context) error {
 	return checkProbeStatus("gemini", resp)
 }
 
-// checkProbeStatus closes resp.Body and returns nil for a 2xx status. A
-// non-2xx status is rendered into an error carrying up to probeBodyLimit
-// bytes of the body so a 401/403 surfaces the provider's diagnostic
-// without exfiltrating an unbounded payload.
+// checkProbeStatus closes resp.Body and returns nil for a 2xx status,
+// draining the body first so the keep-alive connection can be reused by a
+// subsequent probe on the same client. A non-2xx status carries up to
+// probeBodyLimit bytes of the body so a 401/403 surfaces the provider's
+// diagnostic without exfiltrating an unbounded payload.
 func checkProbeStatus(provider string, resp *http.Response) error {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, probeBodyLimit))

--- a/harness/internal/provider/probe.go
+++ b/harness/internal/provider/probe.go
@@ -1,0 +1,155 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// probeBodyLimit caps how much of a non-2xx probe response body is read
+// into the returned error. A metadata endpoint should answer in a few
+// hundred bytes; 4 KiB is generous headroom without letting a hostile or
+// misconfigured intermediary pin a large buffer.
+const probeBodyLimit = 4096
+
+// Probe issues a cheap, read-only reachability and authentication check
+// against the Anthropic API. It hits the models metadata endpoint
+// (GET /v1/models) and never the completion path (/v1/messages), so a
+// dry-run cannot spend tokens. A non-2xx status (notably 401 for a bad
+// key) is surfaced as an error; the caller turns that into a failed
+// preflight step.
+//
+// The same httpClient and auth-header selection the Stream path uses are
+// reused so the probe authenticates identically to a real request.
+func (a *AnthropicAdapter) Probe(ctx context.Context) error {
+	apiKey, err := a.bearer(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve bearer token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, anthropicModelsURL(a.baseURL), nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	switch a.authMode {
+	case AuthModeBearer:
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	default:
+		req.Header.Set("x-api-key", apiKey)
+	}
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	return checkProbeStatus("anthropic", resp)
+}
+
+// anthropicModelsURL derives the models metadata URL from the configured
+// messages base URL by swapping the trailing "/messages" path for
+// "/models". A custom baseURL without that suffix falls back to joining
+// "/models" onto its API root so test servers and gateways still resolve
+// to a metadata path rather than the completion path.
+func anthropicModelsURL(baseURL string) string {
+	if strings.HasSuffix(baseURL, "/messages") {
+		return strings.TrimSuffix(baseURL, "/messages") + "/models"
+	}
+	return strings.TrimRight(baseURL, "/") + "/models"
+}
+
+// Probe issues a read-only reachability and authentication check against
+// the OpenAI-compatible Chat Completions endpoint. It hits the models
+// metadata endpoint (GET {baseURL}/models) and never /chat/completions,
+// so a dry-run cannot spend tokens. The configured auth header and query
+// parameters are applied exactly as on the Stream path.
+func (o *OpenAICompatibleAdapter) Probe(ctx context.Context) error {
+	apiKey, err := resolveBearer(ctx, o.bearer)
+	if err != nil {
+		return err
+	}
+	requestURL, err := composeOpenAIURL(o.baseURL, "/models", o.queryParams)
+	if err != nil {
+		return fmt.Errorf("compose request URL: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	setOpenAIAuthHeader(req, apiKey, o.apiKeyHeader)
+
+	resp, err := o.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	return checkProbeStatus("openai-compatible", resp)
+}
+
+// Probe issues a read-only reachability and authentication check against
+// the OpenAI Responses endpoint. The Responses API shares the same
+// /models metadata route as Chat Completions, so the probe hits
+// GET {baseURL}/models and never /responses.
+func (o *OpenAIResponsesAdapter) Probe(ctx context.Context) error {
+	apiKey, err := resolveBearer(ctx, o.bearer)
+	if err != nil {
+		return err
+	}
+	requestURL, err := composeOpenAIURL(o.baseURL, "/models", o.queryParams)
+	if err != nil {
+		return fmt.Errorf("compose request URL: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	setOpenAIAuthHeader(req, apiKey, o.apiKeyHeader)
+
+	resp, err := o.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	return checkProbeStatus("openai-responses", resp)
+}
+
+// Probe issues a read-only reachability and authentication check against
+// Vertex AI. It performs a GET on the publisher-model resource
+// (.../publishers/google/models) — the list-models route — rather than
+// the :streamGenerateContent action, so no completion is requested and no
+// tokens are spent. The OAuth2 bearer is acquired through the same
+// closure the Stream path uses.
+func (g *GeminiAdapter) Probe(ctx context.Context) error {
+	token, err := g.bearer(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve bearer token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.modelsURL(), nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	return checkProbeStatus("gemini", resp)
+}
+
+// checkProbeStatus closes resp.Body and returns nil for a 2xx status. A
+// non-2xx status is rendered into an error carrying up to probeBodyLimit
+// bytes of the body so a 401/403 surfaces the provider's diagnostic
+// without exfiltrating an unbounded payload.
+func checkProbeStatus(provider string, resp *http.Response) error {
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, probeBodyLimit))
+	if len(body) > 0 {
+		return fmt.Errorf("%s metadata endpoint returned status %d: %s", provider, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return fmt.Errorf("%s metadata endpoint returned status %d", provider, resp.StatusCode)
+}

--- a/harness/internal/provider/probe_test.go
+++ b/harness/internal/provider/probe_test.go
@@ -2,11 +2,14 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // probeRecorder counts requests to a metadata path vs a completion path so
@@ -167,5 +170,71 @@ func TestBedrockAdapter_Probe_NilCredentials(t *testing.T) {
 	adapter := &BedrockAdapter{}
 	if err := adapter.Probe(context.Background()); err != nil {
 		t.Fatalf("Probe with nil credentials should be a no-op, got: %v", err)
+	}
+}
+
+func TestBedrockAdapter_Probe_CredentialError(t *testing.T) {
+	adapter := &BedrockAdapter{
+		region: "us-east-1",
+		credentials: aws.CredentialsProviderFunc(func(_ context.Context) (aws.Credentials, error) {
+			return aws.Credentials{}, errors.New("STS AssumeRole denied")
+		}),
+	}
+	err := adapter.Probe(context.Background())
+	if err == nil {
+		t.Fatal("Probe: expected credential-resolution error, got nil")
+	}
+	if !strings.Contains(err.Error(), "STS AssumeRole denied") {
+		t.Errorf("error should wrap the credential failure, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "us-east-1") {
+		t.Errorf("error should name the region for diagnosis, got: %v", err)
+	}
+}
+
+func TestProbe_FailureStatuses(t *testing.T) {
+	// 401/error responses from the metadata endpoint must surface as an
+	// error for every dialect, carrying the status and the provider's
+	// diagnostic.
+	newServer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"message":"bad key"}}`))
+		}))
+	}
+
+	t.Run("openai-compatible", func(t *testing.T) {
+		srv := newServer()
+		defer srv.Close()
+		a := NewOpenAICompatibleAdapter(staticBearer("bad"), srv.URL+"/v1", OpenAIAuthConfig{}, RetryPolicy{})
+		assertProbeStatusError(t, a.Probe(context.Background()), "openai-compatible")
+	})
+
+	t.Run("openai-responses", func(t *testing.T) {
+		srv := newServer()
+		defer srv.Close()
+		a := NewOpenAIResponsesAdapter(staticBearer("bad"), srv.URL+"/v1", OpenAIAuthConfig{})
+		assertProbeStatusError(t, a.Probe(context.Background()), "openai-responses")
+	})
+
+	t.Run("gemini", func(t *testing.T) {
+		srv := newServer()
+		defer srv.Close()
+		a := NewGeminiAdapter(staticBearer("ya29.bad"), "proj", "us-central1", nil)
+		a.baseURLOverride = srv.URL
+		assertProbeStatusError(t, a.Probe(context.Background()), "gemini")
+	})
+}
+
+func assertProbeStatusError(t *testing.T, err error, providerLabel string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected error for 401, got nil", providerLabel)
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("%s: error should carry the 401 status, got: %v", providerLabel, err)
+	}
+	if !strings.Contains(err.Error(), providerLabel) {
+		t.Errorf("%s: error should name the provider, got: %v", providerLabel, err)
 	}
 }

--- a/harness/internal/provider/probe_test.go
+++ b/harness/internal/provider/probe_test.go
@@ -1,0 +1,171 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// probeRecorder counts requests to a metadata path vs a completion path so
+// the no-completion-endpoint invariant (issue #245 AC) can be asserted.
+type probeRecorder struct {
+	metadataHits   atomic.Int64
+	completionHits atomic.Int64
+}
+
+func TestAnthropicAdapter_Probe(t *testing.T) {
+	var rec probeRecorder
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/models"):
+			rec.metadataHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/messages"):
+			rec.completionHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := NewAnthropicAdapter(staticBearer("sk-test"), AuthModeAPIKey)
+	adapter.baseURL = srv.URL + "/v1/messages"
+
+	if err := adapter.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+	if got := rec.metadataHits.Load(); got != 1 {
+		t.Errorf("metadata endpoint hits = %d, want 1", got)
+	}
+	if got := rec.completionHits.Load(); got != 0 {
+		t.Errorf("completion endpoint hits = %d, want 0 (dry-run must not spend tokens)", got)
+	}
+}
+
+func TestAnthropicAdapter_Probe_BadKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid x-api-key"}}`))
+	}))
+	defer srv.Close()
+
+	adapter := NewAnthropicAdapter(staticBearer("bad"), AuthModeAPIKey)
+	adapter.baseURL = srv.URL + "/v1/messages"
+
+	err := adapter.Probe(context.Background())
+	if err == nil {
+		t.Fatal("Probe: expected error for 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "invalid x-api-key") {
+		t.Errorf("error should carry status and diagnostic, got: %v", err)
+	}
+}
+
+func TestOpenAICompatibleAdapter_Probe(t *testing.T) {
+	var rec probeRecorder
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/models"):
+			rec.metadataHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/chat/completions"):
+			rec.completionHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("sk-test"), srv.URL+"/v1", OpenAIAuthConfig{}, RetryPolicy{})
+	if err := adapter.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+	if got := rec.metadataHits.Load(); got != 1 {
+		t.Errorf("metadata endpoint hits = %d, want 1", got)
+	}
+	if got := rec.completionHits.Load(); got != 0 {
+		t.Errorf("completion endpoint hits = %d, want 0", got)
+	}
+}
+
+func TestOpenAIResponsesAdapter_Probe(t *testing.T) {
+	var rec probeRecorder
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/models"):
+			rec.metadataHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/responses"):
+			rec.completionHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter(staticBearer("sk-test"), srv.URL+"/v1", OpenAIAuthConfig{})
+	if err := adapter.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+	if got := rec.metadataHits.Load(); got != 1 {
+		t.Errorf("metadata endpoint hits = %d, want 1", got)
+	}
+	if got := rec.completionHits.Load(); got != 0 {
+		t.Errorf("completion endpoint hits = %d, want 0", got)
+	}
+}
+
+func TestGeminiAdapter_Probe(t *testing.T) {
+	var rec probeRecorder
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/models"):
+			rec.metadataHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"models":[]}`))
+		case strings.Contains(r.URL.Path, ":streamGenerateContent"):
+			rec.completionHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := NewGeminiAdapter(staticBearer("ya29.token"), "proj", "us-central1", nil)
+	adapter.baseURLOverride = srv.URL
+	if err := adapter.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+	if got := rec.metadataHits.Load(); got != 1 {
+		t.Errorf("metadata endpoint hits = %d, want 1", got)
+	}
+	if got := rec.completionHits.Load(); got != 0 {
+		t.Errorf("completion endpoint hits = %d, want 0", got)
+	}
+}
+
+func TestProbe_CredentialError(t *testing.T) {
+	adapter := NewAnthropicAdapter(erroringBearer("no creds"), AuthModeAPIKey)
+	if err := adapter.Probe(context.Background()); err == nil {
+		t.Fatal("Probe: expected credential error, got nil")
+	}
+}
+
+func TestBedrockAdapter_Probe_NilCredentials(t *testing.T) {
+	// The mock-client construction path leaves credentials nil; Probe must
+	// then be a no-op rather than panicking or failing.
+	adapter := &BedrockAdapter{}
+	if err := adapter.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe with nil credentials should be a no-op, got: %v", err)
+	}
+}

--- a/harness/internal/trace/gcs.go
+++ b/harness/internal/trace/gcs.go
@@ -249,6 +249,20 @@ func (e *GCSTraceEmitter) Finish(ctx context.Context, outcome string) (*types.Ru
 	return trace, nil
 }
 
+// Probe verifies the credential can access the configured bucket for a
+// dry-run preflight via a read-only bucket-metadata GET. It uploads
+// nothing, so a dry-run leaves no trace object behind. A 403/404/401
+// surfaces with the GCS diagnostic so a missing bucket or an
+// insufficiently-scoped credential is caught before the run ends and
+// silently drops its trace.
+func (e *GCSTraceEmitter) Probe(ctx context.Context) error {
+	return gcs.BucketAccessible(ctx, e.httpClient, gcs.BucketProbeOptions{
+		Bucket:          e.bucket,
+		Bearer:          e.bearer,
+		EndpointBaseURL: e.endpointBaseURL,
+	})
+}
+
 // Close is a no-op — the in-memory buffer is released when the emitter
 // is GC'd, and there is no file handle to release. Implementing Close
 // satisfies the io.Closer protocol that the factory uses to register

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -455,6 +455,28 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 	return trace, nil
 }
 
+// Probe checks OTLP exporter reachability for a dry-run preflight. It
+// starts and immediately ends a throwaway span, then ForceFlushes the
+// provider so the configured exporter actually attempts a connection to
+// the collector. A flush error (unreachable endpoint, TLS failure, auth
+// rejection) is surfaced so the preflight step fails with the exporter's
+// diagnostic rather than discovering the misconfiguration only at
+// run-end when the first batch is dropped.
+//
+// The probe span carries no run data and is not the root span, so it does
+// not perturb the run trace; Start has not been called at preflight time.
+func (e *OTelTraceEmitter) Probe(ctx context.Context) error {
+	if e.provider == nil {
+		return nil
+	}
+	_, span := e.tracer.Start(ctx, "stirrup.preflight.probe")
+	span.End()
+	if err := e.provider.ForceFlush(ctx); err != nil {
+		return fmt.Errorf("OTLP exporter flush failed: %w", err)
+	}
+	return nil
+}
+
 // Tracer returns the OTel tracer used by this emitter, allowing the loop
 // to create child spans for component calls.
 func (e *OTelTraceEmitter) Tracer() oteltrace.Tracer {

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -465,11 +465,16 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 //
 // The probe span carries no run data and is not the root span, so it does
 // not perturb the run trace; Start has not been called at preflight time.
+// It does, however, reach the operator's live OTLP collector — this is the
+// only way to confirm reachability — so it is tagged stirrup.preflight=true
+// so dashboards and alert rules can filter out the synthetic span.
+// Operators who want zero collector contact pass --no-probe-trace.
 func (e *OTelTraceEmitter) Probe(ctx context.Context) error {
 	if e.provider == nil {
 		return nil
 	}
-	_, span := e.tracer.Start(ctx, "stirrup.preflight.probe")
+	_, span := e.tracer.Start(ctx, "stirrup.preflight.probe",
+		oteltrace.WithAttributes(attribute.Bool("stirrup.preflight", true)))
 	span.End()
 	if err := e.provider.ForceFlush(ctx); err != nil {
 		return fmt.Errorf("OTLP exporter flush failed: %w", err)

--- a/harness/internal/trace/probe_test.go
+++ b/harness/internal/trace/probe_test.go
@@ -1,0 +1,72 @@
+package trace
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGCSTraceEmitter_Probe_OK(t *testing.T) {
+	var sawBucketGet bool
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/storage/v1/b/") {
+			sawBucketGet = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"name":"my-bucket"}`))
+			return
+		}
+		// Any upload POST here would mean the probe is not read-only.
+		t.Errorf("unexpected request %s %s (probe must be read-only)", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer httpSrv.Close()
+
+	emitter, err := NewGCSTraceEmitter(context.Background(), GCSTraceEmitterOptions{
+		Bucket:           "my-bucket",
+		CredentialSource: &staticBearerSource{token: "tok"},
+		EndpointBaseURL:  httpSrv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewGCSTraceEmitter: %v", err)
+	}
+	if err := emitter.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+	if !sawBucketGet {
+		t.Error("Probe should issue a bucket-metadata GET")
+	}
+}
+
+func TestGCSTraceEmitter_Probe_Denied(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"message":"permission denied"}}`))
+	}))
+	defer httpSrv.Close()
+
+	emitter, err := NewGCSTraceEmitter(context.Background(), GCSTraceEmitterOptions{
+		Bucket:           "denied-bucket",
+		CredentialSource: &staticBearerSource{token: "tok"},
+		EndpointBaseURL:  httpSrv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewGCSTraceEmitter: %v", err)
+	}
+	err = emitter.Probe(context.Background())
+	if err == nil {
+		t.Fatal("Probe: expected error for 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should carry the GCS status, got: %v", err)
+	}
+}
+
+func TestOTelTraceEmitter_Probe_NilProviderIsNoop(t *testing.T) {
+	// A zero-value emitter (nil provider) must not panic; Probe is a no-op.
+	emitter := &OTelTraceEmitter{}
+	if err := emitter.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe with nil provider should be a no-op, got: %v", err)
+	}
+}

--- a/harness/internal/workspaceexport/probe_test.go
+++ b/harness/internal/workspaceexport/probe_test.go
@@ -1,0 +1,70 @@
+package workspaceexport
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGCSExporter_Probe_OK(t *testing.T) {
+	var sawBucketGet bool
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/storage/v1/b/") {
+			sawBucketGet = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"name":"runs"}`))
+			return
+		}
+		// An upload POST during a probe would mean the probe is not
+		// read-only — fail loudly.
+		t.Errorf("unexpected request %s %s (probe must be read-only)", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer httpSrv.Close()
+
+	exp, err := NewGCSExporter(GCSExporterOptions{
+		CredentialSource: &staticBearerSource{token: "tok"},
+		EndpointBaseURL:  httpSrv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewGCSExporter: %v", err)
+	}
+	if err := exp.Probe(context.Background(), "gs://runs/run-1/workspace.tar.gz"); err != nil {
+		t.Fatalf("Probe: unexpected error: %v", err)
+	}
+	if !sawBucketGet {
+		t.Error("Probe should issue a bucket-metadata GET")
+	}
+}
+
+func TestGCSExporter_Probe_BadURI(t *testing.T) {
+	exp, _ := NewGCSExporter(GCSExporterOptions{
+		CredentialSource: &staticBearerSource{token: "tok"},
+	})
+	err := exp.Probe(context.Background(), "s3://bucket/key")
+	if err == nil {
+		t.Fatal("Probe: expected error for non-gs:// URI")
+	}
+}
+
+func TestGCSExporter_Probe_BucketDenied(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"bucket not found"}}`))
+	}))
+	defer httpSrv.Close()
+
+	exp, _ := NewGCSExporter(GCSExporterOptions{
+		CredentialSource: &staticBearerSource{token: "tok"},
+		EndpointBaseURL:  httpSrv.URL,
+	})
+	err := exp.Probe(context.Background(), "gs://missing/run-1/workspace.tar.gz")
+	if err == nil {
+		t.Fatal("Probe: expected error for missing bucket")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should carry the GCS status, got: %v", err)
+	}
+}

--- a/harness/internal/workspaceexport/workspaceexport.go
+++ b/harness/internal/workspaceexport/workspaceexport.go
@@ -165,6 +165,35 @@ func (e *GCSExporter) Export(ctx context.Context, workspaceDir, destURI string) 
 	return nil
 }
 
+// Probe verifies the export destination is reachable for a dry-run
+// preflight: it parses destURI, resolves the credential, and performs a
+// read-only bucket-metadata GET. It tars nothing and uploads nothing, so
+// a dry-run leaves no artifact behind. A malformed URI, an unresolvable
+// credential, or a bucket the credential cannot see is surfaced so the
+// operator catches it before a real run spends wall-clock building a
+// tarball it cannot upload.
+func (e *GCSExporter) Probe(ctx context.Context, destURI string) error {
+	bucket, _, err := parseGCSURI(destURI)
+	if err != nil {
+		return fmt.Errorf("workspace exporter: %w", err)
+	}
+	resolved, err := e.credentialSource.Resolve(ctx)
+	if err != nil {
+		return fmt.Errorf("workspace exporter: resolve credential: %w", err)
+	}
+	if resolved == nil || resolved.BearerToken == nil {
+		return fmt.Errorf("workspace exporter: credential source produced no bearer token")
+	}
+	if err := gcs.BucketAccessible(ctx, e.httpClient, gcs.BucketProbeOptions{
+		Bucket:          bucket,
+		Bearer:          resolved.BearerToken,
+		EndpointBaseURL: e.endpointBaseURL,
+	}); err != nil {
+		return fmt.Errorf("workspace exporter: %w", err)
+	}
+	return nil
+}
+
 // parseGCSURI splits a gs://bucket/object URI into its parts. The
 // object name must be non-empty so callers cannot accidentally
 // overwrite the bucket root or trigger surprising GCS API behaviour.


### PR DESCRIPTION
Adds a `--dry-run` flag to `stirrup harness` that runs every initialisation step *short of* the first agentic turn — validate, construct components, resolve credentials, and probe provider/MCP/Cedar/container-engine/trace/workspace-export/egress reachability — then prints a per-step report and exits. No provider tokens are spent. Closes #245.

## Why

`ValidateRunConfig` catches structural config errors, and `--output-runconfig` (#240) captures the resolved config, but neither answers "did the operator wire credentials, MCP servers, the policy file, and the container image correctly?" Today those failures only surface mid-run, often after a slow, paid first turn. `--dry-run` turns them into a fast, token-free preflight.

## What it does

```
$ stirrup harness --dry-run --prompt "x"
Dry-run preflight:
  [OK  ] config-validation: RunConfig invariants satisfied
  [OK  ] credentials: all provider credentials resolved
  [FAIL] provider-probe:anthropic: anthropic metadata endpoint returned status 401: ...
         hint: verify the API key/credential and base URL for this provider
  ...
Result: FAIL (1 of 13 step(s) did not pass)
```

- New `core.Preflight` entry point mirrors `core.BuildLoop` but stops before the first turn. Components opt in via an optional `Preflighter` interface (`Probe(ctx) error`); a component that does not implement it is recorded as `skip`.
- Probes added across `provider`, `mcp`, `credential`, `executor`, `permission`, `trace`, `workspaceexport`, and `egressproxy`.
- Provider probes hit **metadata endpoints only** (`GET /v1/models`, Gemini list-models, Bedrock credential-chain validation) — never a completion endpoint, so a dry-run cannot spend tokens.
- `--output=json` emits a structured `PreflightReport`. Composes with `--output-runconfig` (both run). `--no-probe-provider|mcp|trace|egress` skip the relevant network probe. `--dry-run-timeout` (default 30s) bounds the whole preflight.

## Two design decisions taken with the maintainer

1. **Exit codes.** #245 prose predates the closed exit-code scheme that landed in #253 (`1`=validation, `2`=parse, `3`=I/O). Rather than overload code `2`, this adds a new **`4` = invalid flag combination** (e.g. a `--no-probe-*` flag without `--dry-run`). Probe failure → `1`; `2`/`3` unchanged. The closed set stays intact and the probe-fail-vs-usage distinction is preserved.
2. **A container dry-run is genuinely read-only.** The container preflight does **not** construct or start a container (or the egress proxy). It runs `executor.ProbeContainerEngine`: socket detection + `GET /_ping` + image-present check (`GET /images/{name}/json`, no pull) — exactly what spec step 7 asks for. This was the top review finding (flagged by the security, code, and functionality reviewers) and was fixed in remediation; a regression test asserts the engine sees zero create/start calls. `runDryRun` also wires a signal handler so a cancelled preflight cleans up.

## Review

Seven-reviewer wave (security, code, spec-compliance, test-coverage, consistency, functionality, doc-tone). All MUST-FIX findings remediated: container read-only path, an MCP client connection leak, non-deterministic JSON step order, a misleading Bedrock step label, an OTel probe span marker + docs note, helper reuse, and added tests (`runDryRun` dispatch, the `--output-runconfig` compose path, Preflight-level MCP/egress/workspace probes, provider failure paths). Docs tone passed clean. The `Preflight`/`BuildLoop` mirror carries a lockstep comment; a shared-construction refactor and a `--no-probe-executor` gate are noted as possible follow-ups.

## Acceptance criteria

- [x] `--dry-run` exits 0 when all components init and all probes succeed (per-step report on stderr)
- [x] Exits 1 when a probe fails; the failed step names the component and a remediation hint
- [x] Does NOT call any provider completion endpoint (recording-mock test asserts zero completion hits)
- [x] `--dry-run --output-runconfig=out.json` runs the dry-run AND writes the captured config
- [x] `--no-probe-provider|mcp|trace|egress` each skip the relevant step
- [x] `--output=json` emits a structured `PreflightReport`
- [x] Documented in `docs/configuration.md` as a dedicated section

## Verification

`just build`, `just test`, `just lint` (0 issues) all green, verified independently in the worktree. Behaviour smoke-tested against the built binary: exit 0/1/4, JSON report, `--output-runconfig` composition (with `Redact()` confirmed — no raw key in output), `--no-probe-*` skips, and the read-only container path (instant clean failure on a Docker-less host, no container created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)