### PR TITLE
executor: install egress NetworkPolicy and ship the stirrup egress-proxy for k8s

### DIFF
--- a/examples/k8s/egress-proxy/README.md
+++ b/examples/k8s/egress-proxy/README.md
@@ -1,0 +1,132 @@
+# Kubernetes egress proxy
+
+Manifests for running the stirrup egress allowlist proxy as a Deployment
+alongside a k8s-executor sandbox Pod. The proxy gates every outbound
+destination against an FQDN allowlist; the sandbox Pod routes its traffic
+through the proxy via `HTTP_PROXY` / `HTTPS_PROXY`, and a NetworkPolicy
+confines the Pod so the proxy is its only route off-cluster.
+
+This is the Kubernetes counterpart to the in-process proxy the container
+executor starts on the host network. A sandbox Pod cannot start its own
+host-side proxy, so the proxy runs as a separate, long-lived Deployment that
+many sandbox Pods share.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `configmap.yaml` | The FQDN allowlist (one entry per line). |
+| `deployment.yaml` | The proxy Deployment running `stirrup egress-proxy`. |
+| `service.yaml` | A ClusterIP Service exposing the proxy at a stable DNS name. |
+| `network-policy.yaml` | A namespace-wide egress baseline for sandbox Pods. |
+
+## Enforcement caveat — read this first
+
+NetworkPolicy is only enforced by a CNI that implements it. **kindnet — the
+default CNI for `kind` clusters — accepts NetworkPolicy objects but does not
+enforce them.** On a stock kind cluster the deny/allowlist policies (both the
+one in `network-policy.yaml` and the per-Pod policy the executor installs at
+runtime) are inert, and a sandbox Pod retains cluster-default egress. The
+allowlist is genuinely enforced only on a NetworkPolicy-enforcing CNI such as
+[Cilium](https://cilium.io/) or [Calico](https://www.tigera.io/project-calico/).
+
+Treat a kind-based smoke test as proof of manifest shape — the objects are
+created with the right selectors, ports, and env — not as proof that egress is
+actually confined. This mirrors the honest fail-open note the container
+executor carries around `host.docker.internal`.
+
+## Applying
+
+```sh
+kubectl apply -f examples/k8s/egress-proxy/configmap.yaml
+kubectl apply -f examples/k8s/egress-proxy/deployment.yaml
+kubectl apply -f examples/k8s/egress-proxy/service.yaml
+kubectl apply -f examples/k8s/egress-proxy/network-policy.yaml
+```
+
+Edit `configmap.yaml` to list the destinations a run is permitted to reach,
+then roll the Deployment so the new allowlist takes effect:
+
+```sh
+kubectl rollout restart deployment/stirrup-egress-proxy
+```
+
+The proxy reads its allowlist once at startup; there is no hot reload. A
+restart is the supported way to change the allowlist.
+
+## Pointing a sandbox run at the proxy
+
+Configure the k8s executor with the proxy's in-cluster URL and an allowlist
+network mode. The executor injects `HTTP_PROXY` / `HTTPS_PROXY` into the
+sandbox container and installs a per-Pod NetworkPolicy confining egress to the
+proxy (plus DNS).
+
+From the CLI:
+
+```sh
+stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace default \
+  --k8s-egress-proxy-url http://stirrup-egress-proxy.default.svc:8080 \
+  ...
+```
+
+The network mode comes from a RunConfig (`executor.network.mode: "allowlist"`)
+— `--k8s-egress-proxy-url` is required whenever that mode is set and rejected
+otherwise. From a RunConfig file:
+
+```json
+{
+  "executor": {
+    "type": "k8s",
+    "image": "ghcr.io/rxbynerd/stirrup-sandbox:latest",
+    "k8sNamespace": "default",
+    "k8sEgressProxyUrl": "http://stirrup-egress-proxy.default.svc:8080",
+    "network": {
+      "mode": "allowlist",
+      "allowlist": ["api.anthropic.com", "github.com"]
+    }
+  }
+}
+```
+
+The Pod-side `network.allowlist` and the proxy ConfigMap allowlist are
+independent surfaces: the proxy enforces the FQDN allowlist for every Pod that
+routes through it, so the ConfigMap is the operator-controlled source of truth.
+Keep the two consistent.
+
+## Allowlist syntax
+
+Entries match the executor allowlist:
+
+```
+example.com           exact match on example.com:443
+*.example.com         any subdomain of example.com on :443 (not example.com itself)
+example.com:80        exact match on example.com:80
+```
+
+Blank lines and lines starting with `#` are ignored. An empty allowlist denies
+every destination (fail closed).
+
+## Running the proxy standalone
+
+The `stirrup egress-proxy` subcommand runs the proxy in the foreground until it
+receives SIGINT or SIGTERM. It is useful for local testing without a cluster:
+
+```sh
+stirrup egress-proxy --listen :8080 --allowlist api.anthropic.com --allowlist github.com
+# or read the allowlist from a file:
+stirrup egress-proxy --listen :8080 --allowlist-file ./allowlist.txt
+```
+
+`egress_allowed` / `egress_blocked` audit events are written to stderr as JSON
+lines, so a Deployment's Pod logs carry every gating decision.
+
+## Scope
+
+These manifests are a minimal, single-replica example. A production deployment
+should run `replicas >= 2` behind a PodDisruptionBudget so a node drain or
+rollout does not sever every sandbox's only egress path at once — see the note
+in `deployment.yaml`. HA, the CNI installation, and DNS-level egress filtering
+are out of scope here.

--- a/examples/k8s/egress-proxy/README.md
+++ b/examples/k8s/egress-proxy/README.md
@@ -61,6 +61,15 @@ network mode. The executor injects `HTTP_PROXY` / `HTTPS_PROXY` into the
 sandbox container and installs a per-Pod NetworkPolicy confining egress to the
 proxy (plus DNS).
 
+The proxy Deployment must run in the **same namespace** as the sandbox Pod.
+The egress NetworkPolicy selects the proxy by a `PodSelector` with no
+`NamespaceSelector`, so it matches only proxy Pods in the sandbox's own
+namespace. A proxy in a different namespace is denied (more restrictive, not a
+bypass) — a confusing misconfiguration that leaves the sandbox unable to reach
+the network at all under an enforcing CNI. Set `--k8s-namespace` and the
+proxy's namespace to the same value, and point `--k8s-egress-proxy-url` at the
+`<service>.<namespace>.svc` name.
+
 From the CLI:
 
 ```sh

--- a/examples/k8s/egress-proxy/configmap.yaml
+++ b/examples/k8s/egress-proxy/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stirrup-egress-allowlist
+  namespace: default
+  labels:
+    app: stirrup-egress-proxy
+data:
+  # One FQDN allowlist entry per line. Blank lines and lines starting with #
+  # are ignored. Entry syntax matches the executor allowlist:
+  #   example.com           exact match on example.com:443
+  #   *.example.com         any subdomain of example.com on :443
+  #   example.com:80        exact match on example.com:80
+  # An empty allowlist denies every destination (fail closed).
+  allowlist.txt: |
+    # Anthropic API
+    api.anthropic.com
+    # GitHub (clone/fetch over HTTPS)
+    github.com
+    *.githubusercontent.com

--- a/examples/k8s/egress-proxy/deployment.yaml
+++ b/examples/k8s/egress-proxy/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stirrup-egress-proxy
+  namespace: default
+  labels:
+    app: stirrup-egress-proxy
+spec:
+  # SCOPE NOTE: a single replica is intentional for this example. A
+  # production deployment should run replicas >= 2 behind a
+  # PodDisruptionBudget so a node drain or rollout does not sever every
+  # sandbox's only egress path at once. HA is out of scope here — the
+  # sample keeps the moving parts minimal.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stirrup-egress-proxy
+  template:
+    metadata:
+      labels:
+        # This label is the NetworkPolicy peer the sandbox Pod's egress
+        # policy selects (allowlistEgressPolicy in the k8s executor). Keep it
+        # in sync with that selector if either side changes.
+        app: stirrup-egress-proxy
+    spec:
+      # The proxy needs no Kubernetes API access. Refuse the token mount so a
+      # compromised proxy cannot reach the API server.
+      automountServiceAccountToken: false
+      containers:
+        - name: egress-proxy
+          # Replace with the published stirrup image. The proxy is the same
+          # binary as the harness, invoked with the egress-proxy subcommand.
+          image: ghcr.io/rxbynerd/stirrup:latest
+          args:
+            - egress-proxy
+            - --listen
+            - ":8080"
+            - --allowlist-file
+            - /etc/stirrup/allowlist.txt
+            - --log-level
+            - info
+          ports:
+            - name: proxy
+              containerPort: 8080
+          volumeMounts:
+            - name: allowlist
+              mountPath: /etc/stirrup
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+      volumes:
+        - name: allowlist
+          configMap:
+            name: stirrup-egress-allowlist

--- a/examples/k8s/egress-proxy/network-policy.yaml
+++ b/examples/k8s/egress-proxy/network-policy.yaml
@@ -1,0 +1,47 @@
+# Namespace-wide egress baseline for stirrup sandbox Pods.
+#
+# The k8s executor ALSO installs a per-Pod egress NetworkPolicy at runtime
+# (deny-all for network mode "none", proxy+DNS allowlist for "allowlist"),
+# selecting that single Pod by its unique stirrup.dev/pod label. This manifest
+# is a complementary standing baseline an operator can apply once: it selects
+# every Pod carrying stirrup-sandbox=true and confines its egress to DNS plus
+# the egress proxy. Applying both is additive and safe — NetworkPolicy egress
+# rules across policies that select the same Pod are OR-combined, and both
+# encode the same allowed peers.
+#
+# ENFORCEMENT CAVEAT: NetworkPolicy is only enforced by a CNI that implements
+# it. kindnet — the default CNI for `kind` clusters — ACCEPTS NetworkPolicy
+# objects but does NOT enforce them, so on a stock kind cluster this policy is
+# inert and the sandbox Pod retains cluster-default egress. Use a
+# NetworkPolicy-enforcing CNI (Cilium, Calico) for the confinement to hold.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stirrup-sandbox-egress
+  namespace: default
+  labels:
+    app: stirrup-egress-proxy
+spec:
+  podSelector:
+    matchLabels:
+      stirrup-sandbox: "true"
+  policyTypes:
+    - Egress
+  egress:
+    # DNS resolution. The in-Pod client must resolve the proxy's Service name,
+    # and the proxy resolves upstream names; 53/UDP and 53/TCP are opened to
+    # whichever Pod/CIDR hosts the cluster DNS.
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Egress to the egress proxy. The proxy enforces the FQDN allowlist; this
+    # rule guarantees the sandbox cannot reach the network except via it.
+    - to:
+        - podSelector:
+            matchLabels:
+              app: stirrup-egress-proxy
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/examples/k8s/egress-proxy/service.yaml
+++ b/examples/k8s/egress-proxy/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stirrup-egress-proxy
+  namespace: default
+  labels:
+    app: stirrup-egress-proxy
+spec:
+  selector:
+    app: stirrup-egress-proxy
+  ports:
+    - name: proxy
+      port: 8080
+      targetPort: proxy
+  # A stable ClusterIP is sufficient: the sandbox Pod reaches the proxy by its
+  # in-cluster DNS name. Configure the executor with
+  #   --k8s-egress-proxy-url http://stirrup-egress-proxy.default.svc:8080
+  # (or executor.k8sEgressProxyUrl in a RunConfig) so the Pod's HTTP_PROXY /
+  # HTTPS_PROXY point here.
+  type: ClusterIP

--- a/harness/cmd/stirrup/cmd/egress_proxy.go
+++ b/harness/cmd/stirrup/cmd/egress_proxy.go
@@ -57,7 +57,14 @@ func init() {
 // driveable from a test with a cancelable context (the CLI path supplies a
 // signal-cancelled one).
 type egressProxyOptions struct {
-	listen    string
+	// listen is the host:port to bind when listener is nil. Ignored when a
+	// pre-bound listener is supplied.
+	listen string
+	// listener, when non-nil, is used directly instead of binding listen.
+	// The CLI leaves it nil and binds listen; tests pass a pre-bound listener
+	// to avoid a free-port-then-rebind TOCTOU that can flake under parallel
+	// runs. serveEgressProxy owns closing it on the Start-failure path.
+	listener  net.Listener
 	allowlist []string
 	level     slog.Level
 }
@@ -110,10 +117,15 @@ func serveEgressProxy(ctx context.Context, opts egressProxyOptions, logW io.Writ
 
 	// Bind the listener explicitly so listen-host overrides (default ":8080")
 	// take effect; egressproxy.Start only opens its own loopback listener when
-	// none is supplied, which would ignore the listen flag.
-	listener, err := net.Listen("tcp", opts.listen)
-	if err != nil {
-		return ioError(fmt.Errorf("listen on %q: %w", opts.listen, err))
+	// none is supplied, which would ignore the listen flag. A caller-supplied
+	// listener (tests) is used as-is.
+	listener := opts.listener
+	if listener == nil {
+		var err error
+		listener, err = net.Listen("tcp", opts.listen)
+		if err != nil {
+			return ioError(fmt.Errorf("listen on %q: %w", opts.listen, err))
+		}
 	}
 
 	proxy, err := egressproxy.Start(ctx, egressproxy.Config{
@@ -148,10 +160,17 @@ func serveEgressProxy(ctx context.Context, opts egressProxyOptions, logW io.Writ
 	return nil
 }
 
+// maxAllowlistFileBytes caps the --allowlist-file read at 1 MiB — far more
+// than thousands of FQDN entries need, and consistent with the project's
+// other bounded file reads (RunConfig 1 MiB, prompt 10 MiB). The cap defends
+// against a runaway or hostile file exhausting memory at startup.
+const maxAllowlistFileBytes int64 = 1 << 20 // 1 MiB
+
 // readAllowlistFile reads one allowlist entry per line, skipping blank lines
 // and #-prefixed comments. Trailing inline comments are NOT stripped — an
 // FQDN never contains '#', and stripping mid-line could silently truncate a
-// malformed entry the matcher should reject loudly.
+// malformed entry the matcher should reject loudly. The read is capped at
+// maxAllowlistFileBytes.
 func readAllowlistFile(path string) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -159,8 +178,19 @@ func readAllowlistFile(path string) ([]string, error) {
 	}
 	defer func() { _ = file.Close() }()
 
+	// Bound the read with io.LimitReader (cap+1 so an exactly-at-cap file is
+	// allowed while an over-cap file is detectable). The scanner draws from
+	// the limited reader, so no more than cap+1 bytes ever reach memory.
+	limited := &countingReader{r: io.LimitReader(file, maxAllowlistFileBytes+1)}
+
 	var entries []string
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(limited)
+	// Raise the scanner's max token size to the cap so a single long line is
+	// drawn through the LimitReader (and counted) rather than tripping the
+	// default 64 KiB token limit with a confusing "token too long" before the
+	// byte-cap check below can govern. The LimitReader still bounds total
+	// memory at cap+1 bytes.
+	scanner.Buffer(make([]byte, 0, 64*1024), int(maxAllowlistFileBytes)+1)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -168,8 +198,27 @@ func readAllowlistFile(path string) ([]string, error) {
 		}
 		entries = append(entries, line)
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read allowlist file %q: %w", path, err)
+	scanErr := scanner.Err()
+	// The cap check takes precedence over any scanner error: a file past the
+	// cap must surface as the byte-cap error.
+	if limited.n > maxAllowlistFileBytes {
+		return nil, fmt.Errorf("allowlist file %q exceeds %d byte cap", path, maxAllowlistFileBytes)
+	}
+	if scanErr != nil {
+		return nil, fmt.Errorf("read allowlist file %q: %w", path, scanErr)
 	}
 	return entries, nil
+}
+
+// countingReader tallies bytes read so the caller can detect that an
+// io.LimitReader hit its ceiling (read cap+1 bytes) versus stopped at EOF.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
 }

--- a/harness/cmd/stirrup/cmd/egress_proxy.go
+++ b/harness/cmd/stirrup/cmd/egress_proxy.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor/egressproxy"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+)
+
+var egressProxyCmd = &cobra.Command{
+	Use:   "egress-proxy",
+	Short: "Run the egress allowlist proxy in the foreground",
+	Long: `Run the in-process egress allowlist proxy as a standalone process. The
+proxy terminates HTTPS CONNECT requests and forwards plain HTTP requests,
+gating every destination against an FQDN allowlist; anything not on the
+allowlist is refused.
+
+This is the same proxy the container and k8s executors start in-process for
+allowlist network mode, exposed as a long-running Deployment so a sandbox Pod
+(which cannot start its own host-side proxy) can route HTTP_PROXY / HTTPS_PROXY
+through it. Deploy it from examples/k8s/egress-proxy/ alongside a sandbox Pod
+configured with --k8s-egress-proxy-url.
+
+The allowlist is supplied via repeatable --allowlist entries and/or an
+--allowlist-file (one entry per line; blank lines and #-comments ignored). An
+empty allowlist denies every destination (fail closed). Entry syntax matches
+the executor allowlist: bare FQDN (port 443), *.example.com wildcard subdomain,
+or host:port. The process serves until it receives SIGINT or SIGTERM.`,
+	Args: cobra.NoArgs,
+	RunE: runEgressProxy,
+}
+
+func init() {
+	f := egressProxyCmd.Flags()
+	f.String("listen", ":8080", "host:port to listen on. A bare \":8080\" binds all interfaces, which a Pod behind a Service needs.")
+	f.StringArray("allowlist", nil, "Repeatable allowlist entry (e.g. --allowlist api.example.com --allowlist *.github.com:443). Combined with --allowlist-file.")
+	f.String("allowlist-file", "", "Path to a file with one allowlist entry per line. Blank lines and lines starting with # are ignored. Combined with --allowlist.")
+	f.String("log-level", "info", "Log level: debug, info, warn, error")
+	rootCmd.AddCommand(egressProxyCmd)
+}
+
+// egressProxyOptions is the resolved configuration for the egress-proxy
+// subcommand, parsed from flags by runEgressProxy and consumed by
+// serveEgressProxy. Splitting parse from serve keeps serveEgressProxy
+// driveable from a test with a cancelable context (the CLI path supplies a
+// signal-cancelled one).
+type egressProxyOptions struct {
+	listen    string
+	allowlist []string
+	level     slog.Level
+}
+
+func runEgressProxy(cmd *cobra.Command, _ []string) error {
+	f := cmd.Flags()
+	listen, _ := f.GetString("listen")
+	allowlistFlag, _ := f.GetStringArray("allowlist")
+	allowlistFile, _ := f.GetString("allowlist-file")
+	logLevelStr, _ := f.GetString("log-level")
+
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(logLevelStr)); err != nil {
+		return parseError(fmt.Errorf("invalid --log-level %q: %w", logLevelStr, err))
+	}
+
+	allowlist := append([]string{}, allowlistFlag...)
+	if allowlistFile != "" {
+		fileEntries, err := readAllowlistFile(allowlistFile)
+		if err != nil {
+			return ioError(err)
+		}
+		allowlist = append(allowlist, fileEntries...)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	return serveEgressProxy(ctx, egressProxyOptions{
+		listen:    listen,
+		allowlist: allowlist,
+		level:     level,
+	}, os.Stderr)
+}
+
+// serveEgressProxy binds the listener, starts the egress proxy, and serves
+// until ctx is cancelled (SIGINT/SIGTERM on the CLI path), then shuts down
+// with a bounded grace period. Logs and audit events are written to logW.
+//
+// Errors are returned wrapped in the CLI exit-code classes: an I/O failure
+// (listen / shutdown) is exit 3, a malformed allowlist is exit 1.
+func serveEgressProxy(ctx context.Context, opts egressProxyOptions, logW io.Writer) error {
+	logger := slog.New(slog.NewTextHandler(logW, &slog.HandlerOptions{Level: opts.level}))
+
+	// A SecurityLogger writing JSON lines gives the proxy the same
+	// egress_allowed / egress_blocked audit surface the in-process executor
+	// path produces, so a Deployment's pod logs carry the gating decisions.
+	// runID is empty: a standalone proxy is not scoped to a single run.
+	audit := security.NewSecurityLogger(logW, "")
+
+	// Bind the listener explicitly so listen-host overrides (default ":8080")
+	// take effect; egressproxy.Start only opens its own loopback listener when
+	// none is supplied, which would ignore the listen flag.
+	listener, err := net.Listen("tcp", opts.listen)
+	if err != nil {
+		return ioError(fmt.Errorf("listen on %q: %w", opts.listen, err))
+	}
+
+	proxy, err := egressproxy.Start(ctx, egressproxy.Config{
+		Allowlist: opts.allowlist,
+		Listener:  listener,
+		Security:  audit,
+		Logger:    logger,
+	})
+	if err != nil {
+		_ = listener.Close()
+		// A malformed allowlist entry surfaces here; it is a configuration
+		// error, not an I/O one.
+		return validationError(fmt.Errorf("start egress proxy: %w", err))
+	}
+
+	logger.Info("egress proxy listening",
+		slog.String("addr", proxy.Addr()),
+		slog.Int("allowlist_entries", len(opts.allowlist)),
+	)
+
+	<-ctx.Done()
+	logger.Info("egress proxy shutting down")
+
+	// Bounded shutdown so a wedged in-flight tunnel cannot hold the process
+	// open past the orchestrator's SIGTERM→SIGKILL grace window. A fresh
+	// context is used because ctx is already cancelled by the time we get here.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := proxy.Stop(shutdownCtx); err != nil {
+		return ioError(fmt.Errorf("stop egress proxy: %w", err))
+	}
+	return nil
+}
+
+// readAllowlistFile reads one allowlist entry per line, skipping blank lines
+// and #-prefixed comments. Trailing inline comments are NOT stripped — an
+// FQDN never contains '#', and stripping mid-line could silently truncate a
+// malformed entry the matcher should reject loudly.
+func readAllowlistFile(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open allowlist file %q: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var entries []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entries = append(entries, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read allowlist file %q: %w", path, err)
+	}
+	return entries, nil
+}

--- a/harness/cmd/stirrup/cmd/egress_proxy_test.go
+++ b/harness/cmd/stirrup/cmd/egress_proxy_test.go
@@ -1,0 +1,354 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// freeLoopbackAddr returns a currently-unused 127.0.0.1:port. It opens and
+// immediately closes a listener to learn a free port, then hands the address
+// to the proxy under test. There is a small TOCTOU window between close and
+// re-bind, acceptable for a local test that does not run concurrently against
+// itself.
+func freeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve free port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return addr
+}
+
+// startTestEgressProxy runs serveEgressProxy in a goroutine against a free
+// loopback port, waits for it to accept connections, and registers cleanup
+// that cancels the context and waits for a clean shutdown. The returned addr
+// is the bound host:port. This drives the real subcommand serve path end to
+// end without a never-returning blocking call on the global rootCmd.
+func startTestEgressProxy(t *testing.T, allowlist []string) (addr string) {
+	t.Helper()
+	addr = freeLoopbackAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- serveEgressProxy(ctx, egressProxyOptions{
+			listen:    addr,
+			allowlist: allowlist,
+			level:     slog.LevelError,
+		}, io.Discard)
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("serveEgressProxy returned error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("serveEgressProxy did not shut down within 10s")
+		}
+	})
+
+	// Wait for the listener to accept (or an early serve failure).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		select {
+		case err := <-done:
+			t.Fatalf("serveEgressProxy exited before listening: %v", err)
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return addr
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("egress proxy did not start listening on %s within 5s", addr)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestEgressProxy_DeniesNonAllowlisted drives a CONNECT for a host that is not
+// on the allowlist through the real serve path and asserts a 403. This is the
+// cluster-free proof that the subcommand wires the allowlist gate: the proxy
+// refuses an un-allowlisted destination.
+func TestEgressProxy_DeniesNonAllowlisted(t *testing.T) {
+	addr := startTestEgressProxy(t, []string{"allowed.example.com"})
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	connectLine := "CONNECT denied.example.com:443 HTTP/1.1\r\nHost: denied.example.com:443\r\n\r\n"
+	if _, err := conn.Write([]byte(connectLine)); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("CONNECT for non-allowlisted host: status = %d, want 403", resp.StatusCode)
+	}
+}
+
+// TestEgressProxy_AllowsCONNECT drives a CONNECT for an allowlisted host
+// through the real serve path and asserts the proxy returns 200 and splices a
+// bidirectional tunnel to the upstream. A ClientHello carrying an SNI that
+// matches the CONNECT host is sent before reading the 200 (the proxy verifies
+// SNI before establishing the tunnel); the upstream echoes the bytes back, so
+// reading them confirms the splice. This is the cluster-free proof the
+// subcommand proxies a CONNECT to an allowlisted destination.
+func TestEgressProxy_AllowsCONNECT(t *testing.T) {
+	upstream := startEchoServer(t)
+	upstreamHost, upstreamPort := hostPort(t, "http://"+upstream.Addr().String())
+	allowEntry := fmt.Sprintf("%s:%s", upstreamHost, upstreamPort)
+	addr := startTestEgressProxy(t, []string{allowEntry})
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	connectLine := fmt.Sprintf("CONNECT %s:%s HTTP/1.1\r\nHost: %s:%s\r\n\r\n", upstreamHost, upstreamPort, upstreamHost, upstreamPort)
+	if _, err := conn.Write([]byte(connectLine)); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+
+	// The proxy peeks the ClientHello SNI before writing the 200, so the
+	// hello must be sent before reading the response. SNI matches the CONNECT
+	// host (both the literal upstream host), which passes the cross-check.
+	hello := clientHelloWithSNI(upstreamHost)
+	if _, err := conn.Write(hello); err != nil {
+		t.Fatalf("write ClientHello: %v", err)
+	}
+
+	r := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(r, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT to allowlisted host: status = %d, want 200", resp.StatusCode)
+	}
+
+	// The upstream echoes the replayed ClientHello back through the tunnel.
+	got := make([]byte, len(hello))
+	if _, err := io.ReadFull(r, got); err != nil {
+		t.Fatalf("read echoed bytes through tunnel: %v", err)
+	}
+	if !bytes.Equal(got, hello) {
+		t.Error("tunnel echo mismatch: spliced bytes differ from sent ClientHello")
+	}
+}
+
+// TestEgressProxy_AllowsAllowlisted drives a plain-HTTP proxy request for an
+// allowlisted host through the real serve path and asserts it is forwarded to
+// the upstream (200). Plain HTTP is used rather than CONNECT so the test needs
+// no TLS ClientHello/SNI handshake; the allowlist gate is identical for both
+// paths, so this proves the allow side of the subcommand wiring.
+func TestEgressProxy_AllowsAllowlisted(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("upstream-ok"))
+	}))
+	defer upstream.Close()
+
+	upstreamHost, upstreamPort := hostPort(t, upstream.URL)
+	allowEntry := fmt.Sprintf("%s:%s", upstreamHost, upstreamPort)
+	addr := startTestEgressProxy(t, []string{allowEntry})
+
+	status, body := proxiedGet(t, addr, upstream.URL)
+	if status != http.StatusOK {
+		t.Errorf("proxied GET to allowlisted host: status = %d, want 200", status)
+	}
+	if body != "upstream-ok" {
+		t.Errorf("proxied body = %q, want %q", body, "upstream-ok")
+	}
+}
+
+// TestEgressProxy_AllowlistFile asserts entries from an allowlist file are
+// honoured by the parse+serve path: a host listed in the file is forwarded.
+// Blank lines and #-comments in the file must be ignored.
+func TestEgressProxy_AllowlistFile(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+	upstreamHost, upstreamPort := hostPort(t, upstream.URL)
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "allowlist.txt")
+	content := fmt.Sprintf("# comment line\n\n%s:%s\n", upstreamHost, upstreamPort)
+	if err := os.WriteFile(file, []byte(content), 0o600); err != nil {
+		t.Fatalf("write allowlist file: %v", err)
+	}
+
+	// Exercise the file reader the subcommand uses, then serve with the parsed
+	// entries — the same composition runEgressProxy performs.
+	entries, err := readAllowlistFile(file)
+	if err != nil {
+		t.Fatalf("readAllowlistFile: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("readAllowlistFile entries = %v, want exactly one (comment/blank ignored)", entries)
+	}
+
+	addr := startTestEgressProxy(t, entries)
+	status, _ := proxiedGet(t, addr, upstream.URL)
+	if status != http.StatusOK {
+		t.Errorf("file-allowlisted host: status = %d, want 200", status)
+	}
+}
+
+// TestEgressProxy_BadAllowlistFails asserts a malformed allowlist entry makes
+// serveEgressProxy return an error rather than serving.
+func TestEgressProxy_BadAllowlistFails(t *testing.T) {
+	addr := freeLoopbackAddr(t)
+	err := serveEgressProxy(context.Background(), egressProxyOptions{
+		listen: addr,
+		// A non-numeric port is rejected by the matcher at Start.
+		allowlist: []string{"bad.example.com:notaport"},
+		level:     slog.LevelError,
+	}, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for malformed allowlist entry")
+	}
+	var ee *exitError
+	if !errors.As(err, &ee) || ee.code != exitValidation {
+		t.Errorf("error = %v, want an exitValidation (exit 1) exitError", err)
+	}
+}
+
+// proxiedGet issues a plain-HTTP proxied GET for targetURL through the proxy
+// at proxyAddr and returns the status code and body. The request line carries
+// the absolute URL, which is what an HTTP_PROXY client sends and what the
+// proxy gates on the allowlist before forwarding.
+func proxiedGet(t *testing.T, proxyAddr, targetURL string) (int, string) {
+	t.Helper()
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	hostOnly := strings.TrimPrefix(targetURL, "http://")
+	req := fmt.Sprintf("GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", targetURL, hostOnly)
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// hostPort splits a http://host:port URL into its host and port components.
+func hostPort(t *testing.T, rawURL string) (host, port string) {
+	t.Helper()
+	hostPort := strings.TrimPrefix(rawURL, "http://")
+	h, p, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		t.Fatalf("split %q: %v", hostPort, err)
+	}
+	return h, p
+}
+
+// startEchoServer runs a TCP echo upstream on loopback. The CONNECT test
+// points the proxy at it and confirms bytes splice through both ways.
+func startEchoServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen echo upstream: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(c, c)
+			}(conn)
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln
+}
+
+// clientHelloWithSNI returns a minimal TLS handshake record carrying the
+// given SNI. It mirrors the egressproxy package's own test helper: the proxy
+// peeks this record to verify SNI matches the CONNECT host before opening the
+// tunnel. A real tls.Client cannot be used here because Go omits SNI for an
+// IP-literal ServerName, which the proxy treats as a tampering signal.
+func clientHelloWithSNI(sni string) []byte {
+	body := buildClientHelloBody(sni)
+	rec := make([]byte, 5+len(body))
+	rec[0] = 0x16 // handshake
+	rec[1] = 0x03 // TLS 1.0 in record layer
+	rec[2] = 0x01
+	binary.BigEndian.PutUint16(rec[3:5], uint16(len(body)))
+	copy(rec[5:], body)
+	return rec
+}
+
+// buildClientHelloBody constructs a ClientHello message body carrying a
+// server_name extension for sni.
+func buildClientHelloBody(sni string) []byte {
+	var inner bytes.Buffer
+	inner.Write([]byte{0x03, 0x03})             // client_version TLS 1.2
+	inner.Write(make([]byte, 32))               // random
+	inner.WriteByte(0x00)                       // session_id (empty)
+	inner.Write([]byte{0x00, 0x02, 0x00, 0x2f}) // cipher_suites: one suite
+	inner.Write([]byte{0x01, 0x00})             // compression_methods: null
+
+	sniBytes := []byte(sni)
+	var hostName bytes.Buffer
+	hostName.WriteByte(0x00) // host_name type
+	_ = binary.Write(&hostName, binary.BigEndian, uint16(len(sniBytes)))
+	hostName.Write(sniBytes)
+	var serverNameList bytes.Buffer
+	_ = binary.Write(&serverNameList, binary.BigEndian, uint16(hostName.Len()))
+	serverNameList.Write(hostName.Bytes())
+	var ext bytes.Buffer
+	ext.Write([]byte{0x00, 0x00}) // extension_type = server_name
+	_ = binary.Write(&ext, binary.BigEndian, uint16(serverNameList.Len()))
+	ext.Write(serverNameList.Bytes())
+	_ = binary.Write(&inner, binary.BigEndian, uint16(ext.Len()))
+	inner.Write(ext.Bytes())
+
+	body := make([]byte, 4+inner.Len())
+	body[0] = 0x01 // ClientHello
+	body[1] = byte(inner.Len() >> 16)
+	body[2] = byte(inner.Len() >> 8)
+	body[3] = byte(inner.Len())
+	copy(body[4:], inner.Bytes())
+	return body
+}

--- a/harness/cmd/stirrup/cmd/egress_proxy_test.go
+++ b/harness/cmd/stirrup/cmd/egress_proxy_test.go
@@ -19,36 +19,36 @@ import (
 	"time"
 )
 
-// freeLoopbackAddr returns a currently-unused 127.0.0.1:port. It opens and
-// immediately closes a listener to learn a free port, then hands the address
-// to the proxy under test. There is a small TOCTOU window between close and
-// re-bind, acceptable for a local test that does not run concurrently against
-// itself.
-func freeLoopbackAddr(t *testing.T) string {
+// boundLoopbackListener opens a listener on an ephemeral 127.0.0.1 port and
+// returns it. Passing this listener straight into serveEgressProxy (via
+// egressProxyOptions.listener) avoids the close-and-rebind TOCTOU that a
+// free-port-then-rebind helper would carry, so the tests stay stable under
+// parallel runs.
+func boundLoopbackListener(t *testing.T) net.Listener {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("reserve free port: %v", err)
+		t.Fatalf("bind loopback listener: %v", err)
 	}
-	addr := l.Addr().String()
-	_ = l.Close()
-	return addr
+	return l
 }
 
-// startTestEgressProxy runs serveEgressProxy in a goroutine against a free
-// loopback port, waits for it to accept connections, and registers cleanup
-// that cancels the context and waits for a clean shutdown. The returned addr
-// is the bound host:port. This drives the real subcommand serve path end to
-// end without a never-returning blocking call on the global rootCmd.
+// startTestEgressProxy runs serveEgressProxy in a goroutine against a
+// pre-bound loopback listener, waits for it to accept connections, and
+// registers cleanup that cancels the context and waits for a clean shutdown.
+// The returned addr is the bound host:port. This drives the real subcommand
+// serve path end to end without a never-returning blocking call on the global
+// rootCmd.
 func startTestEgressProxy(t *testing.T, allowlist []string) (addr string) {
 	t.Helper()
-	addr = freeLoopbackAddr(t)
+	listener := boundLoopbackListener(t)
+	addr = listener.Addr().String()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
 		done <- serveEgressProxy(ctx, egressProxyOptions{
-			listen:    addr,
+			listener:  listener,
 			allowlist: allowlist,
 			level:     slog.LevelError,
 		}, io.Discard)
@@ -222,12 +222,59 @@ func TestEgressProxy_AllowlistFile(t *testing.T) {
 	}
 }
 
+// TestReadAllowlistFile_SizeCap asserts the 1 MiB read cap fires on an
+// oversized allowlist file rather than reading it all into memory. A file at
+// exactly the cap is accepted; one byte over is rejected.
+func TestReadAllowlistFile_SizeCap(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("over cap rejected", func(t *testing.T) {
+		file := filepath.Join(dir, "over.txt")
+		// One byte past the cap. Content shape is irrelevant — the read is
+		// bounded before any parsing.
+		big := bytes.Repeat([]byte("a"), int(maxAllowlistFileBytes)+1)
+		if err := os.WriteFile(file, big, 0o600); err != nil {
+			t.Fatalf("write oversize file: %v", err)
+		}
+		_, err := readAllowlistFile(file)
+		if err == nil {
+			t.Fatal("expected error for an over-cap allowlist file")
+		}
+		if !strings.Contains(err.Error(), "cap") {
+			t.Errorf("error %q should mention the byte cap", err)
+		}
+	})
+
+	t.Run("at cap accepted", func(t *testing.T) {
+		file := filepath.Join(dir, "atcap.txt")
+		// Fill exactly to the cap with a single valid entry followed by
+		// padding comment bytes so the parse yields one entry.
+		entry := "example.com\n"
+		pad := bytes.Repeat([]byte("#x\n"), (int(maxAllowlistFileBytes)-len(entry))/3)
+		content := append([]byte(entry), pad...)
+		// Trim to be at most the cap.
+		if int64(len(content)) > maxAllowlistFileBytes {
+			content = content[:maxAllowlistFileBytes]
+		}
+		if err := os.WriteFile(file, content, 0o600); err != nil {
+			t.Fatalf("write at-cap file: %v", err)
+		}
+		entries, err := readAllowlistFile(file)
+		if err != nil {
+			t.Fatalf("at-cap file should be accepted, got: %v", err)
+		}
+		if len(entries) == 0 || entries[0] != "example.com" {
+			t.Errorf("entries = %v, want it to contain example.com", entries)
+		}
+	})
+}
+
 // TestEgressProxy_BadAllowlistFails asserts a malformed allowlist entry makes
-// serveEgressProxy return an error rather than serving.
+// serveEgressProxy return an error rather than serving. serveEgressProxy
+// closes the supplied listener on the Start-failure path, so no leak.
 func TestEgressProxy_BadAllowlistFails(t *testing.T) {
-	addr := freeLoopbackAddr(t)
 	err := serveEgressProxy(context.Background(), egressProxyOptions{
-		listen: addr,
+		listener: boundLoopbackListener(t),
 		// A non-numeric port is rejected by the matcher at Start.
 		allowlist: []string{"bad.example.com:notaport"},
 		level:     slog.LevelError,

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -213,6 +213,7 @@ type harnessCLIOptions struct {
 	K8sKubeconfig     string
 	K8sServiceAccount string
 	K8sNodeSelector   map[string]string
+	K8sEgressProxyURL string
 
 	// GuardRail escape hatches (issue #43). When any of these is non-zero
 	// the flag-only path constructs a GuardRailConfig; an entirely-zero
@@ -399,6 +400,7 @@ func buildHarnessRunConfigCore(opts harnessCLIOptions) (*types.RunConfig, error)
 			K8sKubeconfig:     opts.K8sKubeconfig,
 			K8sNodeSelector:   opts.K8sNodeSelector,
 			K8sServiceAccount: opts.K8sServiceAccount,
+			K8sEgressProxyURL: opts.K8sEgressProxyURL,
 		},
 		EditStrategy: types.EditStrategyConfig{Type: editStrategyType},
 		Verifier:     types.VerifierConfig{Type: verifierType},
@@ -1065,6 +1067,9 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 	}
 	if changed("k8s-service-account") {
 		cfg.Executor.K8sServiceAccount, _ = f.GetString("k8s-service-account")
+	}
+	if changed("k8s-egress-proxy-url") {
+		cfg.Executor.K8sEgressProxyURL, _ = f.GetString("k8s-egress-proxy-url")
 	}
 	if changed("k8s-node-selector") {
 		raw, _ := f.GetStringArray("k8s-node-selector")

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -390,6 +390,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 	k8sNamespace, _ := f.GetString("k8s-namespace")
 	k8sKubeconfig, _ := f.GetString("k8s-kubeconfig")
 	k8sServiceAccount, _ := f.GetString("k8s-service-account")
+	k8sEgressProxyURL, _ := f.GetString("k8s-egress-proxy-url")
 	k8sNodeSelectorRaw, _ := f.GetStringArray("k8s-node-selector")
 	permissionPolicyFile, _ := f.GetString("permission-policy-file")
 	codeScannerType, _ := f.GetString("code-scanner")
@@ -496,6 +497,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 		K8sNamespace:                 k8sNamespace,
 		K8sKubeconfig:                k8sKubeconfig,
 		K8sServiceAccount:            k8sServiceAccount,
+		K8sEgressProxyURL:            k8sEgressProxyURL,
 		K8sNodeSelector:              k8sNodeSelector,
 		PermissionPolicyFile:         permissionPolicyFile,
 		CodeScannerType:              codeScannerType,

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -69,6 +69,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.String("k8s-kubeconfig", "", "Path to a kubeconfig file for the k8s executor. Empty prefers in-cluster config, then $KUBECONFIG. Mirrors executor.k8sKubeconfig.")
 	f.StringArray("k8s-node-selector", nil, "Repeatable key=value nodeSelector label constraining where the k8s executor's Pod schedules (e.g. --k8s-node-selector disktype=ssd). Mirrors executor.k8sNodeSelector.")
 	f.String("k8s-service-account", "", "ServiceAccount name for the k8s executor's Pod. Empty uses the namespace default. The token is never automounted regardless. Mirrors executor.k8sServiceAccount.")
+	f.String("k8s-egress-proxy-url", "", "URL of the egress proxy the k8s sandbox Pod routes HTTP_PROXY/HTTPS_PROXY through. Required when --executor=k8s and the network mode is \"allowlist\"; rejected otherwise. Deploy the proxy from examples/k8s/egress-proxy/. Mirrors executor.k8sEgressProxyUrl.")
 	f.String("permission-policy-file", "", "Path to a Cedar policy file for the policy-engine PermissionPolicy. When set and --permission-policy is unset elsewhere, also implies permissionPolicy.type=policy-engine. See examples/policies/ for starters.")
 	f.String("code-scanner", "", "CodeScanner type: none, patterns, semgrep, composite. Composite requires --config (codeScanner.scanners). Empty defers to the mode-aware default (patterns for execution, none for read-only modes).")
 

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -906,6 +906,7 @@ func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets securi
 			ServiceAccountName: cfg.K8sServiceAccount,
 			Resources:          cfg.Resources,
 			Network:            cfg.Network,
+			EgressProxyURL:     cfg.K8sEgressProxyURL,
 			Security:           secLogger,
 		})
 	case "api":

--- a/harness/internal/executor/k8s.go
+++ b/harness/internal/executor/k8s.go
@@ -106,6 +106,11 @@ type K8sExecutorConfig struct {
 	// the network only via the proxy) and ignored for Mode == "none". The
 	// proxy itself runs as a separate Deployment — see
 	// examples/k8s/egress-proxy/ and the `stirrup egress-proxy` subcommand.
+	//
+	// The egress proxy Deployment MUST run in the same namespace as the
+	// sandbox Pod: the allowlist NetworkPolicy selects the proxy by
+	// PodSelector with no NamespaceSelector, so a cross-namespace proxy is
+	// denied (more restrictive, not a bypass) and a confusing misconfig.
 	EgressProxyURL string
 	// Security, when non-nil, receives structured security events
 	// (path-traversal blocks, file-size-limit and output-cap hits) so they

--- a/harness/internal/executor/k8s.go
+++ b/harness/internal/executor/k8s.go
@@ -72,10 +72,20 @@ var errK8sOutputCap = errors.New("output exceeded 10 MB cap")
 // is applied to the Pod container (CPU/memory requests+limits, ephemeral
 // storage limit; see resourcesToPodResources).
 //
-// Network is held for Capabilities reporting but egress is not yet
-// enforced — NetworkPolicy wiring is deferred to #178/#83. Until then a
-// Pod with Network == nil reports CanNetwork=false while retaining the
-// cluster-default egress in reality (tracked on Capabilities).
+// Network is REQUIRED (fail-closed): NewK8sExecutor rejects a nil Network
+// at construction, mirroring the container executor's explicit network
+// posture. Mode=="none" installs a deny-all egress NetworkPolicy alongside
+// the Pod; Mode=="allowlist" installs a policy permitting egress only to the
+// egress proxy (plus DNS) and injects HTTP_PROXY/HTTPS_PROXY/NO_PROXY pointing
+// at EgressProxyURL. Capabilities().CanNetwork reflects the installed policy.
+//
+// CAVEAT: NetworkPolicy enforcement depends on the cluster CNI. kindnet (the
+// default kind CNI) accepts the policy object but does NOT enforce it, so on
+// a stock kind cluster the deny/allowlist is inert and the Pod retains
+// cluster-default egress. A NetworkPolicy-enforcing CNI (Cilium, Calico) is
+// required for the posture to hold — see examples/k8s/egress-proxy/README.md.
+// This is the k8s analogue of the container executor's honest fail-open note
+// around host.docker.internal.
 type K8sExecutorConfig struct {
 	// Image is the container image for the agent Pod. It must ship a
 	// POSIX shell at /bin/sh plus the `tar` and `ls` utilities on PATH:
@@ -90,6 +100,13 @@ type K8sExecutorConfig struct {
 	ServiceAccountName string
 	Resources          *types.ResourceLimits
 	Network            *types.NetworkConfig
+	// EgressProxyURL is the URL the sandbox container's HTTP_PROXY /
+	// HTTPS_PROXY point at when Network.Mode == "allowlist". It is required
+	// in that mode (a Pod with an enforced allowlist NetworkPolicy can reach
+	// the network only via the proxy) and ignored for Mode == "none". The
+	// proxy itself runs as a separate Deployment — see
+	// examples/k8s/egress-proxy/ and the `stirrup egress-proxy` subcommand.
+	EgressProxyURL string
 	// Security, when non-nil, receives structured security events
 	// (path-traversal blocks, file-size-limit and output-cap hits) so they
 	// reach the same monitoring surface as the container and local
@@ -110,7 +127,11 @@ type K8sExecutor struct {
 	namespace  string
 	podName    string
 	network    *types.NetworkConfig
-	logger     *slog.Logger
+	// networkPolicyName is the name of the egress NetworkPolicy installed
+	// alongside the Pod. Empty only on a zero-value executor (unit tests);
+	// NewK8sExecutor always installs one. Close() deletes it best-effort.
+	networkPolicyName string
+	logger            *slog.Logger
 	// Security, when non-nil, receives structured security events. It is
 	// nil-checked at every call site so a zero-value executor (used in
 	// unit tests) emits nothing.
@@ -128,6 +149,20 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 	}
 	if cfg.Namespace == "" {
 		return nil, fmt.Errorf("k8s executor requires a namespace")
+	}
+	// Fail-closed: a nil Network leaves egress posture undefined. Rejecting
+	// it here (rather than defaulting to "deny" or "open") forces the caller
+	// to declare intent, matching the container executor's explicit network
+	// handling and keeping CanNetwork honest against an installed policy.
+	if cfg.Network == nil {
+		return nil, fmt.Errorf("k8s executor requires a network config (set executor.network.mode to \"none\" or \"allowlist\")")
+	}
+	// Compute the proxy env and validate the allowlist→URL requirement BEFORE
+	// creating any cluster objects, so a misconfigured allowlist run fails
+	// without leaving an orphaned Pod behind.
+	proxyEnv, err := proxyEnvFor(cfg.Network, cfg.EgressProxyURL)
+	if err != nil {
+		return nil, err
 	}
 
 	restCfg, err := buildRESTConfig(cfg.Kubeconfig)
@@ -168,6 +203,7 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: cfg.Namespace,
+			Labels:    podLabels(podName),
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,
@@ -185,6 +221,7 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 					Image:      cfg.Image,
 					Command:    []string{"/bin/sh", "-c", "sleep infinity"},
 					WorkingDir: k8sWorkspace,
+					Env:        proxyEnv,
 					Resources:  resourcesToPodResources(cfg.Resources),
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: ptr.To(false),
@@ -217,14 +254,30 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 		return nil, fmt.Errorf("pod %s/%s not ready: %w", cfg.Namespace, created.Name, err)
 	}
 
+	// Install the egress NetworkPolicy that backs the declared network mode.
+	// proxyEnvFor already validated the mode above, so egressPolicyFor cannot
+	// hit its default arm here. A failure to install the policy is fatal: a
+	// Pod whose egress is meant to be denied/allowlisted but is not must not
+	// be handed back to the caller. Tear the Pod down before returning.
+	policy, err := egressPolicyFor(cfg.Network, cfg.Namespace, created.Name)
+	if err != nil {
+		deletePodBestEffort(clientset, cfg.Namespace, created.Name, logger)
+		return nil, err
+	}
+	if _, err := clientset.NetworkingV1().NetworkPolicies(cfg.Namespace).Create(ctx, policy, metav1.CreateOptions{}); err != nil {
+		deletePodBestEffort(clientset, cfg.Namespace, created.Name, logger)
+		return nil, fmt.Errorf("install egress NetworkPolicy for pod %s/%s: %w", cfg.Namespace, created.Name, err)
+	}
+
 	return &K8sExecutor{
-		clientset:  clientset,
-		restConfig: restCfg,
-		namespace:  cfg.Namespace,
-		podName:    created.Name,
-		network:    cfg.Network,
-		logger:     logger,
-		Security:   cfg.Security,
+		clientset:         clientset,
+		restConfig:        restCfg,
+		namespace:         cfg.Namespace,
+		podName:           created.Name,
+		network:           cfg.Network,
+		networkPolicyName: policy.Name,
+		logger:            logger,
+		Security:          cfg.Security,
 	}, nil
 }
 
@@ -235,6 +288,20 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 func (e *K8sExecutor) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), k8sCloseTimeout)
 	defer cancel()
+
+	// Delete the egress NetworkPolicy first, best-effort: a leftover policy
+	// is harmless once the Pod it selects is gone (NetworkPolicy with a
+	// podSelector that matches nothing is inert), but leaking one per run
+	// clutters the namespace. A NotFound is success. Any other error is
+	// logged but does not block Pod deletion — the Pod is the resource that
+	// actually costs the operator, so its removal must not hinge on the
+	// policy delete succeeding.
+	if e.networkPolicyName != "" {
+		npErr := e.clientset.NetworkingV1().NetworkPolicies(e.namespace).Delete(ctx, e.networkPolicyName, metav1.DeleteOptions{})
+		if npErr != nil && !apierrors.IsNotFound(npErr) {
+			e.logger.Warn("k8s executor networkpolicy delete failed", "namespace", e.namespace, "networkpolicy", e.networkPolicyName, "err", npErr)
+		}
+	}
 
 	err := e.clientset.CoreV1().Pods(e.namespace).Delete(ctx, e.podName, metav1.DeleteOptions{
 		GracePeriodSeconds: ptr.To(int64(0)),
@@ -623,14 +690,16 @@ func (w *writeCapBuffer) Write(p []byte) (int, error) {
 func (w *writeCapBuffer) Bytes() []byte  { return w.buf.Bytes() }
 func (w *writeCapBuffer) String() string { return w.buf.String() }
 
-// TODO(#178): CanNetwork's accuracy depends on a NetworkPolicy
-// being enforced for the Pod. Until that wiring lands, a Pod with
-// cfg.Network == nil reports CanNetwork=false but has cluster-default
-// egress in reality. Tracked in #178.
+// Capabilities advertises the executor's capabilities. CanNetwork reflects
+// the egress NetworkPolicy installed alongside the Pod (#178): Mode=="none"
+// installs a deny-all policy (CanNetwork=false) and Mode=="allowlist"
+// installs a proxy-only egress policy (CanNetwork=true). The report is honest
+// against the installed object — with the standing CNI caveat that kindnet
+// accepts but does not enforce NetworkPolicy (see K8sExecutorConfig).
 //
-// Capabilities advertises the executor's capabilities. CanNetwork is
-// derived from the held NetworkConfig so callers can branch on the
-// declared policy even while egress enforcement is deferred.
+// A zero-value executor (nil network, used in some unit tests) reports
+// CanNetwork=false; NewK8sExecutor never produces one because it fails-closed
+// on a nil network.
 //
 // MaxTimeout deliberately mirrors container.go and local.go (maxTimeout =
 // 5 min). Returning 0 would silently disable timeout clamping in callers

--- a/harness/internal/executor/k8s.go
+++ b/harness/internal/executor/k8s.go
@@ -138,11 +138,13 @@ type K8sExecutor struct {
 	Security SecurityEventEmitter
 }
 
-// NewK8sExecutor builds a kubernetes clientset, creates a sandbox Pod, and
-// waits for it to become Ready before returning. On any failure after the
-// Pod is created (including readiness-poll failures) the Pod is deleted
-// best-effort before the error is returned, so callers do not have to
-// reason about partial state.
+// NewK8sExecutor builds a kubernetes clientset, installs the egress
+// NetworkPolicy, creates a sandbox Pod, and waits for it to become Ready
+// before returning. The policy is installed BEFORE the Pod so the Pod never
+// runs with unrestricted egress (the Pod name is client-side deterministic,
+// so the policy can target it ahead of time). On any failure the partially
+// created objects (policy and/or Pod) are deleted best-effort before the
+// error is returned, so callers do not have to reason about partial state.
 func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, error) {
 	if cfg.Image == "" {
 		return nil, fmt.Errorf("k8s executor requires an image")
@@ -240,33 +242,42 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 		},
 	}
 
+	// Install the egress NetworkPolicy BEFORE creating the Pod. The Pod name
+	// is client-side deterministic (generatePodName sets ObjectMeta.Name, not
+	// GenerateName) and the policy selects on the stirrup.dev/pod=<name> +
+	// stirrup-sandbox=true labels, both known here — so the policy can be in
+	// place before the Pod exists. Installing AFTER readiness would leave a
+	// Running Pod with cluster-default (unrestricted) egress in the
+	// Ready→policy window, defeating the deny-all/allowlist posture. A failure
+	// to install is fatal: a Pod whose egress is meant to be denied/allowlisted
+	// but is not must never be created.
+	//
+	// proxyEnvFor already validated the mode above, so egressPolicyFor cannot
+	// hit its default arm here.
+	policy, err := egressPolicyFor(cfg.Network, cfg.Namespace, podName)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := clientset.NetworkingV1().NetworkPolicies(cfg.Namespace).Create(ctx, policy, metav1.CreateOptions{}); err != nil {
+		return nil, fmt.Errorf("install egress NetworkPolicy for pod %s/%s: %w", cfg.Namespace, podName, err)
+	}
+
 	created, err := clientset.CoreV1().Pods(cfg.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
+		// The policy is already installed; remove it so a failed construction
+		// leaves no orphaned policy behind.
+		deleteNetworkPolicyBestEffort(clientset, cfg.Namespace, policy.Name, logger)
 		return nil, classifyPodCreateError(cfg.RuntimeClassName, err)
 	}
 
 	if err := waitForPodReady(ctx, clientset, cfg.Namespace, created.Name); err != nil {
 		deletePodBestEffort(clientset, cfg.Namespace, created.Name, logger)
+		deleteNetworkPolicyBestEffort(clientset, cfg.Namespace, policy.Name, logger)
 		// The duration is intentionally omitted: readiness can end on either
 		// k8sReadyTimeout or a shorter caller-context deadline, and a
 		// hardcoded "after 1m0s" would misreport the latter. The wrapped
 		// error (context.DeadlineExceeded or a Get failure) carries the cause.
 		return nil, fmt.Errorf("pod %s/%s not ready: %w", cfg.Namespace, created.Name, err)
-	}
-
-	// Install the egress NetworkPolicy that backs the declared network mode.
-	// proxyEnvFor already validated the mode above, so egressPolicyFor cannot
-	// hit its default arm here. A failure to install the policy is fatal: a
-	// Pod whose egress is meant to be denied/allowlisted but is not must not
-	// be handed back to the caller. Tear the Pod down before returning.
-	policy, err := egressPolicyFor(cfg.Network, cfg.Namespace, created.Name)
-	if err != nil {
-		deletePodBestEffort(clientset, cfg.Namespace, created.Name, logger)
-		return nil, err
-	}
-	if _, err := clientset.NetworkingV1().NetworkPolicies(cfg.Namespace).Create(ctx, policy, metav1.CreateOptions{}); err != nil {
-		deletePodBestEffort(clientset, cfg.Namespace, created.Name, logger)
-		return nil, fmt.Errorf("install egress NetworkPolicy for pod %s/%s: %w", cfg.Namespace, created.Name, err)
 	}
 
 	return &K8sExecutor{
@@ -281,21 +292,27 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 	}, nil
 }
 
-// Close deletes the sandbox Pod with zero grace period. It uses its own
-// background context so cleanup proceeds even if the caller's context is
-// already cancelled — matching the Docker executor's Close discipline.
-// A NotFound result is treated as success (idempotent).
+// Close deletes the sandbox Pod with zero grace period, then the egress
+// NetworkPolicy. It uses its own background context so cleanup proceeds even
+// if the caller's context is already cancelled — matching the Docker
+// executor's Close discipline. A NotFound result is treated as success
+// (idempotent).
+//
+// Ordering matters: the Pod is deleted FIRST so kubelet begins terminating it
+// immediately, then the policy is removed. Deleting the policy first would
+// reopen unrestricted egress for the still-running Pod during termination —
+// the same Ready→policy window the constructor closes by installing the
+// policy first. The policy delete is best-effort: a leftover policy is inert
+// once the Pod it selects is gone (its podSelector matches nothing), so a
+// failed policy delete must not surface as a Close error or block Pod removal.
 func (e *K8sExecutor) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), k8sCloseTimeout)
 	defer cancel()
 
-	// Delete the egress NetworkPolicy first, best-effort: a leftover policy
-	// is harmless once the Pod it selects is gone (NetworkPolicy with a
-	// podSelector that matches nothing is inert), but leaking one per run
-	// clutters the namespace. A NotFound is success. Any other error is
-	// logged but does not block Pod deletion — the Pod is the resource that
-	// actually costs the operator, so its removal must not hinge on the
-	// policy delete succeeding.
+	podErr := e.clientset.CoreV1().Pods(e.namespace).Delete(ctx, e.podName, metav1.DeleteOptions{
+		GracePeriodSeconds: ptr.To(int64(0)),
+	})
+
 	if e.networkPolicyName != "" {
 		npErr := e.clientset.NetworkingV1().NetworkPolicies(e.namespace).Delete(ctx, e.networkPolicyName, metav1.DeleteOptions{})
 		if npErr != nil && !apierrors.IsNotFound(npErr) {
@@ -303,15 +320,12 @@ func (e *K8sExecutor) Close() error {
 		}
 	}
 
-	err := e.clientset.CoreV1().Pods(e.namespace).Delete(ctx, e.podName, metav1.DeleteOptions{
-		GracePeriodSeconds: ptr.To(int64(0)),
-	})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
+	if podErr != nil {
+		if apierrors.IsNotFound(podErr) {
 			e.logger.Debug("k8s executor pod already gone", "namespace", e.namespace, "pod", e.podName)
 			return nil
 		}
-		return fmt.Errorf("delete pod: %w", err)
+		return fmt.Errorf("delete pod: %w", podErr)
 	}
 	return nil
 }
@@ -909,6 +923,19 @@ func deletePodBestEffort(clientset kubernetes.Interface, namespace, name string,
 	})
 	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Warn("k8s executor cleanup delete failed", "namespace", namespace, "pod", name, "err", err)
+	}
+}
+
+// deleteNetworkPolicyBestEffort attempts to delete the egress NetworkPolicy,
+// logging (but not returning) any error. Used on constructor error paths to
+// undo a policy that was installed before the Pod-create / readiness step
+// failed, so a failed construction leaves no orphaned policy behind.
+func deleteNetworkPolicyBestEffort(clientset kubernetes.Interface, namespace, name string, logger *slog.Logger) {
+	ctx, cancel := context.WithTimeout(context.Background(), k8sCloseTimeout)
+	defer cancel()
+	err := clientset.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Warn("k8s executor cleanup networkpolicy delete failed", "namespace", namespace, "networkpolicy", name, "err", err)
 	}
 }
 

--- a/harness/internal/executor/k8s_netpol.go
+++ b/harness/internal/executor/k8s_netpol.go
@@ -28,6 +28,20 @@ const (
 	// traffic still need DNS resolution to function, so the allowlist policy
 	// opens UDP/TCP 53 to kube-dns alongside the proxy.
 	k8sDNSPort = 53
+
+	// k8sEgressProxyLabel is the label the egress proxy Deployment carries
+	// (app=stirrup-egress-proxy) and the value the allowlist policy's egress
+	// peer selects on. It is part of the executor↔manifest contract: the
+	// sample manifests in examples/k8s/egress-proxy/ set this label, and #84's
+	// sample Pod set must keep it stable.
+	k8sEgressProxyLabel = "stirrup-egress-proxy"
+
+	// k8sEgressProxyPort is the port the egress proxy listens on — the default
+	// of the `stirrup egress-proxy` --listen flag (8080). The allowlist policy
+	// confines egress to the proxy to THIS port so an enforcing CNI does not
+	// permit the sandbox to reach the proxy Pod on any other port. It must
+	// match the proxy Service/Deployment containerPort in the manifests.
+	k8sEgressProxyPort = 8080
 )
 
 // podLabels returns the label set applied to every sandbox Pod. The sandbox
@@ -92,8 +106,14 @@ func denyAllEgressPolicy(namespace, podName string) *networkingv1.NetworkPolicy 
 //
 // CAVEAT: as with denyAllEgressPolicy, enforcement depends on a
 // NetworkPolicy-enforcing CNI. On kindnet the policy is accepted but inert.
+// The proxy egress rule selects the proxy by PodSelector with NO
+// NamespaceSelector, so it matches only proxy Pods in the SAME namespace as
+// the sandbox Pod. The egress proxy Deployment must therefore run in the
+// sandbox's namespace; a cross-namespace proxy is denied (more restrictive,
+// not a bypass) and is a confusing misconfiguration to avoid.
 func allowlistEgressPolicy(namespace, podName string) *networkingv1.NetworkPolicy {
 	dnsPort := intstr.FromInt32(k8sDNSPort)
+	proxyPort := intstr.FromInt32(k8sEgressProxyPort)
 	udp := corev1.ProtocolUDP
 	tcp := corev1.ProtocolTCP
 
@@ -120,13 +140,21 @@ func allowlistEgressPolicy(namespace, podName string) *networkingv1.NetworkPolic
 				},
 				{
 					// Egress to the proxy Deployment, selected by the label
-					// the proxy manifests set. The proxy then enforces the
-					// FQDN allowlist on the operator's behalf.
+					// the proxy manifests set, and confined to the proxy's
+					// listen port. Without the Ports restriction an enforcing
+					// CNI would let the sandbox reach the proxy Pod on ANY
+					// port; pinning TCP 8080 matches the standing
+					// network-policy.yaml and the proxy's --listen default.
+					// The proxy then enforces the FQDN allowlist on the
+					// operator's behalf.
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcp, Port: &proxyPort},
+					},
 					To: []networkingv1.NetworkPolicyPeer{
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app": "stirrup-egress-proxy",
+									"app": k8sEgressProxyLabel,
 								},
 							},
 						},

--- a/harness/internal/executor/k8s_netpol.go
+++ b/harness/internal/executor/k8s_netpol.go
@@ -1,0 +1,186 @@
+package executor
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+const (
+	// k8sSandboxLabel marks every Pod the K8sExecutor creates. It is the
+	// stable selector a cluster operator can target with their own policies
+	// and the key the per-Pod NetworkPolicy selects on (combined with the
+	// unique pod name) so the policy binds to exactly this Pod.
+	k8sSandboxLabel = "stirrup-sandbox"
+
+	// k8sPodNameLabel carries the generated Pod name as a label so the
+	// NetworkPolicy's podSelector can bind to this single Pod rather than
+	// every sandbox in the namespace. metadata.name is not selectable by a
+	// LabelSelector, so the name is mirrored into a label.
+	k8sPodNameLabel = "stirrup.dev/pod"
+
+	// k8sDNSPort is the standard DNS port. Both egress modes that permit any
+	// traffic still need DNS resolution to function, so the allowlist policy
+	// opens UDP/TCP 53 to kube-dns alongside the proxy.
+	k8sDNSPort = 53
+)
+
+// podLabels returns the label set applied to every sandbox Pod. The sandbox
+// marker is constant; the pod-name label is unique per Pod so a per-Pod
+// NetworkPolicy can select exactly this Pod.
+func podLabels(podName string) map[string]string {
+	return map[string]string{
+		k8sSandboxLabel: "true",
+		k8sPodNameLabel: podName,
+	}
+}
+
+// networkPolicyName derives the NetworkPolicy object name from the Pod name.
+// One policy is created per Pod and torn down with it, so the names are
+// coupled 1:1.
+func networkPolicyName(podName string) string {
+	return podName + "-egress"
+}
+
+// denyAllEgressPolicy builds a NetworkPolicy that selects the named Pod and
+// permits no egress at all. An Egress policy type with an empty egress rule
+// list is the canonical Kubernetes idiom for "deny all outgoing traffic" for
+// the selected Pods (see the NetworkPolicySpec.Egress and PolicyTypes
+// documentation). It is installed for Mode=="none".
+//
+// CAVEAT: enforcement depends on the cluster CNI. kindnet (kind's default
+// CNI) accepts NetworkPolicy objects but does NOT enforce them, so this
+// policy is inert on a stock kind cluster. A CNI that enforces NetworkPolicy
+// (Cilium, Calico) is required for the deny to take effect. This mirrors the
+// container executor's honest fail-open caveat around host.docker.internal.
+func denyAllEgressPolicy(namespace, podName string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName(podName),
+			Namespace: namespace,
+			Labels:    map[string]string{k8sSandboxLabel: "true"},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{k8sPodNameLabel: podName},
+			},
+			// No egress rules + an explicit Egress policy type = deny all
+			// outgoing traffic. Omitting PolicyTypes would default to
+			// Ingress-only, leaving egress unrestricted.
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+// allowlistEgressPolicy builds a NetworkPolicy that selects the named Pod and
+// permits egress only to (a) the in-namespace egress proxy and (b) DNS, so
+// every other destination is forced through the proxy where the FQDN
+// allowlist applies. It is installed for Mode=="allowlist".
+//
+// The policy intentionally does NOT encode the FQDN allowlist itself:
+// NetworkPolicy operates on IPs/ports/selectors, not hostnames, so the
+// hostname allowlist lives in the proxy (egressproxy.Matcher). This policy's
+// job is the complementary half — guarantee the Pod cannot reach the network
+// except via that proxy. DNS (UDP+TCP 53) is opened unconditionally because
+// the in-Pod client must resolve the proxy's address and the proxy itself
+// resolves upstream names.
+//
+// CAVEAT: as with denyAllEgressPolicy, enforcement depends on a
+// NetworkPolicy-enforcing CNI. On kindnet the policy is accepted but inert.
+func allowlistEgressPolicy(namespace, podName string) *networkingv1.NetworkPolicy {
+	dnsPort := intstr.FromInt32(k8sDNSPort)
+	udp := corev1.ProtocolUDP
+	tcp := corev1.ProtocolTCP
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName(podName),
+			Namespace: namespace,
+			Labels:    map[string]string{k8sSandboxLabel: "true"},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{k8sPodNameLabel: podName},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					// DNS resolution. Left peer-unrestricted (To omitted) so
+					// the rule matches whichever Pod/CIDR hosts kube-dns; the
+					// port restriction confines it to 53.
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &udp, Port: &dnsPort},
+						{Protocol: &tcp, Port: &dnsPort},
+					},
+				},
+				{
+					// Egress to the proxy Deployment, selected by the label
+					// the proxy manifests set. The proxy then enforces the
+					// FQDN allowlist on the operator's behalf.
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "stirrup-egress-proxy",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// egressPolicyFor returns the NetworkPolicy to install for the given network
+// mode, or nil when no policy applies. Mode=="none" yields a deny-all egress
+// policy; Mode=="allowlist" yields the proxy+DNS allowlist policy. Any other
+// (non-empty) mode is a programming error reachable only if validation is
+// bypassed; it is surfaced as an error rather than silently installing no
+// policy, which would leave the Pod with cluster-default egress while
+// CanNetwork might report otherwise.
+func egressPolicyFor(network *types.NetworkConfig, namespace, podName string) (*networkingv1.NetworkPolicy, error) {
+	if network == nil {
+		return nil, fmt.Errorf("k8s executor: network config is required (fail-closed)")
+	}
+	switch network.Mode {
+	case "none":
+		return denyAllEgressPolicy(namespace, podName), nil
+	case "allowlist":
+		return allowlistEgressPolicy(namespace, podName), nil
+	default:
+		return nil, fmt.Errorf("k8s executor: unsupported network mode %q (want \"none\" or \"allowlist\")", network.Mode)
+	}
+}
+
+// proxyEnvFor returns the HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment entries
+// to inject into the sandbox container for the given network mode. Mode==
+// "allowlist" requires a non-empty proxyURL (the run cannot reach the network
+// any other way once the NetworkPolicy is enforced) and returns the three
+// proxy variables. Mode=="none" injects nothing — a denied Pod has no egress
+// to proxy. A nil network is rejected for symmetry with egressPolicyFor.
+func proxyEnvFor(network *types.NetworkConfig, proxyURL string) ([]corev1.EnvVar, error) {
+	if network == nil {
+		return nil, fmt.Errorf("k8s executor: network config is required (fail-closed)")
+	}
+	switch network.Mode {
+	case "none":
+		return nil, nil
+	case "allowlist":
+		if proxyURL == "" {
+			return nil, fmt.Errorf("k8s executor: network mode \"allowlist\" requires an egress proxy URL (set executor.k8sEgressProxyUrl / --k8s-egress-proxy-url)")
+		}
+		return []corev1.EnvVar{
+			{Name: "HTTP_PROXY", Value: proxyURL},
+			{Name: "HTTPS_PROXY", Value: proxyURL},
+			{Name: "NO_PROXY", Value: "localhost,127.0.0.1,::1"},
+		}, nil
+	default:
+		return nil, fmt.Errorf("k8s executor: unsupported network mode %q (want \"none\" or \"allowlist\")", network.Mode)
+	}
+}

--- a/harness/internal/executor/k8s_test.go
+++ b/harness/internal/executor/k8s_test.go
@@ -11,10 +11,13 @@ import (
 	"testing"
 	"time"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/rxbynerd/stirrup/types"
 )
 
 // TestK8sExecutorLifecycle exercises the full create/wait/delete lifecycle
@@ -36,6 +39,7 @@ func TestK8sExecutorLifecycle(t *testing.T) {
 		Image:      "busybox:latest",
 		Namespace:  namespace,
 		Kubeconfig: kubeconfig,
+		Network:    &types.NetworkConfig{Mode: "none"},
 	})
 	if err != nil {
 		t.Fatalf("NewK8sExecutor: %v", err)
@@ -92,6 +96,7 @@ func TestK8sExecutorCloseIdempotent(t *testing.T) {
 		Image:      "busybox:latest",
 		Namespace:  "default",
 		Kubeconfig: kubeconfig,
+		Network:    &types.NetworkConfig{Mode: "none"},
 	})
 	if err != nil {
 		t.Fatalf("NewK8sExecutor: %v", err)
@@ -132,6 +137,7 @@ func newTestK8sExecutor(t *testing.T) *K8sExecutor {
 		Image:      "busybox:latest",
 		Namespace:  "default",
 		Kubeconfig: kubeconfig,
+		Network:    &types.NetworkConfig{Mode: "none"},
 	})
 	if err != nil {
 		t.Fatalf("NewK8sExecutor: %v", err)
@@ -388,6 +394,7 @@ func TestK8sRuntimeClass_Admitted(t *testing.T) {
 				Namespace:        "default",
 				Kubeconfig:       kubeconfig,
 				RuntimeClassName: runtimeClass,
+				Network:          &types.NetworkConfig{Mode: "none"},
 			})
 			if err != nil {
 				// An unregistered RuntimeClass surfaces as the friendly
@@ -442,5 +449,163 @@ func TestK8sRuntimeClass_KataValidatedAsString(t *testing.T) {
 			}
 			t.Skip("kind cannot host Kata Containers (needs nested virtualisation); skipping the live Pod-creation half")
 		})
+	}
+}
+
+// TestK8sEgress_NoneInstallsDenyAllPolicy verifies MANIFEST SHAPE (issue
+// #178): a Mode=="none" run installs a deny-all egress NetworkPolicy that
+// selects exactly this Pod, carries the Egress policy type with no egress
+// rules, and is torn down on Close. The Pod is also labelled
+// stirrup-sandbox=true.
+//
+// MANIFEST-SHAPE ONLY: kindnet accepts the NetworkPolicy but does NOT enforce
+// it (see allowlistEgressPolicy / K8sExecutorConfig CNI caveat). This test
+// proves the object is created with the right shape, NOT that egress is
+// actually denied. Enforcement is only verifiable on a Cilium/Calico cluster.
+func TestK8sEgress_NoneInstallsDenyAllPolicy(t *testing.T) {
+	kubeconfig := os.Getenv("STIRRUP_TEST_KUBECONFIG")
+	if kubeconfig == "" {
+		t.Skip("STIRRUP_TEST_KUBECONFIG not set; skipping k8s integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	exec, err := NewK8sExecutor(ctx, K8sExecutorConfig{
+		Image:      "busybox:latest",
+		Namespace:  "default",
+		Kubeconfig: kubeconfig,
+		Network:    &types.NetworkConfig{Mode: "none"},
+	})
+	if err != nil {
+		t.Fatalf("NewK8sExecutor: %v", err)
+	}
+	t.Cleanup(func() { _ = exec.Close() })
+
+	clientset, err := kubeClientFromConfig(t, kubeconfig)
+	if err != nil {
+		t.Fatalf("build verification clientset: %v", err)
+	}
+
+	// The Pod carries the sandbox marker label.
+	pod, err := clientset.CoreV1().Pods("default").Get(ctx, exec.podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	if pod.Labels[k8sSandboxLabel] != "true" {
+		t.Errorf("pod label %s = %q, want \"true\"", k8sSandboxLabel, pod.Labels[k8sSandboxLabel])
+	}
+
+	// Mode=="none" injects no proxy env.
+	for _, e := range pod.Spec.Containers[0].Env {
+		if e.Name == "HTTP_PROXY" || e.Name == "HTTPS_PROXY" {
+			t.Errorf("Mode==none should inject no proxy env, found %s=%s", e.Name, e.Value)
+		}
+	}
+
+	np, err := clientset.NetworkingV1().NetworkPolicies("default").Get(ctx, networkPolicyName(exec.podName), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get networkpolicy: %v", err)
+	}
+	if np.Spec.PodSelector.MatchLabels[k8sPodNameLabel] != exec.podName {
+		t.Errorf("policy podSelector = %v, want it to select %s=%s", np.Spec.PodSelector.MatchLabels, k8sPodNameLabel, exec.podName)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
+		t.Errorf("policyTypes = %v, want [Egress]", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Egress) != 0 {
+		t.Errorf("deny-all policy must have no egress rules, got %d", len(np.Spec.Egress))
+	}
+
+	// Close removes the policy.
+	if err := exec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, getErr := clientset.NetworkingV1().NetworkPolicies("default").Get(context.Background(), networkPolicyName(exec.podName), metav1.GetOptions{})
+		if apierrors.IsNotFound(getErr) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("networkpolicy %s still present 5s after Close (last get err: %v)", networkPolicyName(exec.podName), getErr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// TestK8sEgress_AllowlistInstallsPolicyAndInjectsProxy verifies MANIFEST
+// SHAPE (issue #83): a Mode=="allowlist" run installs an egress policy that
+// permits DNS plus the egress-proxy peer, and injects HTTP_PROXY/HTTPS_PROXY/
+// NO_PROXY pointing at EgressProxyURL.
+//
+// MANIFEST-SHAPE ONLY: kindnet does not enforce NetworkPolicy, so this proves
+// the object/env shape, not that egress is actually confined to the proxy.
+func TestK8sEgress_AllowlistInstallsPolicyAndInjectsProxy(t *testing.T) {
+	kubeconfig := os.Getenv("STIRRUP_TEST_KUBECONFIG")
+	if kubeconfig == "" {
+		t.Skip("STIRRUP_TEST_KUBECONFIG not set; skipping k8s integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	const proxyURL = "http://stirrup-egress-proxy.default.svc:8080"
+	exec, err := NewK8sExecutor(ctx, K8sExecutorConfig{
+		Image:          "busybox:latest",
+		Namespace:      "default",
+		Kubeconfig:     kubeconfig,
+		Network:        &types.NetworkConfig{Mode: "allowlist", Allowlist: []string{"api.example.com"}},
+		EgressProxyURL: proxyURL,
+	})
+	if err != nil {
+		t.Fatalf("NewK8sExecutor: %v", err)
+	}
+	t.Cleanup(func() { _ = exec.Close() })
+
+	clientset, err := kubeClientFromConfig(t, kubeconfig)
+	if err != nil {
+		t.Fatalf("build verification clientset: %v", err)
+	}
+
+	pod, err := clientset.CoreV1().Pods("default").Get(ctx, exec.podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	env := map[string]string{}
+	for _, e := range pod.Spec.Containers[0].Env {
+		env[e.Name] = e.Value
+	}
+	if env["HTTP_PROXY"] != proxyURL || env["HTTPS_PROXY"] != proxyURL {
+		t.Errorf("proxy env = %v, want HTTP(S)_PROXY=%s", env, proxyURL)
+	}
+	if env["NO_PROXY"] == "" {
+		t.Errorf("NO_PROXY should be set in allowlist mode, env = %v", env)
+	}
+
+	np, err := clientset.NetworkingV1().NetworkPolicies("default").Get(ctx, networkPolicyName(exec.podName), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get networkpolicy: %v", err)
+	}
+	if len(np.Spec.Egress) != 2 {
+		t.Fatalf("allowlist policy egress rules = %d, want 2 (dns + proxy)", len(np.Spec.Egress))
+	}
+}
+
+// TestK8sEgress_AllowlistRequiresProxyURL verifies the construction guard
+// fails closed when Mode=="allowlist" but no EgressProxyURL is supplied. This
+// runs without a cluster — the guard fires before any cluster I/O — so it is
+// not skipped on a missing kubeconfig.
+func TestK8sEgress_AllowlistRequiresProxyURL(t *testing.T) {
+	_, err := NewK8sExecutor(context.Background(), K8sExecutorConfig{
+		Image:     "busybox:latest",
+		Namespace: "default",
+		Network:   &types.NetworkConfig{Mode: "allowlist", Allowlist: []string{"api.example.com"}},
+	})
+	if err == nil {
+		t.Fatal("expected error: allowlist mode without an egress proxy URL must fail closed")
+	}
+	if !strings.Contains(err.Error(), "proxy") {
+		t.Errorf("error %q should mention the missing proxy URL", err)
 	}
 }

--- a/harness/internal/executor/k8s_test.go
+++ b/harness/internal/executor/k8s_test.go
@@ -590,6 +590,12 @@ func TestK8sEgress_AllowlistInstallsPolicyAndInjectsProxy(t *testing.T) {
 	if len(np.Spec.Egress) != 2 {
 		t.Fatalf("allowlist policy egress rules = %d, want 2 (dns + proxy)", len(np.Spec.Egress))
 	}
+	// The proxy egress rule must be port-confined to the proxy's listen port,
+	// not open to every port on the proxy Pod.
+	proxyRule := np.Spec.Egress[1]
+	if len(proxyRule.Ports) != 1 || proxyRule.Ports[0].Port == nil || proxyRule.Ports[0].Port.IntValue() != k8sEgressProxyPort {
+		t.Errorf("proxy egress rule ports = %v, want a single TCP %d", proxyRule.Ports, k8sEgressProxyPort)
+	}
 }
 
 // TestK8sEgress_AllowlistRequiresProxyURL verifies the construction guard

--- a/harness/internal/executor/k8s_unit_test.go
+++ b/harness/internal/executor/k8s_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -91,6 +92,163 @@ func TestNewK8sExecutor_MissingNamespace(t *testing.T) {
 	if !strings.Contains(err.Error(), "namespace") {
 		t.Errorf("error %q should mention 'namespace'", err)
 	}
+}
+
+// TestNewK8sExecutor_NilNetworkRejected asserts the fail-closed guard fires
+// before any cluster I/O: a nil Network leaves egress posture undefined and
+// is rejected at construction (issue #178). This pins the acceptance
+// criterion "nil Network rejected at construction".
+func TestNewK8sExecutor_NilNetworkRejected(t *testing.T) {
+	_, err := NewK8sExecutor(context.Background(), K8sExecutorConfig{
+		Image:     "busybox",
+		Namespace: "default",
+	})
+	if err == nil {
+		t.Fatal("expected error for nil network config")
+	}
+	if !strings.Contains(err.Error(), "network") {
+		t.Errorf("error %q should mention 'network'", err)
+	}
+}
+
+// TestNewK8sExecutor_AllowlistRequiresProxyURL asserts the allowlist-mode
+// guard fails closed before any cluster I/O when no EgressProxyURL is set
+// (issue #83). An enforced allowlist NetworkPolicy makes the proxy the only
+// route to the network, so omitting its URL is a misconfiguration.
+func TestNewK8sExecutor_AllowlistRequiresProxyURL(t *testing.T) {
+	_, err := NewK8sExecutor(context.Background(), K8sExecutorConfig{
+		Image:     "busybox",
+		Namespace: "default",
+		Network:   &types.NetworkConfig{Mode: "allowlist"},
+	})
+	if err == nil {
+		t.Fatal("expected error for allowlist mode without a proxy URL")
+	}
+	if !strings.Contains(err.Error(), "proxy") {
+		t.Errorf("error %q should mention the missing proxy URL", err)
+	}
+}
+
+// TestEgressPolicyFor covers the pure NetworkPolicy construction for each
+// mode without a cluster: deny-all for "none", proxy+DNS allowlist for
+// "allowlist", and an error for a nil or unsupported mode. The shape
+// assertions here are the cluster-free half of the manifest-shape contract
+// that the integration tests pin against a real API server.
+func TestEgressPolicyFor(t *testing.T) {
+	const ns, pod = "default", "stirrup-abc123"
+
+	t.Run("nil network is rejected", func(t *testing.T) {
+		if _, err := egressPolicyFor(nil, ns, pod); err == nil {
+			t.Fatal("expected error for nil network")
+		}
+	})
+
+	t.Run("unsupported mode is rejected", func(t *testing.T) {
+		if _, err := egressPolicyFor(&types.NetworkConfig{Mode: "bridge"}, ns, pod); err == nil {
+			t.Fatal("expected error for unsupported mode")
+		}
+	})
+
+	t.Run("none yields deny-all egress", func(t *testing.T) {
+		np, err := egressPolicyFor(&types.NetworkConfig{Mode: "none"}, ns, pod)
+		if err != nil {
+			t.Fatalf("egressPolicyFor(none): %v", err)
+		}
+		if np.Name != networkPolicyName(pod) || np.Namespace != ns {
+			t.Errorf("policy name/ns = %s/%s, want %s/%s", np.Name, np.Namespace, networkPolicyName(pod), ns)
+		}
+		if np.Spec.PodSelector.MatchLabels[k8sPodNameLabel] != pod {
+			t.Errorf("podSelector = %v, want it to select %s=%s", np.Spec.PodSelector.MatchLabels, k8sPodNameLabel, pod)
+		}
+		if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
+			t.Errorf("policyTypes = %v, want [Egress]", np.Spec.PolicyTypes)
+		}
+		if len(np.Spec.Egress) != 0 {
+			t.Errorf("deny-all must have zero egress rules, got %d", len(np.Spec.Egress))
+		}
+	})
+
+	t.Run("allowlist yields dns + proxy egress", func(t *testing.T) {
+		np, err := egressPolicyFor(&types.NetworkConfig{Mode: "allowlist"}, ns, pod)
+		if err != nil {
+			t.Fatalf("egressPolicyFor(allowlist): %v", err)
+		}
+		if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
+			t.Errorf("policyTypes = %v, want [Egress]", np.Spec.PolicyTypes)
+		}
+		if len(np.Spec.Egress) != 2 {
+			t.Fatalf("allowlist egress rules = %d, want 2 (dns + proxy)", len(np.Spec.Egress))
+		}
+		// First rule is DNS: two ports (UDP/TCP 53), no peer restriction.
+		dns := np.Spec.Egress[0]
+		if len(dns.Ports) != 2 {
+			t.Errorf("dns rule ports = %d, want 2 (udp+tcp)", len(dns.Ports))
+		}
+		for _, p := range dns.Ports {
+			if p.Port == nil || p.Port.IntValue() != k8sDNSPort {
+				t.Errorf("dns rule port = %v, want %d", p.Port, k8sDNSPort)
+			}
+		}
+		// Second rule selects the egress proxy by label.
+		proxy := np.Spec.Egress[1]
+		if len(proxy.To) != 1 || proxy.To[0].PodSelector == nil {
+			t.Fatalf("proxy rule must select the proxy pod, got %+v", proxy.To)
+		}
+		if proxy.To[0].PodSelector.MatchLabels["app"] != "stirrup-egress-proxy" {
+			t.Errorf("proxy peer selector = %v, want app=stirrup-egress-proxy", proxy.To[0].PodSelector.MatchLabels)
+		}
+	})
+}
+
+// TestProxyEnvFor covers the pure proxy-env mapping: none injects nothing,
+// allowlist requires a URL and injects the three proxy variables, and a nil
+// or unsupported mode errors.
+func TestProxyEnvFor(t *testing.T) {
+	t.Run("nil network is rejected", func(t *testing.T) {
+		if _, err := proxyEnvFor(nil, ""); err == nil {
+			t.Fatal("expected error for nil network")
+		}
+	})
+
+	t.Run("none injects nothing", func(t *testing.T) {
+		env, err := proxyEnvFor(&types.NetworkConfig{Mode: "none"}, "")
+		if err != nil {
+			t.Fatalf("proxyEnvFor(none): %v", err)
+		}
+		if len(env) != 0 {
+			t.Errorf("none must inject no env, got %v", env)
+		}
+	})
+
+	t.Run("allowlist without url errors", func(t *testing.T) {
+		if _, err := proxyEnvFor(&types.NetworkConfig{Mode: "allowlist"}, ""); err == nil {
+			t.Fatal("expected error for allowlist without a proxy URL")
+		}
+	})
+
+	t.Run("allowlist with url injects proxy vars", func(t *testing.T) {
+		const url = "http://stirrup-egress-proxy.default.svc:8080"
+		env, err := proxyEnvFor(&types.NetworkConfig{Mode: "allowlist"}, url)
+		if err != nil {
+			t.Fatalf("proxyEnvFor(allowlist): %v", err)
+		}
+		got := map[string]string{}
+		for _, e := range env {
+			got[e.Name] = e.Value
+		}
+		if got["HTTP_PROXY"] != url || got["HTTPS_PROXY"] != url {
+			t.Errorf("proxy env = %v, want HTTP(S)_PROXY=%s", got, url)
+		}
+		if got["NO_PROXY"] == "" {
+			t.Errorf("NO_PROXY must be set, env = %v", got)
+		}
+	})
+
+	t.Run("unsupported mode errors", func(t *testing.T) {
+		if _, err := proxyEnvFor(&types.NetworkConfig{Mode: "bridge"}, "http://x"); err == nil {
+			t.Fatal("expected error for unsupported mode")
+		}
+	})
 }
 
 // TestK8sCapabilities exercises the CanNetwork branch and verifies the

--- a/harness/internal/executor/k8s_unit_test.go
+++ b/harness/internal/executor/k8s_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -196,6 +197,17 @@ func TestEgressPolicyFor(t *testing.T) {
 		}
 		if proxy.To[0].PodSelector.MatchLabels["app"] != "stirrup-egress-proxy" {
 			t.Errorf("proxy peer selector = %v, want app=stirrup-egress-proxy", proxy.To[0].PodSelector.MatchLabels)
+		}
+		// The proxy rule must confine egress to the proxy's listen port so an
+		// enforcing CNI does not permit reaching the proxy Pod on any port.
+		if len(proxy.Ports) != 1 {
+			t.Fatalf("proxy rule ports = %d, want 1 (TCP %d)", len(proxy.Ports), k8sEgressProxyPort)
+		}
+		if proxy.Ports[0].Protocol == nil || *proxy.Ports[0].Protocol != corev1.ProtocolTCP {
+			t.Errorf("proxy rule protocol = %v, want TCP", proxy.Ports[0].Protocol)
+		}
+		if proxy.Ports[0].Port == nil || proxy.Ports[0].Port.IntValue() != k8sEgressProxyPort {
+			t.Errorf("proxy rule port = %v, want %d", proxy.Ports[0].Port, k8sEgressProxyPort)
 		}
 	})
 }

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -872,7 +872,9 @@ type ExecutorConfig struct {
 	// egress NetworkPolicy that confines the Pod to the proxy (plus DNS), so
 	// this URL is required in allowlist mode and rejected otherwise. The proxy
 	// runs as a separate Deployment — see examples/k8s/egress-proxy/ and the
-	// `stirrup egress-proxy` subcommand. Ignored for every non-"k8s" Type.
+	// `stirrup egress-proxy` subcommand. The proxy MUST run in the same
+	// namespace as the sandbox Pod (the policy selects it by PodSelector with
+	// no NamespaceSelector). Ignored for every non-"k8s" Type.
 	K8sEgressProxyURL string `json:"k8sEgressProxyUrl,omitempty"`
 
 	// Runtime selects the OCI sandbox runtime. Empty string means "use the
@@ -3796,6 +3798,16 @@ func validateK8sExecutor(cfg ExecutorConfig, errs *[]string) {
 	if cfg.Workspace != "" {
 		*errs = append(*errs, "executor.workspace is not valid for executor.type=\"k8s\" (the Pod workspace is fixed at /workspace)")
 	}
+	// A nil network leaves egress posture undefined. NewK8sExecutor fails
+	// closed on it, but ValidateRunConfig would otherwise report a false
+	// "valid config"; surface the same requirement at config-load time. When
+	// network is nil the egress-proxy cross-field check is skipped — the nil
+	// error is the primary signal and a second "k8sEgressProxyUrl is only
+	// valid when ..." line would be noise.
+	if cfg.Network == nil {
+		*errs = append(*errs, "executor.network is required for executor.type=\"k8s\" (set mode to \"none\" or \"allowlist\")")
+		return
+	}
 	validateK8sEgressProxy(cfg, errs)
 }
 
@@ -3805,13 +3817,10 @@ func validateK8sExecutor(cfg ExecutorConfig, errs *[]string) {
 // so the URL is mandatory in that mode (the run would otherwise have no route
 // to the network) and pointless otherwise. The executor itself fails closed
 // at construction; surfacing the mismatch here gives the operator a config-
-// load error rather than a runtime one. Called only for executor.type=="k8s".
+// load error rather than a runtime one. Called only for executor.type=="k8s"
+// with a non-nil Network (the caller handles the nil-network case).
 func validateK8sEgressProxy(cfg ExecutorConfig, errs *[]string) {
-	mode := ""
-	if cfg.Network != nil {
-		mode = cfg.Network.Mode
-	}
-	switch mode {
+	switch cfg.Network.Mode {
 	case "allowlist":
 		if cfg.K8sEgressProxyURL == "" {
 			*errs = append(*errs, "executor.k8sEgressProxyUrl is required when executor.network.mode is \"allowlist\" for executor.type=\"k8s\"")

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -867,6 +867,14 @@ type ExecutorConfig struct {
 	K8sNodeSelector   map[string]string `json:"k8sNodeSelector,omitempty"`
 	K8sServiceAccount string            `json:"k8sServiceAccount,omitempty"`
 
+	// K8sEgressProxyURL is the URL the sandbox Pod's HTTP_PROXY / HTTPS_PROXY
+	// point at when Network.Mode == "allowlist". The k8s executor installs an
+	// egress NetworkPolicy that confines the Pod to the proxy (plus DNS), so
+	// this URL is required in allowlist mode and rejected otherwise. The proxy
+	// runs as a separate Deployment — see examples/k8s/egress-proxy/ and the
+	// `stirrup egress-proxy` subcommand. Ignored for every non-"k8s" Type.
+	K8sEgressProxyURL string `json:"k8sEgressProxyUrl,omitempty"`
+
 	// Runtime selects the OCI sandbox runtime. Empty string means "use the
 	// platform default". The closed set of accepted values is enforced by
 	// ValidateRunConfig and is per-Type (see validK8sRuntimes /
@@ -3787,6 +3795,31 @@ func validateK8sExecutor(cfg ExecutorConfig, errs *[]string) {
 	}
 	if cfg.Workspace != "" {
 		*errs = append(*errs, "executor.workspace is not valid for executor.type=\"k8s\" (the Pod workspace is fixed at /workspace)")
+	}
+	validateK8sEgressProxy(cfg, errs)
+}
+
+// validateK8sEgressProxy enforces the cross-field requirement that ties the
+// k8s egress proxy URL to the allowlist network mode. The k8s executor
+// installs a NetworkPolicy that confines an allowlist-mode Pod to the proxy,
+// so the URL is mandatory in that mode (the run would otherwise have no route
+// to the network) and pointless otherwise. The executor itself fails closed
+// at construction; surfacing the mismatch here gives the operator a config-
+// load error rather than a runtime one. Called only for executor.type=="k8s".
+func validateK8sEgressProxy(cfg ExecutorConfig, errs *[]string) {
+	mode := ""
+	if cfg.Network != nil {
+		mode = cfg.Network.Mode
+	}
+	switch mode {
+	case "allowlist":
+		if cfg.K8sEgressProxyURL == "" {
+			*errs = append(*errs, "executor.k8sEgressProxyUrl is required when executor.network.mode is \"allowlist\" for executor.type=\"k8s\"")
+		}
+	default:
+		if cfg.K8sEgressProxyURL != "" {
+			*errs = append(*errs, "executor.k8sEgressProxyUrl is only valid when executor.network.mode is \"allowlist\"")
+		}
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -1683,6 +1683,50 @@ func TestValidateRunConfig_K8sExecutorFields(t *testing.T) {
 			wantErr:     true,
 			errContains: "executor.workspace is not valid",
 		},
+		{
+			name: "allowlist mode with proxy url is valid",
+			exec: ExecutorConfig{
+				Type:              "k8s",
+				Image:             "img",
+				K8sNamespace:      "ns",
+				Network:           &NetworkConfig{Mode: "allowlist", Allowlist: []string{"api.example.com"}},
+				K8sEgressProxyURL: "http://stirrup-egress-proxy.ns.svc:8080",
+			},
+		},
+		{
+			name: "allowlist mode without proxy url rejected",
+			exec: ExecutorConfig{
+				Type:         "k8s",
+				Image:        "img",
+				K8sNamespace: "ns",
+				Network:      &NetworkConfig{Mode: "allowlist", Allowlist: []string{"api.example.com"}},
+			},
+			wantErr:     true,
+			errContains: "executor.k8sEgressProxyUrl is required",
+		},
+		{
+			name: "proxy url set with none mode rejected",
+			exec: ExecutorConfig{
+				Type:              "k8s",
+				Image:             "img",
+				K8sNamespace:      "ns",
+				Network:           &NetworkConfig{Mode: "none"},
+				K8sEgressProxyURL: "http://stirrup-egress-proxy.ns.svc:8080",
+			},
+			wantErr:     true,
+			errContains: "executor.k8sEgressProxyUrl is only valid",
+		},
+		{
+			name: "proxy url set with no network rejected",
+			exec: ExecutorConfig{
+				Type:              "k8s",
+				Image:             "img",
+				K8sNamespace:      "ns",
+				K8sEgressProxyURL: "http://stirrup-egress-proxy.ns.svc:8080",
+			},
+			wantErr:     true,
+			errContains: "executor.k8sEgressProxyUrl is only valid",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -1601,16 +1601,17 @@ func TestValidateRunConfig_RuntimeSetIsPerType(t *testing.T) {
 		runtime     string
 		image       string
 		k8sNS       string
+		network     *NetworkConfig
 		wantErr     bool
 		errContains string
 	}{
 		{name: "container accepts runsc", execType: "container", runtime: "runsc", image: "img", wantErr: false},
 		{name: "container accepts kata-clh", execType: "container", runtime: "kata-clh", image: "img", wantErr: false},
 		{name: "container rejects gvisor", execType: "container", runtime: "gvisor", image: "img", wantErr: true, errContains: "gvisor"},
-		{name: "k8s accepts gvisor", execType: "k8s", runtime: "gvisor", image: "img", k8sNS: "ns", wantErr: false},
-		{name: "k8s accepts kata-clh", execType: "k8s", runtime: "kata-clh", image: "img", k8sNS: "ns", wantErr: false},
-		{name: "k8s rejects runsc", execType: "k8s", runtime: "runsc", image: "img", k8sNS: "ns", wantErr: true, errContains: "runsc"},
-		{name: "k8s rejects kata bare", execType: "k8s", runtime: "kata", image: "img", k8sNS: "ns", wantErr: true, errContains: "kata"},
+		{name: "k8s accepts gvisor", execType: "k8s", runtime: "gvisor", image: "img", k8sNS: "ns", network: &NetworkConfig{Mode: "none"}, wantErr: false},
+		{name: "k8s accepts kata-clh", execType: "k8s", runtime: "kata-clh", image: "img", k8sNS: "ns", network: &NetworkConfig{Mode: "none"}, wantErr: false},
+		{name: "k8s rejects runsc", execType: "k8s", runtime: "runsc", image: "img", k8sNS: "ns", network: &NetworkConfig{Mode: "none"}, wantErr: true, errContains: "runsc"},
+		{name: "k8s rejects kata bare", execType: "k8s", runtime: "kata", image: "img", k8sNS: "ns", network: &NetworkConfig{Mode: "none"}, wantErr: true, errContains: "kata"},
 		{name: "local rejects any runtime", execType: "local", runtime: "runc", wantErr: true, errContains: "only valid"},
 	}
 	for _, tc := range cases {
@@ -1621,6 +1622,7 @@ func TestValidateRunConfig_RuntimeSetIsPerType(t *testing.T) {
 				Runtime:      tc.runtime,
 				Image:        tc.image,
 				K8sNamespace: tc.k8sNS,
+				Network:      tc.network,
 			}
 			err := ValidateRunConfig(c)
 			if tc.wantErr {
@@ -1651,7 +1653,7 @@ func TestValidateRunConfig_K8sExecutorFields(t *testing.T) {
 	}{
 		{
 			name: "valid minimal",
-			exec: ExecutorConfig{Type: "k8s", Image: "img", K8sNamespace: "ns"},
+			exec: ExecutorConfig{Type: "k8s", Image: "img", K8sNamespace: "ns", Network: &NetworkConfig{Mode: "none"}},
 		},
 		{
 			name: "valid with optional fields",
@@ -1663,25 +1665,32 @@ func TestValidateRunConfig_K8sExecutorFields(t *testing.T) {
 				K8sNodeSelector:   map[string]string{"disktype": "ssd"},
 				K8sServiceAccount: "agent-sa",
 				Runtime:           "gvisor",
+				Network:           &NetworkConfig{Mode: "none"},
 			},
 		},
 		{
 			name:        "missing image",
-			exec:        ExecutorConfig{Type: "k8s", K8sNamespace: "ns"},
+			exec:        ExecutorConfig{Type: "k8s", K8sNamespace: "ns", Network: &NetworkConfig{Mode: "none"}},
 			wantErr:     true,
 			errContains: "executor.image is required",
 		},
 		{
 			name:        "missing namespace",
-			exec:        ExecutorConfig{Type: "k8s", Image: "img"},
+			exec:        ExecutorConfig{Type: "k8s", Image: "img", Network: &NetworkConfig{Mode: "none"}},
 			wantErr:     true,
 			errContains: "executor.k8sNamespace is required",
 		},
 		{
 			name:        "workspace rejected",
-			exec:        ExecutorConfig{Type: "k8s", Image: "img", K8sNamespace: "ns", Workspace: "/ws"},
+			exec:        ExecutorConfig{Type: "k8s", Image: "img", K8sNamespace: "ns", Workspace: "/ws", Network: &NetworkConfig{Mode: "none"}},
 			wantErr:     true,
 			errContains: "executor.workspace is not valid",
+		},
+		{
+			name:        "nil network rejected",
+			exec:        ExecutorConfig{Type: "k8s", Image: "img", K8sNamespace: "ns"},
+			wantErr:     true,
+			errContains: "executor.network is required for executor.type=\"k8s\"",
 		},
 		{
 			name: "allowlist mode with proxy url is valid",
@@ -1717,7 +1726,10 @@ func TestValidateRunConfig_K8sExecutorFields(t *testing.T) {
 			errContains: "executor.k8sEgressProxyUrl is only valid",
 		},
 		{
-			name: "proxy url set with no network rejected",
+			// A nil network is the primary error; the egress-proxy cross-field
+			// check is skipped (the nil-network error is the signal), so the
+			// reported error is the network-required one, not the proxy one.
+			name: "proxy url set with no network reports network-required",
 			exec: ExecutorConfig{
 				Type:              "k8s",
 				Image:             "img",
@@ -1725,7 +1737,7 @@ func TestValidateRunConfig_K8sExecutorFields(t *testing.T) {
 				K8sEgressProxyURL: "http://stirrup-egress-proxy.ns.svc:8080",
 			},
 			wantErr:     true,
-			errContains: "executor.k8sEgressProxyUrl is only valid",
+			errContains: "executor.network is required for executor.type=\"k8s\"",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Closes #178 and #83. Third link in the stacked K8s executor chain (#78/#79 → #80–82 → **#178/#83** → #84 → #85).

**Stacked on #397 (`feat/issue-80-82-k8s-factory-wiring`).** Based on that branch, not `main`; review only the commits unique to this branch. Retargets to `main` as the bases merge.

## #178 — honest egress enforcement

`NewK8sExecutor` now installs a per-Pod egress `NetworkPolicy`: **deny-all** egress for `mode="none"`, **proxy + DNS allowlist** egress for `mode="allowlist"`. `Capabilities().CanNetwork` reflects the installed policy. A nil `Network` is rejected at construction (fail-closed) and now also at `ValidateRunConfig` time. The `TODO(#178)` is gone.

The policy is installed **before** the Pod is created (keyed on the deterministic pod name + `stirrup-sandbox=true`/`stirrup.dev/pod=<name>` labels), and torn down **after** the Pod on `Close()` — so there is no window in which a Running Pod has unrestricted egress. The allowlist policy's proxy egress rule is pinned to TCP 8080 (matching the proxy listener), not all-ports.

## #83 — egress proxy

New `stirrup egress-proxy` subcommand (foreground HTTP CONNECT proxy until SIGTERM; `--listen`/`--allowlist`/`--allowlist-file`/`--log-level`), wrapping the existing `egressproxy` package. New `K8sEgressProxyURL` config field + `--k8s-egress-proxy-url` flag; `mode="allowlist"` injects `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` and requires the URL (validated), `mode="none"` injects nothing. Four `examples/k8s/egress-proxy/` manifests + README.

## Security posture (reviewed)

- NetworkPolicy install failure **fails closed** — no executor is returned.
- The proxy CONNECT allowlist is **not bypassable** by the tested vectors: SNI cross-check (IP-literal and SNI-absent/mismatch are dropped), wildcard `.`-boundary matching, oversized-ClientHello rejection, Host-header anti-spoofing, hop-by-hop `Upgrade` stripping (no WebSocket escape), and non-redirect-following.
- Allowlist file read is capped at 1 MiB.

## Tests

CanNetwork-per-mode + nil-Network-rejected unit tests; `egressPolicyFor`/`proxyEnvFor` unit tables; real CONNECT allow (200 + byte-exact splice) / deny (403) tests without a cluster; allowlist-file cap test; manifest-shape integration tests (`integration_k8s`). `just build`, `just test`, `just lint` (0 issues), and tagged lint all pass. The subcommand was driven end-to-end as a built binary (allow/deny/SIGTERM exit 0).

## Verification caveat (accepted)

**kindnet does not enforce NetworkPolicy** — the `integration_k8s` egress tests prove the *installed manifest shape*, not actual enforcement, which requires a Cilium/Calico CNI. This is documented honestly in the executor doc comments, the manifests, and `examples/k8s/egress-proxy/README.md` (mirroring the container executor's existing fail-open caveat). The proxy's own allow/deny logic is fully verified without a cluster.

## Review

One reviewer wave (security + code + spec), fully remediated. The egress-ordering window (policy-before-Pod), the unrestricted proxy-rule port, the teardown order, the allowlist-file DoS, and the nil-Network validation honesty gap were all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)