### PR TITLE
executor: harden container sandbox profile and enforce a registry allowlist

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -187,12 +187,41 @@ The container executor applies these defaults regardless of what
 
 - `CapDrop: ["ALL"]`
 - `SecurityOpt: ["no-new-privileges"]`
+- `ReadonlyRootfs: true` — the container's root filesystem is
+  immutable. All writable scratch is confined to the workspace
+  bind and the explicit tmpfs mounts below, so a compromised run
+  cannot persist a payload outside the paths it actually needs.
+- `User: "65534:65534"` (nobody:nogroup) — the main process and
+  every `run_command` exec run unprivileged, so a container escape
+  lands on a non-root identity rather than uid 0.
+- A 256 MiB `/tmp` tmpfs and a 64 MiB `/dev/shm`, each mounted
+  `nosuid,nodev,noexec`. These provide the writable, non-executable
+  scratch a read-only rootfs otherwise denies; `noexec` stops a
+  dropped binary from being run out of scratch.
+- `PidsLimit` from `resources.pids` (fork-bomb containment),
+  alongside the CPU and memory limits from `resources`.
 - `NetworkMode: "none"` (overridden to `"bridge"` only when
   `network.mode == "allowlist"`, in which case the egress proxy
   enforces FQDN allowlisting on the way out)
+- A registry allowlist on `executor.image`. The default admits
+  only the project's own `ghcr.io/stirrup/*` images and Docker Hub
+  official `docker.io/library/*` images; any other reference is
+  rejected before a container is created. Operators widen or
+  replace the set via `executor.registryAllowlist` (a list of
+  globs over the normalised `host/repo` reference, tag/digest
+  stripped). An explicit list *replaces* the default rather than
+  extending it. Digest-pinned references (`@sha256:…`) are accepted
+  and preferred; cryptographic verification of the digest
+  (cosign/Sigstore) is a deferred follow-up.
 - API keys and `secret://` references are resolved on the *host*
   before tool dispatch; they never enter the container's
   environment.
+
+The workspace bind is *not* mounted `nosuid,nodev,noexec`: the
+Engine API exposes those options for tmpfs mounts but not for bind
+mounts, and the run must be able to execute tooling it writes into
+the workspace. Defence there rests on the dropped capabilities,
+`no-new-privileges`, and the non-root user rather than mount flags.
 
 Optional kernel-isolation runtime selection (`runc`, `runsc`, `kata*`)
 is documented in [`safety-rings.md`](safety-rings.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -209,19 +209,30 @@ The container executor applies these defaults regardless of what
   rejected before a container is created. Operators widen or
   replace the set via `executor.registryAllowlist` (a list of
   globs over the normalised `host/repo` reference, tag/digest
-  stripped). An explicit list *replaces* the default rather than
-  extending it. Digest-pinned references (`@sha256:…`) are accepted
-  and preferred; cryptographic verification of the digest
+  stripped, with the `index.docker.io` / `registry-1.docker.io`
+  pull aliases folded to `docker.io`). Globs follow `path.Match`
+  semantics, so `*` matches one path segment and does not cross
+  `/`: `ghcr.io/stirrup/*` admits `ghcr.io/stirrup/base` but not
+  `ghcr.io/stirrup/team/base` (use `ghcr.io/stirrup/*/*` for the
+  deeper namespace). An explicit list *replaces* the default rather
+  than extending it. Digest-pinned references (`@sha256:…`) are
+  accepted and preferred; cryptographic verification of the digest
   (cosign/Sigstore) is a deferred follow-up.
 - API keys and `secret://` references are resolved on the *host*
   before tool dispatch; they never enter the container's
   environment.
 
-The workspace bind is *not* mounted `nosuid,nodev,noexec`: the
-Engine API exposes those options for tmpfs mounts but not for bind
-mounts, and the run must be able to execute tooling it writes into
-the workspace. Defence there rests on the dropped capabilities,
-`no-new-privileges`, and the non-root user rather than mount flags.
+The workspace bind is *not* mounted `nosuid,nodev,noexec`. The
+legacy `Binds` string form can express those options to the kernel,
+so this is a functional choice, not an Engine-API limitation: the
+run must be able to execute tooling it writes into `/workspace`
+(build outputs, test binaries, vendored scripts), and `noexec`
+there would break that. The compensating controls cover the gap a
+missing `nosuid` would otherwise leave — `CapDrop: ["ALL"]` removes
+`CAP_SETUID` and `CAP_FOWNER`, and `no-new-privileges` blocks the
+setuid bit from elevating, so a setuid binary planted in
+`/workspace` cannot escalate even though the bind permits suid
+mounts.
 
 Optional kernel-isolation runtime selection (`runc`, `runsc`, `kata*`)
 is documented in [`safety-rings.md`](safety-rings.md).

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -873,12 +873,13 @@ func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets securi
 			}
 		}
 		return executor.NewContainerExecutorWithContext(ctx, executor.ContainerExecutorConfig{
-			Image:          cfg.Image,
-			HostDir:        workspace,
-			Network:        cfg.Network,
-			Resources:      cfg.Resources,
-			Runtime:        cfg.Runtime,
-			EgressSecurity: secLogger,
+			Image:             cfg.Image,
+			HostDir:           workspace,
+			Network:           cfg.Network,
+			Resources:         cfg.Resources,
+			Runtime:           cfg.Runtime,
+			RegistryAllowlist: cfg.RegistryAllowlist,
+			EgressSecurity:    secLogger,
 		})
 	case "api":
 		if cfg.VcsBackend == nil {

--- a/harness/internal/core/preflight.go
+++ b/harness/internal/core/preflight.go
@@ -313,9 +313,10 @@ func preflightExecutor(
 // that field exists only on the test-facing ContainerExecutorConfig).
 func containerProbeConfig(cfg types.ExecutorConfig) executor.ContainerExecutorConfig {
 	return executor.ContainerExecutorConfig{
-		Image:   cfg.Image,
-		Network: cfg.Network,
-		Runtime: cfg.Runtime,
+		Image:             cfg.Image,
+		Network:           cfg.Network,
+		Runtime:           cfg.Runtime,
+		RegistryAllowlist: cfg.RegistryAllowlist,
 	}
 }
 

--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -19,6 +19,25 @@ const (
 	containerWorkspace = "/workspace"
 	maxDockerFrameSize = 10 * 1024 * 1024 // 10 MB cap on Docker stream frames
 
+	// hardenedUser is the uid:gid the container's main process and every
+	// exec run under. 65534:65534 is the conventional nobody:nogroup pair,
+	// so a container escape lands on an unprivileged identity. Writes still
+	// succeed against the workspace bind and the tmpfs scratch mounts; the
+	// read-only rootfs is unaffected by the non-root user.
+	hardenedUser = "65534:65534"
+
+	// tmpfsTmpSize and shmSize size the two writable scratch mounts the
+	// read-only rootfs profile provides. /tmp is the catch-all scratch
+	// directory many tools assume is writable; /dev/shm is sized explicitly
+	// rather than inherited from the daemon default. Both carry
+	// nosuid,nodev,noexec so a dropped binary cannot be executed from them.
+	tmpfsTmpSize = 256 * 1024 * 1024 // 256 MiB
+	shmSize      = 64 * 1024 * 1024  // 64 MiB
+
+	// tmpfsMountOpts is the mount-option string applied to both tmpfs
+	// scratch mounts. size is appended per-mount.
+	tmpfsMountOpts = "rw,nosuid,nodev,noexec"
+
 	// hostGatewayHost is the DNS name we add to the container's /etc/hosts
 	// (via ExtraHosts) that resolves to the host's address. Docker Engine
 	// >=20.10 and Podman >=4.0 expand the magic value "host-gateway" into
@@ -34,6 +53,12 @@ type ContainerExecutorConfig struct {
 	Network    *types.NetworkConfig
 	Resources  *types.ResourceLimits
 	SocketPath string // override auto-detection; empty = auto-detect
+	// RegistryAllowlist constrains which image references may be run. Each
+	// entry is a glob over the normalised reference (registry host + repo
+	// path, digest/tag stripped) — e.g. "ghcr.io/stirrup/*". An empty list
+	// falls back to defaultRegistryAllowlist. A reference matching no
+	// pattern is rejected at construction before any container is created.
+	RegistryAllowlist []string
 	// Runtime selects the OCI runtime for the container (e.g. "runsc",
 	// "kata", "kata-qemu", "kata-fc"). Empty means "use the engine
 	// default" — the field is omitted from the create-container request,
@@ -86,6 +111,11 @@ func (e *ContainerExecutor) Probe(ctx context.Context) error {
 // preflight path (core.Preflight) uses this instead of building a full
 // ContainerExecutor (issue #245 step 7).
 func ProbeContainerEngine(ctx context.Context, cfg ContainerExecutorConfig) error {
+	if cfg.Image != "" {
+		if err := checkImageAllowed(cfg.Image, cfg.RegistryAllowlist); err != nil {
+			return err
+		}
+	}
 	socketPath := cfg.SocketPath
 	if socketPath == "" {
 		var err error
@@ -140,6 +170,9 @@ func NewContainerExecutorWithContext(ctx context.Context, cfg ContainerExecutorC
 	if cfg.HostDir == "" {
 		return nil, fmt.Errorf("container executor requires a host directory")
 	}
+	if err := checkImageAllowed(cfg.Image, cfg.RegistryAllowlist); err != nil {
+		return nil, err
+	}
 
 	socketPath := cfg.SocketPath
 	if socketPath == "" {
@@ -153,11 +186,17 @@ func NewContainerExecutorWithContext(ctx context.Context, cfg ContainerExecutorC
 	api := newContainerAPIClient(socketPath)
 
 	hc := &hostConfig{
-		Binds:       []string{fmt.Sprintf("%s:%s", cfg.HostDir, containerWorkspace)},
-		NetworkMode: "none",
-		CapDrop:     []string{"ALL"},
-		SecurityOpt: []string{"no-new-privileges"},
-		Runtime:     cfg.Runtime,
+		Binds:          []string{fmt.Sprintf("%s:%s", cfg.HostDir, containerWorkspace)},
+		NetworkMode:    "none",
+		CapDrop:        []string{"ALL"},
+		SecurityOpt:    []string{"no-new-privileges"},
+		Runtime:        cfg.Runtime,
+		ReadonlyRootfs: true,
+		ShmSize:        shmSize,
+		Tmpfs: map[string]string{
+			"/tmp":     fmt.Sprintf("%s,size=%d", tmpfsMountOpts, tmpfsTmpSize),
+			"/dev/shm": fmt.Sprintf("%s,size=%d", tmpfsMountOpts, shmSize),
+		},
 	}
 
 	var (
@@ -224,6 +263,7 @@ func NewContainerExecutorWithContext(ctx context.Context, cfg ContainerExecutorC
 		Cmd:        []string{"sleep", "infinity"},
 		WorkingDir: containerWorkspace,
 		Env:        env,
+		User:       hardenedUser,
 		HostConfig: hc,
 	})
 	if err != nil {

--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -28,8 +28,9 @@ const (
 
 	// tmpfsTmpSize and shmSize size the two writable scratch mounts the
 	// read-only rootfs profile provides. /tmp is the catch-all scratch
-	// directory many tools assume is writable; /dev/shm is sized explicitly
-	// rather than inherited from the daemon default. Both carry
+	// directory many tools assume is writable; /dev/shm is sized via its own
+	// tmpfs entry rather than the separate ShmSize host-config field so the
+	// size and the nosuid/nodev/noexec flags stay on one mount. Both carry
 	// nosuid,nodev,noexec so a dropped binary cannot be executed from them.
 	tmpfsTmpSize = 256 * 1024 * 1024 // 256 MiB
 	shmSize      = 64 * 1024 * 1024  // 64 MiB
@@ -192,7 +193,6 @@ func NewContainerExecutorWithContext(ctx context.Context, cfg ContainerExecutorC
 		SecurityOpt:    []string{"no-new-privileges"},
 		Runtime:        cfg.Runtime,
 		ReadonlyRootfs: true,
-		ShmSize:        shmSize,
 		Tmpfs: map[string]string{
 			"/tmp":     fmt.Sprintf("%s,size=%d", tmpfsMountOpts, tmpfsTmpSize),
 			"/dev/shm": fmt.Sprintf("%s,size=%d", tmpfsMountOpts, shmSize),

--- a/harness/internal/executor/container_api.go
+++ b/harness/internal/executor/container_api.go
@@ -107,6 +107,10 @@ type containerCreateRequest struct {
 	// when an egress proxy is in front of the container.
 	Env        []string    `json:"Env,omitempty"`
 	HostConfig *hostConfig `json:"HostConfig"`
+	// User runs the container's main process as the given uid[:gid]. The
+	// hardened profile sets "65534:65534" (nobody:nogroup) so a container
+	// escape lands on an unprivileged identity rather than root.
+	User string `json:"User,omitempty"`
 }
 
 type hostConfig struct {
@@ -117,6 +121,20 @@ type hostConfig struct {
 	PidsLimit   *int64   `json:"PidsLimit,omitempty"`
 	CapDrop     []string `json:"CapDrop,omitempty"`
 	SecurityOpt []string `json:"SecurityOpt,omitempty"`
+	// ReadonlyRootfs makes the container's root filesystem read-only. All
+	// writable scratch space is then confined to the workspace bind and the
+	// explicit Tmpfs mounts below, shrinking the attack surface to the paths
+	// the run actually needs.
+	ReadonlyRootfs bool `json:"ReadonlyRootfs,omitempty"`
+	// Tmpfs maps an in-container path to a comma-separated mount-option
+	// string (e.g. "rw,noexec,nosuid,nodev,size=256m"). With a read-only
+	// rootfs the run still needs writable, non-executable scratch at /tmp
+	// and a sized /dev/shm; the option string is the Engine API vehicle for
+	// nosuid/nodev/noexec on a tmpfs, which top-level Binds cannot carry.
+	Tmpfs map[string]string `json:"Tmpfs,omitempty"`
+	// ShmSize bounds /dev/shm in bytes. The engine default (64m) is made
+	// explicit so the hardened profile does not depend on daemon defaults.
+	ShmSize int64 `json:"ShmSize,omitempty"`
 	// Runtime selects the OCI runtime (e.g. "runsc" for gVisor,
 	// "kata-qemu" for Kata Containers). Empty means "use the engine
 	// default", in which case the field is omitted from the wire so the

--- a/harness/internal/executor/container_api.go
+++ b/harness/internal/executor/container_api.go
@@ -121,20 +121,22 @@ type hostConfig struct {
 	PidsLimit   *int64   `json:"PidsLimit,omitempty"`
 	CapDrop     []string `json:"CapDrop,omitempty"`
 	SecurityOpt []string `json:"SecurityOpt,omitempty"`
-	// ReadonlyRootfs makes the container's root filesystem read-only. All
-	// writable scratch space is then confined to the workspace bind and the
-	// explicit Tmpfs mounts below, shrinking the attack surface to the paths
-	// the run actually needs.
-	ReadonlyRootfs bool `json:"ReadonlyRootfs,omitempty"`
+	// ReadonlyRootfs makes the container's root filesystem read-only. The
+	// field is security-critical and deliberately carries no omitempty: a
+	// bool with omitempty drops false from the wire, so a future caller that
+	// forgot to set it would silently get a writable rootfs with no error.
+	// Emitting the field unconditionally fails loud instead.
+	ReadonlyRootfs bool `json:"ReadonlyRootfs"`
 	// Tmpfs maps an in-container path to a comma-separated mount-option
-	// string (e.g. "rw,noexec,nosuid,nodev,size=256m"). With a read-only
-	// rootfs the run still needs writable, non-executable scratch at /tmp
-	// and a sized /dev/shm; the option string is the Engine API vehicle for
-	// nosuid/nodev/noexec on a tmpfs, which top-level Binds cannot carry.
+	// string. The size is expressed in raw bytes (e.g.
+	// "rw,nosuid,nodev,noexec,size=268435456" for 256 MiB). With a read-only
+	// rootfs the run still needs writable, non-executable scratch at /tmp and
+	// /dev/shm; the option string is the Engine API vehicle for
+	// nosuid/nodev/noexec on a tmpfs, which top-level Binds cannot carry. The
+	// /dev/shm entry's size replaces the separate ShmSize field so the size
+	// and the nosuid/nodev/noexec flags travel together as one mount — a
+	// split ShmSize could win on some engines and silently drop noexec.
 	Tmpfs map[string]string `json:"Tmpfs,omitempty"`
-	// ShmSize bounds /dev/shm in bytes. The engine default (64m) is made
-	// explicit so the hardened profile does not depend on daemon defaults.
-	ShmSize int64 `json:"ShmSize,omitempty"`
 	// Runtime selects the OCI runtime (e.g. "runsc" for gVisor,
 	// "kata-qemu" for Kata Containers). Empty means "use the engine
 	// default", in which case the field is omitted from the wire so the

--- a/harness/internal/executor/container_registry.go
+++ b/harness/internal/executor/container_registry.go
@@ -29,6 +29,13 @@ func checkImageAllowed(image string, allowlist []string) error {
 	}
 
 	ref := normaliseImageRef(image)
+	// A normalised ref ending in "/" has an empty final path segment (e.g.
+	// "ghcr.io/stirrup/"), which "ghcr.io/stirrup/*" would match because the
+	// glob "*" accepts the empty string. Reject it here with a clear message
+	// rather than handing a malformed reference to the engine to fail on.
+	if strings.HasSuffix(ref, "/") {
+		return fmt.Errorf("image %q (resolved to %q) has an empty repository name", image, ref)
+	}
 	for _, pattern := range allowlist {
 		ok, err := path.Match(pattern, ref)
 		if err != nil {
@@ -52,7 +59,10 @@ func checkImageAllowed(image string, allowlist []string) error {
 //
 // A registry host is recognised by a "." or ":" in the first path segment, or
 // the literal "localhost"; otherwise the reference is treated as a Docker Hub
-// short name and the docker.io default registry is prepended.
+// short name and the docker.io default registry is prepended. The Docker Hub
+// pull aliases "index.docker.io" and "registry-1.docker.io" are canonicalised
+// to "docker.io" so an explicit "index.docker.io/library/ubuntu" still matches
+// a "docker.io/library/*" allowlist pattern.
 func normaliseImageRef(image string) string {
 	ref := image
 
@@ -73,6 +83,12 @@ func normaliseImageRef(image string) string {
 			host = candidate
 			rest = ref[slash+1:]
 		}
+	}
+
+	// Canonicalise the Docker Hub pull aliases to the registry's display name
+	// so all three forms collapse onto the same allowlist namespace.
+	if host == "index.docker.io" || host == "registry-1.docker.io" {
+		host = "docker.io"
 	}
 
 	// Strip the tag from the repository path. A ":" only delimits a tag once

--- a/harness/internal/executor/container_registry.go
+++ b/harness/internal/executor/container_registry.go
@@ -1,0 +1,93 @@
+package executor
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// defaultRegistryAllowlist is the set of image-reference globs accepted when
+// the operator does not configure RegistryAllowlist. It admits the project's
+// own images on GitHub Container Registry and the curated Docker Hub
+// "library/*" official images, and nothing else — an unqualified or
+// third-party reference is rejected by default so a misconfigured run cannot
+// silently pull an arbitrary image.
+var defaultRegistryAllowlist = []string{
+	"ghcr.io/stirrup/*",
+	"docker.io/library/*",
+}
+
+// checkImageAllowed reports whether image satisfies one of the allowlist
+// globs. An empty allowlist falls back to defaultRegistryAllowlist. The image
+// is normalised to "registry-host/repo-path" form (default registry
+// docker.io, default repo namespace library/) with any tag or digest stripped
+// before matching, so an operator writing "docker.io/library/*" matches a bare
+// "ubuntu:26.04" reference the way Docker itself resolves it.
+func checkImageAllowed(image string, allowlist []string) error {
+	if len(allowlist) == 0 {
+		allowlist = defaultRegistryAllowlist
+	}
+
+	ref := normaliseImageRef(image)
+	for _, pattern := range allowlist {
+		ok, err := path.Match(pattern, ref)
+		if err != nil {
+			return fmt.Errorf("invalid registry allowlist pattern %q: %w", pattern, err)
+		}
+		if ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("image %q (resolved to %q) is not permitted by the registry allowlist %v", image, ref, allowlist)
+}
+
+// normaliseImageRef expands a Docker image reference to its fully-qualified
+// "host/repository" form with the tag and digest removed, mirroring the
+// reference-resolution rules the engine applies:
+//   - "ubuntu"                 -> "docker.io/library/ubuntu"
+//   - "ubuntu:26.04"           -> "docker.io/library/ubuntu"
+//   - "myorg/app:tag"          -> "docker.io/myorg/app"
+//   - "ghcr.io/stirrup/base"   -> "ghcr.io/stirrup/base"
+//   - "host:5000/team/img@sha" -> "host:5000/team/img"
+//
+// A registry host is recognised by a "." or ":" in the first path segment, or
+// the literal "localhost"; otherwise the reference is treated as a Docker Hub
+// short name and the docker.io default registry is prepended.
+func normaliseImageRef(image string) string {
+	ref := image
+
+	// Strip the digest first ("@sha256:...") so a ":" inside it is never
+	// mistaken for a registry port or a tag separator.
+	if at := strings.Index(ref, "@"); at >= 0 {
+		ref = ref[:at]
+	}
+
+	// Split off an optional registry host. The host is everything before the
+	// first "/" when that segment looks like a hostname (contains "." or ":")
+	// or is "localhost".
+	host := ""
+	rest := ref
+	if slash := strings.Index(ref, "/"); slash >= 0 {
+		candidate := ref[:slash]
+		if candidate == "localhost" || strings.ContainsAny(candidate, ".:") {
+			host = candidate
+			rest = ref[slash+1:]
+		}
+	}
+
+	// Strip the tag from the repository path. A ":" only delimits a tag once
+	// the host has been removed, so this never touches a "host:port".
+	if colon := strings.LastIndex(rest, ":"); colon >= 0 {
+		rest = rest[:colon]
+	}
+
+	if host == "" {
+		host = "docker.io"
+		// A Docker Hub short name with no namespace lives under library/.
+		if !strings.Contains(rest, "/") {
+			rest = "library/" + rest
+		}
+	}
+
+	return host + "/" + rest
+}

--- a/harness/internal/executor/container_test.go
+++ b/harness/internal/executor/container_test.go
@@ -1016,6 +1016,211 @@ func TestContainerExecutor_AllowlistMode_BadAllowlistFailsFast(t *testing.T) {
 	}
 }
 
+// TestContainerExecutor_HardeningProfile asserts that the create-container
+// request carries the full sandbox-hardening profile: a read-only rootfs, a
+// sized /tmp tmpfs and /dev/shm, the nobody uid:gid, nosuid/nodev/noexec on
+// the tmpfs scratch mounts, and the retained PidsLimit. The mock engine only
+// captures the request, so this proves what stirrup puts on the wire — not
+// that a live daemon honours every flag (see the report's end-to-end note).
+func TestContainerExecutor_HardeningProfile(t *testing.T) {
+	var receivedBody containerCreateRequest
+
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"POST /containers/create": func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(containerCreateResponse{ID: "test-id"})
+		},
+		"POST /containers/*/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		"POST /containers/*/stop": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		"DELETE /containers/*": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer cleanup()
+
+	exec, err := NewContainerExecutor(ContainerExecutorConfig{
+		Image:      "ubuntu:26.04",
+		HostDir:    "/tmp/workspace",
+		SocketPath: sock,
+		Resources:  &types.ResourceLimits{PIDs: 256},
+	})
+	if err != nil {
+		t.Fatalf("NewContainerExecutor: %v", err)
+	}
+	defer func() { _ = exec.Close() }()
+
+	hc := receivedBody.HostConfig
+	if !hc.ReadonlyRootfs {
+		t.Error("ReadonlyRootfs: got false, want true")
+	}
+	if receivedBody.User != "65534:65534" {
+		t.Errorf("User: got %q, want %q", receivedBody.User, "65534:65534")
+	}
+	if hc.ShmSize != 64*1024*1024 {
+		t.Errorf("ShmSize: got %d, want %d", hc.ShmSize, 64*1024*1024)
+	}
+	if hc.PidsLimit == nil || *hc.PidsLimit != 256 {
+		t.Errorf("PidsLimit: got %v, want 256", hc.PidsLimit)
+	}
+
+	tmpOpts, ok := hc.Tmpfs["/tmp"]
+	if !ok {
+		t.Fatalf("Tmpfs missing /tmp entry; got %v", hc.Tmpfs)
+	}
+	for _, want := range []string{"nosuid", "nodev", "noexec", "size=268435456"} {
+		if !strings.Contains(tmpOpts, want) {
+			t.Errorf("/tmp tmpfs opts %q missing %q", tmpOpts, want)
+		}
+	}
+	shmOpts, ok := hc.Tmpfs["/dev/shm"]
+	if !ok {
+		t.Fatalf("Tmpfs missing /dev/shm entry; got %v", hc.Tmpfs)
+	}
+	for _, want := range []string{"nosuid", "nodev", "noexec", "size=67108864"} {
+		if !strings.Contains(shmOpts, want) {
+			t.Errorf("/dev/shm tmpfs opts %q missing %q", shmOpts, want)
+		}
+	}
+
+	// The hardening profile must not displace the existing baseline.
+	if hc.NetworkMode != "none" {
+		t.Errorf("NetworkMode: got %q, want %q", hc.NetworkMode, "none")
+	}
+	if len(hc.CapDrop) != 1 || hc.CapDrop[0] != "ALL" {
+		t.Errorf("CapDrop: got %v, want [ALL]", hc.CapDrop)
+	}
+	if len(hc.SecurityOpt) != 1 || hc.SecurityOpt[0] != "no-new-privileges" {
+		t.Errorf("SecurityOpt: got %v, want [no-new-privileges]", hc.SecurityOpt)
+	}
+}
+
+// TestContainerExecutor_RegistryAllowlist_Default verifies the built-in
+// allowlist: a Docker Hub official image (library/*) and a ghcr.io/stirrup
+// image construct, while a third-party reference is rejected before any
+// container is created.
+func TestContainerExecutor_RegistryAllowlist_Default(t *testing.T) {
+	createCalled := false
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"POST /containers/create": func(w http.ResponseWriter, r *http.Request) {
+			createCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(containerCreateResponse{ID: "test-id"})
+		},
+		"POST /containers/*/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		"POST /containers/*/stop": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		"DELETE /containers/*": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer cleanup()
+
+	allowed := []string{"ubuntu:26.04", "docker.io/library/alpine", "ghcr.io/stirrup/base:latest"}
+	for _, img := range allowed {
+		exec, err := NewContainerExecutor(ContainerExecutorConfig{
+			Image:      img,
+			HostDir:    "/tmp/workspace",
+			SocketPath: sock,
+		})
+		if err != nil {
+			t.Errorf("image %q should be allowed by default, got: %v", img, err)
+			continue
+		}
+		_ = exec.Close()
+	}
+
+	createCalled = false
+	denied := []string{"evil.example.com/malware:latest", "docker.io/someuser/app", "ghcr.io/attacker/img"}
+	for _, img := range denied {
+		_, err := NewContainerExecutor(ContainerExecutorConfig{
+			Image:      img,
+			HostDir:    "/tmp/workspace",
+			SocketPath: sock,
+		})
+		if err == nil {
+			t.Errorf("image %q should be rejected by the default allowlist", img)
+		}
+		if createCalled {
+			t.Errorf("image %q: container must not be created when the image is disallowed", img)
+		}
+	}
+}
+
+// TestContainerExecutor_RegistryAllowlist_Override verifies an operator can
+// widen the allowlist, and that the override fully replaces (does not extend)
+// the default set.
+func TestContainerExecutor_RegistryAllowlist_Override(t *testing.T) {
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"POST /containers/create": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(containerCreateResponse{ID: "test-id"})
+		},
+		"POST /containers/*/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		"POST /containers/*/stop": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		"DELETE /containers/*": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer cleanup()
+
+	// A custom registry the operator trusts.
+	exec, err := NewContainerExecutor(ContainerExecutorConfig{
+		Image:             "registry.internal:5000/team/runner@sha256:" + strings.Repeat("a", 64),
+		HostDir:           "/tmp/workspace",
+		SocketPath:        sock,
+		RegistryAllowlist: []string{"registry.internal:5000/team/*"},
+	})
+	if err != nil {
+		t.Fatalf("custom-registry image should be allowed by override: %v", err)
+	}
+	_ = exec.Close()
+
+	// The override replaces the default, so a previously-default image is now
+	// rejected.
+	_, err = NewContainerExecutor(ContainerExecutorConfig{
+		Image:             "ubuntu:26.04",
+		HostDir:           "/tmp/workspace",
+		SocketPath:        sock,
+		RegistryAllowlist: []string{"registry.internal:5000/team/*"},
+	})
+	if err == nil {
+		t.Error("ubuntu:26.04 should be rejected when the override does not include docker.io/library/*")
+	}
+}
+
+func TestNormaliseImageRef(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"ubuntu", "docker.io/library/ubuntu"},
+		{"ubuntu:26.04", "docker.io/library/ubuntu"},
+		{"myorg/app:tag", "docker.io/myorg/app"},
+		{"ghcr.io/stirrup/base", "ghcr.io/stirrup/base"},
+		{"ghcr.io/stirrup/base:latest", "ghcr.io/stirrup/base"},
+		{"registry:5000/team/img@sha256:" + strings.Repeat("b", 64), "registry:5000/team/img"},
+		{"localhost/dev", "localhost/dev"},
+		{"localhost:5000/dev:tag", "localhost:5000/dev"},
+		{"docker.io/library/alpine", "docker.io/library/alpine"},
+	}
+	for _, tt := range tests {
+		if got := normaliseImageRef(tt.in); got != tt.want {
+			t.Errorf("normaliseImageRef(%q): got %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestNewContainerExecutor_MissingImage(t *testing.T) {
 	_, err := NewContainerExecutor(ContainerExecutorConfig{
 		HostDir: "/tmp/workspace",

--- a/harness/internal/executor/container_test.go
+++ b/harness/internal/executor/container_test.go
@@ -1019,15 +1019,19 @@ func TestContainerExecutor_AllowlistMode_BadAllowlistFailsFast(t *testing.T) {
 // TestContainerExecutor_HardeningProfile asserts that the create-container
 // request carries the full sandbox-hardening profile: a read-only rootfs, a
 // sized /tmp tmpfs and /dev/shm, the nobody uid:gid, nosuid/nodev/noexec on
-// the tmpfs scratch mounts, and the retained PidsLimit. The mock engine only
-// captures the request, so this proves what stirrup puts on the wire — not
-// that a live daemon honours every flag (see the report's end-to-end note).
+// the tmpfs scratch mounts, and the retained PidsLimit. The /dev/shm size
+// rides on its tmpfs option string (size=…), not a separate ShmSize field, so
+// the size and noexec stay on one mount. The mock engine only captures the
+// request, so this proves what stirrup puts on the wire — not that a live
+// daemon honours every flag (see the report's end-to-end note).
 func TestContainerExecutor_HardeningProfile(t *testing.T) {
 	var receivedBody containerCreateRequest
+	var rawBody []byte
 
 	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
 		"POST /containers/create": func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			rawBody, _ = io.ReadAll(r.Body)
+			_ = json.Unmarshal(rawBody, &receivedBody)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(containerCreateResponse{ID: "test-id"})
 		},
@@ -1043,14 +1047,14 @@ func TestContainerExecutor_HardeningProfile(t *testing.T) {
 	})
 	defer cleanup()
 
-	exec, err := NewContainerExecutor(ContainerExecutorConfig{
+	exec, err := NewContainerExecutorWithContext(context.Background(), ContainerExecutorConfig{
 		Image:      "ubuntu:26.04",
 		HostDir:    "/tmp/workspace",
 		SocketPath: sock,
 		Resources:  &types.ResourceLimits{PIDs: 256},
 	})
 	if err != nil {
-		t.Fatalf("NewContainerExecutor: %v", err)
+		t.Fatalf("NewContainerExecutorWithContext: %v", err)
 	}
 	defer func() { _ = exec.Close() }()
 
@@ -1058,11 +1062,17 @@ func TestContainerExecutor_HardeningProfile(t *testing.T) {
 	if !hc.ReadonlyRootfs {
 		t.Error("ReadonlyRootfs: got false, want true")
 	}
+	// ReadonlyRootfs must appear literally on the wire — a bool with
+	// omitempty would drop false silently, so the field is emitted
+	// unconditionally to keep this security control fail-loud.
+	if !strings.Contains(string(rawBody), `"ReadonlyRootfs":true`) {
+		t.Errorf("create body missing literal ReadonlyRootfs:true; got: %s", string(rawBody))
+	}
+	if strings.Contains(string(rawBody), `"ShmSize"`) {
+		t.Errorf("create body should not carry a separate ShmSize field; got: %s", string(rawBody))
+	}
 	if receivedBody.User != "65534:65534" {
 		t.Errorf("User: got %q, want %q", receivedBody.User, "65534:65534")
-	}
-	if hc.ShmSize != 64*1024*1024 {
-		t.Errorf("ShmSize: got %d, want %d", hc.ShmSize, 64*1024*1024)
 	}
 	if hc.PidsLimit == nil || *hc.PidsLimit != 256 {
 		t.Errorf("PidsLimit: got %v, want 256", hc.PidsLimit)
@@ -1123,9 +1133,17 @@ func TestContainerExecutor_RegistryAllowlist_Default(t *testing.T) {
 	})
 	defer cleanup()
 
-	allowed := []string{"ubuntu:26.04", "docker.io/library/alpine", "ghcr.io/stirrup/base:latest"}
+	allowed := []string{
+		"ubuntu:26.04",
+		"docker.io/library/alpine",
+		"ghcr.io/stirrup/base:latest",
+		// The Docker Hub pull aliases must fold to docker.io and match the
+		// default docker.io/library/* pattern, or operators hit a false deny.
+		"index.docker.io/library/ubuntu",
+		"registry-1.docker.io/library/ubuntu:26.04",
+	}
 	for _, img := range allowed {
-		exec, err := NewContainerExecutor(ContainerExecutorConfig{
+		exec, err := NewContainerExecutorWithContext(context.Background(), ContainerExecutorConfig{
 			Image:      img,
 			HostDir:    "/tmp/workspace",
 			SocketPath: sock,
@@ -1140,7 +1158,7 @@ func TestContainerExecutor_RegistryAllowlist_Default(t *testing.T) {
 	createCalled = false
 	denied := []string{"evil.example.com/malware:latest", "docker.io/someuser/app", "ghcr.io/attacker/img"}
 	for _, img := range denied {
-		_, err := NewContainerExecutor(ContainerExecutorConfig{
+		_, err := NewContainerExecutorWithContext(context.Background(), ContainerExecutorConfig{
 			Image:      img,
 			HostDir:    "/tmp/workspace",
 			SocketPath: sock,
@@ -1176,7 +1194,7 @@ func TestContainerExecutor_RegistryAllowlist_Override(t *testing.T) {
 	defer cleanup()
 
 	// A custom registry the operator trusts.
-	exec, err := NewContainerExecutor(ContainerExecutorConfig{
+	exec, err := NewContainerExecutorWithContext(context.Background(), ContainerExecutorConfig{
 		Image:             "registry.internal:5000/team/runner@sha256:" + strings.Repeat("a", 64),
 		HostDir:           "/tmp/workspace",
 		SocketPath:        sock,
@@ -1189,7 +1207,7 @@ func TestContainerExecutor_RegistryAllowlist_Override(t *testing.T) {
 
 	// The override replaces the default, so a previously-default image is now
 	// rejected.
-	_, err = NewContainerExecutor(ContainerExecutorConfig{
+	_, err = NewContainerExecutorWithContext(context.Background(), ContainerExecutorConfig{
 		Image:             "ubuntu:26.04",
 		HostDir:           "/tmp/workspace",
 		SocketPath:        sock,
@@ -1213,10 +1231,31 @@ func TestNormaliseImageRef(t *testing.T) {
 		{"localhost/dev", "localhost/dev"},
 		{"localhost:5000/dev:tag", "localhost:5000/dev"},
 		{"docker.io/library/alpine", "docker.io/library/alpine"},
+		// Docker Hub pull aliases fold to docker.io.
+		{"index.docker.io/library/ubuntu", "docker.io/library/ubuntu"},
+		{"registry-1.docker.io/library/ubuntu:26.04", "docker.io/library/ubuntu"},
+		{"index.docker.io/myorg/app", "docker.io/myorg/app"},
 	}
 	for _, tt := range tests {
 		if got := normaliseImageRef(tt.in); got != tt.want {
 			t.Errorf("normaliseImageRef(%q): got %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestCheckImageAllowed_RejectsEmptyRepo verifies a reference whose
+// normalised form has an empty final segment (trailing "/") is rejected with
+// a clear error rather than slipping through because the "*" glob matches the
+// empty string.
+func TestCheckImageAllowed_RejectsEmptyRepo(t *testing.T) {
+	for _, img := range []string{"ghcr.io/stirrup/", "docker.io/library/"} {
+		err := checkImageAllowed(img, nil)
+		if err == nil {
+			t.Errorf("image %q with empty repository should be rejected", img)
+			continue
+		}
+		if !strings.Contains(err.Error(), "empty repository") {
+			t.Errorf("image %q: error should mention empty repository, got: %v", img, err)
 		}
 	}
 }

--- a/harness/internal/executor/probe_test.go
+++ b/harness/internal/executor/probe_test.go
@@ -115,6 +115,39 @@ func TestProbeContainerEngine_ImageAbsent(t *testing.T) {
 	}
 }
 
+// TestProbeContainerEngine_DisallowedImage asserts the dry-run preflight
+// enforces the registry allowlist too, and fails fast before pinging the
+// engine — so a misconfigured image is caught without a false-clean dry-run.
+func TestProbeContainerEngine_DisallowedImage(t *testing.T) {
+	var pingHits atomic.Int64
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, _ *http.Request) {
+			pingHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		},
+		"GET /images/*/json": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"sha256:abc"}`))
+		},
+	})
+	defer cleanup()
+
+	err := ProbeContainerEngine(context.Background(), ContainerExecutorConfig{
+		Image:      "evil.example.com/malware:latest",
+		SocketPath: sock,
+	})
+	if err == nil {
+		t.Fatal("ProbeContainerEngine: expected error for disallowed image")
+	}
+	if !strings.Contains(err.Error(), "registry allowlist") {
+		t.Errorf("error should mention the registry allowlist, got: %v", err)
+	}
+	if got := pingHits.Load(); got != 0 {
+		t.Errorf("engine pinged %d times; a disallowed image must be rejected before any engine call", got)
+	}
+}
+
 func TestContainerExecutor_Probe_EngineUnreachable(t *testing.T) {
 	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
 		"GET /_ping": func(w http.ResponseWriter, _ *http.Request) {

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -868,6 +868,16 @@ type ExecutorConfig struct {
 	//   "kata-fc"    — Kata Containers backed by Firecracker
 	Runtime string `json:"runtime,omitempty"`
 
+	// RegistryAllowlist constrains which container image references the
+	// container executor may run. Each entry is a glob over the normalised
+	// reference (registry host + repository path, tag/digest stripped) —
+	// e.g. "ghcr.io/stirrup/*" or "docker.io/library/*". An empty list lets
+	// the executor fall back to its built-in default (the project's own
+	// ghcr.io/stirrup images plus Docker Hub official "library/*" images).
+	// A reference matching no pattern is rejected before any container is
+	// created. Only meaningful for executor.type == "container".
+	RegistryAllowlist []string `json:"registryAllowlist,omitempty"`
+
 	// WorkspaceExportTo, when set, instructs the harness to tarball the
 	// executor's workspace at end-of-run and upload it to the named URI.
 	// Currently only "gs://bucket/path" is accepted. The "api" executor
@@ -1736,6 +1746,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	if config.Executor.Runtime != "" && config.Executor.Type != "container" && config.Executor.Type != "" {
 		errs = append(errs, "executor.runtime is only valid when executor.type is \"container\"")
 	}
+	validateExecutorRegistryAllowlist(config.Executor, &errs)
 	validateOptionalType("editStrategy", config.EditStrategy.Type, validEditStrategyTypes, &errs)
 	validateOptionalType("permissionPolicy", config.PermissionPolicy.Type, validPermissionPolicyTypes, &errs)
 	validatePermissionPolicyFields(config.PermissionPolicy, &errs)
@@ -3738,5 +3749,28 @@ func validateExecutorWorkspaceExportTo(cfg ExecutorConfig, errs *[]string) {
 			"executor.workspaceExportTo %q must contain a non-empty bucket path after gs://",
 			cfg.WorkspaceExportTo,
 		))
+	}
+}
+
+// validateExecutorRegistryAllowlist checks the optional
+// Executor.RegistryAllowlist: every entry must be a syntactically valid glob
+// and the field is only meaningful for the container executor. An empty list
+// is valid — the executor falls back to its built-in default — so this only
+// rejects malformed patterns and misplacement on a non-container executor.
+func validateExecutorRegistryAllowlist(cfg ExecutorConfig, errs *[]string) {
+	if len(cfg.RegistryAllowlist) == 0 {
+		return
+	}
+	if cfg.Type != "container" && cfg.Type != "" {
+		*errs = append(*errs, "executor.registryAllowlist is only valid when executor.type is \"container\"")
+	}
+	for _, pattern := range cfg.RegistryAllowlist {
+		if pattern == "" {
+			*errs = append(*errs, "executor.registryAllowlist entries must be non-empty")
+			continue
+		}
+		if _, err := filepath.Match(pattern, ""); err != nil {
+			*errs = append(*errs, fmt.Sprintf("executor.registryAllowlist pattern %q is not a valid glob: %v", pattern, err))
+		}
 	}
 }

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"math"
 	"net/url"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -869,13 +870,18 @@ type ExecutorConfig struct {
 	Runtime string `json:"runtime,omitempty"`
 
 	// RegistryAllowlist constrains which container image references the
-	// container executor may run. Each entry is a glob over the normalised
-	// reference (registry host + repository path, tag/digest stripped) —
-	// e.g. "ghcr.io/stirrup/*" or "docker.io/library/*". An empty list lets
-	// the executor fall back to its built-in default (the project's own
-	// ghcr.io/stirrup images plus Docker Hub official "library/*" images).
-	// A reference matching no pattern is rejected before any container is
-	// created. Only meaningful for executor.type == "container".
+	// container executor may run. Each entry is a path.Match glob over the
+	// normalised reference (registry host + repository path, tag/digest
+	// stripped) — e.g. "ghcr.io/stirrup/*" or "docker.io/library/*". An empty
+	// list lets the executor fall back to its built-in default (the project's
+	// own ghcr.io/stirrup images plus Docker Hub official "library/*"
+	// images). A reference matching no pattern is rejected before any
+	// container is created. Only meaningful for executor.type == "container".
+	//
+	// Globbing follows path.Match semantics: "*" matches within a single path
+	// segment and does NOT cross "/". So "ghcr.io/stirrup/*" matches
+	// "ghcr.io/stirrup/base" but not "ghcr.io/stirrup/team/base"; allow the
+	// deeper namespace with an explicit "ghcr.io/stirrup/*/*" entry.
 	RegistryAllowlist []string `json:"registryAllowlist,omitempty"`
 
 	// WorkspaceExportTo, when set, instructs the harness to tarball the
@@ -3757,6 +3763,8 @@ func validateExecutorWorkspaceExportTo(cfg ExecutorConfig, errs *[]string) {
 // and the field is only meaningful for the container executor. An empty list
 // is valid — the executor falls back to its built-in default — so this only
 // rejects malformed patterns and misplacement on a non-container executor.
+// The matcher is path.Match, identical to the runtime enforcement path in the
+// executor, so a pattern that validates here behaves the same when enforced.
 func validateExecutorRegistryAllowlist(cfg ExecutorConfig, errs *[]string) {
 	if len(cfg.RegistryAllowlist) == 0 {
 		return
@@ -3769,7 +3777,7 @@ func validateExecutorRegistryAllowlist(cfg ExecutorConfig, errs *[]string) {
 			*errs = append(*errs, "executor.registryAllowlist entries must be non-empty")
 			continue
 		}
-		if _, err := filepath.Match(pattern, ""); err != nil {
+		if _, err := path.Match(pattern, ""); err != nil {
 			*errs = append(*errs, fmt.Sprintf("executor.registryAllowlist pattern %q is not a valid glob: %v", pattern, err))
 		}
 	}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -1625,6 +1625,65 @@ func TestValidateRunConfig_ExecutorRuntimeRejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestValidateRunConfig_RegistryAllowlistAcceptsValidGlobs(t *testing.T) {
+	c := validConfig()
+	c.Executor = ExecutorConfig{
+		Type:              "container",
+		Image:             "ghcr.io/stirrup/base:latest",
+		RegistryAllowlist: []string{"ghcr.io/stirrup/*", "docker.io/library/*", "registry.internal:5000/team/*"},
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("expected valid registry allowlist to validate, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_RegistryAllowlistRejectsBadGlob(t *testing.T) {
+	c := validConfig()
+	c.Executor = ExecutorConfig{
+		Type:              "container",
+		Image:             "ghcr.io/stirrup/base:latest",
+		RegistryAllowlist: []string{"ghcr.io/stirrup/["},
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for malformed registry allowlist glob")
+	}
+	if !strings.Contains(err.Error(), "registryAllowlist") {
+		t.Errorf("expected error to mention registryAllowlist, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_RegistryAllowlistRejectsEmptyEntry(t *testing.T) {
+	c := validConfig()
+	c.Executor = ExecutorConfig{
+		Type:              "container",
+		Image:             "ghcr.io/stirrup/base:latest",
+		RegistryAllowlist: []string{""},
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for empty registry allowlist entry")
+	}
+	if !strings.Contains(err.Error(), "registryAllowlist") {
+		t.Errorf("expected error to mention registryAllowlist, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_RegistryAllowlistRequiresContainerExecutor(t *testing.T) {
+	c := validConfig()
+	c.Executor = ExecutorConfig{
+		Type:              "local",
+		RegistryAllowlist: []string{"ghcr.io/stirrup/*"},
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for registryAllowlist on non-container executor")
+	}
+	if !strings.Contains(err.Error(), "registryAllowlist") || !strings.Contains(err.Error(), "container") {
+		t.Errorf("expected error to mention registryAllowlist and container, got: %v", err)
+	}
+}
+
 // --- PermissionPolicyConfig.Type policy-engine ---
 
 func TestValidateRunConfig_PolicyEngineRequiresPolicyFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses #3, sub-items **1.1** (image registry allowlist), **1.4** (container security profile), and **1.5** (mount options). The container path already had `no-new-privileges`, `CapDrop ALL`, `PidsLimit`, `NetworkMode none`, the allowlist egress proxy, and digest-aware image handling; this adds the remaining "required before processing untrusted inputs" hardening.

This is **not** a full close of #3 — sub-items 1.2 (`.git` read-only mount), 1.3 (Docker-socket isolation / k8s), and cosign/Sigstore signature verification remain as tracked follow-ups.

## What changed

**1.4 — sandbox profile** (hand-rolled Docker Engine REST structs, no SDK added):
- `ReadonlyRootfs: true` (serialised unconditionally — no `omitempty`, so the control can't silently vanish)
- 256 MiB `/tmp` tmpfs, 64 MiB `/dev/shm` tmpfs
- runs as `65534:65534` (nobody) via the create `User` field
- existing `PidsLimit` retained

**1.5 — mount options:** `nosuid,nodev,noexec` on both tmpfs mounts. `/dev/shm` size + options ride on a single Tmpfs entry (the separate `ShmSize` field was removed to avoid an engine-version-dependent interaction where `noexec` could be dropped). The workspace bind intentionally does **not** carry `noexec` — that would break the executor running tooling it writes there; the compensating controls (`CapDrop ALL` removes `CAP_SETUID`/`CAP_FOWNER`, `no-new-privileges` blocks escalation) mean a setuid binary in `/workspace` still cannot escalate.

**1.1 — registry allowlist:** `cfg.Image` is matched (glob, full-string, single path-segment) against an allowlist at construction **and** at dry-run preflight, before any container is created. Default `ghcr.io/stirrup/*` + `docker.io/library/*`; operator-overridable via `executor.registryAllowlist` (validated in `ValidateRunConfig`). Docker Hub pull aliases (`index.docker.io`, `registry-1.docker.io`) are canonicalised to `docker.io` before matching; digests are stripped/accepted; trailing-slash refs are rejected. An explicit list replaces (not extends) the default; an empty/unset allowlist is fail-closed to the default.

## Tests

`TestContainerExecutor_HardeningProfile` asserts every field on the wire via the mock-engine request-capture harness (`ReadonlyRootfs:true`, `/tmp` + `/dev/shm` tmpfs with `nosuid/nodev/noexec` and sizes, `User`, `PidsLimit`, and that no `ShmSize` field is emitted). Allowlist default/override/reject, Docker Hub alias acceptance, empty-repo rejection, and the preflight rejection path are all covered. `just build`, `just lint` (0 issues), `just test` (all packages ok) pass.

## Verification caveat

Docker is not available in the implementation environment, so the read-only-rootfs + non-root profile has **not** been driven end-to-end against a live daemon — all assertions are against the wire form. A live smoke test (confirming the default stirrup image runs `run_command` under the read-only rootfs as uid 65534 with the writable workspace bind + tmpfs) is recommended before relying on the profile in production.

## Review

One reviewer wave (security + code + spec) was run and fully remediated. Security review confirmed **no registry-allowlist bypass** (org boundary holds, fail-closed default, single create call site). The HIGH `omitempty` footgun, the `/dev/shm` `noexec` engine-version gap, the Docker Hub alias false-deny, and the docs rationale for the workspace-bind exemption were all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)