### PR TITLE
mcp: tool allowlisting and URI SSRF protection for MCP servers

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -136,10 +136,12 @@ out:
    `gopher://`, no other URL schemes.
 2. **DNS resolution:** the hostname is resolved before the request is
    issued; the resolved IP is checked against the blocklist.
-3. **IP block list:** RFC 1918 private ranges, loopback (127/8),
-   link-local (169.254/16), and multicast (224/4 and similar) are
-   rejected. This prevents cloud-metadata exfiltration
-   (`169.254.169.254`) and lateral movement to internal services.
+3. **IP block list:** RFC 1918 private ranges, RFC 6598 carrier-grade
+   NAT (`100.64.0.0/10`), loopback (127/8), link-local (169.254/16),
+   and multicast (224/4 and similar) are rejected. This prevents
+   cloud-metadata exfiltration (`169.254.169.254`) and lateral
+   movement to internal services — including deployment targets that
+   route the CGNAT range to internal subnets.
 4. **Response cap:** 100 KB. Larger responses are truncated; the
    truncation is visible to the model.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -127,7 +127,7 @@ response bodies are bounded with `io.LimitReader` to avoid
 unbounded memory consumption when a provider returns an unexpectedly
 large error payload.
 
-## SSRF protection (`web_fetch`)
+## SSRF protection (`web_fetch` and MCP)
 
 The `web_fetch` tool layers four checks before any HTTP request goes
 out:
@@ -142,6 +142,47 @@ out:
    (`169.254.169.254`) and lateral movement to internal services.
 4. **Response cap:** 100 KB. Larger responses are truncated; the
    truncation is visible to the model.
+
+Checks 1–3 live in one place — the `security.ValidatePublicHost`
+guard — and are reused by every component that dials a
+caller-supplied host. The MCP client shares the same guard so there
+is a single SSRF blocklist to audit, not one per consumer.
+
+The transport `DialContext` re-runs the host check at connect time
+(`security.SafeDialContext` for `web_fetch`,
+`security.LoopbackAwareDialContext` for MCP), so a hostname that
+passes the resolve-time check but whose DNS answer later flips to a
+private address — a DNS-rebinding attack — is still refused when the
+socket is actually opened. The rebinding guard is best-effort across
+the resolve→dial gap; it does not pin a specific IP for the lifetime
+of a long-lived connection.
+
+### MCP server trust model
+
+An MCP server is untrusted: it supplies tool definitions and tool
+results the harness threads into the model's context and, for
+write-capable tools, into actions. Two operator controls bound what
+a compromised or misconfigured server can do (`MCPServerConfig`):
+
+- **`uri` scheme and host:** the URI must be `http`/`https`. A remote
+  (non-loopback) host must use `https`, so credentials and tool-call
+  payloads are not sent in clear; plain `http` is permitted only for
+  `localhost`/loopback during local development. The host is then run
+  through the shared SSRF guard above, so a server URI resolving to a
+  private or reserved address is refused at connect. `ValidateRunConfig`
+  rejects the malformed-config cases (missing name/uri, bad scheme,
+  non-`https` remote, malformed `allowedMCPHosts`) before a run starts.
+- **`allowedTools`:** an optional per-server allowlist matched against
+  the server-reported tool name. When set, any advertised tool not on
+  the list is refused at registration with a logged reason, so a
+  server cannot smuggle in tools beyond the set it was trusted for.
+  The filter runs before the per-server tool-count cap. An unset list
+  registers every advertised tool (the historical, backward-compatible
+  behaviour).
+- **`allowedMCPHosts`:** an optional host pin. When set, the URI host
+  must appear in the list (exact, case-insensitive) in addition to
+  passing the SSRF guard — a defence against a server URI being
+  repointed at an unexpected host.
 
 ## Path traversal prevention
 

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -275,6 +276,96 @@ func (c *Client) warn(msg string, args ...any) {
 	}
 }
 
+// validateMCPHost enforces the connect-time trust-model gate on a server
+// URI: a parseable http/https scheme, a present host, https for any remote
+// (non-loopback) target, the shared SSRF guard against private/reserved
+// addresses, and the optional AllowedMCPHosts pin. It mirrors the static
+// checks in types.ValidateRunConfig but also runs the resolving SSRF guard,
+// because a config that validated at parse time can still point at a name
+// that resolves to a private address — the same reuse web_fetch relies on.
+//
+// Loopback http URIs are permitted for local development; the resolving SSRF
+// guard is therefore skipped only for a loopback IP literal or a
+// localhost name, never for a remote host.
+func validateMCPHost(config types.MCPServerConfig) error {
+	parsed, err := url.Parse(config.URI)
+	if err != nil {
+		return fmt.Errorf("mcp: invalid URI for server %q: %w", config.Name, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("mcp: server %q URI scheme %q not allowed (must be http or https)", config.Name, parsed.Scheme)
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("mcp: server %q URI must include a host", config.Name)
+	}
+
+	local := isLoopbackHost(host)
+	if parsed.Scheme == "http" && !local {
+		return fmt.Errorf("mcp: server %q must use https for remote host %q (http is only permitted for localhost/loopback)", config.Name, host)
+	}
+	if !local {
+		if err := security.ValidatePublicHost(host); err != nil {
+			return fmt.Errorf("mcp: server %q: %w", config.Name, err)
+		}
+	}
+
+	if len(config.AllowedMCPHosts) > 0 {
+		want := strings.ToLower(host)
+		permitted := false
+		for _, h := range config.AllowedMCPHosts {
+			if strings.ToLower(strings.TrimSpace(h)) == want {
+				permitted = true
+				break
+			}
+		}
+		if !permitted {
+			return fmt.Errorf("mcp: server %q host %q is not in allowedMCPHosts", config.Name, host)
+		}
+	}
+	return nil
+}
+
+// isLoopbackHost reports whether host is a loopback target (localhost name or
+// loopback IP literal) for which a plain http MCP URI is acceptable.
+func isLoopbackHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// filterAllowedTools applies the per-server AllowedTools allowlist to the set
+// of advertised tools. An empty allowlist returns the input unchanged
+// (register everything). Otherwise only tools whose server-reported name is
+// listed survive; the rest are dropped with a warning so a server advertising
+// tools beyond its trust grant is visible to operators.
+func (c *Client) filterAllowedTools(config types.MCPServerConfig, tools []mcpTool) []mcpTool {
+	if len(config.AllowedTools) == 0 {
+		return tools
+	}
+	allowed := make(map[string]bool, len(config.AllowedTools))
+	for _, name := range config.AllowedTools {
+		allowed[name] = true
+	}
+	var kept []mcpTool
+	for _, mt := range tools {
+		if allowed[mt.Name] {
+			kept = append(kept, mt)
+			continue
+		}
+		c.warn("mcp tool not in allowlist; rejected at registration",
+			"server", config.Name,
+			"tool", sanitizeMCPToolName(mt.Name),
+		)
+	}
+	return kept
+}
+
 // serverSession holds per-server connection state.
 type serverSession struct {
 	uri       string
@@ -282,15 +373,26 @@ type serverSession struct {
 	sessionID string // Mcp-Session-Id from server
 }
 
+const mcpClientTimeout = 30 * time.Second
+
 // NewClient creates an MCP client that registers discovered tools into the
 // given registry. It uses the provided http.Client for all requests; if nil,
 // a default client with a 30-second timeout is used to prevent unbounded
 // connections to remote MCP servers.
+//
+// The default client's transport re-validates every dialled host through the
+// shared SSRF guard (security.SafeDialContext), so a server whose DNS record
+// flips to a private/reserved address between the connect-time check and the
+// actual dial is still refused — DNS-rebinding protection consistent with
+// web_fetch. Loopback targets are permitted because a remote http:// URI is
+// already rejected upstream (ValidateRunConfig / validateMCPHost) and a
+// localhost MCP server is a supported local-dev case.
 func NewClient(registry *tool.Registry, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: mcpClientTimeout,
 			Transport: &http.Transport{
+				DialContext:           security.LoopbackAwareDialContext(mcpClientTimeout),
 				TLSHandshakeTimeout:   10 * time.Second,
 				ResponseHeaderTimeout: 15 * time.Second,
 				IdleConnTimeout:       90 * time.Second,
@@ -315,13 +417,8 @@ func (c *Client) Connect(ctx context.Context, config types.MCPServerConfig, secr
 		return fmt.Errorf("mcp: server %q missing required URI field", config.Name)
 	}
 
-	// Validate URI scheme to prevent SSRF via file://, gopher://, etc.
-	parsed, err := url.Parse(config.URI)
-	if err != nil {
-		return fmt.Errorf("mcp: invalid URI for server %q: %w", config.Name, err)
-	}
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return fmt.Errorf("mcp: server %q URI scheme %q not allowed (must be http or https)", config.Name, parsed.Scheme)
+	if err := validateMCPHost(config); err != nil {
+		return err
 	}
 
 	// Resolve bearer token if configured.
@@ -348,6 +445,14 @@ func (c *Client) Connect(ctx context.Context, config types.MCPServerConfig, secr
 	if err != nil {
 		return fmt.Errorf("mcp: list tools from server %q: %w", config.Name, err)
 	}
+
+	// Apply the per-server tool allowlist BEFORE the cardinality cap so a
+	// hostile server cannot fill the cap with disallowed tools and starve
+	// the legitimate ones. An empty AllowedTools registers everything
+	// (backward-compatible); a non-empty list drops any advertised tool not
+	// named, with a warning so operators can spot a server advertising more
+	// than it was trusted for.
+	tools = c.filterAllowedTools(config, tools)
 
 	// Cap the number of tools we register per server. A misconfigured or
 	// hostile MCP server could otherwise expose thousands of unique
@@ -392,16 +497,13 @@ func (c *Client) Probe(ctx context.Context, config types.MCPServerConfig, secret
 		return fmt.Errorf("mcp: server %q missing required URI field", config.Name)
 	}
 
-	parsed, err := url.Parse(config.URI)
-	if err != nil {
-		return fmt.Errorf("mcp: invalid URI for server %q: %w", config.Name, err)
-	}
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return fmt.Errorf("mcp: server %q URI scheme %q not allowed (must be http or https)", config.Name, parsed.Scheme)
+	if err := validateMCPHost(config); err != nil {
+		return err
 	}
 
 	var token string
 	if config.APIKeyRef != "" {
+		var err error
 		token, err = secrets.Resolve(ctx, config.APIKeyRef)
 		if err != nil {
 			return fmt.Errorf("mcp: resolve auth for server %q: %w", config.Name, err)

--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -300,7 +299,7 @@ func validateMCPHost(config types.MCPServerConfig) error {
 		return fmt.Errorf("mcp: server %q URI must include a host", config.Name)
 	}
 
-	local := isLoopbackHost(host)
+	local := security.IsLoopbackHost(host)
 	if parsed.Scheme == "http" && !local {
 		return fmt.Errorf("mcp: server %q must use https for remote host %q (http is only permitted for localhost/loopback)", config.Name, host)
 	}
@@ -324,19 +323,6 @@ func validateMCPHost(config types.MCPServerConfig) error {
 		}
 	}
 	return nil
-}
-
-// isLoopbackHost reports whether host is a loopback target (localhost name or
-// loopback IP literal) for which a plain http MCP URI is acceptable.
-func isLoopbackHost(host string) bool {
-	host = strings.TrimSpace(strings.ToLower(host))
-	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
-		return true
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		return ip.IsLoopback()
-	}
-	return false
 }
 
 // filterAllowedTools applies the per-server AllowedTools allowlist to the set
@@ -368,6 +354,7 @@ func (c *Client) filterAllowedTools(config types.MCPServerConfig, tools []mcpToo
 
 // serverSession holds per-server connection state.
 type serverSession struct {
+	name      string // operator-supplied logical name, for log attribution
 	uri       string
 	token     string // bearer token, empty if no auth
 	sessionID string // Mcp-Session-Id from server
@@ -381,12 +368,12 @@ const mcpClientTimeout = 30 * time.Second
 // connections to remote MCP servers.
 //
 // The default client's transport re-validates every dialled host through the
-// shared SSRF guard (security.SafeDialContext), so a server whose DNS record
-// flips to a private/reserved address between the connect-time check and the
-// actual dial is still refused — DNS-rebinding protection consistent with
-// web_fetch. Loopback targets are permitted because a remote http:// URI is
-// already rejected upstream (ValidateRunConfig / validateMCPHost) and a
-// localhost MCP server is a supported local-dev case.
+// shared SSRF guard (security.LoopbackAwareDialContext), so a server whose DNS
+// record flips to a non-loopback private/reserved address between the
+// connect-time check and the actual dial is still refused — DNS-rebinding
+// protection consistent with web_fetch. Loopback targets are permitted because
+// a remote http:// URI is already rejected upstream (ValidateRunConfig /
+// validateMCPHost) and a localhost MCP server is a supported local-dev case.
 func NewClient(registry *tool.Registry, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{
@@ -410,30 +397,9 @@ func NewClient(registry *tool.Registry, httpClient *http.Client) *Client {
 // discovers tools via tools/list, and registers each tool into the registry.
 // The server name from config is used to prefix tool names.
 func (c *Client) Connect(ctx context.Context, config types.MCPServerConfig, secrets security.SecretStore) error {
-	if config.Name == "" {
-		return fmt.Errorf("mcp: server config missing required Name field")
-	}
-	if config.URI == "" {
-		return fmt.Errorf("mcp: server %q missing required URI field", config.Name)
-	}
-
-	if err := validateMCPHost(config); err != nil {
+	sess, err := newSession(ctx, config, secrets)
+	if err != nil {
 		return err
-	}
-
-	// Resolve bearer token if configured.
-	var token string
-	if config.APIKeyRef != "" {
-		var err error
-		token, err = secrets.Resolve(ctx, config.APIKeyRef)
-		if err != nil {
-			return fmt.Errorf("mcp: resolve auth for server %q: %w", config.Name, err)
-		}
-	}
-
-	sess := &serverSession{
-		uri:   config.URI,
-		token: token,
 	}
 
 	c.mu.Lock()
@@ -490,15 +456,30 @@ func (c *Client) Connect(ctx context.Context, config types.MCPServerConfig, secr
 // A returned error names the server so the preflight step can point the
 // operator at the specific misconfigured entry.
 func (c *Client) Probe(ctx context.Context, config types.MCPServerConfig, secrets security.SecretStore) error {
+	sess, err := newSession(ctx, config, secrets)
+	if err != nil {
+		return err
+	}
+	if _, err := c.listTools(ctx, sess); err != nil {
+		return fmt.Errorf("mcp: list tools from server %q: %w", config.Name, err)
+	}
+	return nil
+}
+
+// newSession runs the shared Connect/Probe prologue: it validates the
+// required Name/URI fields and the trust-model host gate (scheme, https,
+// SSRF, allowedMCPHosts), resolves the bearer token, and returns a session
+// carrying the logical name for log attribution. Factoring it here keeps the
+// two entry points from drifting in their gating.
+func newSession(ctx context.Context, config types.MCPServerConfig, secrets security.SecretStore) (*serverSession, error) {
 	if config.Name == "" {
-		return fmt.Errorf("mcp: server config missing required Name field")
+		return nil, fmt.Errorf("mcp: server config missing required Name field")
 	}
 	if config.URI == "" {
-		return fmt.Errorf("mcp: server %q missing required URI field", config.Name)
+		return nil, fmt.Errorf("mcp: server %q missing required URI field", config.Name)
 	}
-
 	if err := validateMCPHost(config); err != nil {
-		return err
+		return nil, err
 	}
 
 	var token string
@@ -506,15 +487,11 @@ func (c *Client) Probe(ctx context.Context, config types.MCPServerConfig, secret
 		var err error
 		token, err = secrets.Resolve(ctx, config.APIKeyRef)
 		if err != nil {
-			return fmt.Errorf("mcp: resolve auth for server %q: %w", config.Name, err)
+			return nil, fmt.Errorf("mcp: resolve auth for server %q: %w", config.Name, err)
 		}
 	}
 
-	sess := &serverSession{uri: config.URI, token: token}
-	if _, err := c.listTools(ctx, sess); err != nil {
-		return fmt.Errorf("mcp: list tools from server %q: %w", config.Name, err)
-	}
-	return nil
+	return &serverSession{name: config.Name, uri: config.URI, token: token}, nil
 }
 
 // Close releases resources held by the client. Currently a no-op since
@@ -819,7 +796,7 @@ func (c *Client) call(ctx context.Context, sess *serverSession, method string, p
 	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
 		if len(sid) > maxMCPSessionIDLen {
 			c.warn("mcp session ID exceeded cap; ignoring",
-				"server", sess.uri, "len", len(sid), "cap", maxMCPSessionIDLen)
+				"server", sess.name, "len", len(sid), "cap", maxMCPSessionIDLen)
 		} else {
 			c.mu.Lock()
 			sess.sessionID = sid

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -991,4 +992,161 @@ func TestConnect_CapsToolsPerServer(t *testing.T) {
 	if got != maxMCPToolsPerServer {
 		t.Errorf("registered tool count = %d, want %d (cap)", got, maxMCPToolsPerServer)
 	}
+}
+
+// TestConnect_AllowedToolsFiltersAdvertised verifies the per-server allowlist
+// (#4 2.2): a server advertising a tool not in AllowedTools has that tool
+// rejected at registration, while allowlisted tools register.
+func TestConnect_AllowedToolsFiltersAdvertised(t *testing.T) {
+	tools := []mcpTool{
+		{Name: "search", Description: "ok", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "exfiltrate", Description: "evil", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "fetch", Description: "ok", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+
+	srv, _ := fakeMCPServer(t, tools, "")
+	registry := tool.NewRegistry()
+	client := NewClient(registry, srv.Client())
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+
+	config := types.MCPServerConfig{
+		Name:         "docs",
+		URI:          srv.URL,
+		AllowedTools: []string{"search", "fetch"},
+	}
+	if err := client.Connect(context.Background(), config, secrets); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	if registry.Resolve("mcp_docs_search") == nil {
+		t.Error("allowlisted tool 'search' should be registered")
+	}
+	if registry.Resolve("mcp_docs_fetch") == nil {
+		t.Error("allowlisted tool 'fetch' should be registered")
+	}
+	if registry.Resolve("mcp_docs_exfiltrate") != nil {
+		t.Error("tool 'exfiltrate' is not in the allowlist and must be rejected")
+	}
+	if got := len(registry.List()); got != 2 {
+		t.Errorf("registered tool count = %d, want 2", got)
+	}
+}
+
+// TestConnect_EmptyAllowedToolsRegistersAll pins the backward-compatible
+// default: an unset AllowedTools registers every advertised tool.
+func TestConnect_EmptyAllowedToolsRegistersAll(t *testing.T) {
+	tools := []mcpTool{
+		{Name: "a", Description: "", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "b", Description: "", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+
+	srv, _ := fakeMCPServer(t, tools, "")
+	registry := tool.NewRegistry()
+	client := NewClient(registry, srv.Client())
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+
+	config := types.MCPServerConfig{Name: "srv", URI: srv.URL}
+	if err := client.Connect(context.Background(), config, secrets); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if got := len(registry.List()); got != 2 {
+		t.Errorf("registered tool count = %d, want 2 (unset allowlist registers all)", got)
+	}
+}
+
+// TestConnect_RejectsNonHTTPSRemote verifies a remote (non-loopback) server
+// reached over plain http is refused — credentials and tool-call payloads
+// must not travel in clear (#4 2.5).
+func TestConnect_RejectsNonHTTPSRemote(t *testing.T) {
+	registry := tool.NewRegistry()
+	client := NewClient(registry, nil)
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+
+	err := client.Connect(context.Background(), types.MCPServerConfig{
+		Name: "remote",
+		URI:  "http://mcp.example.com/rpc",
+	}, secrets)
+	if err == nil {
+		t.Fatal("expected error for non-https remote URI")
+	}
+	if !contains(err.Error(), "https") {
+		t.Errorf("error = %q, want it to mention https", err.Error())
+	}
+}
+
+// TestConnect_RejectsPrivateIPURI verifies the connect-time SSRF guard refuses
+// a server URI whose host is a non-loopback private address, reusing the
+// shared web_fetch validator (security.ValidatePublicHost). 169.254.169.254 is
+// the cloud metadata endpoint; 10.0.0.1 is RFC1918.
+func TestConnect_RejectsPrivateIPURI(t *testing.T) {
+	cases := []struct{ name, uri string }{
+		{"link_local_metadata", "https://169.254.169.254/latest/meta-data"},
+		{"rfc1918", "https://10.0.0.1/rpc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := tool.NewRegistry()
+			client := NewClient(registry, nil)
+			secrets := &stubSecretStore{secrets: map[string]string{}}
+
+			err := client.Connect(context.Background(), types.MCPServerConfig{
+				Name: "ssrf",
+				URI:  tc.uri,
+			}, secrets)
+			if err == nil {
+				t.Fatalf("expected SSRF rejection for %q", tc.uri)
+			}
+			if !contains(err.Error(), "private host") {
+				t.Errorf("error = %q, want it to mention 'private host'", err.Error())
+			}
+		})
+	}
+}
+
+// TestConnect_AllowedMCPHostsPin verifies AllowedMCPHosts rejects a URI whose
+// host is not pinned and admits one that is.
+func TestConnect_AllowedMCPHostsPin(t *testing.T) {
+	srv, _ := fakeMCPServer(t, []mcpTool{
+		{Name: "a", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}, "")
+	registry := tool.NewRegistry()
+	client := NewClient(registry, srv.Client())
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+
+	// A pin that does not include the server's loopback host must reject.
+	err := client.Connect(context.Background(), types.MCPServerConfig{
+		Name:            "pinned",
+		URI:             srv.URL,
+		AllowedMCPHosts: []string{"only.example.com"},
+	}, secrets)
+	if err == nil {
+		t.Fatal("expected rejection: host not in allowedMCPHosts")
+	}
+	if !contains(err.Error(), "allowedMCPHosts") {
+		t.Errorf("error = %q, want it to mention allowedMCPHosts", err.Error())
+	}
+
+	// A pin that includes the actual host (127.0.0.1) must admit.
+	host := mustHost(t, srv.URL)
+	registry2 := tool.NewRegistry()
+	client2 := NewClient(registry2, srv.Client())
+	if err := client2.Connect(context.Background(), types.MCPServerConfig{
+		Name:            "pinned",
+		URI:             srv.URL,
+		AllowedMCPHosts: []string{host},
+	}, secrets); err != nil {
+		t.Fatalf("Connect with matching pin: %v", err)
+	}
+	if registry2.Resolve("mcp_pinned_a") == nil {
+		t.Error("tool should register when host is pinned")
+	}
+}
+
+func mustHost(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u.Hostname()
 }

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -431,7 +432,7 @@ func TestConnect_JSONRPCError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from Connect")
 	}
-	if got := err.Error(); !contains(got, "JSON-RPC error") {
+	if got := err.Error(); !strings.Contains(got, "JSON-RPC error") {
 		t.Errorf("error = %q, want it to contain 'JSON-RPC error'", got)
 	}
 }
@@ -480,7 +481,7 @@ func TestConnect_MultipleServers(t *testing.T) {
 	// Both servers share an http client that can reach both test servers.
 	// Since httptest servers use different ports, we need to use the default
 	// transport which can reach any local address.
-	client := NewClient(registry, &http.Client{})
+	client := NewClient(registry, &http.Client{Timeout: 30 * time.Second})
 	secrets := &stubSecretStore{secrets: map[string]string{}}
 
 	configA := types.MCPServerConfig{Name: "alpha", URI: srvA.URL}
@@ -574,7 +575,7 @@ func TestConnect_ToolCallError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from tool call")
 	}
-	if !contains(err.Error(), "something went wrong") {
+	if !strings.Contains(err.Error(), "something went wrong") {
 		t.Errorf("error = %q, want it to contain 'something went wrong'", err.Error())
 	}
 }
@@ -603,19 +604,6 @@ func TestClose(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
-}
-
-func containsSubstr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
 func TestConnect_RejectsFileSchemeURI(t *testing.T) {
 	registry := tool.NewRegistry()
 	client := NewClient(registry, nil)
@@ -628,7 +616,7 @@ func TestConnect_RejectsFileSchemeURI(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for file:// URI scheme")
 	}
-	if !contains(err.Error(), "not allowed") {
+	if !strings.Contains(err.Error(), "not allowed") {
 		t.Errorf("error = %q, want it to contain 'not allowed'", err.Error())
 	}
 }
@@ -645,7 +633,7 @@ func TestConnect_RejectsNoSchemeURI(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for URI without http/https scheme")
 	}
-	if !contains(err.Error(), "not allowed") {
+	if !strings.Contains(err.Error(), "not allowed") {
 		t.Errorf("error = %q, want it to contain 'not allowed'", err.Error())
 	}
 }
@@ -1069,7 +1057,7 @@ func TestConnect_RejectsNonHTTPSRemote(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-https remote URI")
 	}
-	if !contains(err.Error(), "https") {
+	if !strings.Contains(err.Error(), "https") {
 		t.Errorf("error = %q, want it to mention https", err.Error())
 	}
 }
@@ -1096,7 +1084,7 @@ func TestConnect_RejectsPrivateIPURI(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected SSRF rejection for %q", tc.uri)
 			}
-			if !contains(err.Error(), "private host") {
+			if !strings.Contains(err.Error(), "private host") {
 				t.Errorf("error = %q, want it to mention 'private host'", err.Error())
 			}
 		})
@@ -1122,7 +1110,7 @@ func TestConnect_AllowedMCPHostsPin(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected rejection: host not in allowedMCPHosts")
 	}
-	if !contains(err.Error(), "allowedMCPHosts") {
+	if !strings.Contains(err.Error(), "allowedMCPHosts") {
 		t.Errorf("error = %q, want it to mention allowedMCPHosts", err.Error())
 	}
 

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -1138,3 +1138,47 @@ func mustHost(t *testing.T, raw string) string {
 	}
 	return u.Hostname()
 }
+
+// TestConnect_LocalhostNameDefaultTransport drives a full tool call to an
+// http://localhost server through the DEFAULT transport
+// (LoopbackAwareDialContext), pinning the review-wave-1 regression: a loopback
+// NAME (which net.ParseIP cannot recognise as loopback) must be admitted at
+// dial time, not refused by the SSRF guard. Reaching the registered tool's
+// result is the proof the dial succeeded.
+func TestConnect_LocalhostNameDefaultTransport(t *testing.T) {
+	tools := []mcpTool{{Name: "ping", InputSchema: json.RawMessage(`{"type":"object"}`)}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "tools/list":
+			writeJSONRPCResult(w, req.ID, toolsListResult{Tools: tools})
+		case "tools/call":
+			writeJSONRPCResult(w, req.ID, toolsCallResult{Content: []contentItem{{Type: "text", Text: "pong"}}})
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// httptest binds 127.0.0.1; rewrite to the localhost NAME so the dial
+	// exercises the name path rather than the IP-literal path.
+	uri := strings.Replace(srv.URL, "127.0.0.1", "localhost", 1)
+
+	registry := tool.NewRegistry()
+	client := NewClient(registry, nil) // default transport: LoopbackAwareDialContext
+	secrets := &stubSecretStore{secrets: map[string]string{}}
+
+	if err := client.Connect(context.Background(), types.MCPServerConfig{Name: "local", URI: uri}, secrets); err != nil {
+		t.Fatalf("Connect to %s: %v", uri, err)
+	}
+	resolved := registry.Resolve("mcp_local_ping")
+	if resolved == nil {
+		t.Fatal("tool not registered")
+	}
+	out, err := resolved.StructuredHandler(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("tool call through loopback-name dial failed: %v", err)
+	}
+	if out.Text != "pong" {
+		t.Fatalf("tool result = %q, want pong", out.Text)
+	}
+}

--- a/harness/internal/security/ssrf.go
+++ b/harness/internal/security/ssrf.go
@@ -82,3 +82,29 @@ func SafeDialContext(allowPrivateHosts bool, timeout time.Duration) func(context
 		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
 	}
 }
+
+// LoopbackAwareDialContext returns a DialContext that admits loopback
+// addresses (for local-dev servers reached over http://localhost) but
+// re-runs the SSRF guard against every other dialled address. It is the
+// MCP-client variant of SafeDialContext: a remote server URI that passed the
+// connect-time host check but whose DNS later rebinds to a non-loopback
+// private/reserved address (10.0.0.0/8, the 169.254.169.254 metadata
+// endpoint, …) is refused at dial time, while a legitimately-local server is
+// not. Loopback is the only relaxation because a remote http:// URI is
+// already rejected upstream, so any non-loopback target here is a remote one
+// that must be public.
+func LoopbackAwareDialContext(timeout time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: timeout}
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+			if err := ValidatePublicHost(host); err != nil {
+				return nil, err
+			}
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+	}
+}

--- a/harness/internal/security/ssrf.go
+++ b/harness/internal/security/ssrf.go
@@ -1,0 +1,84 @@
+package security
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// ValidatePublicHost is the canonical SSRF guard shared by every harness
+// component that dials an operator- or model-supplied host (web_fetch, the
+// MCP client). It refuses "localhost" and any host that resolves to a
+// loopback, private, link-local, multicast, or unspecified address, so a
+// request cannot be steered at the harness's own loopback services, the
+// cloud metadata endpoint, or other internal infrastructure (CWE-918).
+//
+// When host is a literal IP it is checked directly. When it is a name it is
+// resolved and EVERY returned address must be public — a single private
+// answer fails the host, which also blunts DNS-rebinding answers that mix a
+// public and a private record. Callers that dial through a transport
+// DialContext built with SafeDialContext re-run this check at connect time,
+// closing the resolve→dial rebinding window; see docs/security.md.
+func ValidatePublicHost(host string) error {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return fmt.Errorf("url must include a host")
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return fmt.Errorf("refusing to reach private host %q", host)
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if !IsPublicIP(ip) {
+			return fmt.Errorf("refusing to reach private host %q", host)
+		}
+		return nil
+	}
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	if err != nil {
+		return fmt.Errorf("resolve host %q: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return fmt.Errorf("resolve host %q: no addresses found", host)
+	}
+	for _, addr := range addrs {
+		if !IsPublicIP(addr.IP) {
+			return fmt.Errorf("refusing to reach private host %q", host)
+		}
+	}
+	return nil
+}
+
+// IsPublicIP reports whether ip is a globally routable unicast address —
+// i.e. not loopback, private, multicast, link-local, or unspecified.
+func IsPublicIP(ip net.IP) bool {
+	return !ip.IsLoopback() &&
+		!ip.IsPrivate() &&
+		!ip.IsMulticast() &&
+		!ip.IsLinkLocalMulticast() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsUnspecified()
+}
+
+// SafeDialContext returns a transport DialContext that re-validates the
+// dialled host with ValidatePublicHost before connecting, closing the
+// DNS-rebinding window between an initial resolve and the actual dial. When
+// allowPrivateHosts is true the guard is skipped (local-dev / explicit
+// opt-in paths).
+func SafeDialContext(allowPrivateHosts bool, timeout time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: timeout}
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if !allowPrivateHosts {
+			if err := ValidatePublicHost(host); err != nil {
+				return nil, err
+			}
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+	}
+}

--- a/harness/internal/security/ssrf.go
+++ b/harness/internal/security/ssrf.go
@@ -51,9 +51,40 @@ func ValidatePublicHost(host string) error {
 	return nil
 }
 
+// cgnatNet is the RFC 6598 carrier-grade-NAT shared address space
+// (100.64.0.0/10). Go's net.IP.IsPrivate covers only RFC 1918 and RFC 4193,
+// not this range, so it is checked explicitly: on a deployment target such as
+// GCP Cloud Run that routes 100.64/10 to internal subnets, a host in this
+// range is a private target an SSRF should not reach.
+var cgnatNet = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
+// IsLoopbackHost reports whether host is a loopback target — the literal
+// "localhost"/"*.localhost" names or a loopback IP literal. It is the single
+// definition shared by every loopback-exemption site (the MCP connect-time
+// gate and the MCP dial-time guard) so the two cannot drift; net.ParseIP does
+// not resolve the "localhost" name, which is why a name check is required in
+// addition to the IP check.
+func IsLoopbackHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
 // IsPublicIP reports whether ip is a globally routable unicast address —
-// i.e. not loopback, private, multicast, link-local, or unspecified.
+// i.e. not loopback, private (incl. RFC 6598 CGNAT), multicast, link-local,
+// or unspecified.
 func IsPublicIP(ip net.IP) bool {
+	if v4 := ip.To4(); v4 != nil && cgnatNet.Contains(v4) {
+		return false
+	}
 	return !ip.IsLoopback() &&
 		!ip.IsPrivate() &&
 		!ip.IsMulticast() &&
@@ -100,7 +131,7 @@ func LoopbackAwareDialContext(timeout time.Duration) func(context.Context, strin
 		if err != nil {
 			return nil, err
 		}
-		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+		if !IsLoopbackHost(host) {
 			if err := ValidatePublicHost(host); err != nil {
 				return nil, err
 			}

--- a/harness/internal/security/ssrf_test.go
+++ b/harness/internal/security/ssrf_test.go
@@ -1,0 +1,69 @@
+package security
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestValidatePublicHost(t *testing.T) {
+	cases := []struct {
+		name    string
+		host    string
+		wantErr bool
+	}{
+		{"loopback_ipv4", "127.0.0.1", true},
+		{"loopback_ipv6", "::1", true},
+		{"localhost_name", "localhost", true},
+		{"localhost_suffix", "svc.localhost", true},
+		{"rfc1918", "10.0.0.1", true},
+		{"link_local_metadata", "169.254.169.254", true},
+		{"unspecified", "0.0.0.0", true},
+		{"public_ip", "1.1.1.1", false},
+		{"empty", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePublicHost(tc.host)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("ValidatePublicHost(%q) err = %v, wantErr = %v", tc.host, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsPublicIP(t *testing.T) {
+	if IsPublicIP(net.ParseIP("127.0.0.1")) {
+		t.Error("loopback should not be public")
+	}
+	if IsPublicIP(net.ParseIP("169.254.169.254")) {
+		t.Error("link-local metadata IP should not be public")
+	}
+	if !IsPublicIP(net.ParseIP("1.1.1.1")) {
+		t.Error("1.1.1.1 should be public")
+	}
+}
+
+func TestSafeDialContext_BlocksPrivate(t *testing.T) {
+	dial := SafeDialContext(false, 0)
+	_, err := dial(t.Context(), "tcp", "10.0.0.1:443")
+	if err == nil {
+		t.Fatal("SafeDialContext should refuse a private dial target")
+	}
+	if !strings.Contains(err.Error(), "private host") {
+		t.Errorf("err = %v, want 'private host'", err)
+	}
+}
+
+func TestLoopbackAwareDialContext_BlocksNonLoopbackPrivate(t *testing.T) {
+	dial := LoopbackAwareDialContext(0)
+	// A non-loopback private address (e.g. a rebind to the metadata endpoint)
+	// must still be refused.
+	_, err := dial(t.Context(), "tcp", "169.254.169.254:443")
+	if err == nil {
+		t.Fatal("LoopbackAwareDialContext should refuse a non-loopback private target")
+	}
+	if !strings.Contains(err.Error(), "private host") {
+		t.Errorf("err = %v, want 'private host'", err)
+	}
+}

--- a/harness/internal/security/ssrf_test.go
+++ b/harness/internal/security/ssrf_test.go
@@ -17,6 +17,7 @@ func TestValidatePublicHost(t *testing.T) {
 		{"localhost_name", "localhost", true},
 		{"localhost_suffix", "svc.localhost", true},
 		{"rfc1918", "10.0.0.1", true},
+		{"cgnat", "100.64.0.1", true},
 		{"link_local_metadata", "169.254.169.254", true},
 		{"unspecified", "0.0.0.0", true},
 		{"public_ip", "1.1.1.1", false},
@@ -39,8 +40,48 @@ func TestIsPublicIP(t *testing.T) {
 	if IsPublicIP(net.ParseIP("169.254.169.254")) {
 		t.Error("link-local metadata IP should not be public")
 	}
+	if IsPublicIP(net.ParseIP("100.64.0.1")) {
+		t.Error("RFC 6598 CGNAT (100.64.0.0/10) should not be public")
+	}
+	if !IsPublicIP(net.ParseIP("100.63.255.255")) {
+		t.Error("100.63.255.255 is just below the CGNAT range and should be public")
+	}
 	if !IsPublicIP(net.ParseIP("1.1.1.1")) {
 		t.Error("1.1.1.1 should be public")
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"svc.localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"LOCALHOST", true},
+		{"mcp.example.com", false},
+		{"10.0.0.1", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsLoopbackHost(tc.host); got != tc.want {
+			t.Errorf("IsLoopbackHost(%q) = %v, want %v", tc.host, got, tc.want)
+		}
+	}
+}
+
+// TestLoopbackAwareDialContext_AdmitsLoopbackName pins the regression fixed in
+// review wave 1: a dial to the "localhost" NAME (which net.ParseIP cannot
+// resolve to a loopback IP) must be admitted, not refused by the SSRF guard.
+// The dial itself targets a closed port so a connection error is expected, but
+// it must be a dial error, never the "private host" rejection.
+func TestLoopbackAwareDialContext_AdmitsLoopbackName(t *testing.T) {
+	dial := LoopbackAwareDialContext(0)
+	_, err := dial(t.Context(), "tcp", "localhost:1")
+	if err != nil && strings.Contains(err.Error(), "private host") {
+		t.Fatalf("loopback name must not be SSRF-rejected, got %v", err)
 	}
 }
 

--- a/harness/internal/tool/builtins/webfetch.go
+++ b/harness/internal/tool/builtins/webfetch.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 )
 
@@ -51,7 +50,7 @@ func newWebFetchTool(opts webFetchOptions) *tool.Tool {
 		client = &http.Client{
 			Timeout: fetchTimeout,
 			Transport: &http.Transport{
-				DialContext: safeFetchDialContext(opts.allowPrivateHosts),
+				DialContext: security.SafeDialContext(opts.allowPrivateHosts, fetchTimeout),
 			},
 		}
 	}
@@ -129,64 +128,9 @@ func validateFetchURL(rawURL string, allowPrivateHosts bool) (*url.URL, error) {
 		return nil, fmt.Errorf("url must include a host")
 	}
 	if !allowPrivateHosts {
-		if err := validatePublicHost(host); err != nil {
+		if err := security.ValidatePublicHost(host); err != nil {
 			return nil, err
 		}
 	}
 	return parsedURL, nil
-}
-
-func safeFetchDialContext(allowPrivateHosts bool) func(context.Context, string, string) (net.Conn, error) {
-	dialer := &net.Dialer{Timeout: fetchTimeout}
-	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		host, port, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, err
-		}
-		if !allowPrivateHosts {
-			if err := validatePublicHost(host); err != nil {
-				return nil, err
-			}
-		}
-		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
-	}
-}
-
-func validatePublicHost(host string) error {
-	host = strings.TrimSpace(strings.ToLower(host))
-	if host == "" {
-		return fmt.Errorf("url must include a host")
-	}
-	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
-		return fmt.Errorf("refusing to fetch private host %q", host)
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		if !isPublicIP(ip) {
-			return fmt.Errorf("refusing to fetch private host %q", host)
-		}
-		return nil
-	}
-
-	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
-	if err != nil {
-		return fmt.Errorf("resolve host %q: %w", host, err)
-	}
-	if len(addrs) == 0 {
-		return fmt.Errorf("resolve host %q: no addresses found", host)
-	}
-	for _, addr := range addrs {
-		if !isPublicIP(addr.IP) {
-			return fmt.Errorf("refusing to fetch private host %q", host)
-		}
-	}
-	return nil
-}
-
-func isPublicIP(ip net.IP) bool {
-	return !ip.IsLoopback() &&
-		!ip.IsPrivate() &&
-		!ip.IsMulticast() &&
-		!ip.IsLinkLocalMulticast() &&
-		!ip.IsLinkLocalUnicast() &&
-		!ip.IsUnspecified()
 }

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1135,11 +1135,11 @@ type MCPServerConfig struct {
 
 	// AllowedTools optionally restricts which advertised tools the harness
 	// will register from this server. When non-empty it is an allowlist
-	// matched against the server-reported (unprefixed) tool name: any tool
-	// the server advertises that is not listed is refused at registration,
-	// so a compromised or misconfigured server cannot smuggle in unexpected
-	// tools. An empty/unset list registers every advertised tool (the
-	// historical behaviour) and is backward-compatible.
+	// matched case-sensitively against the server-reported (unprefixed) tool
+	// name — the exact name the server advertises: any tool not listed is
+	// refused at registration, so a compromised or misconfigured server
+	// cannot smuggle in unexpected tools. An empty/unset list registers every
+	// advertised tool (the historical behaviour) and is backward-compatible.
 	AllowedTools []string `json:"allowedTools,omitempty"`
 
 	// AllowedMCPHosts optionally pins the set of hostnames this server's URI
@@ -2579,13 +2579,26 @@ func validateMCPServers(servers []MCPServerConfig, errs *[]string) {
 			}
 		}
 		for j, host := range server.AllowedMCPHosts {
-			if strings.TrimSpace(host) == "" {
+			trimmed := strings.TrimSpace(host)
+			if trimmed == "" {
 				*errs = append(*errs, fmt.Sprintf("%s.allowedMCPHosts[%d] must not be empty", path, j))
 				continue
 			}
-			if host != strings.TrimSpace(host) || strings.ContainsAny(host, "/:") {
+			// An IP literal (including IPv6, which legitimately contains
+			// colons) is a valid bare host; only apply the no-scheme/port/path
+			// check to non-IP names so "::1" or "2001:db8::1" is not rejected
+			// as if the colons were a port separator.
+			if net.ParseIP(trimmed) != nil {
+				continue
+			}
+			if host != trimmed || strings.ContainsAny(host, "/:") {
 				*errs = append(*errs, fmt.Sprintf(
-					"%s.allowedMCPHosts[%d] %q must be a bare hostname (no scheme, port, or path)", path, j, host))
+					"%s.allowedMCPHosts[%d] %q must be a bare hostname or IP literal (no scheme, port, or path)", path, j, host))
+			}
+		}
+		for j, name := range server.AllowedTools {
+			if strings.TrimSpace(name) == "" {
+				*errs = append(*errs, fmt.Sprintf("%s.allowedTools[%d] must not be empty", path, j))
 			}
 		}
 	}

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -1131,6 +1132,22 @@ type MCPServerConfig struct {
 	Name      string `json:"name"`
 	URI       string `json:"uri"`
 	APIKeyRef string `json:"apiKeyRef,omitempty"`
+
+	// AllowedTools optionally restricts which advertised tools the harness
+	// will register from this server. When non-empty it is an allowlist
+	// matched against the server-reported (unprefixed) tool name: any tool
+	// the server advertises that is not listed is refused at registration,
+	// so a compromised or misconfigured server cannot smuggle in unexpected
+	// tools. An empty/unset list registers every advertised tool (the
+	// historical behaviour) and is backward-compatible.
+	AllowedTools []string `json:"allowedTools,omitempty"`
+
+	// AllowedMCPHosts optionally pins the set of hostnames this server's URI
+	// may resolve to. When non-empty, the URI host must appear in this list
+	// (exact, case-insensitive match) in addition to passing the SSRF guard.
+	// It is an operator-side defence against a server URI being repointed at
+	// an unexpected host. Empty/unset applies no host pinning.
+	AllowedMCPHosts []string `json:"allowedMCPHosts,omitempty"`
 }
 
 var validProviderTypes = map[string]bool{
@@ -1749,6 +1766,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateProviderConfigs(config, retryDefaulted, &errs)
 	validateAPIKeyRefs(config, &errs)
 	validateBuiltInTools(config.Tools.BuiltIn, &errs)
+	validateMCPServers(config.Tools.MCPServers, &errs)
 	validateToolsProfile(config.Tools.Profile, &errs)
 	validateCredentialConfig(config.Provider.Credential, "provider.credential", &errs)
 	for name, prov := range config.Providers {
@@ -2526,6 +2544,65 @@ func validateBuiltInTools(builtIns []string, errs *[]string) {
 			*errs = append(*errs, fmt.Sprintf("tools.builtIn contains unsupported tool %q", name))
 		}
 	}
+}
+
+// validateMCPServers checks the structural trust-model fields on every
+// configured MCP server: a parseable http/https URI, https required for any
+// remote (non-loopback) host so credentials and tool-call payloads are not
+// sent in clear, and well-formed AllowedMCPHosts entries. Connect-time SSRF
+// resolution (private/reserved-IP blocking, DNS-rebinding re-validation)
+// lives in the MCP client, which shares security.ValidatePublicHost with
+// web_fetch; this layer rejects the malformed-config cases an operator can
+// fix before a run starts.
+func validateMCPServers(servers []MCPServerConfig, errs *[]string) {
+	for i, server := range servers {
+		path := fmt.Sprintf("tools.mcpServers[%d]", i)
+		if server.Name == "" {
+			*errs = append(*errs, fmt.Sprintf("%s.name is required", path))
+		}
+		if server.URI == "" {
+			*errs = append(*errs, fmt.Sprintf("%s.uri is required", path))
+		} else {
+			u, err := url.Parse(server.URI)
+			switch {
+			case err != nil:
+				*errs = append(*errs, fmt.Sprintf("%s.uri %q is not a valid URL: %v", path, server.URI, err))
+			case u.Scheme != "http" && u.Scheme != "https":
+				*errs = append(*errs, fmt.Sprintf(
+					"%s.uri scheme %q is not allowed (must be http or https)", path, u.Scheme))
+			case u.Hostname() == "":
+				*errs = append(*errs, fmt.Sprintf("%s.uri %q must include a host", path, server.URI))
+			case u.Scheme == "http" && !isLocalMCPHost(u.Hostname()):
+				*errs = append(*errs, fmt.Sprintf(
+					"%s.uri %q must use https for a remote host (http is only permitted for localhost/loopback)",
+					path, server.URI))
+			}
+		}
+		for j, host := range server.AllowedMCPHosts {
+			if strings.TrimSpace(host) == "" {
+				*errs = append(*errs, fmt.Sprintf("%s.allowedMCPHosts[%d] must not be empty", path, j))
+				continue
+			}
+			if host != strings.TrimSpace(host) || strings.ContainsAny(host, "/:") {
+				*errs = append(*errs, fmt.Sprintf(
+					"%s.allowedMCPHosts[%d] %q must be a bare hostname (no scheme, port, or path)", path, j, host))
+			}
+		}
+	}
+}
+
+// isLocalMCPHost reports whether host is a loopback target for which a plain
+// http:// MCP URI is acceptable (local development). It accepts the literal
+// "localhost"/"*.localhost" names and any loopback IP literal.
+func isLocalMCPHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // validateAPIKeyRefs enforces that every secret-bearing apiKeyRef on

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -359,6 +359,76 @@ func TestValidateRunConfig_InvalidBuiltInTool(t *testing.T) {
 	}
 }
 
+func TestValidateRunConfig_MCPServers(t *testing.T) {
+	cases := []struct {
+		name    string
+		server  MCPServerConfig
+		wantErr string // substring; "" means the config must validate
+	}{
+		{
+			name:   "https_remote_valid",
+			server: MCPServerConfig{Name: "ok", URI: "https://mcp.example.com/rpc"},
+		},
+		{
+			name:   "http_localhost_valid",
+			server: MCPServerConfig{Name: "local", URI: "http://localhost:8080"},
+		},
+		{
+			name:   "http_loopback_ip_valid",
+			server: MCPServerConfig{Name: "local", URI: "http://127.0.0.1:9000"},
+		},
+		{
+			name:    "missing_name",
+			server:  MCPServerConfig{URI: "https://mcp.example.com"},
+			wantErr: "tools.mcpServers[0].name is required",
+		},
+		{
+			name:    "bad_scheme",
+			server:  MCPServerConfig{Name: "x", URI: "file:///etc/passwd"},
+			wantErr: "scheme",
+		},
+		{
+			name:    "http_remote_rejected",
+			server:  MCPServerConfig{Name: "x", URI: "http://mcp.example.com/rpc"},
+			wantErr: "must use https",
+		},
+		{
+			name:    "allowedhost_with_scheme",
+			server:  MCPServerConfig{Name: "x", URI: "https://mcp.example.com", AllowedMCPHosts: []string{"https://evil.example.com"}},
+			wantErr: "allowedMCPHosts[0]",
+		},
+		{
+			name:    "allowedhost_empty",
+			server:  MCPServerConfig{Name: "x", URI: "https://mcp.example.com", AllowedMCPHosts: []string{" "}},
+			wantErr: "allowedMCPHosts[0]",
+		},
+		{
+			name:   "allowedtools_set_validates",
+			server: MCPServerConfig{Name: "x", URI: "https://mcp.example.com", AllowedTools: []string{"search"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			c.Tools = ToolsConfig{MCPServers: []MCPServerConfig{tc.server}}
+			err := ValidateRunConfig(c)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected valid config, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %v, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateRunConfig_UnknownToolsProfile(t *testing.T) {
 	c := validConfig()
 	c.Tools.Profile = "provider-native-but-unimplemented"

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -383,6 +383,11 @@ func TestValidateRunConfig_MCPServers(t *testing.T) {
 			wantErr: "tools.mcpServers[0].name is required",
 		},
 		{
+			name:    "missing_uri",
+			server:  MCPServerConfig{Name: "x"},
+			wantErr: "tools.mcpServers[0].uri is required",
+		},
+		{
 			name:    "bad_scheme",
 			server:  MCPServerConfig{Name: "x", URI: "file:///etc/passwd"},
 			wantErr: "scheme",
@@ -403,8 +408,21 @@ func TestValidateRunConfig_MCPServers(t *testing.T) {
 			wantErr: "allowedMCPHosts[0]",
 		},
 		{
+			name:   "allowedhost_ipv6_literal_valid",
+			server: MCPServerConfig{Name: "x", URI: "https://mcp.example.com", AllowedMCPHosts: []string{"::1", "2001:db8::1"}},
+		},
+		{
+			name:   "allowedhost_bare_name_valid",
+			server: MCPServerConfig{Name: "x", URI: "https://mcp.example.com", AllowedMCPHosts: []string{"mcp.example.com"}},
+		},
+		{
 			name:   "allowedtools_set_validates",
 			server: MCPServerConfig{Name: "x", URI: "https://mcp.example.com", AllowedTools: []string{"search"}},
+		},
+		{
+			name:    "allowedtools_empty_entry",
+			server:  MCPServerConfig{Name: "x", URI: "https://mcp.example.com", AllowedTools: []string{"search", "  "}},
+			wantErr: "allowedTools[1]",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Addresses #4, sub-items **2.2** (tool allowlisting) and **2.5** (URI SSRF protection) — the two "required before processing untrusted inputs" items. Does **not** fully close #4: 2.3 (server sandboxing) and 2.4 (connection security / stdio binary hash) remain as tracked follow-ups.

## What changed

**2.2 — tool allowlisting:** `MCPServerConfig` gains `AllowedTools []string`. When set, a server-advertised tool not in the allowlist is rejected at registration (logged with the server name), *before* the per-server cardinality cap — so a compromised server can't smuggle an unexpected tool or starve the cap. Unset = all tools register (backward-compatible). Matching is case-sensitive against the exact advertised name (documented).

**2.5 — URI SSRF protection:** `MCPServerConfig` gains `AllowedMCPHosts []string`. The MCP client validates the URI scheme at connect (https required for remote; http only for genuine loopback) and resolves the host through the **shared** `security.ValidatePublicHost` — the same validator web_fetch uses, extracted into `harness/internal/security/ssrf.go` (no duplication). DNS-rebinding is mitigated by re-validating at dial time via the shared `security.LoopbackAwareDialContext`. `ValidateRunConfig` rejects bad schemes / non-https remotes / malformed `AllowedMCPHosts` / empty `AllowedTools` entries with field-path errors.

This also **hardens the shared validator for web_fetch too**: the CGNAT range 100.64.0.0/10 (RFC 6598), which Go's `ip.IsPrivate()` misses, is now blocked.

## Notable fixes from review

- `http://localhost` MCP servers were being rejected at *dial* time (`net.ParseIP("localhost")` is nil) — fixed by sharing one `security.IsLoopbackHost` between the connect-time and dial-time gates; verified by an end-to-end dial test.
- IPv6 literals (`::1`) are now accepted in `AllowedMCPHosts` (the previous `:`-rejection blocked them).
- The new session-ID-cap warning now logs the server *name*, not the raw URI (which may carry embedded credentials).

## Tests

Tool-allowlist filtering, SSRF rejection (private IP, CGNAT, non-https remote), localhost-name dial admission, IPv6 pin, missing-URI / empty-allowedTools validation, and backward-compat (unset = today). `just build`, `just lint` (0 issues), `just test` (all green).

## Follow-ups (tracked separately)

- The gRPC/proto path does not yet carry `AllowedTools`/`AllowedMCPHosts` (JSON RunConfig only — additive, proto callers get today's behaviour). → see linked issue.
- Two pre-existing `call()`-site error logs still interpolate the raw `sess.uri` (potential credential-in-log). → see linked issue.

## Review

One reviewer wave (security + code + spec). Spec verdict COMPLIANT; security confirmed the SSRF extraction is byte-for-byte faithful (web_fetch unweakened) and the host gate is not bypassable via decimal/octal/IPv4-mapped/rebinding vectors. The two HIGH functional bugs (localhost dial, IPv6 pin) and all hardening items were remediated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)