### PR TITLE
core: enforce dry-run preflight parity and add --no-probe-executor gate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,8 @@ a billable runtime operation (so it confirms credentials resolve, not
 that the Bedrock endpoint is reachable). A container-executor dry-run is
 read-only: it pings the engine socket and checks the image is present
 locally without creating a container, starting the egress proxy, or
-pulling the image.
+pulling the image. Pass `--no-probe-executor` to suppress even that
+contact, recording the executor step as a `skip`.
 
 The trace probe is the one step that reaches a live backend: for
 `traceEmitter.type=otel` it exports a single throwaway span (tagged
@@ -207,6 +208,7 @@ fail the run:
 | `--no-probe-mcp` | The MCP `initialize` / `tools/list` handshake for every configured server. |
 | `--no-probe-trace` | The trace-emitter reachability probe (`otel` flush, `gcs` bucket check). |
 | `--no-probe-egress` | The egress-allowlist DNS resolution (container executor in `allowlist` network mode). |
+| `--no-probe-executor` | The container-engine probe (socket ping + image-present, container executor only). The executor step then records `skip`; no engine is contacted. No effect on `local`/`api` executors, which construct without an engine. |
 | `--dry-run-timeout` | Not a gate — bounds the total preflight wall-clock. Defaults to `30s`. |
 
 A `--no-probe-*` gate or `--dry-run-timeout` supplied **without**
@@ -434,6 +436,7 @@ full workflow, the per-step report, and how the flags compose.
 | `--no-probe-mcp` | `false` | Skip the MCP server handshake probe. Meaningless without `--dry-run` (exit `4`). |
 | `--no-probe-trace` | `false` | Skip the trace-emitter reachability probe. Meaningless without `--dry-run` (exit `4`). |
 | `--no-probe-egress` | `false` | Skip the egress-allowlist DNS probe. Meaningless without `--dry-run` (exit `4`). |
+| `--no-probe-executor` | `false` | Skip the container-engine probe (container executor only). Meaningless without `--dry-run` (exit `4`). |
 | `--dry-run-timeout` | `30s` | Total wall-clock budget for the preflight. Meaningless without `--dry-run` (exit `4`). |
 
 `--output=json` (above) emits the `PreflightReport` to stdout when paired
@@ -452,7 +455,7 @@ stderr. The scheme is uniform across `harness`, `job`, and
 | `1` | Validation / precondition | `ValidateRunConfig` (or `run-config --validate`) rejected the resolved config; a required prompt had no source; `job` ran without `CONTROL_PLANE_ADDR`. Also the default for any failure not in a more specific class. |
 | `2` | Parse error | The JSON in a `--config` file or piped stdin failed to decode (syntax error, unknown field, type mismatch). |
 | `3` | I/O error | A `--config` or `--prompt-file` path could not be opened, read, or stat'd; an empty / oversize input; an `--output-runconfig` write or close failure. |
-| `4` | Usage error | An invalid flag combination — currently a `--dry-run` probe gate (`--no-probe-provider`/`--no-probe-mcp`/`--no-probe-trace`/`--no-probe-egress`) or `--dry-run-timeout` supplied without `--dry-run`. See [Dry-run preflight](#dry-run-preflight). |
+| `4` | Usage error | An invalid flag combination — currently a `--dry-run` probe gate (`--no-probe-provider`/`--no-probe-mcp`/`--no-probe-trace`/`--no-probe-egress`/`--no-probe-executor`) or `--dry-run-timeout` supplied without `--dry-run`. See [Dry-run preflight](#dry-run-preflight). |
 
 A failed `--dry-run` (one or more probes reported `fail`) exits `1` on
 the default path, not `4`: code `4` is reserved for the command-line

--- a/harness/cmd/stirrup/cmd/dryrun_test.go
+++ b/harness/cmd/stirrup/cmd/dryrun_test.go
@@ -189,6 +189,7 @@ func TestDryRunOptionsFromFlags(t *testing.T) {
 	f := cmd.Flags()
 	_ = f.Set("no-probe-provider", "true")
 	_ = f.Set("no-probe-egress", "true")
+	_ = f.Set("no-probe-executor", "true")
 	_ = f.Set("dry-run-timeout", "12s")
 
 	opts := dryRunOptionsFromFlags(f)
@@ -200,6 +201,9 @@ func TestDryRunOptionsFromFlags(t *testing.T) {
 	}
 	if !opts.SkipEgress {
 		t.Error("SkipEgress should be true")
+	}
+	if !opts.SkipExecutor {
+		t.Error("SkipExecutor should be true")
 	}
 	if opts.Timeout.String() != "12s" {
 		t.Errorf("Timeout = %v, want 12s", opts.Timeout)

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -768,6 +768,7 @@ func init() {
 	f.Bool("no-probe-mcp", false, "With --dry-run, skip the MCP server reachability probe. Meaningless without --dry-run (exit 4).")
 	f.Bool("no-probe-trace", false, "With --dry-run, skip the trace-emitter reachability probe. Meaningless without --dry-run (exit 4).")
 	f.Bool("no-probe-egress", false, "With --dry-run, skip the egress-allowlist DNS probe. Meaningless without --dry-run (exit 4).")
+	f.Bool("no-probe-executor", false, "With --dry-run, skip the container-engine probe (socket ping + image-present). The executor step reports skip; no engine is contacted. Meaningless without --dry-run (exit 4).")
 	f.Duration("dry-run-timeout", core.DefaultPreflightTimeout, "With --dry-run, the total wall-clock budget for the preflight. Meaningless without --dry-run (exit 4).")
 	f.StringP("output", "o", "text", "Post-run summary format: text (default human-readable summary on stderr), json (structured RunResult JSON on stdout, suppresses stderr summary), none (suppresses both). When json is set together with resultSink.type=stdout-json the line is emitted once (the flag wins); pair json with a trace emitter that does not target stdout (the default jsonl file path is fine).")
 
@@ -1384,6 +1385,7 @@ var dryRunProbeGates = []string{
 	"no-probe-mcp",
 	"no-probe-trace",
 	"no-probe-egress",
+	"no-probe-executor",
 	"dry-run-timeout",
 }
 
@@ -1411,12 +1413,14 @@ func dryRunOptionsFromFlags(f *flag.FlagSet) core.PreflightOptions {
 	skipMCP, _ := f.GetBool("no-probe-mcp")
 	skipTrace, _ := f.GetBool("no-probe-trace")
 	skipEgress, _ := f.GetBool("no-probe-egress")
+	skipExecutor, _ := f.GetBool("no-probe-executor")
 	timeout, _ := f.GetDuration("dry-run-timeout")
 	return core.PreflightOptions{
 		SkipProvider: skipProvider,
 		SkipMCP:      skipMCP,
 		SkipTrace:    skipTrace,
 		SkipEgress:   skipEgress,
+		SkipExecutor: skipExecutor,
 		Timeout:      timeout,
 	}
 }

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -603,6 +603,7 @@ func newTestHarnessCommand() *cobra.Command {
 	f.Bool("no-probe-mcp", false, "")
 	f.Bool("no-probe-trace", false, "")
 	f.Bool("no-probe-egress", false, "")
+	f.Bool("no-probe-executor", false, "")
 	f.Duration("dry-run-timeout", core.DefaultPreflightTimeout, "")
 	return cmd
 }

--- a/harness/internal/core/components.go
+++ b/harness/internal/core/components.go
@@ -22,34 +22,82 @@ import (
 // fields to assemble the AgenticLoop, and Preflight iterates probeSteps()
 // to run a dry-run reachability/auth probe against each.
 //
-// The parity invariant the type enforces is: a probe-eligible component
-// cannot be added to BuildLoop without also surfacing in the dry-run.
-// Because both paths construct the set through buildComponents, and
-// Preflight derives its step list from probeSteps(), a new component added
-// to buildComponents is automatically probed by Preflight. The matching
-// parity test (TestPreflightParity) fails if a component in probeSteps()
-// produces no step in a representative-config Preflight report — catching
-// the inverse drift where a step name diverges from the probe set.
+// The parity guarantee, made structural (not by convention): Preflight and
+// BuildLoopWithTransport BOTH construct the uniform components (providers,
+// permission policy, trace emitter) by calling buildComponents — the same
+// function — so a component cannot be added to the real run's construction
+// without also being constructed, enumerated by probeSteps(), and probed in
+// the dry-run. TestPreflightParity asserts every probeSteps() entry both
+// appears in a representative report AND is not a "not constructed" skip
+// (catching a field left nil), and TestProbeStepsCoversBuiltComponents
+// asserts every probe-tagged field of builtComponents is named in
+// probeSteps() and vice versa (catching a field added to the struct but
+// omitted from the enumeration, or the reverse).
+//
+// The executor is the one documented exception: its construction semantics
+// diverge (BuildLoop starts a real container; a dry-run must only probe the
+// engine read-only), so it is supplied by the caller rather than built
+// inside buildComponents.
+//
+// The `probe:"<step-prefix>"` struct tag marks a field as probe-eligible and
+// names the probeSteps() step (or step prefix, for the providers map) it
+// must be enumerated under. TestProbeStepsCoversBuiltComponents reflects over
+// these tags. Untagged fields (defaultProvider, resolvedHeaders) are
+// bookkeeping, not independently probed.
 type builtComponents struct {
 	// defaultProvider is the adapter for config.Provider; it is also keyed
 	// into providers by its type, so it is probed via the providers map and
 	// is retained here only because BuildLoop assembles the loop around it.
 	defaultProvider provider.ProviderAdapter
-	providers       map[string]provider.ProviderAdapter
+	providers       map[string]provider.ProviderAdapter `probe:"provider-probe:"`
 
 	// executor is the constructed executor. The two callers supply it via
 	// divergent construction (BuildLoop starts a real container; Preflight
-	// substitutes a read-only engine probe — see preflightExecutor), so it
-	// is passed into buildComponents rather than constructed here.
-	executor executor.Executor
+	// substitutes a read-only engine probe — see preflightExecutorConstruct),
+	// so it is passed into buildComponents rather than constructed there.
+	executor executor.Executor `probe:"executor-probe"`
 
-	permissionPolicy permission.PermissionPolicy
-	traceEmitter     trace.TraceEmitter
+	permissionPolicy permission.PermissionPolicy `probe:"permission-policy-probe"`
+	traceEmitter     trace.TraceEmitter          `probe:"trace-emitter-probe"`
 
 	// resolvedHeaders are the secret://-dereferenced traceEmitter.Headers.
 	// BuildLoop reuses them for the metrics exporter so traces and metrics
 	// authenticate identically; retained here to avoid a second resolve.
 	resolvedHeaders map[string]string
+}
+
+// componentStepSink lets buildComponents emit a per-component construction
+// step as it builds each component. Preflight supplies a sink so the dry-run
+// report carries a row for every component buildComponents constructs —
+// making the construction-step set a property of the shared constructor, not
+// a hand-maintained mirror. BuildLoop passes a nil sink (it emits no
+// per-component steps). The step names a sink receives
+// ("credentials"/"executor"/"permission-policy"/"trace-emitter") match the
+// report rows the operator sees.
+//
+// ok records a successful construction; failStep records a failed one with a
+// remediation hint. buildComponents calls exactly one of them per component,
+// then (on failure) returns so the dry-run stops at the first construction
+// error.
+type componentStepSink struct {
+	ok       func(name, detail string)
+	failStep func(name string, err error, hint string)
+}
+
+// executorBuildResult carries the executor a caller constructed (or chose
+// not to) so buildComponents can thread it onto builtComponents and emit its
+// construction step in the report's canonical position (after credentials,
+// before the permission policy) without owning the executor's divergent
+// construction. BuildLoop fills exec with the live executor it already built
+// and leaves the report fields zero (nil sink ⇒ no step). Preflight fills the
+// report fields from preflightExecutorConstruct: a container dry-run sets
+// exec nil with an ok note that the engine is probed read-only; local/api set
+// exec to the constructed executor; a construction failure sets err.
+type executorBuildResult struct {
+	exec   executor.Executor
+	detail string // ok note when err is nil
+	err    error  // non-nil ⇒ construction failed; detail is unused
+	hint   string // remediation hint for a failed construction
 }
 
 // probeComponentStep names a probe-eligible component and the value to
@@ -62,14 +110,20 @@ type probeComponentStep struct {
 // probeSteps returns the probe-eligible components in deterministic report
 // order. Preflight type-asserts each component to Preflighter and records
 // ok/skip/fail. This is the structural parity seam: every field of
-// builtComponents that represents a reachable component is enumerated here,
-// so adding a component to buildComponents without adding it to probeSteps
-// is the omission TestPreflightParity catches.
+// builtComponents that represents a reachable component is enumerated here.
+// TestProbeStepsCoversBuiltComponents asserts the converse — that no
+// probe-tagged field is omitted from this list, and no step here lacks a
+// backing tagged field.
 //
 // Providers are enumerated by sorted name so a multi-provider config yields
 // a reproducible step order (matching --output=json determinism).
 func (b *builtComponents) probeSteps() []probeComponentStep {
-	steps := make([]probeComponentStep, 0, len(b.providers)+3)
+	nonProvider := []probeComponentStep{
+		{name: "executor-probe", component: b.executor},
+		{name: "permission-policy-probe", component: b.permissionPolicy},
+		{name: "trace-emitter-probe", component: b.traceEmitter},
+	}
+	steps := make([]probeComponentStep, 0, len(b.providers)+len(nonProvider))
 
 	names := make([]string, 0, len(b.providers))
 	for name := range b.providers {
@@ -80,19 +134,15 @@ func (b *builtComponents) probeSteps() []probeComponentStep {
 		steps = append(steps, probeComponentStep{name: "provider-probe:" + name, component: b.providers[name]})
 	}
 
-	steps = append(steps,
-		probeComponentStep{name: "executor-probe", component: b.executor},
-		probeComponentStep{name: "permission-policy-probe", component: b.permissionPolicy},
-		probeComponentStep{name: "trace-emitter-probe", component: b.traceEmitter},
-	)
-	return steps
+	return append(steps, nonProvider...)
 }
 
 // buildComponents constructs the probe-eligible components shared by
 // BuildLoopWithTransport and Preflight: the provider adapters, the
 // permission policy, and the trace emitter. The executor is supplied by the
 // caller (its construction semantics diverge — see builtComponents.executor)
-// and threaded onto the returned struct so probeSteps enumerates it.
+// via execResult and threaded onto the returned struct so probeSteps
+// enumerates it.
 //
 // resolvedHeaders must be the already-dereferenced traceEmitter.Headers
 // (the caller resolves them once and reuses them for the metrics exporter);
@@ -101,10 +151,20 @@ func (b *builtComponents) probeSteps() []probeComponentStep {
 // transport). secLogger receives security events from constructed
 // components; pass an io.Discard-backed logger in a dry-run.
 //
+// When sink is non-nil, buildComponents emits a per-component construction
+// step (ok on success, failStep on failure) as it builds each component,
+// including the caller-supplied executor (execResult). This makes the
+// dry-run's construction-step report a property of the shared constructor:
+// adding a component here automatically adds its construction step (and, via
+// probeSteps, its probe step) to the dry-run. BuildLoop passes a nil sink.
+// The step names ("credentials", "executor", "permission-policy",
+// "trace-emitter") match the dry-run report rows.
+//
 // A construction failure returns a nil struct and an error naming the
-// failing component so the caller can map it to a failed preflight step or a
-// build error. Owned closers (trace emitter) are NOT closed here — the
-// caller owns the lifecycle.
+// failing component (so a non-dry-run caller still gets a wrapped error) and,
+// when a sink is present, records the failed step before returning — the
+// dry-run stops at the first construction error. Owned closers (trace
+// emitter) are NOT closed here — the caller owns the lifecycle.
 func buildComponents(
 	ctx context.Context,
 	config *types.RunConfig,
@@ -112,32 +172,65 @@ func buildComponents(
 	secLogger *security.SecurityLogger,
 	registry *tool.Registry,
 	tp transport.Transport,
-	exec executor.Executor,
+	execResult executorBuildResult,
 	resolvedHeaders map[string]string,
 	resourceOpts observability.ResourceOptions,
+	sink *componentStepSink,
 ) (*builtComponents, error) {
 	// Error prefixes mirror BuildLoop's historical inline messages
 	// ("build providers", etc.) so the composition root's operator-facing
 	// error text is unchanged by the extraction.
 	defaultProvider, providers, err := buildProviders(ctx, config, secrets)
 	if err != nil {
+		if sink != nil {
+			sink.failStep("credentials", err, "verify the credential source resolves (env var set, federation rule valid, key present)")
+		}
 		return nil, fmt.Errorf("build providers: %w", err)
+	}
+	if sink != nil {
+		sink.ok("credentials", "all provider credentials resolved")
+	}
+
+	// Executor construction step. The executor itself was built by the
+	// caller (its semantics diverge), but its step is emitted here so the
+	// dry-run report keeps its canonical row order and so a future
+	// caller-supplied component cannot skip the construction step.
+	if execResult.err != nil {
+		if sink != nil {
+			sink.failStep("executor", execResult.err, execResult.hint)
+		}
+		return nil, fmt.Errorf("build executor: %w", execResult.err)
+	}
+	if sink != nil {
+		sink.ok("executor", execResult.detail)
 	}
 
 	pp, err := buildPermissionPolicy(config, registry, tp, secLogger)
 	if err != nil {
+		if sink != nil {
+			sink.failStep("permission-policy", err, "check permissionPolicy.policyFile parses as Cedar")
+		}
 		return nil, fmt.Errorf("build permission policy: %w", err)
+	}
+	if sink != nil {
+		sink.ok("permission-policy", fmt.Sprintf("%s policy constructed", config.PermissionPolicy.Type))
 	}
 
 	te, err := buildTraceEmitter(ctx, config.TraceEmitter, resolvedHeaders, resourceOpts)
 	if err != nil {
+		if sink != nil {
+			sink.failStep("trace-emitter", err, traceHint(config.TraceEmitter.Type))
+		}
 		return nil, fmt.Errorf("build trace emitter: %w", err)
+	}
+	if sink != nil {
+		sink.ok("trace-emitter", fmt.Sprintf("%s trace emitter constructed", traceTypeName(config.TraceEmitter.Type)))
 	}
 
 	return &builtComponents{
 		defaultProvider:  defaultProvider,
 		providers:        providers,
-		executor:         exec,
+		executor:         execResult.exec,
 		permissionPolicy: pp,
 		traceEmitter:     te,
 		resolvedHeaders:  resolvedHeaders,

--- a/harness/internal/core/components.go
+++ b/harness/internal/core/components.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/permission"
+	"github.com/rxbynerd/stirrup/harness/internal/provider"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// builtComponents is the set of probe-eligible components constructed by
+// buildComponents. It is the single source of truth shared by the two
+// composition entry points: BuildLoopWithTransport consumes the typed
+// fields to assemble the AgenticLoop, and Preflight iterates probeSteps()
+// to run a dry-run reachability/auth probe against each.
+//
+// The parity invariant the type enforces is: a probe-eligible component
+// cannot be added to BuildLoop without also surfacing in the dry-run.
+// Because both paths construct the set through buildComponents, and
+// Preflight derives its step list from probeSteps(), a new component added
+// to buildComponents is automatically probed by Preflight. The matching
+// parity test (TestPreflightParity) fails if a component in probeSteps()
+// produces no step in a representative-config Preflight report — catching
+// the inverse drift where a step name diverges from the probe set.
+type builtComponents struct {
+	// defaultProvider is the adapter for config.Provider; it is also keyed
+	// into providers by its type, so it is probed via the providers map and
+	// is retained here only because BuildLoop assembles the loop around it.
+	defaultProvider provider.ProviderAdapter
+	providers       map[string]provider.ProviderAdapter
+
+	// executor is the constructed executor. The two callers supply it via
+	// divergent construction (BuildLoop starts a real container; Preflight
+	// substitutes a read-only engine probe — see preflightExecutor), so it
+	// is passed into buildComponents rather than constructed here.
+	executor executor.Executor
+
+	permissionPolicy permission.PermissionPolicy
+	traceEmitter     trace.TraceEmitter
+
+	// resolvedHeaders are the secret://-dereferenced traceEmitter.Headers.
+	// BuildLoop reuses them for the metrics exporter so traces and metrics
+	// authenticate identically; retained here to avoid a second resolve.
+	resolvedHeaders map[string]string
+}
+
+// probeComponentStep names a probe-eligible component and the value to
+// type-assert to Preflighter. Order is the report's display order.
+type probeComponentStep struct {
+	name      string
+	component any
+}
+
+// probeSteps returns the probe-eligible components in deterministic report
+// order. Preflight type-asserts each component to Preflighter and records
+// ok/skip/fail. This is the structural parity seam: every field of
+// builtComponents that represents a reachable component is enumerated here,
+// so adding a component to buildComponents without adding it to probeSteps
+// is the omission TestPreflightParity catches.
+//
+// Providers are enumerated by sorted name so a multi-provider config yields
+// a reproducible step order (matching --output=json determinism).
+func (b *builtComponents) probeSteps() []probeComponentStep {
+	steps := make([]probeComponentStep, 0, len(b.providers)+3)
+
+	names := make([]string, 0, len(b.providers))
+	for name := range b.providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		steps = append(steps, probeComponentStep{name: "provider-probe:" + name, component: b.providers[name]})
+	}
+
+	steps = append(steps,
+		probeComponentStep{name: "executor-probe", component: b.executor},
+		probeComponentStep{name: "permission-policy-probe", component: b.permissionPolicy},
+		probeComponentStep{name: "trace-emitter-probe", component: b.traceEmitter},
+	)
+	return steps
+}
+
+// buildComponents constructs the probe-eligible components shared by
+// BuildLoopWithTransport and Preflight: the provider adapters, the
+// permission policy, and the trace emitter. The executor is supplied by the
+// caller (its construction semantics diverge — see builtComponents.executor)
+// and threaded onto the returned struct so probeSteps enumerates it.
+//
+// resolvedHeaders must be the already-dereferenced traceEmitter.Headers
+// (the caller resolves them once and reuses them for the metrics exporter);
+// resourceOpts is the OTel resource identity. registry and tp are inputs to
+// the permission policy (mutating/approval tool sets, ask-upstream
+// transport). secLogger receives security events from constructed
+// components; pass an io.Discard-backed logger in a dry-run.
+//
+// A construction failure returns a nil struct and an error naming the
+// failing component so the caller can map it to a failed preflight step or a
+// build error. Owned closers (trace emitter) are NOT closed here — the
+// caller owns the lifecycle.
+func buildComponents(
+	ctx context.Context,
+	config *types.RunConfig,
+	secrets security.SecretStore,
+	secLogger *security.SecurityLogger,
+	registry *tool.Registry,
+	tp transport.Transport,
+	exec executor.Executor,
+	resolvedHeaders map[string]string,
+	resourceOpts observability.ResourceOptions,
+) (*builtComponents, error) {
+	// Error prefixes mirror BuildLoop's historical inline messages
+	// ("build providers", etc.) so the composition root's operator-facing
+	// error text is unchanged by the extraction.
+	defaultProvider, providers, err := buildProviders(ctx, config, secrets)
+	if err != nil {
+		return nil, fmt.Errorf("build providers: %w", err)
+	}
+
+	pp, err := buildPermissionPolicy(config, registry, tp, secLogger)
+	if err != nil {
+		return nil, fmt.Errorf("build permission policy: %w", err)
+	}
+
+	te, err := buildTraceEmitter(ctx, config.TraceEmitter, resolvedHeaders, resourceOpts)
+	if err != nil {
+		return nil, fmt.Errorf("build trace emitter: %w", err)
+	}
+
+	return &builtComponents{
+		defaultProvider:  defaultProvider,
+		providers:        providers,
+		executor:         exec,
+		permissionPolicy: pp,
+		traceEmitter:     te,
+		resolvedHeaders:  resolvedHeaders,
+	}, nil
+}

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -85,19 +85,14 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		return nil, fmt.Errorf("build secret store: %w", err)
 	}
 
-	// 1. Provider adapters.
-	prov, providers, err := buildProviders(ctx, config, secrets)
-	if err != nil {
-		return nil, fmt.Errorf("build providers: %w", err)
-	}
-
-	// 2. Model router.
+	// 1. Model router. Needs only the provider TYPE (a string), not the
+	// constructed adapter, so it precedes buildComponents.
 	rtr := buildRouter(config.ModelRouter, config.Provider.Type)
 
-	// 3. Prompt builder.
+	// 2. Prompt builder.
 	pb := buildPromptBuilder(config.PromptBuilder, config.SystemPromptOverride)
 
-	// 4. Executor (built early because context strategy may need it).
+	// 3. Executor (built early because context strategy may need it).
 	// Thread the security logger into the container executor so the
 	// in-process egress proxy (started when network.mode == "allowlist")
 	// can emit egress_allowed / egress_blocked events through the same
@@ -110,10 +105,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		ownedClosers = append(ownedClosers, closer)
 	}
 
-	// 5. Context strategy.
-	cs := buildContextStrategy(config.ContextStrategy, prov, config.ModelRouter.Model, exec)
-
-	// 6. Tool registry.
+	// 4. Tool registry.
 	// The base edit strategy is constructed first, then optionally wrapped
 	// with a CodeScanner pass when one is configured. ValidateRunConfig
 	// fills CodeScanner with a sensible default per mode (patterns for
@@ -146,7 +138,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		logger = logger.With("sessionName", config.SessionName)
 	}
 
-	// 6b. MCP tool discovery — connect to remote MCP servers and register
+	// 5. MCP tool discovery — connect to remote MCP servers and register
 	// their tools into the registry alongside the built-in tools.
 	// Connection failures are non-fatal: the server's tools are skipped
 	// so the harness can still operate with its built-in tools.
@@ -172,24 +164,9 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		}
 	}
 
-	// 7. Verifier. Declared here so step 8+ can reference it, but actual
-	// construction is deferred to step 13 (line ~296) once the run's
-	// metrics instance exists. buildVerifier wraps its result in a
-	// metric-recorder when metrics is non-nil, so calling it twice (once
-	// without metrics here, once with) would discard the first build —
-	// hence the deferred single construction.
-	var v verifier.Verifier
-
-	// 8. GuardRail. Constructed AFTER providers are built so cloud-judge
-	// can reuse the default ProviderAdapter. Returns guard.NewNoop() when
-	// no guard is configured, so the loop's call sites are unconditional.
-	gr, err := buildGuardRail(config.GuardRail, providers, prov)
-	if err != nil {
-		cleanup()
-		return nil, fmt.Errorf("build guardrail: %w", err)
-	}
-
-	// 9. Transport — use the injected one if provided, otherwise build from config.
+	// 6. Transport — use the injected one if provided, otherwise build from
+	// config. Built before buildComponents because the ask-upstream
+	// permission policy needs it.
 	if tp == nil {
 		tp, err = buildTransport(ctx, config.Transport)
 		if err != nil {
@@ -208,52 +185,64 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		t.Security = secLogger
 	}
 
-	// 10. Permission policy. The raw policy is built once here; the
-	// metric-recording wrapper is applied below after the run's
-	// observability.Metrics instance is constructed. Splitting these
-	// steps avoids re-reading the Cedar policy file on the rebuild
-	// path — the previous double-call made the factory parse the
-	// policy file twice on every policy-engine run, which both cost
-	// extra latency and opened a TOCTOU window on workspace-relative
-	// paths between the two reads (CWE-367).
-	pp, err := buildPermissionPolicy(config, registry, tp, secLogger)
-	if err != nil {
-		cleanup()
-		return nil, fmt.Errorf("build permission policy: %w", err)
-	}
-
-	// 11. Git strategy.
-	gs := buildGitStrategy(config.GitStrategy)
-
-	// 12. Trace emitter.
-	// resourceOpts captures the run-scoped attributes that ride on the
-	// OTel Resource (deployment.environment, service.namespace,
-	// harness.run.mode). Threaded into both the trace emitter and the
-	// metrics provider so the two signals share a consistent resource
-	// identity — without that, a Grafana query that joins traces to
-	// metrics on resource attributes would silently miss rows when the
-	// two providers carried different defaults.
+	// 7. Probe-eligible components — providers, permission policy, trace
+	// emitter — through the SHARED construction path buildComponents, which
+	// Preflight also calls. This is the structural parity seam (issue #356):
+	// a probe-eligible component cannot be added to a real run without also
+	// surfacing in the dry-run, because both paths construct the set here.
+	// See builtComponents.probeSteps and TestPreflightParity.
 	//
-	// resolvedHeaders dereferences any "secret://" values in
-	// TraceEmitter.Headers via the SecretStore so neither the OTel SDK
-	// nor any downstream code path sees the raw reference. Resolving
-	// once here (rather than separately for traces and metrics) keeps
-	// both signals authenticated identically and ensures a missing-env
-	// failure surfaces with one error instead of two.
+	// resourceOpts captures the run-scoped OTel Resource attributes
+	// (deployment.environment, service.namespace, harness.run.mode), threaded
+	// into both the trace emitter and the metrics provider so the two signals
+	// share a consistent resource identity. resolvedHeaders dereferences any
+	// "secret://" values in TraceEmitter.Headers once and is reused for the
+	// metrics exporter so traces and metrics authenticate identically.
 	resourceOpts := resourceOptionsFromConfig(config)
 	resolvedHeaders, err := observability.ResolveHeaders(ctx, secrets, config.TraceEmitter.Headers)
 	if err != nil {
 		cleanup()
 		return nil, fmt.Errorf("resolve trace emitter headers: %w", err)
 	}
-	te, err := buildTraceEmitter(ctx, config.TraceEmitter, resolvedHeaders, resourceOpts)
+	components, err := buildComponents(ctx, config, secrets, secLogger, registry, tp, exec, resolvedHeaders, resourceOpts)
 	if err != nil {
 		cleanup()
-		return nil, fmt.Errorf("build trace emitter: %w", err)
+		// buildComponents already prefixes the failing component
+		// ("build providers" / "build permission policy" / "build trace
+		// emitter"), matching BuildLoop's historical inline messages.
+		return nil, err
 	}
+	prov := components.defaultProvider
+	providers := components.providers
+	pp := components.permissionPolicy
+	te := components.traceEmitter
 	if closer, ok := te.(io.Closer); ok {
 		ownedClosers = append(ownedClosers, closer)
 	}
+
+	// 8. Context strategy. Built after buildComponents because the
+	// "summarise" strategy needs the default provider adapter.
+	cs := buildContextStrategy(config.ContextStrategy, prov, config.ModelRouter.Model, exec)
+
+	// 9. Verifier. Declared here so later steps can reference it, but actual
+	// construction is deferred to step 13 (line ~296) once the run's
+	// metrics instance exists. buildVerifier wraps its result in a
+	// metric-recorder when metrics is non-nil, so calling it twice (once
+	// without metrics here, once with) would discard the first build —
+	// hence the deferred single construction.
+	var v verifier.Verifier
+
+	// 10. GuardRail. Constructed AFTER providers are built so cloud-judge
+	// can reuse the default ProviderAdapter. Returns guard.NewNoop() when
+	// no guard is configured, so the loop's call sites are unconditional.
+	gr, err := buildGuardRail(config.GuardRail, providers, prov)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("build guardrail: %w", err)
+	}
+
+	// 11. Git strategy.
+	gs := buildGitStrategy(config.GitStrategy)
 
 	// 13. OTel metrics.
 	var metrics *observability.Metrics

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -204,7 +204,11 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		cleanup()
 		return nil, fmt.Errorf("resolve trace emitter headers: %w", err)
 	}
-	components, err := buildComponents(ctx, config, secrets, secLogger, registry, tp, exec, resolvedHeaders, resourceOpts)
+	// exec was built (and its closer registered) above; wrap it so
+	// buildComponents threads it onto the component set. The nil sink means
+	// no per-component construction steps are emitted (those are a dry-run
+	// concern only).
+	components, err := buildComponents(ctx, config, secrets, secLogger, registry, tp, executorBuildResult{exec: exec}, resolvedHeaders, resourceOpts, nil)
 	if err != nil {
 		cleanup()
 		// buildComponents already prefixes the failing component

--- a/harness/internal/core/parity_test.go
+++ b/harness/internal/core/parity_test.go
@@ -1,0 +1,120 @@
+package core
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// reportStepNames collects the step names present in a preflight report.
+func reportStepNames(report *PreflightReport) map[string]bool {
+	names := make(map[string]bool, len(report.Steps))
+	for _, s := range report.Steps {
+		names[s.Name] = true
+	}
+	return names
+}
+
+// missingProbeSteps returns the probeSteps names absent from the report's
+// step set — the parity violation the dry-run must never have: a
+// probe-eligible component BuildLoop constructs that the dry-run does not
+// surface.
+func missingProbeSteps(steps []probeComponentStep, report *PreflightReport) []string {
+	have := reportStepNames(report)
+	var missing []string
+	for _, s := range steps {
+		if !have[s.name] {
+			missing = append(missing, s.name)
+		}
+	}
+	return missing
+}
+
+// buildComponentsForParity constructs the probe-eligible set through the
+// SAME buildComponents path BuildLoop uses, so the test measures parity
+// against the real construction rather than a re-listing. The executor is
+// built read-only-safe (local) for the representative config.
+func buildComponentsForParity(t *testing.T, config *types.RunConfig) *builtComponents {
+	t.Helper()
+	ctx := context.Background()
+	secLogger := security.NewSecurityLogger(io.Discard, config.RunID)
+	secrets, err := security.NewAutoSecretStore(ctx, config)
+	if err != nil {
+		t.Fatalf("secret store: %v", err)
+	}
+	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
+	if err != nil {
+		t.Fatalf("build executor: %v", err)
+	}
+	resolvedHeaders, err := observability.ResolveHeaders(ctx, secrets, config.TraceEmitter.Headers)
+	if err != nil {
+		t.Fatalf("resolve headers: %v", err)
+	}
+	tp := transport.NewStdioTransport(io.Discard, nil)
+	bc, err := buildComponents(ctx, config, secrets, secLogger, tool.NewRegistry(), tp, exec, resolvedHeaders, resourceOptionsFromConfig(config))
+	if err != nil {
+		t.Fatalf("buildComponents: %v", err)
+	}
+	return bc
+}
+
+// TestPreflightParity is the #356 regression guard: every probe-eligible
+// component BuildLoop constructs (enumerated by builtComponents.probeSteps,
+// the set buildComponents produces) MUST surface as a step in a
+// representative-config Preflight report. If a future change adds a
+// component to buildComponents/probeSteps without teaching Preflight to
+// build+probe it, this test fails — closing the false-clean-dry-run gap.
+func TestPreflightParity(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	config := preflightTestConfig(t, srv.URL+"/v1")
+
+	bc := buildComponentsForParity(t, config)
+	steps := bc.probeSteps()
+	if len(steps) == 0 {
+		t.Fatal("probeSteps returned no components; the parity check would be vacuous")
+	}
+
+	report, err := Preflight(context.Background(), config, PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+
+	if missing := missingProbeSteps(steps, report); len(missing) > 0 {
+		t.Fatalf("probe-eligible components missing from the dry-run report: %v\n"+
+			"every component in builtComponents.probeSteps must produce a Preflight step "+
+			"(add construction + probe handling in Preflight)\nreport steps: %+v", missing, report.Steps)
+	}
+}
+
+// TestPreflightParity_DetectsOmission proves the parity check actually
+// catches an omission: a fabricated probe set carrying a component name the
+// representative report does not produce must be flagged by
+// missingProbeSteps. Without this, TestPreflightParity could pass trivially
+// if the comparison logic were broken.
+func TestPreflightParity_DetectsOmission(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	config := preflightTestConfig(t, srv.URL+"/v1")
+	report, err := Preflight(context.Background(), config, PreflightOptions{})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+
+	// Simulate a component added to BuildLoop (probeSteps) but never built
+	// or probed by Preflight.
+	fabricated := []probeComponentStep{{name: "phantom-component-probe", component: nil}}
+	if missing := missingProbeSteps(fabricated, report); len(missing) != 1 || missing[0] != "phantom-component-probe" {
+		t.Fatalf("parity check failed to flag an omitted component; missing=%v", missing)
+	}
+}

--- a/harness/internal/core/parity_test.go
+++ b/harness/internal/core/parity_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"io"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
@@ -12,34 +14,20 @@ import (
 	"github.com/rxbynerd/stirrup/types"
 )
 
-// reportStepNames collects the step names present in a preflight report.
-func reportStepNames(report *PreflightReport) map[string]bool {
-	names := make(map[string]bool, len(report.Steps))
+// reportStep returns the step with the given name, or false.
+func reportStep(report *PreflightReport, name string) (PreflightStep, bool) {
 	for _, s := range report.Steps {
-		names[s.Name] = true
-	}
-	return names
-}
-
-// missingProbeSteps returns the probeSteps names absent from the report's
-// step set — the parity violation the dry-run must never have: a
-// probe-eligible component BuildLoop constructs that the dry-run does not
-// surface.
-func missingProbeSteps(steps []probeComponentStep, report *PreflightReport) []string {
-	have := reportStepNames(report)
-	var missing []string
-	for _, s := range steps {
-		if !have[s.name] {
-			missing = append(missing, s.name)
+		if s.Name == name {
+			return s, true
 		}
 	}
-	return missing
+	return PreflightStep{}, false
 }
 
-// buildComponentsForParity constructs the probe-eligible set through the
-// SAME buildComponents path BuildLoop uses, so the test measures parity
-// against the real construction rather than a re-listing. The executor is
-// built read-only-safe (local) for the representative config.
+// buildComponentsForParity constructs the probe-eligible set through the SAME
+// buildComponents path BuildLoop uses, so the test measures parity against the
+// real construction rather than a re-listing. The executor is built
+// read-only-safe (local) for the representative config.
 func buildComponentsForParity(t *testing.T, config *types.RunConfig) *builtComponents {
 	t.Helper()
 	ctx := context.Background()
@@ -48,28 +36,30 @@ func buildComponentsForParity(t *testing.T, config *types.RunConfig) *builtCompo
 	if err != nil {
 		t.Fatalf("secret store: %v", err)
 	}
-	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
-	if err != nil {
-		t.Fatalf("build executor: %v", err)
+	execResult := preflightExecutorConstruct(ctx, config, secrets, secLogger)
+	if execResult.err != nil {
+		t.Fatalf("executor construct: %v", execResult.err)
 	}
 	resolvedHeaders, err := observability.ResolveHeaders(ctx, secrets, config.TraceEmitter.Headers)
 	if err != nil {
 		t.Fatalf("resolve headers: %v", err)
 	}
 	tp := transport.NewStdioTransport(io.Discard, nil)
-	bc, err := buildComponents(ctx, config, secrets, secLogger, tool.NewRegistry(), tp, exec, resolvedHeaders, resourceOptionsFromConfig(config))
+	bc, err := buildComponents(ctx, config, secrets, secLogger, tool.NewRegistry(), tp, execResult, resolvedHeaders, resourceOptionsFromConfig(config), nil)
 	if err != nil {
 		t.Fatalf("buildComponents: %v", err)
 	}
 	return bc
 }
 
-// TestPreflightParity is the #356 regression guard: every probe-eligible
+// TestPreflightParity is the #356 regression guard. Every probe-eligible
 // component BuildLoop constructs (enumerated by builtComponents.probeSteps,
 // the set buildComponents produces) MUST surface as a step in a
-// representative-config Preflight report. If a future change adds a
-// component to buildComponents/probeSteps without teaching Preflight to
-// build+probe it, this test fails — closing the false-clean-dry-run gap.
+// representative-config Preflight report AND that step must have actually
+// run — not be a "not constructed" skip standing in for a component the
+// dry-run forgot to build. The second assertion closes the hole where a
+// probeSteps entry left nil would emit a present-but-vacuous skip and a naive
+// name-only check would pass.
 func TestPreflightParity(t *testing.T) {
 	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
 	srv, _ := metadataOnlyServer(t)
@@ -88,33 +78,121 @@ func TestPreflightParity(t *testing.T) {
 		t.Fatalf("Preflight: %v", err)
 	}
 
-	if missing := missingProbeSteps(steps, report); len(missing) > 0 {
-		t.Fatalf("probe-eligible components missing from the dry-run report: %v\n"+
-			"every component in builtComponents.probeSteps must produce a Preflight step "+
-			"(add construction + probe handling in Preflight)\nreport steps: %+v", missing, report.Steps)
+	for _, ps := range steps {
+		step, found := reportStep(report, ps.name)
+		if !found {
+			t.Errorf("probe-eligible component %q produced no step in the dry-run report\n"+
+				"every component in builtComponents.probeSteps must produce a Preflight step "+
+				"(add construction + probe handling in Preflight)\nreport steps: %+v", ps.name, report.Steps)
+			continue
+		}
+		// A "not constructed" skip means the probeSteps entry was nil — the
+		// component was enumerated but Preflight never built it. That is the
+		// false-clean-dry-run drift the parity guarantee exists to kill, so
+		// it must fail the test rather than satisfy a name-only check.
+		if step.Status == PreflightSkip && strings.Contains(step.Detail, "not constructed") {
+			t.Errorf("probe step %q is a 'not constructed' skip: the component is enumerated "+
+				"but Preflight did not build it (false-clean dry-run). detail=%q", ps.name, step.Detail)
+		}
 	}
 }
 
-// TestPreflightParity_DetectsOmission proves the parity check actually
-// catches an omission: a fabricated probe set carrying a component name the
-// representative report does not produce must be flagged by
-// missingProbeSteps. Without this, TestPreflightParity could pass trivially
-// if the comparison logic were broken.
-func TestPreflightParity_DetectsOmission(t *testing.T) {
+// TestProbeStepsCoversBuiltComponents closes the converse hole: a
+// probe-eligible field added to builtComponents (and built by buildComponents)
+// but omitted from probeSteps() would never be probed, and nothing else would
+// catch it. Every field tagged `probe:"..."` must be represented in
+// probeSteps(), and every probeSteps() step must map back to a tagged field —
+// so adding a probe-eligible field without enumerating it (or vice versa)
+// fails here.
+func TestProbeStepsCoversBuiltComponents(t *testing.T) {
 	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
 	srv, _ := metadataOnlyServer(t)
 	defer srv.Close()
 
 	config := preflightTestConfig(t, srv.URL+"/v1")
-	report, err := Preflight(context.Background(), config, PreflightOptions{})
-	if err != nil {
-		t.Fatalf("Preflight: %v", err)
+	bc := buildComponentsForParity(t, config)
+
+	emitted := make(map[string]bool)
+	for _, ps := range bc.probeSteps() {
+		emitted[ps.name] = true
 	}
 
-	// Simulate a component added to BuildLoop (probeSteps) but never built
-	// or probed by Preflight.
-	fabricated := []probeComponentStep{{name: "phantom-component-probe", component: nil}}
-	if missing := missingProbeSteps(fabricated, report); len(missing) != 1 || missing[0] != "phantom-component-probe" {
-		t.Fatalf("parity check failed to flag an omitted component; missing=%v", missing)
+	// Collect the step names (or prefixes) declared by the probe struct tags.
+	tagged := make(map[string]bool)
+	rt := reflect.TypeOf(*bc)
+	for i := 0; i < rt.NumField(); i++ {
+		tag, ok := rt.Field(i).Tag.Lookup("probe")
+		if !ok {
+			continue
+		}
+		tagged[tag] = true
+	}
+	if len(tagged) == 0 {
+		t.Fatal("no probe-tagged fields found; the coverage check would be vacuous")
+	}
+
+	matches := func(stepName, tag string) bool {
+		if stepName == tag {
+			return true
+		}
+		// A tag ending in ":" is a prefix for a map field that expands to one
+		// step per entry (the providers map → "provider-probe:<name>").
+		return strings.HasSuffix(tag, ":") && strings.HasPrefix(stepName, tag)
+	}
+
+	// Every tagged field must be represented in probeSteps. The representative
+	// config has at least one provider, so the prefix tag matches at least one
+	// emitted step.
+	for tag := range tagged {
+		found := false
+		for name := range emitted {
+			if matches(name, tag) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("probe-eligible field tagged %q is not enumerated by probeSteps(); "+
+				"add it to probeSteps or remove the probe tag", tag)
+		}
+	}
+
+	// Every emitted step must map back to a tagged field, so a step added to
+	// probeSteps without a corresponding tagged field (drift in the other
+	// direction) is also caught.
+	for name := range emitted {
+		found := false
+		for tag := range tagged {
+			if matches(name, tag) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("probeSteps emits %q but no builtComponents field is tagged for it; "+
+				"tag the backing field or drop the step", name)
+		}
+	}
+}
+
+// TestPreflightParity_DetectsNotConstructedSkip proves the strengthened
+// assertion in TestPreflightParity actually fires: a synthesized report whose
+// probe step is a "not constructed" skip must be recognised as vacuous by the
+// same check. Without this, a broken assertion could let the false-clean case
+// through.
+func TestPreflightParity_DetectsNotConstructedSkip(t *testing.T) {
+	report := &PreflightReport{
+		Steps: []PreflightStep{
+			{Name: "trace-emitter-probe", Status: PreflightSkip, Detail: "component not constructed"},
+		},
+		OK: true,
+	}
+	step, found := reportStep(report, "trace-emitter-probe")
+	if !found {
+		t.Fatal("expected the fabricated step to be found")
+	}
+	isVacuous := step.Status == PreflightSkip && strings.Contains(step.Detail, "not constructed")
+	if !isVacuous {
+		t.Fatal("the parity assertion would not have flagged a 'not constructed' skip")
 	}
 }

--- a/harness/internal/core/preflight.go
+++ b/harness/internal/core/preflight.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sort"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
@@ -12,7 +13,6 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/executor/egressproxy"
 	"github.com/rxbynerd/stirrup/harness/internal/mcp"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
-	"github.com/rxbynerd/stirrup/harness/internal/provider"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/harness/internal/workspaceexport"
@@ -78,6 +78,13 @@ type PreflightOptions struct {
 	SkipMCP      bool
 	SkipTrace    bool
 	SkipEgress   bool
+	// SkipExecutor gates the container-engine probe (--no-probe-executor).
+	// When true the executor-probe step records a skip with a reason
+	// instead of pinging the container engine, so an operator can suppress
+	// the engine probe symmetrically with the network probes. It has no
+	// effect on local/api executors, which construct without contacting an
+	// engine and expose no Probe regardless.
+	SkipExecutor bool
 	Timeout      time.Duration
 }
 
@@ -87,26 +94,33 @@ type PreflightOptions struct {
 const DefaultPreflightTimeout = 30 * time.Second
 
 // Preflight runs every initialisation step short of the first agentic
-// turn and returns a per-step report. It mirrors BuildLoop's construction
-// sequence but stops before assembling the AgenticLoop: it validates the
-// config, constructs each component (a construction failure becomes a
-// failed step naming the component — this is where credential resolution,
-// which BuildLoop performs inline during provider construction, surfaces),
-// then probes each constructed component that implements Preflighter and
-// is not gated off by opts.
+// turn and returns a per-step report. It validates the config, constructs
+// each probe-eligible component (a construction failure becomes a failed
+// step naming the component — this is where credential resolution, which
+// BuildLoop performs inline during provider construction, surfaces), then
+// probes each constructed component by iterating builtComponents.probeSteps,
+// the SAME probe enumeration BuildLoop's components satisfy.
 //
-// MAINTENANCE INVARIANT: this construction sequence intentionally mirrors
-// BuildLoopWithTransport in factory.go and MUST be updated in lockstep
-// with it. There is no shared construction helper today (a refactor to
-// extract one is a deferred follow-up), so a new component added to
-// BuildLoop that resolves credentials or validates connectivity will be
-// silently ABSENT from the dry-run — giving a false "all OK" — unless a
-// corresponding step is added here. See factory.go:BuildLoopWithTransport.
+// PARITY INVARIANT (issue #356): the probe-eligible set is defined once in
+// builtComponents.probeSteps and constructed by buildComponents, which
+// BuildLoopWithTransport also calls. A new probe-eligible component added to
+// buildComponents is therefore enumerated by probeSteps and probed here
+// automatically; TestPreflightParity fails if a probeSteps entry has no
+// corresponding step in a representative-config report. This removes the
+// old "keep in lockstep" hazard where a component added to BuildLoop alone
+// produced a false "all OK" dry-run.
+//
+// Construction here is per-component (not the bundled buildComponents call
+// BuildLoop uses) so a single component's failure is isolated to its own
+// step rather than aborting the whole report — the dry-run's value is
+// showing EVERY step's outcome. The probe phase then drives off the
+// assembled builtComponents.probeSteps so the shared enumeration still
+// governs what is probed.
 //
 // The whole sequence runs under a context.WithTimeout(ctx, opts.Timeout)
 // so a wedged endpoint cannot hang the dry-run past the operator's budget.
-// Owned resources (the executor's container, trace exporters) are closed
-// before returning so a dry-run leaves nothing running.
+// Owned resources (trace exporters) are closed before returning so a
+// dry-run leaves nothing running.
 //
 // Preflight returns a non-nil error only for an internal failure that
 // prevents producing a report at all; a report with failed steps is
@@ -153,36 +167,49 @@ func Preflight(ctx context.Context, config *types.RunConfig, opts PreflightOptio
 	}
 	ok("secret-store", "secret store constructed")
 
+	// Assemble the probe-eligible component set with per-component
+	// construction so each failure is an isolated step. The successfully
+	// built components populate `bc`, whose probeSteps drives the probe
+	// phase below — the same enumeration BuildLoop's buildComponents
+	// produces.
+	bc := &builtComponents{}
+
 	// 3. Providers + credential resolution. buildProviders resolves the
 	// credential source for every provider (default + named) inline, so a
 	// failure here is the credential/auth-config surface. Reported as a
-	// "credentials" step to match the issue's step naming. Provider
-	// reachability probes follow only if construction succeeded.
+	// "credentials" step to match the issue's step naming.
 	prov, providers, err := buildProviders(ctx, config, secrets)
 	if err != nil {
 		fail("credentials", err, "verify the credential source resolves (env var set, federation rule valid, key present)")
 	} else {
 		ok("credentials", "all provider credentials resolved")
-		preflightProviders(ctx, config, providers, opts, ok, skip, fail)
+		bc.defaultProvider = prov
+		bc.providers = providers
 	}
 
-	// 4. Executor.
-	preflightExecutor(ctx, config, secrets, secLogger, ok, skip, fail)
+	// 4. Executor construction. The container path is deliberately NOT
+	// routed through buildExecutor (which would create and START a real
+	// container); preflightExecutorConstruct returns nil for container and
+	// the engine is probed read-only in the probe phase. local/api executors
+	// are cheap and side-effect-free to construct, so they are built here
+	// and probed (they expose no Probe → skip).
+	bc.executor = preflightExecutorConstruct(ctx, config, secrets, secLogger, ok, fail)
 
 	// 5. Permission policy. The policy-engine arm loads + parses the Cedar
 	// file at construction, so a malformed policy fails here; its Probe
 	// then smoke-tests evaluation. Other policy types implement no Probe.
+	// An empty registry and nil transport match the dry-run intent: the
+	// construction (and any Cedar parse) is what is being validated, not the
+	// run's tool set or upstream approval channel.
 	pp, err := buildPermissionPolicy(config, tool.NewRegistry(), nil, secLogger)
 	if err != nil {
 		fail("permission-policy", err, "check permissionPolicy.policyFile parses as Cedar")
 	} else {
 		ok("permission-policy", fmt.Sprintf("%s policy constructed", config.PermissionPolicy.Type))
-		probeComponent(ctx, "permission-policy-probe", pp, false, "", ok, skip, fail)
+		bc.permissionPolicy = pp
 	}
 
-	// 6. Trace emitter. otel/gcs probe network reachability; jsonl opens
-	// its file at construction and implements no Probe (skip). Gated by
-	// --no-probe-trace. Built via the same buildTraceEmitter path BuildLoop
+	// 6. Trace emitter. Built via the same buildTraceEmitter path BuildLoop
 	// uses so the preflight exercises the real construction (secret://
 	// header resolution included).
 	resolvedHeaders, hdrErr := observability.ResolveHeaders(ctx, secrets, config.TraceEmitter.Headers)
@@ -194,35 +221,81 @@ func Preflight(ctx context.Context, config *types.RunConfig, opts PreflightOptio
 			fail("trace-emitter", err, traceHint(config.TraceEmitter.Type))
 		} else {
 			ok("trace-emitter", fmt.Sprintf("%s trace emitter constructed", traceTypeName(config.TraceEmitter.Type)))
-			probeComponent(ctx, "trace-emitter-probe", te, opts.SkipTrace, "--no-probe-trace set", ok, skip, fail)
+			bc.traceEmitter = te
 			if closer, isCloser := te.(interface{ Close() error }); isCloser {
 				defer func() { _ = closer.Close() }()
 			}
 		}
 	}
 
-	// 7. MCP servers. Probed per-server with a tools/list handshake that
+	// 7. Probe phase. Drive off the SHARED probe enumeration so the set of
+	// things probed here is exactly the set BuildLoop's components satisfy.
+	// A component that failed construction above is nil in `bc` and records
+	// a skip ("not constructed") rather than a second failure — its
+	// construction failure already failed the report.
+	for _, step := range bc.probeSteps() {
+		runProbeStep(ctx, config, step, opts, ok, skip, fail)
+	}
+
+	// 8. MCP servers. Probed per-server with a tools/list handshake that
 	// does not register tools. Gated by --no-probe-mcp.
 	preflightMCP(ctx, config, secrets, opts, ok, skip, fail)
 
-	// 8. Egress allowlist. Only relevant for the container executor in
+	// 9. Egress allowlist. Only relevant for the container executor in
 	// allowlist network mode. Gated by --no-probe-egress.
 	preflightEgress(ctx, config, opts, ok, skip, fail)
 
-	// 9. Workspace export destination. Only when a gs:// export URI is
+	// 10. Workspace export destination. Only when a gs:// export URI is
 	// configured. It has no dedicated --no-probe gate: the probe is a
 	// read-only bucket-metadata GET that spends nothing, so it always runs
 	// when an export destination is set.
 	preflightWorkspaceExport(ctx, config, ok, skip, fail)
 
-	// prov is the default provider adapter; it was probed via the
-	// providers map above (which keys the default by its type), so the
-	// value is not needed again here. Retained from buildProviders' return
-	// for parity with BuildLoop's signature.
-	_ = prov
-
 	report.finalise()
 	return report, nil
+}
+
+// runProbeStep runs one probe-eligible component's probe, applying the
+// per-component gating and (for the executor) the read-only container-engine
+// probe that replaces a Preflighter assertion. The step name comes from
+// builtComponents.probeSteps, so this dispatch is keyed on it.
+func runProbeStep(
+	ctx context.Context,
+	config *types.RunConfig,
+	step probeComponentStep,
+	opts PreflightOptions,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	switch {
+	case step.name == "executor-probe":
+		preflightExecutorProbe(ctx, config, step.component, opts, ok, skip, fail)
+	case step.name == "trace-emitter-probe":
+		probeComponent(ctx, step.name, step.component, opts.SkipTrace, "--no-probe-trace set", ok, skip, fail)
+	case strings.HasPrefix(step.name, "provider-probe:"):
+		if step.component == nil {
+			skip(step.name, "provider not constructed")
+			return
+		}
+		if opts.SkipProvider {
+			skip(step.name, "--no-probe-provider set")
+			return
+		}
+		probe, isProbe := step.component.(Preflighter)
+		if !isProbe {
+			skip(step.name, "provider exposes no probe")
+			return
+		}
+		name := strings.TrimPrefix(step.name, "provider-probe:")
+		if err := probe.Probe(ctx); err != nil {
+			fail(step.name, err, "verify the API key/credential and base URL for this provider")
+			return
+		}
+		ok(step.name, providerProbeDetail(providerTypeFor(config, name)))
+	default:
+		probeComponent(ctx, step.name, step.component, false, "", ok, skip, fail)
+	}
 }
 
 // finalise sets report.OK to true iff no step failed.
@@ -237,10 +310,13 @@ func (r *PreflightReport) finalise() {
 }
 
 // probeComponent type-asserts component to Preflighter and records the
-// outcome. A component implementing no Probe records a skip with a
-// generic note; a gated component (skipGate true) records a skip with
-// gateNote. The name is the step name (distinct from the construction
-// step so the report shows both construction and probe outcomes).
+// outcome. A nil component (one whose construction failed above) records a
+// skip with "not constructed" — its construction step already failed the
+// report, so a second failure here would double-count. A component
+// implementing no Probe records a skip with a generic note; a gated
+// component (skipGate true) records a skip with gateNote. The name is the
+// step name (distinct from the construction step so the report shows both
+// construction and probe outcomes).
 func probeComponent(
 	ctx context.Context,
 	name string,
@@ -251,6 +327,10 @@ func probeComponent(
 	skip func(string, string),
 	fail func(string, error, string),
 ) {
+	if isNilComponent(component) {
+		skip(name, "component not constructed")
+		return
+	}
 	probe, isProbe := component.(Preflighter)
 	if !isProbe {
 		skip(name, "component exposes no probe")
@@ -267,44 +347,91 @@ func probeComponent(
 	ok(name, "probe succeeded")
 }
 
-// preflightExecutor checks the configured executor. The container path is
-// deliberately NOT routed through buildExecutor: constructing a
-// ContainerExecutor creates and STARTS a real container (and the egress
-// proxy in allowlist mode) as a side effect, which contradicts the
-// read-only intent of a dry-run (issue #245 step 7). Instead it calls
-// executor.ProbeContainerEngine, which only pings the engine socket and
-// inspects the requested image (no pull, no container, no proxy). local
-// and api executors are cheap to construct and have no live side effects,
-// so they keep the construction path; neither implements a Probe, so the
-// probe step records a skip.
-func preflightExecutor(
+// isNilComponent reports whether an `any` holding a probe-eligible component
+// is effectively nil — either an untyped nil or a typed nil interface value
+// (e.g. a builtComponents field left unset after a construction failure).
+// The plain `== nil` check misses the typed-nil case, so reflect is used.
+func isNilComponent(component any) bool {
+	if component == nil {
+		return true
+	}
+	v := reflect.ValueOf(component)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+// preflightExecutorConstruct records the "executor" construction step and
+// returns the constructed executor for the probe phase, or nil. The
+// container path is deliberately NOT routed through buildExecutor:
+// constructing a ContainerExecutor creates and STARTS a real container (and
+// the egress proxy in allowlist mode) as a side effect, which contradicts
+// the read-only intent of a dry-run (issue #245 step 7). For container it
+// records the construction step as a skip and returns nil; the engine is
+// probed read-only in preflightExecutorProbe. local and api executors are
+// cheap to construct and have no live side effects, so they are built here
+// and returned for the probe phase (neither implements a Probe → skip).
+//
+// A returned executor is closed by the caller's defer chain is unnecessary:
+// local/api executors hold no live resource, so the dry-run leaves nothing
+// running. (The container path, which would, is never constructed.)
+func preflightExecutorConstruct(
 	ctx context.Context,
 	config *types.RunConfig,
 	secrets security.SecretStore,
 	secLogger *security.SecurityLogger,
 	ok func(string, string),
-	skip func(string, string),
 	fail func(string, error, string),
-) {
+) executor.Executor {
 	if config.Executor.Type == "container" {
-		if err := executor.ProbeContainerEngine(ctx, containerProbeConfig(config.Executor)); err != nil {
-			fail("executor", err, executorHint("container"))
-			return
-		}
-		ok("executor", "container engine reachable and image present")
-		return
+		// The container engine is probed read-only in the probe phase, not
+		// constructed here. Record the construction step as a skip so the
+		// report is honest that no executor object was built.
+		ok("executor", "container engine probed read-only (executor not constructed in dry-run)")
+		return nil
 	}
 
 	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
 	if err != nil {
 		fail("executor", err, executorHint(config.Executor.Type))
-		return
+		return nil
 	}
 	ok("executor", fmt.Sprintf("%s executor constructed", executorTypeName(config.Executor.Type)))
-	probeComponent(ctx, "executor-probe", exec, false, "", ok, skip, fail)
-	if closer, isCloser := exec.(interface{ Close() error }); isCloser {
-		_ = closer.Close()
+	return exec
+}
+
+// preflightExecutorProbe runs the "executor-probe" step. For the container
+// executor this is the read-only engine probe (socket ping + image-present,
+// no pull, no container, no proxy) gated by --no-probe-executor. For
+// local/api it delegates to the generic probeComponent against the executor
+// constructed in preflightExecutorConstruct (neither implements a Probe, so
+// the step records a skip; a nil executor — construction failed — likewise
+// skips).
+func preflightExecutorProbe(
+	ctx context.Context,
+	config *types.RunConfig,
+	exec any,
+	opts PreflightOptions,
+	ok func(string, string),
+	skip func(string, string),
+	fail func(string, error, string),
+) {
+	if config.Executor.Type == "container" {
+		if opts.SkipExecutor {
+			skip("executor-probe", "--no-probe-executor set")
+			return
+		}
+		if err := executor.ProbeContainerEngine(ctx, containerProbeConfig(config.Executor)); err != nil {
+			fail("executor-probe", err, executorHint("container"))
+			return
+		}
+		ok("executor-probe", "container engine reachable and image present")
+		return
 	}
+	probeComponent(ctx, "executor-probe", exec, false, "", ok, skip, fail)
 }
 
 // containerProbeConfig projects the RunConfig's executor block onto the
@@ -316,48 +443,6 @@ func containerProbeConfig(cfg types.ExecutorConfig) executor.ContainerExecutorCo
 		Image:   cfg.Image,
 		Network: cfg.Network,
 		Runtime: cfg.Runtime,
-	}
-}
-
-// preflightProviders probes the default and every named provider adapter
-// for metadata-endpoint reachability. Gated by --no-probe-provider. Each
-// adapter is the raw streaming adapter (the normalizer/batch wrappers are
-// not applied in preflight), so the Probe methods on the concrete adapter
-// types are reached directly. Provider names are sorted so the report's
-// step order is deterministic for a multi-provider config (reproducible
-// --output=json).
-func preflightProviders(
-	ctx context.Context,
-	config *types.RunConfig,
-	providers map[string]provider.ProviderAdapter,
-	opts PreflightOptions,
-	ok func(string, string),
-	skip func(string, string),
-	fail func(string, error, string),
-) {
-	names := make([]string, 0, len(providers))
-	for name := range providers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		p := providers[name]
-		step := "provider-probe:" + name
-		if opts.SkipProvider {
-			skip(step, "--no-probe-provider set")
-			continue
-		}
-		probe, isProbe := p.(Preflighter)
-		if !isProbe {
-			skip(step, "provider exposes no probe")
-			continue
-		}
-		if err := probe.Probe(ctx); err != nil {
-			fail(step, err, "verify the API key/credential and base URL for this provider")
-			continue
-		}
-		ok(step, providerProbeDetail(providerTypeFor(config, name)))
 	}
 }
 

--- a/harness/internal/core/preflight.go
+++ b/harness/internal/core/preflight.go
@@ -357,7 +357,7 @@ func isNilComponent(component any) bool {
 	}
 	v := reflect.ValueOf(component)
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
 		return v.IsNil()
 	default:
 		return false
@@ -370,14 +370,15 @@ func isNilComponent(component any) bool {
 // constructing a ContainerExecutor creates and STARTS a real container (and
 // the egress proxy in allowlist mode) as a side effect, which contradicts
 // the read-only intent of a dry-run (issue #245 step 7). For container it
-// records the construction step as a skip and returns nil; the engine is
-// probed read-only in preflightExecutorProbe. local and api executors are
-// cheap to construct and have no live side effects, so they are built here
-// and returned for the probe phase (neither implements a Probe → skip).
+// returns nil with a construction-step note that the engine is probed
+// read-only in preflightExecutorProbe rather than built here. local and api
+// executors are cheap to construct and have no live side effects, so they
+// are built here and returned for the probe phase (neither implements a
+// Probe → the probe step records a skip).
 //
-// A returned executor is closed by the caller's defer chain is unnecessary:
-// local/api executors hold no live resource, so the dry-run leaves nothing
-// running. (The container path, which would, is never constructed.)
+// A returned local/api executor needs no Close: it holds no live resource,
+// so the dry-run leaves nothing running. The container path, which would,
+// is never constructed.
 func preflightExecutorConstruct(
 	ctx context.Context,
 	config *types.RunConfig,
@@ -387,10 +388,11 @@ func preflightExecutorConstruct(
 	fail func(string, error, string),
 ) executor.Executor {
 	if config.Executor.Type == "container" {
-		// The container engine is probed read-only in the probe phase, not
-		// constructed here. Record the construction step as a skip so the
-		// report is honest that no executor object was built.
-		ok("executor", "container engine probed read-only (executor not constructed in dry-run)")
+		// No ContainerExecutor object is built in a dry-run (that would start
+		// a container); the engine is checked read-only in the executor-probe
+		// step. Record an honest construction note rather than claiming a
+		// build that did not happen.
+		ok("executor", "container executor not constructed in dry-run; engine checked in executor-probe")
 		return nil
 	}
 

--- a/harness/internal/core/preflight.go
+++ b/harness/internal/core/preflight.go
@@ -167,72 +167,50 @@ func Preflight(ctx context.Context, config *types.RunConfig, opts PreflightOptio
 	}
 	ok("secret-store", "secret store constructed")
 
-	// Assemble the probe-eligible component set with per-component
-	// construction so each failure is an isolated step. The successfully
-	// built components populate `bc`, whose probeSteps drives the probe
-	// phase below — the same enumeration BuildLoop's buildComponents
-	// produces.
-	bc := &builtComponents{}
+	// 3. Decide the dry-run executor (read-only: nil for container, built
+	// for local/api). Its construction step is emitted by buildComponents,
+	// not here, so the executor step stays a property of the shared
+	// constructor.
+	execResult := preflightExecutorConstruct(ctx, config, secrets, secLogger)
 
-	// 3. Providers + credential resolution. buildProviders resolves the
-	// credential source for every provider (default + named) inline, so a
-	// failure here is the credential/auth-config surface. Reported as a
-	// "credentials" step to match the issue's step naming.
-	prov, providers, err := buildProviders(ctx, config, secrets)
-	if err != nil {
-		fail("credentials", err, "verify the credential source resolves (env var set, federation rule valid, key present)")
-	} else {
-		ok("credentials", "all provider credentials resolved")
-		bc.defaultProvider = prov
-		bc.providers = providers
-	}
-
-	// 4. Executor construction. The container path is deliberately NOT
-	// routed through buildExecutor (which would create and START a real
-	// container); preflightExecutorConstruct returns nil for container and
-	// the engine is probed read-only in the probe phase. local/api executors
-	// are cheap and side-effect-free to construct, so they are built here
-	// and probed (they expose no Probe → skip).
-	bc.executor = preflightExecutorConstruct(ctx, config, secrets, secLogger, ok, fail)
-
-	// 5. Permission policy. The policy-engine arm loads + parses the Cedar
-	// file at construction, so a malformed policy fails here; its Probe
-	// then smoke-tests evaluation. Other policy types implement no Probe.
-	// An empty registry and nil transport match the dry-run intent: the
-	// construction (and any Cedar parse) is what is being validated, not the
-	// run's tool set or upstream approval channel.
-	pp, err := buildPermissionPolicy(config, tool.NewRegistry(), nil, secLogger)
-	if err != nil {
-		fail("permission-policy", err, "check permissionPolicy.policyFile parses as Cedar")
-	} else {
-		ok("permission-policy", fmt.Sprintf("%s policy constructed", config.PermissionPolicy.Type))
-		bc.permissionPolicy = pp
-	}
-
-	// 6. Trace emitter. Built via the same buildTraceEmitter path BuildLoop
-	// uses so the preflight exercises the real construction (secret://
-	// header resolution included).
+	// 4. Resolve trace-emitter headers up front so a secret:// resolution
+	// failure surfaces as its own dedicated step rather than as an opaque
+	// trace-emitter construction error inside buildComponents.
 	resolvedHeaders, hdrErr := observability.ResolveHeaders(ctx, secrets, config.TraceEmitter.Headers)
 	if hdrErr != nil {
 		fail("trace-emitter", hdrErr, "resolve secret:// references in traceEmitter.headers")
-	} else {
-		te, err := buildTraceEmitter(ctx, config.TraceEmitter, resolvedHeaders, resourceOptionsFromConfig(config))
-		if err != nil {
-			fail("trace-emitter", err, traceHint(config.TraceEmitter.Type))
-		} else {
-			ok("trace-emitter", fmt.Sprintf("%s trace emitter constructed", traceTypeName(config.TraceEmitter.Type)))
-			bc.traceEmitter = te
-			if closer, isCloser := te.(interface{ Close() error }); isCloser {
-				defer func() { _ = closer.Close() }()
-			}
-		}
+		report.finalise()
+		return report, nil
 	}
 
-	// 7. Probe phase. Drive off the SHARED probe enumeration so the set of
+	// 5. Construct the probe-eligible component set through buildComponents —
+	// the SAME constructor BuildLoopWithTransport calls. This is what makes
+	// the parity structural: a component cannot be built for a real run
+	// without also being built (and step-reported, and probe-enumerated) in
+	// the dry-run. The sink emits each component's construction step; a
+	// construction failure stops the dry-run at the first error (an
+	// acceptable trade for a single shared construction path — every later
+	// step depends on this one anyway, and a valid config builds the whole
+	// set so its report is unchanged).
+	//
+	// An empty registry and nil transport match the dry-run intent for the
+	// permission policy: the construction (and any Cedar parse) is what is
+	// validated, not the run's tool set or upstream approval channel.
+	sink := &componentStepSink{ok: ok, failStep: fail}
+	bc, err := buildComponents(ctx, config, secrets, secLogger, tool.NewRegistry(), nil, execResult, resolvedHeaders, resourceOptionsFromConfig(config), sink)
+	if err != nil {
+		// The sink already recorded the failed construction step; the
+		// wrapped error is for internal logging only and does not become a
+		// second report step.
+		report.finalise()
+		return report, nil
+	}
+	if closer, isCloser := bc.traceEmitter.(interface{ Close() error }); isCloser {
+		defer func() { _ = closer.Close() }()
+	}
+
+	// 6. Probe phase. Drive off the SHARED probe enumeration so the set of
 	// things probed here is exactly the set BuildLoop's components satisfy.
-	// A component that failed construction above is nil in `bc` and records
-	// a skip ("not constructed") rather than a second failure — its
-	// construction failure already failed the report.
 	for _, step := range bc.probeSteps() {
 		runProbeStep(ctx, config, step, opts, ok, skip, fail)
 	}
@@ -364,45 +342,45 @@ func isNilComponent(component any) bool {
 	}
 }
 
-// preflightExecutorConstruct records the "executor" construction step and
-// returns the constructed executor for the probe phase, or nil. The
-// container path is deliberately NOT routed through buildExecutor:
+// preflightExecutorConstruct decides the dry-run executor and returns it as
+// an executorBuildResult for buildComponents to thread onto the component set
+// and emit as the "executor" construction step. It does NOT emit the step
+// itself — buildComponents owns step emission so the construction-step set is
+// a property of the shared constructor.
+//
+// The container path is deliberately NOT routed through buildExecutor:
 // constructing a ContainerExecutor creates and STARTS a real container (and
 // the egress proxy in allowlist mode) as a side effect, which contradicts
 // the read-only intent of a dry-run (issue #245 step 7). For container it
-// returns nil with a construction-step note that the engine is probed
+// returns a nil executor with an ok note that the engine is checked
 // read-only in preflightExecutorProbe rather than built here. local and api
 // executors are cheap to construct and have no live side effects, so they
 // are built here and returned for the probe phase (neither implements a
 // Probe → the probe step records a skip).
 //
 // A returned local/api executor needs no Close: it holds no live resource,
-// so the dry-run leaves nothing running. The container path, which would,
-// is never constructed.
+// so the dry-run leaves nothing running. The container path, which would, is
+// never constructed.
 func preflightExecutorConstruct(
 	ctx context.Context,
 	config *types.RunConfig,
 	secrets security.SecretStore,
 	secLogger *security.SecurityLogger,
-	ok func(string, string),
-	fail func(string, error, string),
-) executor.Executor {
+) executorBuildResult {
 	if config.Executor.Type == "container" {
-		// No ContainerExecutor object is built in a dry-run (that would start
-		// a container); the engine is checked read-only in the executor-probe
-		// step. Record an honest construction note rather than claiming a
-		// build that did not happen.
-		ok("executor", "container executor not constructed in dry-run; engine checked in executor-probe")
-		return nil
+		return executorBuildResult{
+			detail: "container executor not constructed in dry-run; engine checked in executor-probe",
+		}
 	}
 
 	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
 	if err != nil {
-		fail("executor", err, executorHint(config.Executor.Type))
-		return nil
+		return executorBuildResult{err: err, hint: executorHint(config.Executor.Type)}
 	}
-	ok("executor", fmt.Sprintf("%s executor constructed", executorTypeName(config.Executor.Type)))
-	return exec
+	return executorBuildResult{
+		exec:   exec,
+		detail: fmt.Sprintf("%s executor constructed", executorTypeName(config.Executor.Type)),
+	}
 }
 
 // preflightExecutorProbe runs the "executor-probe" step. For the container

--- a/harness/internal/core/preflight_test.go
+++ b/harness/internal/core/preflight_test.go
@@ -268,6 +268,68 @@ func TestPreflight_Egress_Skip(t *testing.T) {
 	}
 }
 
+// stepDetail returns the Detail of a named step.
+func stepDetail(report *PreflightReport, name string) (string, bool) {
+	for _, s := range report.Steps {
+		if s.Name == name {
+			return s.Detail, true
+		}
+	}
+	return "", false
+}
+
+// TestPreflight_Executor_Skip is the #357 skip path: a container-executor
+// dry-run with SkipExecutor must record the executor-probe step as a skip
+// (no engine contacted) and keep the report honest the engine was not
+// probed. The container engine is never reachable in CI, so without the
+// gate this step would fail; the gate must turn it into a clean skip.
+func TestPreflight_Executor_Skip(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1")
+	cfg.Executor = types.ExecutorConfig{Type: "container", Image: "ubuntu:26.04"}
+
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{SkipExecutor: true})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "executor-probe")
+	if !ok || st != PreflightSkip {
+		t.Errorf("executor-probe step = %v (found=%v), want skip", st, ok)
+	}
+	if detail, _ := stepDetail(report, "executor-probe"); !strings.Contains(detail, "--no-probe-executor") {
+		t.Errorf("executor-probe skip detail = %q, want it to name --no-probe-executor", detail)
+	}
+	if !report.OK {
+		t.Errorf("a skipped executor probe must not fail the report; steps: %+v", report.Steps)
+	}
+}
+
+// TestPreflight_Executor_LocalProbeRunsWhenNotSkipped pins that
+// SkipExecutor is a container-only gate: a local executor still produces an
+// executor-probe step (a skip, since the local executor exposes no Probe),
+// and SkipExecutor does not suppress it with the gate reason.
+func TestPreflight_Executor_LocalUnaffectedBySkip(t *testing.T) {
+	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
+	srv, _ := metadataOnlyServer(t)
+	defer srv.Close()
+
+	cfg := preflightTestConfig(t, srv.URL+"/v1") // local executor
+	report, err := Preflight(context.Background(), cfg, PreflightOptions{SkipExecutor: true})
+	if err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	st, ok := stepStatus(report, "executor-probe")
+	if !ok || st != PreflightSkip {
+		t.Errorf("executor-probe step = %v (found=%v), want skip", st, ok)
+	}
+	if detail, _ := stepDetail(report, "executor-probe"); strings.Contains(detail, "--no-probe-executor") {
+		t.Errorf("local executor-probe must not report the container gate reason; detail = %q", detail)
+	}
+}
+
 func TestPreflight_Egress_Fail_MalformedAllowlist(t *testing.T) {
 	t.Setenv("TEST_PREFLIGHT_KEY", "sk-test")
 	srv, _ := metadataOnlyServer(t)


### PR DESCRIPTION
## Summary

Closes #356 and #357. Both are follow-ups of the #245/PR #338 `--dry-run` preflight and share the same surface (`core/preflight.go`, `core/factory.go`, `cmd/stirrup/cmd/harness.go`).

## #356 — structural preflight parity

Previously `Preflight` and `BuildLoop` constructed the probe-eligible component set via separately-maintained, manually-mirrored code, guarded only by a "keep in lockstep" comment. A component added to the real loop build but not to Preflight produced a **false-clean dry-run**.

This makes the parity structural:
- `buildComponents` is now the single shared constructor for both `BuildLoopWithTransport` and `Preflight`. Preflight passes a `componentStepSink` to emit per-component construction steps; `BuildLoop` passes `nil`. A component therefore cannot be built for a real run without also being built, step-reported, and probe-enumerated in the dry-run.
- The container executor remains the documented divergent exception (its probe is read-only but a live build starts a container), supplied via `executorBuildResult` so its construction step still emits in canonical report order.
- Two regression tests close the residual gaps: `TestPreflightParity` now rejects a `probeSteps` entry that surfaces as a "not constructed" skip (the false-clean case a name-only check accepted), and `TestProbeStepsCoversBuiltComponents` reflects over `probe:"…"` struct tags to assert every probe-eligible field is enumerated. Both were destructively verified to fail on a deliberately-omitted/nil component and pass when wired.

`loop.go` is untouched and `buildComponents` reads no env/filesystem (inputs are injected) — the loop-purity invariant holds.

## #357 — `--no-probe-executor`

Adds the missing executor probe-gate, symmetric with the existing `--no-probe-provider/mcp/trace/egress`. The executor step reports `skip` with the reason; the report stays honest that the engine was not contacted. Supplying it without `--dry-run` is exit 4, consistent with the other gates. Documented in the `docs/configuration.md` probe-gate and exit-code tables.

## Tests

`TestPreflightParity`, `TestProbeStepsCoversBuiltComponents`, `TestPreflight_Executor_Skip`, `TestPreflight_Executor_LocalUnaffectedBySkip`, and the exit-4 table case (`TestValidateDryRunFlags`). Valid-config dry-run output (step set + order) is unchanged — scope-out preserved. `just build`, `just lint` (0 issues), `just test` (all green).

## Note on overlap

This refactors `core/factory.go` (`BuildLoopWithTransport`) and `core/preflight.go`, which also see additive changes in #390 (container registry-allowlist threading). Expect a small additive merge conflict in those two files at merge time; both sets of changes are independent in intent.

## Review

One reviewer wave (code + spec). #357 was confirmed MET on the first pass. The #356 parity gap (the original mechanism only checked step-name presence, allowing a false-clean skip) was the wave's central finding and is now closed structurally plus by the two strengthened tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)