### PR TITLE
executor: bound LocalExecutor.Exec output with a streaming cap

### DIFF
--- a/harness/internal/executor/local.go
+++ b/harness/internal/executor/local.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -209,22 +208,31 @@ func (e *LocalExecutor) Exec(ctx context.Context, command string, timeout time.D
 	cmd.Dir = e.workspace
 	cmd.Env = filteredCommandEnv()
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Stream into capped writers so peak memory is bounded to ~maxOutputSize
+	// per stream rather than buffering all output. This mirrors
+	// ContainerExecutor.demuxDockerStream's drain-on-cap behaviour: bytes past
+	// the cap are accepted (so the process never blocks on a full pipe) but not
+	// retained. The reported "original size" is therefore the retained, capped
+	// size — matching the container path, which likewise discards drained bytes
+	// without counting them.
+	stdout := &cappedWriter{limit: maxOutputSize}
+	stderr := &cappedWriter{limit: maxOutputSize}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	err := cmd.Run()
 
 	result := &ExecResult{
-		Stdout: truncate(stdout.String(), maxOutputSize),
-		Stderr: truncate(stderr.String(), maxOutputSize),
+		Stdout: stdout.result(),
+		Stderr: stderr.result(),
 	}
 
-	if e.Security != nil {
-		combinedSize := stdout.Len() + stderr.Len()
-		if combinedSize > maxOutputSize {
-			e.Security.OutputTruncated(command, combinedSize, maxOutputSize)
-		}
+	if e.Security != nil && (stdout.truncated || stderr.truncated) {
+		// Report the retained (capped) size as the original size. The true
+		// pre-cap byte count is not tracked: it is discarded unbuffered to bound
+		// peak memory, matching ContainerExecutor which likewise reports its
+		// retained size rather than the drained total.
+		e.Security.OutputTruncated(command, stdout.retained()+stderr.retained(), maxOutputSize)
 	}
 
 	if err != nil {
@@ -350,4 +358,41 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + truncatedSuffix
+}
+
+// cappedWriter is an io.Writer that retains at most limit bytes. Writes past
+// the cap are accepted and reported as fully written — so a process streaming
+// into it never blocks on a full pipe — but their bytes are discarded rather
+// than buffered, bounding peak memory to ~limit. Once the cap is reached the
+// writer records that truncation occurred. It is not safe for concurrent use;
+// exec.Cmd serialises writes per stream.
+type cappedWriter struct {
+	limit     int
+	buf       []byte
+	truncated bool
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - len(w.buf)
+	take := len(p)
+	if take > remaining {
+		take = remaining
+		w.truncated = true
+	}
+	if take > 0 {
+		w.buf = append(w.buf, p[:take]...)
+	}
+	return len(p), nil
+}
+
+// retained reports the number of bytes currently buffered (at most limit).
+func (w *cappedWriter) retained() int { return len(w.buf) }
+
+// result returns the retained output, appending the truncation notice when
+// bytes were dropped.
+func (w *cappedWriter) result() string {
+	if w.truncated {
+		return string(w.buf) + truncatedSuffix
+	}
+	return string(w.buf)
 }

--- a/harness/internal/executor/local.go
+++ b/harness/internal/executor/local.go
@@ -212,11 +212,11 @@ func (e *LocalExecutor) Exec(ctx context.Context, command string, timeout time.D
 	// per stream rather than buffering all output. This mirrors
 	// ContainerExecutor.demuxDockerStream's drain-on-cap behaviour: bytes past
 	// the cap are accepted (so the process never blocks on a full pipe) but not
-	// retained. The reported "original size" is therefore the retained, capped
-	// size — matching the container path, which likewise discards drained bytes
-	// without counting them.
-	stdout := &cappedWriter{limit: maxOutputSize}
-	stderr := &cappedWriter{limit: maxOutputSize}
+	// retained. Each writer still counts every byte it sees, so the true
+	// pre-truncation size and trigger condition reported to OutputTruncated
+	// match the container path byte-for-byte.
+	stdout := newCappedWriter(maxOutputSize)
+	stderr := newCappedWriter(maxOutputSize)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
@@ -227,12 +227,11 @@ func (e *LocalExecutor) Exec(ctx context.Context, command string, timeout time.D
 		Stderr: stderr.result(),
 	}
 
-	if e.Security != nil && (stdout.truncated || stderr.truncated) {
-		// Report the retained (capped) size as the original size. The true
-		// pre-cap byte count is not tracked: it is discarded unbuffered to bound
-		// peak memory, matching ContainerExecutor which likewise reports its
-		// retained size rather than the drained total.
-		e.Security.OutputTruncated(command, stdout.retained()+stderr.retained(), maxOutputSize)
+	if e.Security != nil {
+		combinedSize := stdout.seen() + stderr.seen()
+		if combinedSize > maxOutputSize {
+			e.Security.OutputTruncated(command, combinedSize, maxOutputSize)
+		}
 	}
 
 	if err != nil {
@@ -363,35 +362,47 @@ func truncate(s string, maxLen int) string {
 // cappedWriter is an io.Writer that retains at most limit bytes. Writes past
 // the cap are accepted and reported as fully written — so a process streaming
 // into it never blocks on a full pipe — but their bytes are discarded rather
-// than buffered, bounding peak memory to ~limit. Once the cap is reached the
-// writer records that truncation occurred. It is not safe for concurrent use;
-// exec.Cmd serialises writes per stream.
+// than buffered, bounding peak memory to ~limit. It counts every byte seen in
+// total so the true pre-truncation size can be reported, matching the
+// container path which buffers everything and reports its full length.
+//
+// Not safe for concurrent use. exec.Cmd copies stdout and stderr on separate
+// goroutines that run concurrently, so each stream must use its own distinct
+// cappedWriter instance; sharing a single instance across both streams would
+// race.
 type cappedWriter struct {
-	limit     int
-	buf       []byte
-	truncated bool
+	limit int
+	buf   []byte
+	total int
+}
+
+// newCappedWriter returns a cappedWriter that retains up to limit bytes. The
+// retained buffer is pre-allocated to limit so append growth does not
+// transiently allocate roughly twice the cap.
+func newCappedWriter(limit int) *cappedWriter {
+	return &cappedWriter{limit: limit, buf: make([]byte, 0, limit)}
 }
 
 func (w *cappedWriter) Write(p []byte) (int, error) {
-	remaining := w.limit - len(w.buf)
-	take := len(p)
-	if take > remaining {
-		take = remaining
-		w.truncated = true
-	}
-	if take > 0 {
+	w.total += len(p)
+	if remaining := w.limit - len(w.buf); remaining > 0 {
+		take := len(p)
+		if take > remaining {
+			take = remaining
+		}
 		w.buf = append(w.buf, p[:take]...)
 	}
 	return len(p), nil
 }
 
-// retained reports the number of bytes currently buffered (at most limit).
-func (w *cappedWriter) retained() int { return len(w.buf) }
+// seen reports the total number of bytes written, including bytes dropped past
+// the cap. This is the true pre-truncation size.
+func (w *cappedWriter) seen() int { return w.total }
 
 // result returns the retained output, appending the truncation notice when
-// bytes were dropped.
+// bytes were dropped past the cap.
 func (w *cappedWriter) result() string {
-	if w.truncated {
+	if w.total > w.limit {
 		return string(w.buf) + truncatedSuffix
 	}
 	return string(w.buf)

--- a/harness/internal/executor/local_test.go
+++ b/harness/internal/executor/local_test.go
@@ -283,13 +283,34 @@ func TestExec_OutputTruncation(t *testing.T) {
 	}
 }
 
+// capturingEmitter records the originalSize argument of the most recent
+// OutputTruncated call so tests can assert the true pre-truncation byte count.
+type capturingEmitter struct {
+	outputTruncCount int
+	lastOriginalSize int
+}
+
+func (e *capturingEmitter) PathTraversalBlocked(_, _ string)           {}
+func (e *capturingEmitter) FileSizeLimitExceeded(_ string, _, _ int64) {}
+func (e *capturingEmitter) OutputTruncated(_ string, originalSize, _ int) {
+	e.outputTruncCount++
+	e.lastOriginalSize = originalSize
+}
+
+var _ SecurityEventEmitter = (*capturingEmitter)(nil)
+
 // TestExec_OutputStreamingBounded asserts that streaming far more than the cap
 // does not retain more than maxOutputSize bytes of payload — peak memory is
-// bounded, not proportional to total output.
+// bounded, not proportional to total output — while the OutputTruncated event
+// still reports the TRUE pre-truncation byte count, matching the container path.
 func TestExec_OutputStreamingBounded(t *testing.T) {
 	exec, _ := newTestExecutor(t)
 
+	emitter := &capturingEmitter{}
+	exec.Security = emitter
+
 	// 16 MB of stdout, well past the 1 MB cap.
+	const totalBytes = 16777216
 	result, err := exec.Exec(context.Background(), "head -c 16777216 /dev/zero", 30*time.Second)
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -301,17 +322,55 @@ func TestExec_OutputStreamingBounded(t *testing.T) {
 	if !strings.HasSuffix(result.Stdout, truncatedSuffix) {
 		t.Errorf("expected truncation suffix on over-cap output")
 	}
+	if emitter.outputTruncCount != 1 {
+		t.Errorf("OutputTruncated fired %d times, want 1", emitter.outputTruncCount)
+	}
+	if emitter.lastOriginalSize != totalBytes {
+		t.Errorf("OutputTruncated originalSize = %d, want true total %d (not the capped %d)",
+			emitter.lastOriginalSize, totalBytes, maxOutputSize)
+	}
+}
+
+// TestExec_OutputTruncated_CombinedAcrossStreams locks in the trigger
+// alignment: stdout and stderr each under the 1 MB cap but together over it
+// must fire OutputTruncated, matching the container path's combined-size
+// trigger. Neither stream is individually truncated, so a per-stream trigger
+// would miss this.
+func TestExec_OutputTruncated_CombinedAcrossStreams(t *testing.T) {
+	exec, _ := newTestExecutor(t)
+
+	emitter := &capturingEmitter{}
+	exec.Security = emitter
+
+	// 600 KB to stdout + 600 KB to stderr = 1.2 MB combined, each under 1 MB.
+	const perStream = 600 * 1024
+	cmd := "head -c 614400 /dev/zero; head -c 614400 /dev/zero 1>&2"
+	if _, err := exec.Exec(context.Background(), cmd, 30*time.Second); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if emitter.outputTruncCount != 1 {
+		t.Fatalf("OutputTruncated fired %d times, want 1 (combined streams exceed cap)", emitter.outputTruncCount)
+	}
+	if want := 2 * perStream; emitter.lastOriginalSize != want {
+		t.Errorf("OutputTruncated originalSize = %d, want combined total %d", emitter.lastOriginalSize, want)
+	}
+}
+
+// retainedLen returns the number of payload bytes a cappedWriter currently
+// holds, excluding any appended truncation suffix.
+func retainedLen(w *cappedWriter) int {
+	return len(strings.TrimSuffix(w.result(), truncatedSuffix))
 }
 
 func TestCappedWriter(t *testing.T) {
 	t.Run("retains all bytes under the cap", func(t *testing.T) {
-		w := &cappedWriter{limit: 100}
+		w := newCappedWriter(100)
 		n, err := w.Write([]byte("hello"))
 		if err != nil || n != 5 {
 			t.Fatalf("Write = (%d, %v), want (5, nil)", n, err)
 		}
-		if w.truncated {
-			t.Error("under-cap write must not mark truncated")
+		if w.seen() != 5 {
+			t.Errorf("seen = %d, want 5", w.seen())
 		}
 		if got := w.result(); got != "hello" {
 			t.Errorf("result = %q, want %q", got, "hello")
@@ -319,29 +378,30 @@ func TestCappedWriter(t *testing.T) {
 	})
 
 	t.Run("exact-fit is not truncated", func(t *testing.T) {
-		w := &cappedWriter{limit: 5}
+		w := newCappedWriter(5)
 		_, _ = w.Write([]byte("hello"))
-		if w.truncated {
-			t.Error("filling exactly to the cap must not mark truncated")
+		if w.seen() != 5 {
+			t.Errorf("seen = %d, want 5", w.seen())
 		}
 		if got := w.result(); got != "hello" {
-			t.Errorf("result = %q, want %q", got, "hello")
+			t.Errorf("filling exactly to the cap must not append suffix: result = %q", got)
 		}
 	})
 
-	t.Run("stops retaining past the cap but accepts all bytes", func(t *testing.T) {
-		w := &cappedWriter{limit: 4}
+	t.Run("stops retaining past the cap but accepts and counts all bytes", func(t *testing.T) {
+		w := newCappedWriter(4)
 		// A single oversized write: the writer must report it fully consumed so
-		// the producer never blocks, while retaining only the first limit bytes.
+		// the producer never blocks, while retaining only the first limit bytes
+		// and counting the true total.
 		n, err := w.Write([]byte("abcdefghij"))
 		if err != nil || n != 10 {
 			t.Fatalf("Write = (%d, %v), want (10, nil)", n, err)
 		}
-		if !w.truncated {
-			t.Error("over-cap write must mark truncated")
+		if w.seen() != 10 {
+			t.Errorf("seen = %d, want true total 10", w.seen())
 		}
-		if w.retained() != 4 {
-			t.Errorf("retained = %d, want cap 4", w.retained())
+		if rl := retainedLen(w); rl != 4 {
+			t.Errorf("retained = %d, want cap 4", rl)
 		}
 		if got := w.result(); got != "abcd"+truncatedSuffix {
 			t.Errorf("result = %q, want %q", got, "abcd"+truncatedSuffix)
@@ -349,19 +409,22 @@ func TestCappedWriter(t *testing.T) {
 	})
 
 	t.Run("drops bytes across multiple writes once full", func(t *testing.T) {
-		w := &cappedWriter{limit: 4}
+		w := newCappedWriter(4)
 		_, _ = w.Write([]byte("ab"))
 		_, _ = w.Write([]byte("cd"))
-		// Now full; further writes are accepted but discarded.
+		// Now full; further writes are accepted, counted, but discarded.
 		n, err := w.Write([]byte("efgh"))
 		if err != nil || n != 4 {
 			t.Fatalf("post-fill Write = (%d, %v), want (4, nil)", n, err)
 		}
-		if !w.truncated {
-			t.Error("write past a full buffer must mark truncated")
+		if w.seen() != 8 {
+			t.Errorf("seen = %d, want true total 8", w.seen())
 		}
-		if w.retained() != 4 {
-			t.Errorf("retained = %d, want cap 4", w.retained())
+		if rl := retainedLen(w); rl != 4 {
+			t.Errorf("retained = %d, want cap 4", rl)
+		}
+		if got := w.result(); got != "abcd"+truncatedSuffix {
+			t.Errorf("result must append truncation suffix once full: got %q, want %q", got, "abcd"+truncatedSuffix)
 		}
 	})
 }

--- a/harness/internal/executor/local_test.go
+++ b/harness/internal/executor/local_test.go
@@ -283,6 +283,89 @@ func TestExec_OutputTruncation(t *testing.T) {
 	}
 }
 
+// TestExec_OutputStreamingBounded asserts that streaming far more than the cap
+// does not retain more than maxOutputSize bytes of payload — peak memory is
+// bounded, not proportional to total output.
+func TestExec_OutputStreamingBounded(t *testing.T) {
+	exec, _ := newTestExecutor(t)
+
+	// 16 MB of stdout, well past the 1 MB cap.
+	result, err := exec.Exec(context.Background(), "head -c 16777216 /dev/zero", 30*time.Second)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	payload := strings.TrimSuffix(result.Stdout, truncatedSuffix)
+	if len(payload) != maxOutputSize {
+		t.Errorf("retained payload = %d bytes, want exactly cap %d", len(payload), maxOutputSize)
+	}
+	if !strings.HasSuffix(result.Stdout, truncatedSuffix) {
+		t.Errorf("expected truncation suffix on over-cap output")
+	}
+}
+
+func TestCappedWriter(t *testing.T) {
+	t.Run("retains all bytes under the cap", func(t *testing.T) {
+		w := &cappedWriter{limit: 100}
+		n, err := w.Write([]byte("hello"))
+		if err != nil || n != 5 {
+			t.Fatalf("Write = (%d, %v), want (5, nil)", n, err)
+		}
+		if w.truncated {
+			t.Error("under-cap write must not mark truncated")
+		}
+		if got := w.result(); got != "hello" {
+			t.Errorf("result = %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("exact-fit is not truncated", func(t *testing.T) {
+		w := &cappedWriter{limit: 5}
+		_, _ = w.Write([]byte("hello"))
+		if w.truncated {
+			t.Error("filling exactly to the cap must not mark truncated")
+		}
+		if got := w.result(); got != "hello" {
+			t.Errorf("result = %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("stops retaining past the cap but accepts all bytes", func(t *testing.T) {
+		w := &cappedWriter{limit: 4}
+		// A single oversized write: the writer must report it fully consumed so
+		// the producer never blocks, while retaining only the first limit bytes.
+		n, err := w.Write([]byte("abcdefghij"))
+		if err != nil || n != 10 {
+			t.Fatalf("Write = (%d, %v), want (10, nil)", n, err)
+		}
+		if !w.truncated {
+			t.Error("over-cap write must mark truncated")
+		}
+		if w.retained() != 4 {
+			t.Errorf("retained = %d, want cap 4", w.retained())
+		}
+		if got := w.result(); got != "abcd"+truncatedSuffix {
+			t.Errorf("result = %q, want %q", got, "abcd"+truncatedSuffix)
+		}
+	})
+
+	t.Run("drops bytes across multiple writes once full", func(t *testing.T) {
+		w := &cappedWriter{limit: 4}
+		_, _ = w.Write([]byte("ab"))
+		_, _ = w.Write([]byte("cd"))
+		// Now full; further writes are accepted but discarded.
+		n, err := w.Write([]byte("efgh"))
+		if err != nil || n != 4 {
+			t.Fatalf("post-fill Write = (%d, %v), want (4, nil)", n, err)
+		}
+		if !w.truncated {
+			t.Error("write past a full buffer must mark truncated")
+		}
+		if w.retained() != 4 {
+			t.Errorf("retained = %d, want cap 4", w.retained())
+		}
+	})
+}
+
 func TestExec_WorkingDirectory(t *testing.T) {
 	exec, dir := newTestExecutor(t)
 


### PR DESCRIPTION
## Summary

Closes #337.

`LocalExecutor.Exec` previously buffered **all** command output in a `bytes.Buffer` before applying the 1 MB cap — so a runaway or hostile command could exhaust memory proportional to its total output. This replaces that with a per-stream `cappedWriter` that retains at most `maxOutputSize` (1 MB) bytes and discards the rest while reporting every write as fully consumed, so the child process never blocks on a full pipe. Peak memory is now bounded to ~1 MB per stream, matching `ContainerExecutor.demuxDockerStream`'s drain-on-cap semantics.

This widens the value of the read-only modes (where `run_command` is disabled but the read-only git tools still stream `git diff` over arbitrarily large files): an operator who chose a read-only mode for lower blast radius now also gets bounded executor memory, not execution-mode memory behaviour.

## Behaviour

- **Memory bound:** each stream retains at most 1 MB; the buffer is pre-allocated to the cap to bound backing-array growth.
- **`OutputTruncated` consistency:** the security event now reports the **true pre-truncation byte count** (`stdout.seen() + stderr.seen()`), byte-for-byte matching the container path's `originalStdoutLen + originalStderrLen`. The trigger is also aligned to the container path (`combinedSize > maxOutputSize`), closing a blind spot where e.g. 600 KB stdout + 600 KB stderr previously fired on the container executor but was silent on the local one.
- Sub-cap output is byte-exact (no regression).
- `ContainerExecutor` is untouched; the 1 MB cap value is unchanged.

## Tests

- `TestExec_OutputStreamingBounded` — streams 16 MB through `Exec`, asserts exactly the cap is retained **and** `OutputTruncated` fires once with `originalSize == 16777216` (true total, not the capped size).
- `TestExec_OutputTruncated_CombinedAcrossStreams` — locks in the combined-streams trigger (600 KB + 600 KB → fires, `originalSize == 1228800`).
- `TestCappedWriter` — under-cap, exact-fit (no false truncation), single oversized write, drop-across-writes-once-full (now also asserts the truncation suffix and true `seen()` total).

`just build`, `just lint` (0 issues), and `just test` (39 packages ok) all pass.

## Review

One reviewer wave (code-reviewer + security-reviewer) was run and fully remediated: the HIGH finding (the security event was reporting the *capped* size, inconsistent with the container path) and the MEDIUM trigger-divergence finding are both fixed and test-locked, plus buffer pre-allocation and a corrected concurrency comment.

## Note (out of scope)

`go test -race` flags a pre-existing data race in `TestContainerExecutor_AllowlistMode_WiringConfig` that reproduces on clean `main` and is unrelated to this change (`just test` does not run with `-race`). Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)