### PR TITLE
core, trace, mcp, tool, provider: wave-4 tool-use polish (#346)

### DIFF
--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -339,11 +341,18 @@ func (l *AgenticLoop) planAndDispatch(
 
 		metricToolName := l.emitToolCallMetrics(ctx, p, callDuration, providerType, providerModel, config.Mode)
 
+		// p.structured.payload is a json.RawMessage ([]byte) consumed by both
+		// the ToolResult below and the ToolCallRecord further down. Hand each
+		// struct its own copy so the two trace surfaces never alias the same
+		// backing slice: a downstream in-place edit (scrub, redaction) to one
+		// must not silently mutate the other.
+		structuredForResult := cloneRawMessage(p.structured.payload)
+		structuredForRecord := cloneRawMessage(p.structured.payload)
 		toolResults[i] = types.ToolResult{
 			ToolUseID:  p.call.ID,
 			Content:    p.output,
 			IsError:    !p.success,
-			Structured: p.structured.payload,
+			Structured: structuredForResult,
 			Kind:       p.structured.kind,
 		}
 		// Full record carries raw input/output for the turn transcript.
@@ -361,7 +370,7 @@ func (l *AgenticLoop) planAndDispatch(
 			Output:       p.output,
 			DurationMs:   callDuration.Milliseconds(),
 			Success:      p.success,
-			Structured:   p.structured.payload,
+			Structured:   structuredForRecord,
 			Kind:         p.structured.kind,
 		}
 
@@ -482,4 +491,13 @@ func (l *AgenticLoop) emitToolCallMetrics(
 		}
 	}
 	return metricToolName
+}
+
+// cloneRawMessage returns an independent copy of a json.RawMessage so two
+// trace structs derived from the same dispatch result do not alias one
+// backing slice. bytes.Clone preserves the nil/empty distinction: a nil
+// payload (the "no structured data" case) stays nil rather than becoming an
+// empty non-nil slice, keeping the trace wire shape unchanged.
+func cloneRawMessage(raw json.RawMessage) json.RawMessage {
+	return bytes.Clone(raw)
 }

--- a/harness/internal/core/dispatch_structured_test.go
+++ b/harness/internal/core/dispatch_structured_test.go
@@ -118,3 +118,36 @@ func TestPlanAndDispatch_StructuredFlowsToResult(t *testing.T) {
 		t.Errorf("ToolCallRecord.Kind mismatch: %q", records[0].Kind)
 	}
 }
+
+// TestPlanAndDispatch_StructuredResultAndRecordDoNotAlias pins that the
+// ToolResult and ToolCallRecord receive independent copies of the structured
+// payload rather than aliasing one backing slice. The two flow to different
+// surfaces (model-facing result vs. trace record), and a later in-place edit
+// (scrub, redaction) to one must not silently mutate the other.
+func TestPlanAndDispatch_StructuredResultAndRecordDoNotAlias(t *testing.T) {
+	tr := newAsyncTestTransport()
+	loop := buildAsyncTestLoop(t, tr, structuredEchoTool())
+
+	results, records, stall := loop.planAndDispatch(
+		context.Background(),
+		&types.RunConfig{Mode: "execution"},
+		[]types.ToolCall{{ID: "tc1", Name: "structured_echo", Input: json.RawMessage(`{}`)}},
+		&stallDetector{},
+		"anthropic",
+		"claude-sonnet-4-6",
+	)
+	if stall != "" {
+		t.Fatalf("unexpected stall outcome: %q", stall)
+	}
+	if len(results) != 1 || len(records) != 1 {
+		t.Fatalf("expected 1 result/record, got %d/%d", len(results), len(records))
+	}
+	if len(results[0].Structured) == 0 || len(records[0].Structured) == 0 {
+		t.Fatalf("both structured payloads must be populated")
+	}
+	// Mutate the result's payload in place; the record's copy must be unaffected.
+	results[0].Structured[0] = 'X'
+	if string(records[0].Structured) != `{"field":"value"}` {
+		t.Errorf("record payload mutated via result alias: %s", records[0].Structured)
+	}
+}

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -90,6 +90,14 @@ const maxMCPToolNameLen = 128
 // misconfigured servers.
 const maxMCPToolsPerServer = 64
 
+// maxMCPSessionIDLen caps the length of the Mcp-Session-Id value accepted from
+// a server response. The captured value is echoed back verbatim on every
+// subsequent request header, so an unbounded server-controlled string would
+// let a hostile or buggy server grow the harness's outbound request size
+// without limit. A session ID past this cap is rejected (not stored) and the
+// prior value is kept. 512 bytes is well above any legitimate opaque token.
+const maxMCPSessionIDLen = 512
+
 // sanitizeMCPToolName truncates a remote tool name to maxMCPToolNameLen
 // runes. Returns the input unchanged when it is already within the cap.
 //
@@ -441,9 +449,10 @@ func (c *Client) listTools(ctx context.Context, sess *serverSession) ([]mcpTool,
 // intent rather than transport target.
 //
 // The returned structured envelope is the marshalled mcpStructuredResult or
-// nil for a text-only result. It is NOT scrubbed here: scrubbing happens on
-// the same footing as the text Content in the core dispatch path (the value
-// flows back through tool.StructuredResult → dispatch → trace scrub). Size
+// nil for a text-only result. It is NOT scrubbed here: scrubbing is applied at
+// the trace-emission boundary, when the trace emitter's RecordTurnRecord runs
+// the payload through scrubRawJSON before writing each line (the value flows
+// back through tool.StructuredResult → dispatch → RecordTurnRecord). Size
 // bounding, however, is enforced here at the trust boundary so an oversized
 // untrusted payload is never materialised into the loop in the first place.
 func (c *Client) callTool(ctx context.Context, sess *serverSession, serverName, name string, arguments json.RawMessage) (string, json.RawMessage, error) {
@@ -702,11 +711,18 @@ func (c *Client) call(ctx context.Context, sess *serverSession, method string, p
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Capture session ID from response.
+	// Capture session ID from response. Reject an over-cap value rather than
+	// store it: the ID is echoed back on every later request, so an unbounded
+	// server-controlled string would inflate outbound headers indefinitely.
 	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
-		c.mu.Lock()
-		sess.sessionID = sid
-		c.mu.Unlock()
+		if len(sid) > maxMCPSessionIDLen {
+			c.warn("mcp session ID exceeded cap; ignoring",
+				"server", sess.uri, "len", len(sid), "cap", maxMCPSessionIDLen)
+		} else {
+			c.mu.Lock()
+			sess.sessionID = sid
+			c.mu.Unlock()
+		}
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -328,6 +328,40 @@ func TestConnect_SessionIDManagement(t *testing.T) {
 	}
 }
 
+// TestConnect_RejectsOversizedSessionID pins the maxMCPSessionIDLen cap: a
+// server that returns an Mcp-Session-Id longer than the cap must not have that
+// value stored or echoed back, since the ID rides on every later request and an
+// unbounded value would inflate outbound headers without limit.
+func TestConnect_RejectsOversizedSessionID(t *testing.T) {
+	oversized := strings.Repeat("x", maxMCPSessionIDLen+1)
+	tools := []mcpTool{
+		{Name: "ping", Description: "Ping", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+
+	srv, log := fakeMCPServer(t, tools, oversized)
+	registry := tool.NewRegistry()
+	client := NewClient(registry, srv.Client())
+
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+	config := types.MCPServerConfig{Name: "sess", URI: srv.URL}
+
+	if err := client.Connect(context.Background(), config, secrets); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	resolved := registry.Resolve("mcp_sess_ping")
+	if resolved == nil {
+		t.Fatal("tool not found")
+	}
+	_, _ = callMCPText(t, resolved, json.RawMessage(`{}`))
+
+	for i, r := range log.get() {
+		if r.SessionID != "" {
+			t.Errorf("request %d carried a session ID %q; oversized ID should have been rejected", i, r.SessionID)
+		}
+	}
+}
+
 func TestConnect_AuthHeader(t *testing.T) {
 	tools := []mcpTool{}
 

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -252,6 +252,14 @@ func anthropicToolChoiceFromParams(params types.StreamParams, cap quirks.ToolCho
 		// ToolChoiceAuto (zero value) and ToolChoiceNone both emit no
 		// tool_choice field: auto is the wire default, and Anthropic has
 		// no native none.
+		//
+		// Degradation of ToolChoiceNone: this adapter does not also strip
+		// the tools array, so a "none" turn still ships the tool
+		// definitions with no tool_choice field. Anthropic therefore
+		// treats it as auto and the model may emit a tool_use block the
+		// caller asked to suppress. Honouring none strictly would require
+		// dropping tools from the request body (a larger change in
+		// buildAnthropicRequest); until then "none" is best-effort.
 		return nil
 	}
 }

--- a/harness/internal/provider/gemini_request_test.go
+++ b/harness/internal/provider/gemini_request_test.go
@@ -999,3 +999,52 @@ func TestGeminiThoughtSignatureFullRoundTrip(t *testing.T) {
 		t.Errorf("round-tripped request body missing thoughtSignature=%q\nbody=%s", sig, body)
 	}
 }
+
+// TestGeminiToolResultResponse_MarshalErrorOnInvalidStructured covers the
+// error return of geminiToolResultResponse. The structured envelope is a
+// json.RawMessage, so a malformed payload makes json.Marshal fail when it
+// validates the embedded raw bytes. The function must surface that as a wrapped
+// error rather than emit a broken functionResponse body onto the wire.
+func TestGeminiToolResultResponse_MarshalErrorOnInvalidStructured(t *testing.T) {
+	block := types.ContentBlock{
+		Type:       "tool_result",
+		ToolUseID:  "c1",
+		Content:    "ok",
+		Structured: json.RawMessage(`{not json`),
+		Kind:       "file_excerpt",
+	}
+	cap := quirks.StructuredToolResultCapability{Supported: true, ObjectResponse: true}
+
+	if _, err := geminiToolResultResponse(block, cap); err == nil {
+		t.Fatal("expected marshal error for invalid Structured payload, got nil")
+	}
+}
+
+// TestGeminiToolResultResponse_TextOnlyWhenCapabilityWithholdsStructured pins
+// the companion path: the same invalid Structured payload does NOT reach
+// json.Marshal when the capability withholds the object-response shape, so a
+// text-only result still marshals cleanly. This guards that the capability gate
+// — not the payload — decides whether Structured is embedded.
+func TestGeminiToolResultResponse_TextOnlyWhenCapabilityWithholdsStructured(t *testing.T) {
+	block := types.ContentBlock{
+		Type:       "tool_result",
+		ToolUseID:  "c1",
+		Content:    "ok",
+		Structured: json.RawMessage(`{not json`),
+		Kind:       "file_excerpt",
+	}
+	raw, err := geminiToolResultResponse(block, quirks.StructuredToolResultCapability{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("text-only body should be valid JSON: %v (raw=%s)", err, raw)
+	}
+	if body["content"] != "ok" {
+		t.Errorf("content = %v, want ok", body["content"])
+	}
+	if _, ok := body["structured"]; ok {
+		t.Errorf("structured must be absent when capability withholds it, got %v", body["structured"])
+	}
+}

--- a/harness/internal/tool/builtins/filesystem.go
+++ b/harness/internal/tool/builtins/filesystem.go
@@ -183,6 +183,11 @@ func readFileExcerpt(path, content string, startLine, limit int) fileExcerpt {
 	}
 	totalLines := len(lines)
 	if startLine > totalLines {
+		// PastEOF deliberately yields StartLine > EndLine: StartLine echoes the
+		// out-of-range request while EndLine reports the true last line. The
+		// usual StartLine <= EndLine invariant does not hold here, and that
+		// inversion is itself the sentinel — consumers should branch on PastEOF
+		// rather than treating the line range as a normal window.
 		return fileExcerpt{
 			Path:      path,
 			StartLine: startLine,

--- a/harness/internal/tool/builtins/shell_test.go
+++ b/harness/internal/tool/builtins/shell_test.go
@@ -1,0 +1,17 @@
+package builtins
+
+import "testing"
+
+// TestFormatRunCommand_ExitCodeOnlyNoOutput locks the exact text for a command
+// that produced no stdout or stderr but exited non-zero. The "[exit code: N]"
+// line is written with a leading newline unconditionally, so an otherwise empty
+// rendering still begins with "\n". This byte-for-byte shape is part of the
+// pre-#231 text contract every provider must accept; a regression here would
+// silently change the model-visible output for silent-but-failing commands.
+func TestFormatRunCommand_ExitCodeOnlyNoOutput(t *testing.T) {
+	got := formatRunCommand("", "", 2)
+	const want = "\n[exit code: 2]"
+	if got != want {
+		t.Fatalf("formatRunCommand(\"\", \"\", 2) = %q, want %q", got, want)
+	}
+}

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -367,8 +368,13 @@ func scrubRawJSON(raw json.RawMessage) json.RawMessage {
 	// any embedded quotes/backslashes so the result is always valid.
 	wrapped, err := json.Marshal(scrubbed)
 	if err != nil {
-		// json.Marshal on a string cannot fail in practice; fall back
-		// to a defensive empty-object literal so the line stays valid.
+		// json.Marshal on a string cannot fail in practice, so this branch
+		// is effectively dead. Warn if it is ever reached: it would mean an
+		// invariant about encoding/json broke, and the empty-object fallback
+		// silently discards the scrubbed tool payload from the recording.
+		slog.Default().Warn("scrubRawJSON string marshal failed; dropping payload to empty object",
+			"error", err)
+		// Fall back to a defensive empty-object literal so the line stays valid.
 		return json.RawMessage(`{}`)
 	}
 	return json.RawMessage(wrapped)

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -437,3 +437,52 @@ func TestJSONLTraceEmitter_PartialStream(t *testing.T) {
 		t.Errorf("turn_record Turn: got %d, want 1", events[1].Turn)
 	}
 }
+
+// TestScrubRawJSON_WrapsWhenScrubBreaksValidity exercises the branch where the
+// scrubbed byte stream is no longer valid JSON. The "[REDACTED]" placeholder is
+// a bare token, so a secret that was sitting as an unquoted JSON value leaves
+// the document unparseable after replacement. scrubRawJSON must then re-wrap
+// the scrubbed text as a JSON string literal so the on-disk line stays valid,
+// rather than emitting raw broken JSON.
+func TestScrubRawJSON_WrapsWhenScrubBreaksValidity(t *testing.T) {
+	// secret:// matches the secret_ref pattern; sitting as an unquoted value it
+	// is replaced by the bare "[REDACTED]" token, breaking JSON validity.
+	in := json.RawMessage(`{"a":secret://leaked}`)
+	out := scrubRawJSON(in)
+
+	if !json.Valid(out) {
+		t.Fatalf("scrubRawJSON output is not valid JSON: %s", out)
+	}
+	// The wrap path encodes the scrubbed text as a JSON string. Decoding it
+	// back must yield the scrubbed-but-invalid intermediate, with the secret
+	// gone.
+	var decoded string
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("wrapped output should decode as a JSON string: %v (out=%s)", err, out)
+	}
+	if strings.Contains(decoded, "secret://leaked") {
+		t.Errorf("secret survived scrub: %q", decoded)
+	}
+	if !strings.Contains(decoded, "[REDACTED]") {
+		t.Errorf("expected redaction marker in wrapped text, got %q", decoded)
+	}
+}
+
+// TestScrubRawJSON_PreservesValidJSON guards the common path: a secret embedded
+// in a well-formed JSON string is scrubbed in place and the result stays valid
+// JSON without the string-wrap fallback.
+func TestScrubRawJSON_PreservesValidJSON(t *testing.T) {
+	in := json.RawMessage(`{"token":"ghp_deadbeefcafef00d"}`)
+	out := scrubRawJSON(in)
+
+	if !json.Valid(out) {
+		t.Fatalf("scrubRawJSON output is not valid JSON: %s", out)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("scrubbed output should decode as an object: %v (out=%s)", err, out)
+	}
+	if decoded["token"] != "[REDACTED]" {
+		t.Errorf("token field = %q, want [REDACTED]", decoded["token"])
+	}
+}


### PR DESCRIPTION
Part of #346 (unconditional items only; conditional items remain tracked on the issue).

## Commits (5)
- 2e64822 mcp: cap session ID length, sharpen tool-result scrub comment
- 286b07e trace: warn on scrubRawJSON empty-object fallback, cover wrap branch
- 319efb6 core: copy structured payload so result and record do not alias
- 61cec2a tool: explain past-EOF line inversion, lock exit-only run output
- 1dce00c provider: document anthropic none degradation, cover gemini result paths

## Review
Reviewed this session by independent code-review and spec-compliance
sub-agents (one of each against this branch's diff). No blocking findings;
`go build`, `go test`, and `golangci-lint` pass on the branch. Minor
deferred/optional findings, where any, are tracked on the linked issues.

## Provenance
Recovered from a coordinator implementation run interrupted by an HTTP 429
at the push step; the branch's work and its review were completed before
the interruption, then re-verified this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)