### PR TITLE
types: ToolChoiceMode hardening and wire-form tests (#369, #371)

### DIFF
--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -198,7 +198,7 @@ func (f *OpenAITokenField) UnmarshalJSON(data []byte) error {
 	case `"max_tokens"`:
 		*f = TokenFieldMaxTokens
 	default:
-		return fmt.Errorf("quirks: unknown OpenAITokenField %s", data)
+		return fmt.Errorf("quirks: unknown OpenAITokenField %.64s", data)
 	}
 	return nil
 }
@@ -277,7 +277,7 @@ func (s *GeminiStreamArgsShape) UnmarshalJSON(data []byte) error {
 	case `"v3_deltas"`:
 		*s = StreamArgsV3Deltas
 	default:
-		return fmt.Errorf("quirks: unknown GeminiStreamArgsShape %s", data)
+		return fmt.Errorf("quirks: unknown GeminiStreamArgsShape %.64s", data)
 	}
 	return nil
 }

--- a/types/events.go
+++ b/types/events.go
@@ -182,9 +182,21 @@ func (m *ToolChoiceMode) UnmarshalJSON(data []byte) error {
 	case `"tool"`:
 		*m = ToolChoiceTool
 	default:
-		return fmt.Errorf("types: unknown ToolChoiceMode %.64s", data)
+		return fmt.Errorf("types: unknown ToolChoiceMode %s", truncateForError(data))
 	}
 	return nil
+}
+
+// truncateForError renders raw unmarshal input safely for an error
+// surfaced into structured logs: control bytes are escaped (the value is
+// quoted), and an over-long value is capped at 64 bytes with a trailing
+// marker so a truncated value is visibly distinct from a complete one.
+// The 64-byte bound matches toolChoiceNamePattern's length limit.
+func truncateForError(data []byte) string {
+	if len(data) > 64 {
+		return fmt.Sprintf("%q…", data[:64])
+	}
+	return fmt.Sprintf("%q", data)
 }
 
 // toolChoiceNamePattern is the character-set and length bound enforced on

--- a/types/events.go
+++ b/types/events.go
@@ -191,7 +191,8 @@ func (m *ToolChoiceMode) UnmarshalJSON(data []byte) error {
 // surfaced into structured logs: control bytes are escaped (the value is
 // quoted), and an over-long value is capped at 64 bytes with a trailing
 // marker so a truncated value is visibly distinct from a complete one.
-// The 64-byte bound matches toolChoiceNamePattern's length limit.
+// The 64-byte cap simply keeps the error message bounded; valid mode
+// forms are far shorter, so only hostile or malformed input is truncated.
 func truncateForError(data []byte) string {
 	if len(data) > 64 {
 		return fmt.Sprintf("%q…", data[:64])

--- a/types/events.go
+++ b/types/events.go
@@ -182,7 +182,7 @@ func (m *ToolChoiceMode) UnmarshalJSON(data []byte) error {
 	case `"tool"`:
 		*m = ToolChoiceTool
 	default:
-		return fmt.Errorf("types: unknown ToolChoiceMode %s", data)
+		return fmt.Errorf("types: unknown ToolChoiceMode %.64s", data)
 	}
 	return nil
 }

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -165,3 +165,23 @@ func TestToolChoiceModeMarshalRejects(t *testing.T) {
 		}
 	}
 }
+
+// TestToolChoiceModeUnmarshalErrorTruncates pins the bounded, escaped
+// rendering of hostile input: an unknown value far longer than the
+// 64-byte cap surfaces a quoted, ellipsis-terminated excerpt rather than
+// the full raw payload, so the error stays log-safe and bounded.
+func TestToolChoiceModeUnmarshalErrorTruncates(t *testing.T) {
+	long := `"` + strings.Repeat("x", 200) + `"`
+	var m ToolChoiceMode
+	err := json.Unmarshal([]byte(long), &m)
+	if err == nil {
+		t.Fatal("expected error for unknown ToolChoiceMode, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "…") {
+		t.Errorf("error must mark truncation with an ellipsis, got: %s", msg)
+	}
+	if len(msg) > 120 {
+		t.Errorf("error message must stay bounded, got %d bytes: %s", len(msg), msg)
+	}
+}

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -60,8 +60,8 @@ func TestStreamParamsToolChoiceOmitempty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal required: %v", err)
 	}
-	if !strings.Contains(string(b), "toolChoice") {
-		t.Errorf("non-auto ToolChoice must appear in JSON, got: %s", b)
+	if !strings.Contains(string(b), `"toolChoice":"required"`) {
+		t.Errorf("non-auto ToolChoice must marshal to its string form, got: %s", b)
 	}
 }
 
@@ -92,6 +92,29 @@ func TestToolChoiceModeRoundTrip(t *testing.T) {
 		}
 		if got != tc.mode {
 			t.Errorf("round-trip %s = %v, want %v", b, got, tc.mode)
+		}
+	}
+}
+
+// TestToolChoiceModeString documents that String stays usable on
+// out-of-range values: unlike MarshalJSON (which rejects them), String
+// never errors so it remains safe in fmt verbs and log lines. The
+// default branch renders "unknown(N)".
+func TestToolChoiceModeString(t *testing.T) {
+	cases := []struct {
+		mode ToolChoiceMode
+		want string
+	}{
+		{ToolChoiceAuto, "auto"},
+		{ToolChoiceRequired, "required"},
+		{ToolChoiceNone, "none"},
+		{ToolChoiceTool, "tool"},
+		{ToolChoiceMode(99), "unknown(99)"},
+		{ToolChoiceMode(-1), "unknown(-1)"},
+	}
+	for _, tc := range cases {
+		if got := tc.mode.String(); got != tc.want {
+			t.Errorf("ToolChoiceMode(%d).String() = %q, want %q", int(tc.mode), got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Closes #369, closes #371.

## Commits (4)
- b7df00b types: fix truncateForError rationale comment, pin truncation in test
- efbd1b0 types: truncate raw JSON in ToolChoiceMode unknown-value error
- ac7bbfb types: cover ToolChoiceMode String fallback and pin toolChoice form
- 672fafe types, quirks: truncate raw JSON in unmarshal error text

## Review
Reviewed this session by independent code-review and spec-compliance
sub-agents (one of each against this branch's diff). No blocking findings;
`go build`, `go test`, and `golangci-lint` pass on the branch. Minor
deferred/optional findings, where any, are tracked on the linked issues.

## Provenance
Recovered from a coordinator implementation run interrupted by an HTTP 429
at the push step; the branch's work and its review were completed before
the interruption, then re-verified this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)