### PR TITLE
tool, core, types, eval: wave-5 tool-use polish (#347)

### DIFF
--- a/eval/judge/tooltrace.go
+++ b/eval/judge/tooltrace.go
@@ -81,11 +81,16 @@ func checkSequence(want []string, calls []types.ToolCallSummary) (eval.JudgeVerd
 	if idx == len(want) {
 		return eval.JudgeVerdict{}, true
 	}
+	// Everything from idx onward failed to match in order: idx is the first
+	// element with no in-order occurrence, and the greedy scan above could
+	// not advance past it, so the whole tail is unsatisfied. Naming only
+	// want[idx] hides the rest and makes a multi-step gap look like a
+	// single missing call.
 	return eval.JudgeVerdict{
 		Passed: false,
 		Reason: fmt.Sprintf(
-			"expected tool-call sequence %s; matched %d of %d (missing %q or out of order)",
-			strings.Join(want, " -> "), idx, len(want), want[idx],
+			"expected tool-call sequence %s; matched %d of %d (missing or out of order: %s)",
+			strings.Join(want, " -> "), idx, len(want), strings.Join(want[idx:], ", "),
 		),
 	}, false
 }

--- a/eval/spec/hcl.go
+++ b/eval/spec/hcl.go
@@ -454,7 +454,11 @@ func convertJudge(j judgeSpec, context string, depth int) (types.EvalJudge, erro
 				context,
 			)
 		}
-		out.ToolTrace = toolTraceSpecToType(j.ToolTrace)
+		tt, err := toolTraceSpecToType(j.ToolTrace, context)
+		if err != nil {
+			return types.EvalJudge{}, err
+		}
+		out.ToolTrace = tt
 	}
 
 	if j.Type == "composite" {
@@ -499,14 +503,28 @@ func convertJudge(j judgeSpec, context string, depth int) (types.EvalJudge, erro
 // canonical types.ToolTraceCriteria. The HCL `call` blocks carry the
 // matched internal tool name as a block label; everything else is an
 // optional attribute.
-func toolTraceSpecToType(s *toolTraceSpec) *types.ToolTraceCriteria {
+//
+// Two `call` blocks sharing a label are rejected: a per-tool expectation
+// keys on the tool name, so a duplicate is either a copy-paste mistake or
+// a silently-shadowed second expectation. The HCL grammar permits repeated
+// labels (the binding gathers them into a slice), so the constraint is
+// enforced here rather than by the decoder.
+func toolTraceSpecToType(s *toolTraceSpec, context string) (*types.ToolTraceCriteria, error) {
 	out := &types.ToolTraceCriteria{
 		Sequence:      s.Sequence,
 		ForbidUnknown: s.ForbidUnknown,
 	}
 	if len(s.Calls) > 0 {
 		out.Calls = make([]types.ToolCallExpectation, 0, len(s.Calls))
+		seen := make(map[string]struct{}, len(s.Calls))
 		for _, c := range s.Calls {
+			if _, dup := seen[c.Name]; dup {
+				return nil, fmt.Errorf(
+					"%s: duplicate call block for tool %q in tool_trace; merge the expectations into one",
+					context, c.Name,
+				)
+			}
+			seen[c.Name] = struct{}{}
 			out.Calls = append(out.Calls, types.ToolCallExpectation{
 				Name:         c.Name,
 				MinCalls:     c.MinCalls,
@@ -515,7 +533,7 @@ func toolTraceSpecToType(s *toolTraceSpec) *types.ToolTraceCriteria {
 			})
 		}
 	}
-	return out
+	return out, nil
 }
 
 // formatDiagnostics renders an hcl.Diagnostics into a single wrapped

--- a/eval/spec/hcl_test.go
+++ b/eval/spec/hcl_test.go
@@ -462,6 +462,24 @@ suite "s" {
 }`,
 			wantErrFrags: []string{"duplicate file path"},
 		},
+		{
+			name: "duplicate tool_trace call block",
+			src: `
+suite "s" {
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type = "tool-trace"
+      tool_trace {
+        call "edit_file" { min_calls = 1 }
+        call "edit_file" { max_calls = 2 }
+      }
+    }
+  }
+}`,
+			wantErrFrags: []string{"duplicate call block", "edit_file"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/eval/suites/tooluse.hcl
+++ b/eval/suites/tooluse.hcl
@@ -40,7 +40,7 @@
 # credential note.
 
 suite "tooluse-reliability" {
-  description = "Tool-use reliability regression for the Wave 1-5 tool redesign (#233). Each task is a small synthetic repo exercising one behaviour — read/search/edit loops, read-before-edit, line-range reads, bounded search, invalid-argument recovery, renamed-tool recovery, no-tool-answer escalation, multi-tool turns, MCP name normalization — with judges asserting both workspace state and tool-call trace. The default no-credential gate is the in-process replay regression in harness/internal/core/tooluse_replay_test.go; this HCL form is the live-provider-comparable suite (opt-in, needs a provider credential since stirrup-eval run spawns the real harness)."
+  description = "Tool-use reliability regression for the Wave 1-5 tool redesign (#233); see the file header for the full per-behaviour breakdown and the run/compare workflow."
 
   task "read-search-edit-loop" {
     description = "Search for a function, read the file, edit it. Judge confirms the edit landed AND the trace shows grep_files -> read_file -> edit_file in order. Regression-covers the #225 grep_files/read_file/edit_file split and the core coding loop."

--- a/harness/internal/core/tooluse_replay_test.go
+++ b/harness/internal/core/tooluse_replay_test.go
@@ -618,6 +618,7 @@ func TestToolUse_StreamingToolCallParsing(t *testing.T) {
 	// Turn 1 streams a tool_calls delta with the function name in the first
 	// chunk and the arguments split across two subsequent chunks, so the
 	// adapter's accumulator is exercised. Turn 2 is the final answer.
+	var requestBodies []string
 	server := newOpenAIServer(t, nil, []string{
 		openAIChunk(`{"id":"t1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search_replace","arguments":"{\"path\":\"target.txt\",\"old"}}]},"finish_reason":null}]}`) +
 			openAIChunk(`{"id":"t1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_string\":\"old\",\"new_string\":\"new\"}"}}]},"finish_reason":null}]}`) +
@@ -626,8 +627,7 @@ func TestToolUse_StreamingToolCallParsing(t *testing.T) {
 		openAIChunk(`{"id":"t2","choices":[{"index":0,"delta":{"content":"done"},"finish_reason":null}]}`) +
 			openAIChunk(`{"id":"t2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`) +
 			"data: [DONE]\n\n",
-	}, nil)
-	defer server.Close()
+	}, &requestBodies)
 
 	timeout := 30
 	enforce := false
@@ -655,6 +655,12 @@ func TestToolUse_StreamingToolCallParsing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildLoopWithTransport: %v", err)
 	}
+	// Order matters: defers run LIFO, so server.Close() is registered first
+	// and loop.Close() second, ensuring the loop tears down its provider
+	// transport before the httptest server stops listening. Closing the
+	// server first would race the in-flight HTTP teardown and emit spurious
+	// connection-error logs.
+	defer server.Close()
 	defer func() { _ = loop.Close() }()
 
 	runTrace, err := loop.Run(context.Background(), config)
@@ -674,5 +680,16 @@ func TestToolUse_StreamingToolCallParsing(t *testing.T) {
 	}
 	if total, failed := countCalls(runTrace, "search_replace"); total != 1 || failed != 0 {
 		t.Fatalf("search_replace calls: total=%d failed=%d, want 1/0", total, failed)
+	}
+	// Assert the tool reached the wire: the first request must advertise
+	// search_replace in its tools payload. Without this, a regression that
+	// dropped the tool from the request body could still pass on the
+	// streamed-response parse alone (the canned response names the tool
+	// regardless of what was sent).
+	if len(requestBodies) == 0 {
+		t.Fatalf("no provider requests captured")
+	}
+	if !strings.Contains(requestBodies[0], "search_replace") {
+		t.Fatalf("first request body does not advertise search_replace tool:\n%s", requestBodies[0])
 	}
 }

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -68,6 +68,14 @@ type AgenticLoop struct {
 	// under the same profile, keeping parent and child tool names
 	// consistent. The factory always sets Tools to a *tool.Presenter built
 	// with this profile.
+	//
+	// Invariant: when Tools is a *tool.Presenter, its Profile() must equal
+	// ToolProfile. The factory guarantees this by construction; a caller
+	// assembling an AgenticLoop by hand (tests, embedders) must uphold it
+	// or SpawnSubAgent will re-present children under a profile that
+	// disagrees with the parent's presented names. There is no runtime
+	// guard — compare Tools.(*tool.Presenter).Profile() against ToolProfile
+	// at construction if the wiring is not obviously consistent.
 	ToolProfile  *tool.Profile
 	Executor     executor.Executor
 	Edit         edit.EditStrategy

--- a/harness/internal/tool/profile.go
+++ b/harness/internal/tool/profile.go
@@ -58,6 +58,11 @@ var codingClassicProfile = &Profile{
 		"find_files":  "find",
 		"run_command": "bash",
 	},
+	// Renames only — the registered descriptions already read well under
+	// the terser names, so no override is needed. Initialised empty (not
+	// left nil) to match aliases and to signal the omission is deliberate
+	// rather than a forgotten field.
+	descriptions: map[string]string{},
 }
 
 // NewProfile constructs a Profile from an internal-ID→alias map and an
@@ -273,6 +278,15 @@ func (p *Presenter) Resolve(name string) *Tool {
 // binding is honoured; Unwrap is an escape hatch, not the common path.
 func (p *Presenter) Unwrap() ToolRegistry {
 	return p.inner
+}
+
+// Profile returns the Profile this presenter applies. It is never nil —
+// NewPresenter substitutes the default profile for a nil argument. Exposed
+// so a caller assembling an AgenticLoop outside the factory can assert the
+// loop's ToolProfile matches the profile baked into its Tools presenter,
+// the consistency invariant documented on AgenticLoop.
+func (p *Presenter) Profile() *Profile {
+	return p.profile
 }
 
 // InternalName returns the internal tool ID for a model-facing name,

--- a/harness/internal/tool/toolname/toolname.go
+++ b/harness/internal/tool/toolname/toolname.go
@@ -214,11 +214,16 @@ func BuildFromCandidates(keys, candidates []string, policy Policy) (*Mapping, er
 	for i, ext := range candidates {
 		key := keys[i]
 		if existing, taken := used[ext]; taken && existing != key {
+			// Capture the pre-disambiguation candidate so the irresolvable
+			// error names the alias the author actually wrote, not the
+			// SHA-suffixed form disambiguate derived (which appears nowhere
+			// in their input and would misdirect the fix).
+			origExt := ext
 			ext = disambiguate(ext, key, policy)
 			if other, stillCollides := used[ext]; stillCollides && other != key {
 				return nil, fmt.Errorf(
 					"toolname: cannot resolve collision between %q and %q (both normalise to %q under policy MaxLen=%d AllowHyphen=%v AllowLeadingDigit=%v)",
-					key, other, ext, policy.MaxLen, policy.AllowHyphen, policy.AllowLeadingDigit,
+					key, other, origExt, policy.MaxLen, policy.AllowHyphen, policy.AllowLeadingDigit,
 				)
 			}
 		}

--- a/types/eval.go
+++ b/types/eval.go
@@ -138,9 +138,17 @@ type ToolTraceCriteria struct {
 	Calls []ToolCallExpectation `json:"calls,omitempty"`
 
 	// ForbidUnknown, when true, fails the judge if any tool call recorded
-	// an unknown-tool / renamed-tool failure that was never followed by a
-	// successful call to the named replacement. Used to assert in-loop
-	// recovery from a renamed-tool miss actually happened.
+	// a failure that was never followed by a later successful call to the
+	// same tool. Used to assert in-loop recovery from a renamed-tool miss
+	// actually happened.
+	//
+	// Warning: the check is a heuristic keyed on call success, not on the
+	// failure's cause. It fires on ANY unrecovered failure — a permission
+	// denial, an invalid-argument error, a handler error — not only on
+	// renamed- or unknown-tool misses, and it also fails on an empty trace
+	// (no calls cannot demonstrate recovery). Reserve it for tasks whose
+	// expected trace contains no deliberate terminal failures, or those
+	// failures will be misreported as unresolved unknown-tool misses.
 	ForbidUnknown bool `json:"forbidUnknown,omitempty"`
 }
 


### PR DESCRIPTION
Part of #347 (unconditional items only; conditional items remain tracked on the issue).

## Commits (5)
- 49ef736 test: assert streaming request body and order loop/server teardown
- 5689042 types: warn ForbidUnknown fires on any unrecovered tool failure
- a071d2b eval: reject duplicate call labels, report full sequence gap, trim suite desc
- 448d4fb core: document ToolProfile/Tools consistency invariant
- 0dc144e tool: quote original alias in collision error, init coding-classic descriptions

## Review
Reviewed this session by independent code-review and spec-compliance
sub-agents (one of each against this branch's diff). No blocking findings;
`go build`, `go test`, and `golangci-lint` pass on the branch. Minor
deferred/optional findings, where any, are tracked on the linked issues.

## Provenance
Recovered from a coordinator implementation run interrupted by an HTTP 429
at the push step; the branch's work and its review were completed before
the interruption, then re-verified this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)