### PR TITLE
docs: warn against acting on stale issue file:line citations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,15 @@ there is no native output channel. Operator walkthrough at
 - **Don't claim a UI / CLI feature is done from a passing build.**
   Type-check passes ≠ feature works. If the change is observable,
   drive it end-to-end before reporting completion.
+- **Don't act on an issue's `file:line` citations without
+  re-verifying.** The backlog tracks deferred work in detail
+  ("Deferred from #NNN … becomes load-bearing when …"), so issue
+  bodies and their line references drift as the code moves around
+  them. Before creating a task or implementing from an issue,
+  confirm each cited symbol/line against current `main`: issues are
+  routinely already-resolved or refactored past, and the closing
+  PR is often discoverable via `git log -L` or `git blame` on the
+  cited lines. Cross-reference that PR before assuming work remains.
 
 ## Known false positives
 


### PR DESCRIPTION
## Why

A triage pass over the `tool-use debacle` backlog found that several open issues were already implemented and that one issue's "actionable" items had been refactored away — in every case because the issue body's `file:line` references had drifted as the surrounding code moved. The backlog's detailed deferred-work tracking style ("Deferred from #NNN … becomes load-bearing when …") makes this drift common, so acting on an issue's citations without re-checking wastes effort or, worse, re-implements landed work.

Concretely, that pass closed #344, #370, #375 as already-implemented (referencing the closing PRs #378 / #364) and pruned #351 down to genuine future-work.

## What

Adds one bullet to the **Things not to do** section of `CLAUDE.md`: re-verify each cited symbol/line against current `main` before creating a task or implementing from an issue, and cross-reference the closing PR (discoverable via `git log -L` / `git blame` on the cited lines) before assuming work remains.

Docs-only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
