### PR TITLE
test: replace deprecated attribute.Value.Emit with Value.String

### DIFF
--- a/harness/internal/core/tool_failure_metrics_test.go
+++ b/harness/internal/core/tool_failure_metrics_test.go
@@ -130,15 +130,15 @@ func collectFailures(t *testing.T, reader *sdkmetric.ManualReader) []failureData
 				for _, kv := range dp.Attributes.ToSlice() {
 					switch string(kv.Key) {
 					case "tool.name":
-						fp.tool = kv.Value.Emit()
+						fp.tool = kv.Value.String()
 					case "category":
-						fp.category = kv.Value.Emit()
+						fp.category = kv.Value.String()
 					case "provider.type":
-						fp.provider = kv.Value.Emit()
+						fp.provider = kv.Value.String()
 					case "provider.model":
-						fp.model = kv.Value.Emit()
+						fp.model = kv.Value.String()
 					case "run.mode":
-						fp.mode = kv.Value.Emit()
+						fp.mode = kv.Value.String()
 					}
 				}
 				out = append(out, fp)

--- a/harness/internal/edit/metrics_test.go
+++ b/harness/internal/edit/metrics_test.go
@@ -414,7 +414,7 @@ func collectInt64DataPoints(t *testing.T, rm metricdata.ResourceMetrics, name st
 			for _, dp := range sum.DataPoints {
 				attrs := make(map[string]string)
 				for _, kv := range dp.Attributes.ToSlice() {
-					attrs[string(kv.Key)] = kv.Value.Emit()
+					attrs[string(kv.Key)] = kv.Value.String()
 				}
 				out = append(out, int64DataPoint{value: dp.Value, attrs: attrs})
 			}

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -797,7 +797,7 @@ func findInt64Counter(t *testing.T, rm metricdata.ResourceMetrics, name string) 
 			dp := sum.DataPoints[0]
 			attrs := make(map[string]string)
 			for _, kv := range dp.Attributes.ToSlice() {
-				attrs[string(kv.Key)] = kv.Value.Emit()
+				attrs[string(kv.Key)] = kv.Value.String()
 			}
 			return counterDataPoint{total: dp.Value, attrs: attrs}
 		}
@@ -828,7 +828,7 @@ func findFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name stri
 			dp := h.DataPoints[0]
 			attrs := make(map[string]string)
 			for _, kv := range dp.Attributes.ToSlice() {
-				attrs[string(kv.Key)] = kv.Value.Emit()
+				attrs[string(kv.Key)] = kv.Value.String()
 			}
 			return histogramDataPoint{count: dp.Count, attrs: attrs}
 		}

--- a/harness/internal/permission/metrics_test.go
+++ b/harness/internal/permission/metrics_test.go
@@ -203,7 +203,7 @@ func collectInt64Counters(t *testing.T, rm metricdata.ResourceMetrics, name stri
 			for _, dp := range sum.DataPoints {
 				attrs := make(map[string]string)
 				for _, kv := range dp.Attributes.ToSlice() {
-					attrs[string(kv.Key)] = kv.Value.Emit()
+					attrs[string(kv.Key)] = kv.Value.String()
 				}
 				out = append(out, counterDataPoint{value: dp.Value, attrs: attrs})
 			}

--- a/harness/internal/verifier/metrics_test.go
+++ b/harness/internal/verifier/metrics_test.go
@@ -144,7 +144,7 @@ func collectInt64Counters(t *testing.T, rm metricdata.ResourceMetrics, name stri
 			for _, dp := range sum.DataPoints {
 				attrs := make(map[string]string)
 				for _, kv := range dp.Attributes.ToSlice() {
-					attrs[string(kv.Key)] = kv.Value.Emit()
+					attrs[string(kv.Key)] = kv.Value.String()
 				}
 				out = append(out, counterDataPoint{value: dp.Value, attrs: attrs})
 			}


### PR DESCRIPTION
## Why

The go-dependencies dependabot bump merged in #360 deprecated otel `attribute.Value.Emit()` (`SA1019: Use Value.String() instead`). Five metrics test files still called the old method, so `just lint` (golangci-lint / staticcheck) now fails on `main` — and consequently on every branch cut from it. `main`'s lint check was already red before this PR.

## What

Migrates all ten `kv.Value.Emit()` call sites to `kv.Value.String()` across:

- `harness/internal/core/tool_failure_metrics_test.go`
- `harness/internal/edit/metrics_test.go`
- `harness/internal/mcp/client_test.go`
- `harness/internal/permission/metrics_test.go`
- `harness/internal/verifier/metrics_test.go`

`Value.String()` is the documented drop-in replacement and returns the same representation for the string-typed attribute values these tests inspect, so behaviour is unchanged. golangci-lint's default `max-same-issues: 3` masked the real count in CI logs (only 3 of 10 shown).

Verified locally: `just build`, `just test`, and `just lint` (0 issues) all pass.

## Impact

Unblocks the lint check on the open tool-use-tier PRs (#362, #363, #364, #378, #379), which all inherited this pre-existing failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
