### PR TITLE
provider: warn when tool-choice is silently dropped on unsupported adapters

### DIFF
--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -351,6 +351,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		case *provider.BedrockAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics
+			pa.Logger = logger
 		case *provider.GeminiAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -2761,6 +2761,52 @@ func TestBuildLoopWithTransport_NormalizingAdapterWrapsBedrockProvider(t *testin
 	}
 }
 
+// TestBuildLoopWithTransport_BedrockAdapterHasLogger asserts that
+// BuildLoopWithTransport injects a non-nil Logger into the BedrockAdapter,
+// so its tool-choice downgrade warn runs through the factory's
+// ScrubHandler-backed logger (carrying run/trace correlation) rather than
+// the slog.Default fallback. A future deletion of the `pa.Logger = logger`
+// line in the *provider.BedrockAdapter factory arm would silently regress
+// the scrub and correlation invariants for that warn; this test surfaces
+// the regression at the assembly seam.
+func TestBuildLoopWithTransport_BedrockAdapterHasLogger(t *testing.T) {
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-bedrock-logger",
+		Mode:             "planning",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "bedrock", Region: "us-east-1"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "bedrock", Model: "anthropic.claude-3-5-sonnet-20241022-v2:0"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	adapter, ok := unwrapNormalizer(loop.Provider).(*provider.BedrockAdapter)
+	if !ok {
+		t.Fatalf("loop.Provider (after unwrap) type = %T, want *provider.BedrockAdapter", unwrapNormalizer(loop.Provider))
+	}
+	if adapter.Logger == nil {
+		t.Error("BedrockAdapter.Logger is nil; factory should inject the ScrubHandler-backed logger so the tool-choice downgrade warn keeps run/trace correlation and scrubbing")
+	}
+}
+
 // --- stubSecretStore ---
 
 type stubSecretStore struct {

--- a/harness/internal/provider/bedrock.go
+++ b/harness/internal/provider/bedrock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -39,6 +40,7 @@ type BedrockAdapter struct {
 	client  bedrockConverseStreamer
 	Tracer  oteltrace.Tracer       // optional, set by factory for span instrumentation
 	Metrics *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
+	Logger  *slog.Logger           // optional, set by factory; nil falls back to slog.Default()
 
 	// credentials and region are captured from the resolved AWS config so
 	// Probe can validate the credential chain without issuing a billable
@@ -110,6 +112,24 @@ func (b *BedrockAdapter) Stream(ctx context.Context, params types.StreamParams) 
 		attribute.String("provider.type", "bedrock"),
 		attribute.String("provider.model", params.Model),
 	)
+
+	// buildConverseStreamInput does not project ToolChoice onto the
+	// ConverseStream request, so a non-auto ToolChoice requested against
+	// this adapter is silently downgraded to auto. Warn so the downgrade
+	// is observable (#343). Only the static mode integer and the adapter /
+	// model identifiers are logged — never message content or any
+	// secret-derived value.
+	if params.ToolChoice != types.ToolChoiceAuto {
+		logger := b.Logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.WarnContext(ctx, "bedrock tool-choice downgraded to auto: adapter does not support tool-choice",
+			slog.String("provider.type", "bedrock"),
+			slog.String("provider.model", params.Model),
+			slog.Int("tool_choice", int(params.ToolChoice)),
+		)
+	}
 
 	input, err := buildConverseStreamInput(params)
 	if err != nil {

--- a/harness/internal/provider/bedrock_test.go
+++ b/harness/internal/provider/bedrock_test.go
@@ -722,6 +722,11 @@ func TestBedrock_ToolChoiceNonAuto_WarnsDowngrade(t *testing.T) {
 	if strings.Contains(out, "secret-prompt-text") {
 		t.Errorf("warn log leaked message content: %s", out)
 	}
+	// The downgrade is log-only: the request body must never carry a tool
+	// choice, mirroring the openai-responses wire-body guard.
+	if input := client.capturedInput; input != nil && input.ToolConfig != nil && input.ToolConfig.ToolChoice != nil {
+		t.Errorf("request must not project ToolChoice onto ConverseStreamInput, got: %#v", input.ToolConfig.ToolChoice)
+	}
 }
 
 // TestBedrock_ToolChoiceAuto_NoWarn pins the negative: the zero-value

--- a/harness/internal/provider/bedrock_test.go
+++ b/harness/internal/provider/bedrock_test.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -684,6 +686,62 @@ func TestBedrock_APIError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "access denied") {
 		t.Errorf("error = %q, want to contain 'access denied'", err)
+	}
+}
+
+// TestBedrock_ToolChoiceNonAuto_WarnsDowngrade pins #343: Bedrock's
+// ConverseStream request carries no tool-choice field, so a non-auto
+// ToolChoice is silently downgraded to auto. The warn must fire (so the
+// downgrade is observable) and must NOT leak message content or any
+// secret-derived value — only the static mode integer and the adapter /
+// model identifiers. The mock client's deliberate error is irrelevant:
+// the warn is emitted before the build/client call.
+func TestBedrock_ToolChoiceNonAuto_WarnsDowngrade(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	client := &mockBedrockClient{apiErr: fmt.Errorf("mock")}
+	adapter := &BedrockAdapter{client: client, Logger: logger}
+
+	_, _ = adapter.Stream(context.Background(), types.StreamParams{
+		Model:      "anthropic.claude-sonnet-4-6-v1",
+		MaxTokens:  1024,
+		ToolChoice: types.ToolChoiceRequired,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "secret-prompt-text"}}},
+		},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "bedrock tool-choice downgraded to auto") {
+		t.Errorf("expected tool-choice downgrade warn, got: %s", out)
+	}
+	if !strings.Contains(out, "anthropic.claude-sonnet-4-6-v1") {
+		t.Errorf("warn log missing model identifier: %s", out)
+	}
+	if strings.Contains(out, "secret-prompt-text") {
+		t.Errorf("warn log leaked message content: %s", out)
+	}
+}
+
+// TestBedrock_ToolChoiceAuto_NoWarn pins the negative: the zero-value
+// ToolChoiceAuto must not emit the downgrade warn (the auto case is the
+// always-satisfied no-op).
+func TestBedrock_ToolChoiceAuto_NoWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	client := &mockBedrockClient{apiErr: fmt.Errorf("mock")}
+	adapter := &BedrockAdapter{client: client, Logger: logger}
+
+	_, _ = adapter.Stream(context.Background(), types.StreamParams{
+		Model:      "anthropic.claude-sonnet-4-6-v1",
+		MaxTokens:  1024,
+		ToolChoice: types.ToolChoiceAuto,
+	})
+
+	if out := buf.String(); strings.Contains(out, "tool-choice downgraded") {
+		t.Errorf("auto tool-choice must not warn, got: %s", out)
 	}
 }
 

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -575,6 +575,22 @@ func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.Stream
 		slog.Any("rules", ruleDescriptions(appliedRules)),
 	)
 
+	// The Responses request body carries no tool_choice field, so a
+	// non-auto ToolChoice requested against this adapter is silently
+	// downgraded to auto. Warn once per Stream call so the downgrade is
+	// observable (#343). Only the static mode integer and the adapter /
+	// model identifiers are logged — never message content or any
+	// secret-derived value. q.ToolChoice.Supported is always false today
+	// (no openai-responses tool-choice rule), but the flag is checked so a
+	// future rule that adds native support suppresses the warning.
+	if params.ToolChoice != types.ToolChoiceAuto && !q.ToolChoice.Supported {
+		logger.WarnContext(ctx, "openai-responses tool-choice downgraded to auto: adapter does not support tool-choice",
+			slog.String("provider.type", "openai-responses"),
+			slog.String("provider.model", params.Model),
+			slog.Int("tool_choice", int(params.ToolChoice)),
+		)
+	}
+
 	if q.BehaviourFlags.OpenAI.StrictMode {
 		// Dormant in v1: no built-in rule currently sets
 		// StrictMode=true for any openai-responses model, so this

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -740,6 +740,48 @@ func TestOpenAIResponsesAdapter_RequestBody(t *testing.T) {
 	}
 }
 
+// TestOpenAIResponsesAdapter_RequestBody_NonAutoToolChoiceOmitsField pins the
+// wire-level half of #343: even when a non-auto ToolChoice is requested, the
+// Responses request body must never carry a "tool_choice" field, because the
+// adapter does not support it and silently downgrades to auto. A regression
+// that accidentally serialised the field would be invisible to the warn tests
+// above, which only observe the log.
+func TestOpenAIResponsesAdapter_RequestBody_NonAutoToolChoiceOmitsField(t *testing.T) {
+	var rawBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`))
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAIResponsesAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:      "gpt-4.1",
+		MaxTokens:  1024,
+		ToolChoice: types.ToolChoiceRequired,
+		Tools: []types.ToolDefinition{
+			{
+				Name:        "read_file",
+				Description: "Read a file",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	for range ch {
+	}
+
+	if strings.Contains(string(rawBody), `"tool_choice"`) {
+		t.Errorf("request body must not contain 'tool_choice' for non-auto input — the Responses adapter downgrades to auto: %s", rawBody)
+	}
+}
+
 func TestOpenAIResponsesAdapter_RequestBody_EmptyToolResult(t *testing.T) {
 	// End-to-end pin for #172: drives Stream() with an empty tool_result
 	// block and asserts on the raw HTTP body the adapter actually sends.

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,6 +75,86 @@ func TestOpenAIResponsesAdapter_StreamTextDelta(t *testing.T) {
 	}
 	if events[2].OutputTokens != 5 {
 		t.Errorf("event[2].OutputTokens = %d, want 5", events[2].OutputTokens)
+	}
+}
+
+// responsesWarnStubServer is a minimal Responses stub that returns a single
+// response.completed event, used by the tool-choice downgrade warn tests.
+func responsesWarnStubServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	body := makeResponsesEvent("response.completed", `{"response":{"id":"resp_1","status":"completed","output":[{"type":"message","id":"msg_1"}],"usage":{"input_tokens":1,"output_tokens":1}}}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestOpenAIResponsesAdapter_ToolChoiceNonAuto_WarnsDowngrade pins #343: the
+// Responses request body carries no tool_choice field, so a non-auto
+// ToolChoice is silently downgraded to auto. The warn must fire (so the
+// downgrade is observable) and must NOT leak message content or any
+// secret-derived value — only the static mode integer and the adapter /
+// model identifiers.
+func TestOpenAIResponsesAdapter_ToolChoiceNonAuto_WarnsDowngrade(t *testing.T) {
+	srv := responsesWarnStubServer(t)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAIResponsesAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:      "gpt-4.1",
+		MaxTokens:  1024,
+		ToolChoice: types.ToolChoiceRequired,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "secret-prompt-text"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	collectEvents(t, ch)
+
+	out := buf.String()
+	if !strings.Contains(out, "openai-responses tool-choice downgraded to auto") {
+		t.Errorf("expected tool-choice downgrade warn, got: %s", out)
+	}
+	if !strings.Contains(out, "gpt-4.1") {
+		t.Errorf("warn log missing model identifier: %s", out)
+	}
+	if strings.Contains(out, "secret-prompt-text") {
+		t.Errorf("warn log leaked message content: %s", out)
+	}
+}
+
+// TestOpenAIResponsesAdapter_ToolChoiceAuto_NoWarn pins the negative: the
+// zero-value ToolChoiceAuto must not emit the downgrade warn.
+func TestOpenAIResponsesAdapter_ToolChoiceAuto_NoWarn(t *testing.T) {
+	srv := responsesWarnStubServer(t)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAIResponsesAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:      "gpt-4.1",
+		MaxTokens:  1024,
+		ToolChoice: types.ToolChoiceAuto,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	collectEvents(t, ch)
+
+	if out := buf.String(); strings.Contains(out, "tool-choice downgraded") {
+		t.Errorf("auto tool-choice must not warn, got: %s", out)
 	}
 }
 


### PR DESCRIPTION
The `openai-responses` and `bedrock` adapters silently no-op a requested tool-choice mode (`ToolChoiceRequired`/`ToolChoiceNone`) instead of signalling the downgrade. Once tool-choice escalation (#230) is enabled against one of these runs, a dropped required-tool request looks like a model failure rather than an unsupported-capability degradation, leaving operators no observable signal.

This adds a `slog.Warn` at each drop site — `buildResponsesRequest` (when the requested choice is unsupported) and `BedrockAdapter.Stream` (when a non-auto choice is requested) — pins the absence of `tool_choice` on the Responses wire body, and asserts the Bedrock drop is fully guarded via a factory check. Tests cover both warning paths.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
