### PR TITLE
tool: harden search-tool probe-cap (#365-#368)

### DIFF
--- a/harness/internal/tool/builtins/search.go
+++ b/harness/internal/tool/builtins/search.go
@@ -368,7 +368,8 @@ func FindFilesTool(exec executor.Executor) *tool.Tool {
 			// Collect one path past maxResults so a count landing exactly on
 			// the cap is not misreported as truncated; the probe path is
 			// trimmed before serialization (issue #341).
-			paths, err := findNative(resolvedDir, params.Name, params.Include, params.Exclude, maxResults+1)
+			probeMax := maxResults + 1
+			paths, err := findNative(resolvedDir, params.Name, params.Include, params.Exclude, probeMax)
 			if err != nil {
 				return tool.StructuredResult{}, err
 			}
@@ -493,9 +494,11 @@ func grepViaRipgrep(ctx context.Context, exec executor.Executor, dir, pattern st
 }
 
 // parseRipgrepJSON walks rg's newline-delimited JSON event stream and collects
-// the "match" events into searchMatch structs, capped at maxResults. rg's
-// --max-count is per-file, so a workspace with many files can exceed the global
-// bound; the cap here enforces it. Non-"match" events (begin/end/summary) and
+// the "match" events into searchMatch structs, capped at maxResults (callers
+// pass probeMax = userMax+1 so the one-past-the-cap probe element survives here
+// and is detectable by the caller). rg's --max-count is per-file, so a
+// workspace with many files can exceed the global bound; the cap here enforces
+// it. Non-"match" events (begin/end/summary) and
 // any line that does not parse as a JSON object are skipped — rg only emits
 // well-formed objects, so a parse miss is a defensive no-op, never a dropped
 // match for a colon-bearing path.

--- a/harness/internal/tool/builtins/search_test.go
+++ b/harness/internal/tool/builtins/search_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -797,9 +798,9 @@ func decodeFindResult(t *testing.T, tl *tool.Tool, input json.RawMessage) findRe
 func rgMatchEvents(n int) string {
 	var b strings.Builder
 	for i := 0; i < n; i++ {
-		b.WriteString(`{"type":"match","data":{"path":{"text":"f`)
-		b.WriteString(string(rune('a' + i%26)))
-		b.WriteString(`.go"},"lines":{"text":"hit\n"},"line_number":1}}` + "\n")
+		// Distinct path per event so n > 26 cannot collapse onto duplicate
+		// paths the way an 'a'+i%26 rune cycle would (issue #367).
+		fmt.Fprintf(&b, `{"type":"match","data":{"path":{"text":"f%d.go"},"lines":{"text":"hit\n"},"line_number":1}}`+"\n", i)
 	}
 	return b.String()
 }
@@ -862,16 +863,26 @@ func TestGrepFilesTool_TruncatedBoundary_Ripgrep(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			var gotCmd string
 			fe := &fsExecutor{
 				root:    t.TempDir(),
 				canExec: true,
-				execFn: func(context.Context, string, time.Duration) (*executor.ExecResult, error) {
+				execFn: func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+					gotCmd = command
 					return &executor.ExecResult{ExitCode: 0, Stdout: rgMatchEvents(tc.events)}, nil
 				},
 			}
 			grep := GrepFilesTool(fe)
 			input, _ := json.Marshal(map[string]any{"pattern": "hit", "max_results": maxResults})
 			sr := decodeSearchResult(t, grep, input)
+			// The look-ahead probe lives in --max-count: rg must be asked for
+			// maxResults+1 so a count landing exactly on the cap stays
+			// distinguishable from genuine truncation. Pinning the literal
+			// catches a revert to plain maxResults (issue #366).
+			wantMaxCount := fmt.Sprintf("--max-count %d", maxResults+1)
+			if !strings.Contains(gotCmd, wantMaxCount) {
+				t.Errorf("rg command = %q, want it to contain %q", gotCmd, wantMaxCount)
+			}
 			if sr.Truncated != tc.wantTruncated {
 				t.Errorf("Truncated = %v, want %v", sr.Truncated, tc.wantTruncated)
 			}


### PR DESCRIPTION
Closes #365, closes #366, closes #367, closes #368.

## Commits (1)
- d7bfcdf tool: harden search probe-cap intent in code and tests

## Review
Reviewed this session by independent code-review and spec-compliance
sub-agents (one of each against this branch's diff). No blocking findings;
`go build`, `go test`, and `golangci-lint` pass on the branch. Minor
deferred/optional findings, where any, are tracked on the linked issues.

## Provenance
Recovered from a coordinator implementation run interrupted by an HTTP 429
at the push step; the branch's work and its review were completed before
the interruption, then re-verified this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)