### PR TITLE
types: marshal ToolChoiceMode via explicit switch

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -147,12 +147,23 @@ func (m ToolChoiceMode) IsValid() bool {
 // Providers never serialise a ToolChoiceMode onto a request body — they
 // project the enum value directly onto their native tool_choice shape —
 // so the string form does not alter any outbound provider request.
-// An out-of-range value is rejected rather than coerced.
+// An out-of-range value is rejected rather than coerced. The explicit
+// switch (rather than delegating to String) mirrors the sibling enums
+// OpenAITokenField and GeminiStreamArgsShape, keeping one marshalling
+// style across the project's closed enums.
 func (m ToolChoiceMode) MarshalJSON() ([]byte, error) {
-	if !m.IsValid() {
+	switch m {
+	case ToolChoiceAuto:
+		return []byte(`"auto"`), nil
+	case ToolChoiceRequired:
+		return []byte(`"required"`), nil
+	case ToolChoiceNone:
+		return []byte(`"none"`), nil
+	case ToolChoiceTool:
+		return []byte(`"tool"`), nil
+	default:
 		return nil, fmt.Errorf("types: invalid ToolChoiceMode %d", int(m))
 	}
-	return []byte(`"` + m.String() + `"`), nil
 }
 
 // UnmarshalJSON is the inverse of MarshalJSON. It accepts only the defined

--- a/types/events.go
+++ b/types/events.go
@@ -105,6 +105,77 @@ const (
 // ToolChoiceAuto fails to compile the moment ToolChoiceAuto is non-zero.
 var _ = [1]struct{}{}[ToolChoiceAuto]
 
+// String renders ToolChoiceMode as its stable lowercase wire form. These
+// are the same tokens MarshalJSON/UnmarshalJSON round-trip through, so a
+// trace or log line names the mode rather than an opaque integer. An
+// out-of-range value renders as "unknown(N)" — String never returns an
+// error, so it stays usable in fmt verbs; IsValid is the predicate that
+// rejects such values, and MarshalJSON refuses to emit them.
+func (m ToolChoiceMode) String() string {
+	switch m {
+	case ToolChoiceAuto:
+		return "auto"
+	case ToolChoiceRequired:
+		return "required"
+	case ToolChoiceNone:
+		return "none"
+	case ToolChoiceTool:
+		return "tool"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(m))
+	}
+}
+
+// IsValid reports whether m is one of the defined ToolChoiceMode members.
+// Out-of-range integers (e.g. from a corrupt trace or a hostile JSON
+// payload) are rejected rather than coerced to a default.
+func (m ToolChoiceMode) IsValid() bool {
+	switch m {
+	case ToolChoiceAuto, ToolChoiceRequired, ToolChoiceNone, ToolChoiceTool:
+		return true
+	default:
+		return false
+	}
+}
+
+// MarshalJSON emits the lowercase string form so ToolChoice is
+// self-documenting wherever a StreamParams is serialised for a trace or
+// recording. omitempty on StreamParams.ToolChoice still suppresses the
+// zero value (ToolChoiceAuto): encoding/json tests the Go zero value
+// before invoking MarshalJSON, so the field stays off the wire for the
+// default and this method is only reached for explicitly-set modes.
+// Providers never serialise a ToolChoiceMode onto a request body — they
+// project the enum value directly onto their native tool_choice shape —
+// so the string form does not alter any outbound provider request.
+// An out-of-range value is rejected rather than coerced.
+func (m ToolChoiceMode) MarshalJSON() ([]byte, error) {
+	if !m.IsValid() {
+		return nil, fmt.Errorf("types: invalid ToolChoiceMode %d", int(m))
+	}
+	return []byte(`"` + m.String() + `"`), nil
+}
+
+// UnmarshalJSON is the inverse of MarshalJSON. It accepts only the defined
+// string forms; an unknown string or out-of-range value is rejected with
+// an error rather than silently mapped to ToolChoiceAuto. Permissive
+// coercion here would defeat the closed-enum contract and let malformed
+// trace/config input flow into StreamParams unchecked.
+func (m *ToolChoiceMode) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case `"auto"`:
+		*m = ToolChoiceAuto
+	case `"required"`:
+		*m = ToolChoiceRequired
+	case `"none"`:
+		*m = ToolChoiceNone
+	case `"tool"`:
+		*m = ToolChoiceTool
+	default:
+		return fmt.Errorf("types: unknown ToolChoiceMode %s", data)
+	}
+	return nil
+}
+
 // toolChoiceNamePattern is the character-set and length bound enforced on
 // StreamParams.ToolChoiceName before it is serialised onto any provider
 // wire. It is the intersection of the three providers' documented

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -64,3 +64,70 @@ func TestStreamParamsToolChoiceOmitempty(t *testing.T) {
 		t.Errorf("non-auto ToolChoice must appear in JSON, got: %s", b)
 	}
 }
+
+// TestToolChoiceModeRoundTrip pins the MarshalJSON/UnmarshalJSON
+// inverse: every defined member marshals to its lowercase string form
+// and unmarshals back to the same value.
+func TestToolChoiceModeRoundTrip(t *testing.T) {
+	cases := []struct {
+		mode ToolChoiceMode
+		json string
+	}{
+		{ToolChoiceAuto, `"auto"`},
+		{ToolChoiceRequired, `"required"`},
+		{ToolChoiceNone, `"none"`},
+		{ToolChoiceTool, `"tool"`},
+	}
+	for _, tc := range cases {
+		b, err := json.Marshal(tc.mode)
+		if err != nil {
+			t.Fatalf("marshal %v: %v", tc.mode, err)
+		}
+		if string(b) != tc.json {
+			t.Errorf("marshal %v = %s, want %s", tc.mode, b, tc.json)
+		}
+		var got ToolChoiceMode
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal %s: %v", b, err)
+		}
+		if got != tc.mode {
+			t.Errorf("round-trip %s = %v, want %v", b, got, tc.mode)
+		}
+	}
+}
+
+// TestToolChoiceModeUnmarshalRejects guards the deserialisation
+// hardening: an unknown string and an out-of-range integer-as-string
+// both error rather than being silently coerced to ToolChoiceAuto.
+func TestToolChoiceModeUnmarshalRejects(t *testing.T) {
+	bad := []string{
+		`"any"`,        // OpenAI/Anthropic native token, not a ToolChoiceMode form
+		`"AUTO"`,       // case-sensitive
+		`"unknown(9)"`, // the String() fallback form must not round-trip
+		`4`,            // out-of-range integer
+		`"4"`,          // out-of-range as a string
+		`""`,           // empty
+		`null`,         // not a defined form
+	}
+	for _, in := range bad {
+		var m ToolChoiceMode
+		if err := json.Unmarshal([]byte(in), &m); err == nil {
+			t.Errorf("Unmarshal(%s) = nil error, want rejection", in)
+		}
+	}
+}
+
+// TestToolChoiceModeIsValid checks the predicate is true for defined
+// members and false for out-of-range values.
+func TestToolChoiceModeIsValid(t *testing.T) {
+	for _, m := range []ToolChoiceMode{ToolChoiceAuto, ToolChoiceRequired, ToolChoiceNone, ToolChoiceTool} {
+		if !m.IsValid() {
+			t.Errorf("IsValid(%v) = false, want true", m)
+		}
+	}
+	for _, m := range []ToolChoiceMode{-1, 4, 100} {
+		if m.IsValid() {
+			t.Errorf("IsValid(%d) = true, want false", int(m))
+		}
+	}
+}

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -131,3 +131,14 @@ func TestToolChoiceModeIsValid(t *testing.T) {
 		}
 	}
 }
+
+// TestToolChoiceModeMarshalRejects guards the serialisation hardening:
+// an out-of-range value must surface a marshal error rather than emit
+// the "unknown(N)" String() fallback onto a trace or recording.
+func TestToolChoiceModeMarshalRejects(t *testing.T) {
+	for _, m := range []ToolChoiceMode{99, -1} {
+		if _, err := json.Marshal(m); err == nil {
+			t.Errorf("Marshal(%d) = nil error, want rejection", int(m))
+		}
+	}
+}


### PR DESCRIPTION
The `ToolChoiceMode` enum previously marshalled its JSON value indirectly, diverging from the explicit-switch style its sibling enums use. This follow-up rewrites `MarshalJSON` as an explicit `switch` over the known modes so the marshalling path matches the rest of the package and an invalid value is handled in one obvious branch. Also adds `String`, `IsValid`, and `UnmarshalJSON` for parity, with test coverage of the invalid-value branch.

Closes #0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
