### PR TITLE
provider: adapter logger guards and no-tool-choice wire tests (#372-#376)

### DIFF
--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -2820,3 +2820,52 @@ func (s *stubSecretStore) Resolve(_ context.Context, ref string) (string, error)
 	}
 	return v, nil
 }
+
+// TestBuildLoopWithTransport_OpenAIResponsesAdapterHasLogger asserts that
+// BuildLoopWithTransport injects a non-nil Logger into the
+// OpenAIResponsesAdapter, so its quirks-resolution debug log and
+// tool-choice downgrade warn run through the factory's ScrubHandler-backed
+// logger rather than the slog.Default fallback. A future deletion of the
+// `pa.Logger = logger` line in the *provider.OpenAIResponsesAdapter factory
+// arm would silently regress the scrub and correlation invariants for that
+// output; this test surfaces the regression at the assembly seam, mirroring
+// the Bedrock and OpenAICompatible equivalents.
+func TestBuildLoopWithTransport_OpenAIResponsesAdapterHasLogger(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-responses-logger",
+		Mode:             "execution",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-responses", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-responses", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	adapter, ok := unwrapNormalizer(loop.Provider).(*provider.OpenAIResponsesAdapter)
+	if !ok {
+		t.Fatalf("loop.Provider (after unwrap) type = %T, want *provider.OpenAIResponsesAdapter", unwrapNormalizer(loop.Provider))
+	}
+	if adapter.Logger == nil {
+		t.Error("OpenAIResponsesAdapter.Logger is nil; factory should inject the ScrubHandler-backed logger so the quirks debug log and tool-choice downgrade warn keep run/trace correlation and scrubbing")
+	}
+}

--- a/harness/internal/provider/bedrock.go
+++ b/harness/internal/provider/bedrock.go
@@ -113,6 +113,19 @@ func (b *BedrockAdapter) Stream(ctx context.Context, params types.StreamParams) 
 		attribute.String("provider.model", params.Model),
 	)
 
+	// Resolve the logger once at the top so it is available on every
+	// early-return path, not only inside the tool-choice branch below.
+	logger := b.Logger
+	if logger == nil {
+		// The slog.Default() fallback bypasses the ScrubHandler-backed
+		// logger the factory injects. On the production path the factory
+		// always supplies a real logger (guarded by
+		// TestBuildLoopWithTransport_BedrockAdapterHasLogger); only direct
+		// struct-literal construction reaches this branch, where the
+		// default handler is unscrubbable.
+		logger = slog.Default()
+	}
+
 	// buildConverseStreamInput does not project ToolChoice onto the
 	// ConverseStream request, so a non-auto ToolChoice requested against
 	// this adapter is silently downgraded to auto. Warn so the downgrade
@@ -120,10 +133,6 @@ func (b *BedrockAdapter) Stream(ctx context.Context, params types.StreamParams) 
 	// model identifiers are logged — never message content or any
 	// secret-derived value.
 	if params.ToolChoice != types.ToolChoiceAuto {
-		logger := b.Logger
-		if logger == nil {
-			logger = slog.Default()
-		}
 		logger.WarnContext(ctx, "bedrock tool-choice downgraded to auto: adapter does not support tool-choice",
 			slog.String("provider.type", "bedrock"),
 			slog.String("provider.model", params.Model),

--- a/harness/internal/provider/bedrock_test.go
+++ b/harness/internal/provider/bedrock_test.go
@@ -703,10 +703,21 @@ func TestBedrock_ToolChoiceNonAuto_WarnsDowngrade(t *testing.T) {
 	client := &mockBedrockClient{apiErr: fmt.Errorf("mock")}
 	adapter := &BedrockAdapter{client: client, Logger: logger}
 
+	// Tools are supplied so buildConverseStreamInput populates ToolConfig.
+	// Without a tool the ToolConfig is nil and the wire-body assertion below
+	// would pass vacuously, never exercising the "ToolChoice not projected"
+	// invariant it is meant to pin.
 	_, _ = adapter.Stream(context.Background(), types.StreamParams{
 		Model:      "anthropic.claude-sonnet-4-6-v1",
 		MaxTokens:  1024,
 		ToolChoice: types.ToolChoiceRequired,
+		Tools: []types.ToolDefinition{
+			{
+				Name:        "read_file",
+				Description: "Read a file",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+			},
+		},
 		Messages: []types.Message{
 			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "secret-prompt-text"}}},
 		},
@@ -723,8 +734,18 @@ func TestBedrock_ToolChoiceNonAuto_WarnsDowngrade(t *testing.T) {
 		t.Errorf("warn log leaked message content: %s", out)
 	}
 	// The downgrade is log-only: the request body must never carry a tool
-	// choice, mirroring the openai-responses wire-body guard.
-	if input := client.capturedInput; input != nil && input.ToolConfig != nil && input.ToolConfig.ToolChoice != nil {
+	// choice, mirroring the openai-responses wire-body guard. The mock
+	// captures the input before its apiErr fires, so capturedInput reflects
+	// the body the adapter built; with Tools present ToolConfig is non-nil,
+	// so the ToolChoice check below is exercised rather than skipped.
+	input := client.capturedInput
+	if input == nil {
+		t.Fatal("client never reached: buildConverseStreamInput must succeed so the wire body can be inspected")
+	}
+	if input.ToolConfig == nil {
+		t.Fatal("ToolConfig must be populated (Tools were supplied) for the ToolChoice assertion to be meaningful")
+	}
+	if input.ToolConfig.ToolChoice != nil {
 		t.Errorf("request must not project ToolChoice onto ConverseStreamInput, got: %#v", input.ToolConfig.ToolChoice)
 	}
 }

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -562,6 +562,11 @@ func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.Stream
 
 	logger := o.Logger
 	if logger == nil {
+		// The slog.Default() fallback bypasses the ScrubHandler-backed
+		// logger the factory injects. On the production path the factory
+		// always supplies a real logger; only direct struct-literal
+		// construction reaches this branch, where the default handler is
+		// unscrubbable.
 		logger = slog.Default()
 	}
 	// Debug-level log mirrors the chat adapter so an operator gets the

--- a/harness/internal/provider/openai_responses_test.go
+++ b/harness/internal/provider/openai_responses_test.go
@@ -738,6 +738,43 @@ func TestOpenAIResponsesAdapter_RequestBody(t *testing.T) {
 	if strings.Contains(string(rawBody), `"function":{"name"`) {
 		t.Error("request body contains nested 'function' object — Responses API uses a flat tool shape")
 	}
+
+	// The default case above exercises ToolChoiceAuto (the zero value). Drive
+	// the same request shape with a non-auto ToolChoice and confirm the raw
+	// body still omits "tool_choice": the adapter downgrades to auto and must
+	// never serialise the field. This pins the omission inside the primary
+	// request-body test, independently of the warn-focused tests.
+	t.Run("ToolChoiceRequired", func(t *testing.T) {
+		var rawBody []byte
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rawBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, makeResponsesEvent("response.completed", `{"response":{"status":"completed"}}`))
+		}))
+		defer srv.Close()
+
+		adapter := NewOpenAIResponsesAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{})
+
+		ch, err := adapter.Stream(context.Background(), types.StreamParams{
+			Model:      "gpt-4.1",
+			MaxTokens:  4096,
+			ToolChoice: types.ToolChoiceRequired,
+			Tools:      tools,
+			Messages: []types.Message{
+				{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "Hello"}}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Stream() error: %v", err)
+		}
+		for range ch {
+		}
+
+		if strings.Contains(string(rawBody), `"tool_choice"`) {
+			t.Errorf("request body must not contain 'tool_choice' for non-auto input — the Responses adapter downgrades to auto: %s", rawBody)
+		}
+	})
 }
 
 // TestOpenAIResponsesAdapter_RequestBody_NonAutoToolChoiceOmitsField pins the


### PR DESCRIPTION
Closes #372, closes #373, closes #374, closes #376.

## Commits (3)
- 55fec4a core: add factory-seam test for OpenAIResponsesAdapter logger injection
- 733c9c0 provider: pin no-tool-choice wire invariant in adapter tests
- a1f0560 provider: hoist bedrock logger guard and note scrub bypass

## Review
Reviewed this session by independent code-review and spec-compliance
sub-agents (one of each against this branch's diff). No blocking findings;
`go build`, `go test`, and `golangci-lint` pass on the branch. Minor
deferred/optional findings, where any, are tracked on the linked issues.

## Provenance
Recovered from a coordinator implementation run interrupted by an HTTP 429
at the push step; the branch's work and its review were completed before
the interruption, then re-verified this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)