### PR TITLE
examples: add k8s reference manifests for the sandbox executor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,11 @@ docs are:
 - [`docs/security.md`](docs/security.md) and
   [`docs/safety-rings.md`](docs/safety-rings.md) — security
   foundations and the five operator-configurable rings.
+- [`docs/executors/k8s.md`](docs/executors/k8s.md) — the
+  Kubernetes (Pod-per-run) executor: architecture, config
+  reference, deployment recipes, and egress. Reference manifests
+  in [`examples/k8s/`](examples/k8s/); local `kind` cluster in
+  [`scripts/dev/`](scripts/dev/).
 - [`AGENTS.md`](AGENTS.md) — per-package map of `harness/internal/*`.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — build, test, lint,
   commit/PR conventions.
@@ -133,6 +138,9 @@ Quick map for "I need to change X" lookups:
 | Permission gating logic | `harness/internal/permission/<type>.go` |
 | Cedar policy semantics | `harness/internal/permission/policyengine.go` |
 | Container runtime / network mode wiring | `harness/internal/executor/container*.go` |
+| K8s executor (Pod-per-run) + egress NetworkPolicy | `harness/internal/executor/k8s.go`, `k8s_netpol.go` (operator doc: `docs/executors/k8s.md`) |
+| `--k8s-*` CLI flags (`--k8s-namespace`, `--k8s-kubeconfig`, `--k8s-node-selector`, `--k8s-service-account`, `--k8s-egress-proxy-url`) | `harness/cmd/stirrup/cmd/runconfigflags.go` (defs), `harness.go` (mapping) |
+| `stirrup egress-proxy` subcommand | `harness/cmd/stirrup/cmd/egress_proxy.go` |
 | Egress proxy | `harness/internal/executor/egressproxy/` |
 | Code scanner | `harness/internal/security/codescanner/` |
 | Result sink (RunResult payload) | `harness/internal/resultsink/` |

--- a/README.md
+++ b/README.md
@@ -74,6 +74,55 @@ config a flag-only invocation *would* have used — useful for
 post-mortem replays or pinning a stable configuration. See
 [`docs/configuration.md`](docs/configuration.md#building-runconfigs-interactively).
 
+### Executors
+
+The agent runs inside one of four executors, selected with
+`--executor` / `executor.type`:
+
+| Executor | Boundary | Notes |
+|---|---|---|
+| `local` | none (host process) | Trusted local iteration. |
+| `container` | a Docker/Podman container | Single-host sandbox with an in-process egress proxy. |
+| `k8s` | a Pod on a Kubernetes cluster | Pod-per-run with a hardened `securityContext`, per-tenant RuntimeClass, and `NetworkPolicy` egress. See [`docs/executors/k8s.md`](docs/executors/k8s.md). |
+| `api` | no shell (VCS-backed, read-only) | Reviews/plans against a Git host without a workspace. |
+
+The relevant executor flags are:
+
+| Flag | Notes |
+|---|---|
+| `--executor` | `local` (default), `container`, `k8s`, or `api`. |
+| `--image` | Sandbox container image (`container` / `k8s`). |
+| `--container-runtime` | OCI runtime (`container`) or Pod `RuntimeClassName` (`k8s`): `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh`, `runc`. |
+| `--k8s-namespace` | Namespace for the `k8s` sandbox Pod (required for `k8s`). |
+| `--k8s-kubeconfig` | Kubeconfig path; empty prefers in-cluster config then `$KUBECONFIG`. |
+| `--k8s-node-selector` | Repeatable `key=value` Pod `nodeSelector` constraint. |
+| `--k8s-service-account` | ServiceAccount name; the token is never automounted. |
+| `--k8s-egress-proxy-url` | Egress proxy URL (required in `allowlist` network mode). |
+
+#### Running on Kubernetes
+
+```sh
+# Apply the standing objects once per cluster (namespace, RBAC, RuntimeClasses):
+kubectl apply -f examples/k8s/namespace.yaml
+kubectl apply -f examples/k8s/rbac.yaml
+kubectl apply -f examples/k8s/runtimeclass.yaml
+
+# Run the agent in a sandbox Pod under gVisor:
+ANTHROPIC_API_KEY=... ./stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --container-runtime gvisor \
+  --mode execution \
+  --prompt "Fix the failing test in main_test.go"
+```
+
+Full reference manifests are under
+[`examples/k8s/`](examples/k8s/) and a local `kind` cluster under
+[`scripts/dev/`](scripts/dev/). The operator guide —
+architecture, config reference, deployment recipes, egress, and
+troubleshooting — is [`docs/executors/k8s.md`](docs/executors/k8s.md).
+
 `stirrup harness --output <text|json|none>` (alias `-o`) selects the
 post-run summary surface. `text` (default) prints today's stderr
 summary, `json` emits a single `STIRRUP_RESULT` line on stdout
@@ -94,6 +143,7 @@ See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.
 | Component model, agentic loop, deep dives | [`docs/architecture.md`](docs/architecture.md) |
 | CLI flags, `RunConfig` precedence, examples | [`docs/configuration.md`](docs/configuration.md) |
 | Production deployment via `stirrup job` (K8s, gRPC) | [`docs/deployment.md`](docs/deployment.md) |
+| Kubernetes executor (Pod-per-run sandbox) | [`docs/executors/k8s.md`](docs/executors/k8s.md) |
 | Running stirrup as a Google Cloud Run job | [`docs/cloud-run-jobs.md`](docs/cloud-run-jobs.md) |
 | Five safety rings (operator guide) | [`docs/safety-rings.md`](docs/safety-rings.md) |
 | In-harness security foundations | [`docs/security.md`](docs/security.md) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -367,14 +367,23 @@ Walkthrough: [`azure-workload-identity.md`](azure-workload-identity.md).
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--executor` | `local` | One of `local`, `container`, `api`. |
-| `--container-runtime` | (none) | OCI runtime: `runc`, `runsc` (gVisor), `kata`, `kata-qemu`, `kata-fc`. Empty = engine default. Requires the runtime to be registered with the host Docker/Podman daemon. |
+| `--executor` | `local` | One of `local`, `container`, `k8s`, `api`. |
+| `--container-runtime` | (none) | Per-`executor` closed set. For `container` (host OCI runtime): `runc`, `runsc` (gVisor), `kata`, `kata-qemu`, `kata-fc`, `kata-clh` — must be registered with the host Docker/Podman daemon. For `k8s` (Pod `RuntimeClassName`): `runc`, `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh` — note the name is `gvisor`, not `runsc`. Empty = engine default for `container`, cluster-default RuntimeClass for `k8s`. |
+| `--k8s-namespace` | (none) | Namespace for the `k8s` executor's sandbox Pod. Required when `--executor=k8s`. JSON path: `executor.k8sNamespace`. |
+| `--k8s-kubeconfig` | (none) | Path to a kubeconfig for the `k8s` executor. An explicit value wins even in-cluster; empty prefers in-cluster config, then `$KUBECONFIG`. JSON path: `executor.k8sKubeconfig`. |
+| `--k8s-node-selector` | (none) | Repeatable `key=value` `nodeSelector` constraining where the `k8s` Pod schedules (e.g. `--k8s-node-selector disktype=ssd`). JSON path: `executor.k8sNodeSelector`. |
+| `--k8s-service-account` | (none) | ServiceAccount name for the `k8s` Pod. Empty uses the namespace `default`. The token is never automounted regardless. JSON path: `executor.k8sServiceAccount`. |
+| `--k8s-egress-proxy-url` | (none) | URL the `k8s` sandbox Pod routes `HTTP_PROXY`/`HTTPS_PROXY` through. Required when `--executor=k8s` and the network mode is `allowlist`; rejected otherwise. JSON path: `executor.k8sEgressProxyUrl`. |
 | `--edit-strategy` | `multi` | One of `whole-file`, `search-replace`, `udiff`, `multi`. `composite` is reachable only via `--config`. |
 | `--verifier` | `none` | One of `none`, `test-runner`, `llm-judge`. `composite` is reachable only via `--config`. |
 | `--git-strategy` | `none` | One of `none`, `deterministic`. |
 | `--permission-policy-file` | (none) | Path to a Cedar policy file. When set and the policy type is unset elsewhere, implies `permissionPolicy.type=policy-engine`. Starters live under [`examples/policies/`](../examples/policies/). |
 | `--code-scanner` | (none) | One of `none`, `patterns`, `semgrep`. `composite` is accepted only via `--config` (it requires `codeScanner.scanners`). Empty defers to the mode-aware default (`patterns` for execution, `none` for read-only modes). |
 | `--tools-profile` | (none) | Model-facing toolset profile. Closed enum: `""`/`default` (no aliasing, internal tool names) or `coding-classic` (terse coding-CLI aliases). Changes only the names the model sees; dispatch identities and gating are unchanged. JSON path: `tools.profile`. See [Toolset profiles](#toolset-profiles). |
+
+See also: [`docs/executors/k8s.md`](executors/k8s.md) for the `k8s`
+executor's architecture, deployment recipes, egress model, and the full
+`executor.k8s*` field reference.
 
 ### Transport
 

--- a/docs/executors/k8s.md
+++ b/docs/executors/k8s.md
@@ -23,7 +23,7 @@ those files.
 - [Architecture](#architecture)
 - [Configuration reference](#configuration-reference)
 - [Deployment recipes](#deployment-recipes)
-- [Per-tenant RuntimeClass selection](#per-tenant-runtimeclass-selection)
+- [RuntimeClass selection per run](#runtimeclass-selection-per-run)
 - [Egress](#egress)
 - [Safety rings on Kubernetes](#safety-rings-on-kubernetes)
 - [Troubleshooting](#troubleshooting)
@@ -49,7 +49,7 @@ host proxy).
 ```mermaid
 flowchart LR
   subgraph Orchestrator["Orchestrator (harness binary)"]
-    SA[ServiceAccount<br/>stirrup-orchestrator]
+    SA[authenticates as<br/>stirrup-orchestrator SA]
   end
   subgraph NS["Sandbox namespace (PodSecurity: restricted)"]
     NP{{Per-Pod egress<br/>NetworkPolicy}}
@@ -67,14 +67,18 @@ flowchart LR
 The pieces and their lifecycle:
 
 - **The orchestrator** is whatever runs the harness (a CI runner, a
-  controller, an operator shell). It authenticates with the cluster via
-  the in-cluster ServiceAccount, the kubeconfig at
-  `executor.k8sKubeconfig`, or `$KUBECONFIG` — resolved in that order
-  (see [`buildRESTConfig`](../../harness/internal/executor/k8s.go)). It
-  holds the RBAC the executor's lifecycle needs:
+  controller, an operator shell). It authenticates with the cluster in
+  this order (see
+  [`buildRESTConfig`](../../harness/internal/executor/k8s.go)): an
+  explicit kubeconfig at `executor.k8sKubeconfig` if set (it wins even
+  when running in-cluster), then the in-cluster ServiceAccount, then
+  `$KUBECONFIG`. It holds the RBAC the executor's lifecycle needs:
   `pods` (create/get/delete), `pods/exec` (create), and
-  `networkpolicies` (create/delete). The reference Role is
-  [`examples/k8s/rbac.yaml`](../../examples/k8s/rbac.yaml).
+  `networkpolicies` (create/delete). The reference Role
+  ([`examples/k8s/rbac.yaml`](../../examples/k8s/rbac.yaml)) also grants
+  `pods/log` (get); the executor does not use it, so it is granted only
+  for operator `kubectl logs` debugging and may be dropped to tighten
+  the Role to the executor's minimum.
 
 - **The sandbox Pod** is created per run with a fixed, config-independent
   hardened `securityContext`: `allowPrivilegeEscalation: false`,
@@ -303,7 +307,7 @@ The RuntimeClass's `scheduling.nodeSelector` and any
 `--k8s-node-selector` the run supplies are merged by Kubernetes into the
 effective node selection.
 
-## Per-tenant RuntimeClass selection
+## RuntimeClass selection per run
 
 `executor.runtime` maps directly to the Pod `RuntimeClassName`, so a
 multi-tenant orchestrator selects the isolation level per run by setting
@@ -349,6 +353,9 @@ HTTPS_PROXY = <k8sEgressProxyUrl>
 NO_PROXY    = localhost,127.0.0.1,::1
 ```
 
+The `NO_PROXY` set (`localhost,127.0.0.1,::1`) is fixed in the executor
+and not flag-configurable.
+
 The `NetworkPolicy` intentionally does **not** encode the FQDN allowlist
 — NetworkPolicy operates on IPs/ports/selectors, not hostnames. The
 hostname allowlist lives in the proxy. The policy's job is the
@@ -371,7 +378,10 @@ stirrup egress-proxy --listen :8080 --allowlist-file ./allowlist.txt
 ```
 
 The proxy reads its allowlist once at startup (no hot reload); roll the
-Deployment to change it.
+Deployment to change it. During a rolling update, in-flight runs keep
+routing through the old Pod (and its old allowlist) until the new Pod is
+Ready; pause runs across the roll if that overlap window is
+unacceptable.
 
 **The proxy MUST run in the same namespace as the sandbox Pod.** The
 allowlist policy selects the proxy by a `PodSelector` with **no**
@@ -419,7 +429,9 @@ Defence-in-depth on K8s additionally relies on cluster-level controls the
 reference manifests configure: the sandbox namespace enforces the
 `restricted` Pod Security Standard (pinned to a version, not `latest`),
 and the orchestrator's RBAC is the minimal `pods` / `pods/exec` /
-`networkpolicies` verb set. The sandbox Pod has no API access of its own
+`networkpolicies` verb set the executor needs (the reference Role adds
+`pods/log` get for operator debugging only; drop it to reach the
+executor's exact minimum). The sandbox Pod has no API access of its own
 (`automountServiceAccountToken: false`).
 
 ## Troubleshooting
@@ -434,7 +446,7 @@ and the orchestrator's RBAC is the minimal `pods` / `pods/exec` /
 | `not in cluster and KUBECONFIG is unset` | No in-cluster config, no kubeconfig. | Set `--k8s-kubeconfig` or `$KUBECONFIG`, or run in-cluster. |
 | Pod scheduling fails / pending forever | RuntimeClass `nodeSelector` matches no node, or the handler is missing. | Label the node for the runtime; confirm the handler is installed. |
 | Egress not actually confined on `kind` | kindnet does not enforce NetworkPolicy. | Use a NetworkPolicy-enforcing CNI (Cilium, Calico) for real confinement. |
-| `pod ... not ready` after 60s | Image lacks `/bin/sh`, or the runtime cannot start the Pod. | Use an image shipping `/bin/sh`, `tar`, `ls`; check `kubectl describe pod`. |
+| `pod ... not ready` after the readiness timeout (default 60 s, or the caller context deadline if shorter) | Image lacks `/bin/sh`, or the runtime cannot start the Pod. | Use an image shipping `/bin/sh`, `tar`, `ls`; check `kubectl describe pod`. |
 | Exec/file I/O fails with API errors | The orchestrator lacks `pods/exec` create. | Apply [`rbac.yaml`](../../examples/k8s/rbac.yaml) (or grant the verb). |
 
 ## See also

--- a/docs/executors/k8s.md
+++ b/docs/executors/k8s.md
@@ -1,0 +1,448 @@
+# Kubernetes executor
+
+The `k8s` executor runs the agent inside a hardened, single-use
+**sandbox Pod** rather than a local Docker/Podman container. It is the
+executor for running stirrup *on* a Kubernetes cluster: an orchestrator
+process (the harness binary holding a kubeconfig or in-cluster
+ServiceAccount) creates one Pod per run, drives command execution and
+file I/O over the `pods/exec` subresource, confines the Pod's egress
+with a per-Pod `NetworkPolicy`, and deletes the Pod when the run ends.
+
+This document is the operator reference. The reference manifests it
+points at live under [`examples/k8s/`](../../examples/k8s/) and the
+local development cluster under [`scripts/dev/`](../../scripts/dev/).
+The executor implementation is
+[`harness/internal/executor/k8s.go`](../../harness/internal/executor/k8s.go)
+and [`k8s_netpol.go`](../../harness/internal/executor/k8s_netpol.go);
+every flag, field, and label documented here is cross-checked against
+those files.
+
+## Contents
+
+- [When to use it](#when-to-use-it)
+- [Architecture](#architecture)
+- [Configuration reference](#configuration-reference)
+- [Deployment recipes](#deployment-recipes)
+- [Per-tenant RuntimeClass selection](#per-tenant-runtimeclass-selection)
+- [Egress](#egress)
+- [Safety rings on Kubernetes](#safety-rings-on-kubernetes)
+- [Troubleshooting](#troubleshooting)
+
+## When to use it
+
+| Executor | Boundary | Use when |
+|---|---|---|
+| `local` | none (host process) | Trusted local iteration. |
+| `container` | a Docker/Podman container on the harness host | A single host with a container engine is the deployment target. |
+| `k8s` | a Pod on a Kubernetes cluster | The deployment target is a cluster; multi-tenant isolation, per-tenant RuntimeClass, and cluster-native NetworkPolicy egress are required. |
+
+The `k8s` executor is the cluster-native analogue of the `container`
+executor. The two share the `image`, `network`, `resources`, and
+`runtime` configuration surface; the differences are that the sandbox
+is a Pod (not a host container), the runtime maps to a Pod
+`RuntimeClassName` (not a host OCI runtime), and egress is enforced by
+a `NetworkPolicy` plus an in-cluster proxy Deployment (not an in-process
+host proxy).
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph Orchestrator["Orchestrator (harness binary)"]
+    SA[ServiceAccount<br/>stirrup-orchestrator]
+  end
+  subgraph NS["Sandbox namespace (PodSecurity: restricted)"]
+    NP{{Per-Pod egress<br/>NetworkPolicy}}
+    Pod[/"Sandbox Pod (agent)<br/>hardened securityContext<br/>RuntimeClass = runtime"/]
+    Proxy[Egress proxy<br/>Deployment]
+  end
+  SA -->|pods: create/get/delete| Pod
+  SA -->|pods/exec: create| Pod
+  SA -->|networkpolicies: create/delete| NP
+  NP -.->|binds| Pod
+  Pod -->|HTTP_PROXY allowlist mode| Proxy
+  Proxy -->|FQDN allowlist| Net([Internet])
+```
+
+The pieces and their lifecycle:
+
+- **The orchestrator** is whatever runs the harness (a CI runner, a
+  controller, an operator shell). It authenticates with the cluster via
+  the in-cluster ServiceAccount, the kubeconfig at
+  `executor.k8sKubeconfig`, or `$KUBECONFIG` — resolved in that order
+  (see [`buildRESTConfig`](../../harness/internal/executor/k8s.go)). It
+  holds the RBAC the executor's lifecycle needs:
+  `pods` (create/get/delete), `pods/exec` (create), and
+  `networkpolicies` (create/delete). The reference Role is
+  [`examples/k8s/rbac.yaml`](../../examples/k8s/rbac.yaml).
+
+- **The sandbox Pod** is created per run with a fixed, config-independent
+  hardened `securityContext`: `allowPrivilegeEscalation: false`,
+  `capabilities.drop: [ALL]`, `runAsNonRoot: true`, `runAsUser: 65532`
+  (the distroless "nonroot" UID), and `seccompProfile.type:
+  RuntimeDefault`. `automountServiceAccountToken` is **always** `false`,
+  so the sandbox itself has no Kubernetes API access regardless of the
+  ServiceAccount named. `restartPolicy` is `Never` (one-shot), the
+  container is named `agent`, the working directory is `/workspace`, and
+  the entrypoint is `/bin/sh -c "sleep infinity"` — all real work runs
+  through subsequent `exec` calls, not the entrypoint. The exact spec is
+  annotated field-by-field in
+  [`examples/k8s/sample-sandbox-pod.yaml`](../../examples/k8s/sample-sandbox-pod.yaml).
+
+- **Command execution and file I/O** both ride the `pods/exec`
+  subresource. `Exec` runs `/bin/sh -c`; `ReadFile`/`WriteFile` stream a
+  `tar` archive over exec; `ListDirectory` runs `ls -A1`. The image must
+  therefore ship a POSIX shell at `/bin/sh` plus `tar` and `ls` on
+  `PATH` — a shell-less distroless static image will not work. Output
+  and file payloads are capped at 10 MB (matching the container
+  executor).
+
+- **Egress** is enforced by a per-Pod `NetworkPolicy` the executor
+  installs *before* the Pod is created (closing the window in which a
+  Running Pod would otherwise have cluster-default egress). Mode `none`
+  installs a deny-all egress policy; mode `allowlist` installs a policy
+  permitting egress only to DNS and the in-cluster egress proxy, and
+  injects `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` into the container. See
+  [Egress](#egress).
+
+The label contract knits these together: every sandbox Pod carries
+`stirrup-sandbox: "true"` and `stirrup.dev/pod: <pod-name>`, and the
+allowlist policy selects the proxy by `app=stirrup-egress-proxy` on TCP
+8080. These labels are fixed in `k8s_netpol.go`; the manifests must keep
+them in sync.
+
+## Configuration reference
+
+The `k8s` executor is selected by `--executor k8s` /
+`executor.type: "k8s"`. It draws on the shared executor fields (`image`,
+`network`, `resources`, `runtime`) plus a set of `K8s*` fields. Every
+flag and field below is verified against
+[`runconfigflags.go`](../../harness/cmd/stirrup/cmd/runconfigflags.go),
+[`harness.go`](../../harness/cmd/stirrup/cmd/harness.go), and
+[`types/runconfig.go`](../../types/runconfig.go).
+
+### Flags and fields
+
+| CLI flag | RunConfig field | Required | Notes |
+|---|---|---|---|
+| `--executor k8s` | `executor.type: "k8s"` | yes | Selects the executor. |
+| `--image` | `executor.image` | yes for `k8s` | Pod container image. Must ship `/bin/sh`, `tar`, and `ls`. |
+| `--k8s-namespace` | `executor.k8sNamespace` | yes for `k8s` | Namespace the sandbox Pod (and its `NetworkPolicy`) is created in. |
+| `--k8s-kubeconfig` | `executor.k8sKubeconfig` | no | Path to a kubeconfig file. Empty prefers in-cluster config, then `$KUBECONFIG`. |
+| `--k8s-node-selector key=value` | `executor.k8sNodeSelector` | no | Repeatable `nodeSelector` constraint, e.g. `--k8s-node-selector disktype=ssd`. Merged with any `nodeSelector` the RuntimeClass contributes. |
+| `--k8s-service-account` | `executor.k8sServiceAccount` | no | ServiceAccount name for the Pod. Empty uses the namespace `default`. The token is never automounted regardless. |
+| `--k8s-egress-proxy-url` | `executor.k8sEgressProxyUrl` | conditional | Egress proxy URL the Pod's `HTTP_PROXY`/`HTTPS_PROXY` point at. Required when `network.mode` is `allowlist`; rejected otherwise. |
+| `--container-runtime` | `executor.runtime` | no | Pod `RuntimeClassName`. Closed set: `runc`, `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh`. Empty selects the cluster-default RuntimeClass (and logs an isolation warning). |
+| *(RunConfig only)* | `executor.network` | yes for `k8s` | Mode `none` or `allowlist`. A nil network is rejected at config load (fail closed). |
+| *(RunConfig only)* | `executor.resources` | no | CPU/memory/disk mapped onto the Pod container. See [Resource mapping](#resource-mapping). |
+
+`--container-runtime` is shared with the `container` executor, where it
+names a host OCI runtime. For `k8s` the same field names a Pod
+`RuntimeClassName`, which is **not** the same namespace of values: the
+closed set for `k8s` is `runc / gvisor / kata-qemu / kata-fc / kata-clh`
+(`gvisor`, not the OCI runtime name `runsc`). Shell completions list the
+container set only, so `gvisor` is valid but not offered by completion.
+
+### Validation rules
+
+`ValidateRunConfig` enforces the following for `executor.type: "k8s"`
+(see `validateK8sExecutor` / `validateK8sEgressProxy` /
+`validateExecutorRuntime` in
+[`types/runconfig.go`](../../types/runconfig.go)):
+
+- `executor.image` is **required**.
+- `executor.k8sNamespace` is **required**.
+- `executor.workspace` is **rejected** — the Pod workspace is fixed at
+  `/workspace`, not a mapped host directory.
+- `executor.network` is **required** (set `mode` to `none` or
+  `allowlist`). A nil network leaves egress posture undefined and is
+  surfaced at config-load time rather than at runtime.
+- `executor.k8sEgressProxyUrl` is **required** when `network.mode` is
+  `allowlist` and **rejected** when it is not.
+- `executor.runtime`, when non-empty, must be one of the closed set
+  `runc / gvisor / kata-qemu / kata-fc / kata-clh`; any other value is
+  rejected.
+- `executor.resources`, when set, must not carry negative values — a
+  negative bound would silently map to "no limit".
+
+### Resource mapping
+
+`executor.resources` maps onto the Pod container as follows
+(`resourcesToPodResources`):
+
+| Field | Pod mapping |
+|---|---|
+| `cpus` | `requests.cpu` **and** `limits.cpu`. Whole cores render as an integer (`"2"`), fractional cores as milli-CPU (`"500m"`). |
+| `memoryMb` | `requests.memory` **and** `limits.memory` (Mi). |
+| `diskMb` | `limits.ephemeral-storage` **only** (Mi) — the eviction ceiling. No request, so the scheduler is not forced to find a node with that much free scratch. |
+| `pids` | **Logged and ignored.** Per-Pod PID limits are a kubelet setting (`--pod-max-pids`), not a container resource field. |
+
+A nil or all-zero `resources` block leaves the Pod's requirements empty
+so it inherits namespace defaults.
+
+## Deployment recipes
+
+Each recipe below is a `kind`/cluster bring-up plus the run invocation.
+The standing objects (namespace, RBAC, RuntimeClasses) come from
+[`examples/k8s/`](../../examples/k8s/); apply them once per cluster:
+
+```sh
+kubectl apply -f examples/k8s/namespace.yaml
+kubectl apply -f examples/k8s/rbac.yaml
+kubectl apply -f examples/k8s/runtimeclass.yaml   # registered handlers only
+```
+
+Register only the RuntimeClasses whose handlers are actually installed
+on the nodes — a RuntimeClass whose handler is missing makes Pod
+scheduling fail. The recipes set `--mode execution` and a network mode;
+fill in the provider/model and prompt as for any run.
+
+### kind + runc (manifest-shape smoke test)
+
+A stock `kind` cluster runs every Pod under `runc` and does **not**
+enforce `NetworkPolicy` (its default CNI, kindnet, accepts policy objects
+but ignores them). This recipe proves the executor can create, exec
+into, and tear down a Pod — it does **not** prove egress confinement.
+
+```sh
+./scripts/dev/kind-up.sh        # or: just kind-up
+kubectl config use-context kind-stirrup-sandbox
+
+stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --mode execution \
+  --prompt "..."
+# network.mode comes from a RunConfig; use "none" for the smoke test.
+```
+
+### kind + gVisor (sandboxed runtime, unenforced egress)
+
+`scripts/dev/kind-up.sh` installs gVisor (`runsc` + the containerd shim)
+into the kind node and registers a `gvisor` RuntimeClass, so a Pod can
+schedule onto a kernel-isolated runtime. Egress is still unenforced on
+kindnet — combine gVisor with a real CNI for the full posture.
+
+```sh
+./scripts/dev/kind-up.sh        # installs gVisor + RuntimeClasses
+./scripts/dev/smoke-test.sh     # or: just kind-smoke — verifies gVisor runs
+
+stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --container-runtime gvisor \
+  --mode execution \
+  --prompt "..."
+```
+
+Kata backends are deliberately absent from the kind dev cluster: kind
+nodes are themselves containers and Kata needs nested KVM, which is not
+available inside a containerised host. Exercise Kata on a real cluster.
+
+### GKE Sandbox (gVisor on GKE)
+
+GKE Sandbox runs Pods under gVisor and exposes a `gvisor` RuntimeClass
+on Sandbox-enabled node pools. No node-level gVisor install is needed —
+GKE manages it. A NetworkPolicy-enforcing CNI is available on GKE
+(Dataplane V2 / Calico), so the egress policy is genuinely enforced.
+
+```sh
+# Create a node pool with GKE Sandbox enabled, then:
+stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --container-runtime gvisor \
+  --k8s-node-selector sandbox.gke.io/runtime=gvisor \
+  --mode execution \
+  --prompt "..."
+```
+
+The `--k8s-node-selector` pins scheduling to the Sandbox node pool;
+adjust the label to the cluster's node pool labelling.
+
+### Kata Containers (kata-qemu / kata-fc / kata-clh)
+
+The three Kata backends give hardware-virtualization isolation: each Pod
+runs in a lightweight VM. They are **not** interchangeable on one node —
+`kata-fc` needs a devmapper snapshotter, `kata-clh` a different VMM — so
+[`examples/k8s/runtimeclass.yaml`](../../examples/k8s/runtimeclass.yaml)
+gives each a **distinct** `nodeSelector` label. Label each node only for
+the handler(s) it actually has:
+
+```sh
+kubectl label node <node> stirrup.dev/runtime-kata-qemu=true
+kubectl label node <node> stirrup.dev/runtime-kata-fc=true
+kubectl label node <node> stirrup.dev/runtime-kata-clh=true
+```
+
+Then select the matching runtime per run:
+
+```sh
+# kata-qemu — broadest compatibility, needs KVM (bare metal or nested virt)
+stirrup harness --executor k8s --container-runtime kata-qemu \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox --mode execution --prompt "..."
+
+# kata-fc — Firecracker, fast boot, needs a devmapper snapshotter + KVM
+stirrup harness --executor k8s --container-runtime kata-fc \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox --mode execution --prompt "..."
+
+# kata-clh — Cloud Hypervisor, needs KVM
+stirrup harness --executor k8s --container-runtime kata-clh \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox --mode execution --prompt "..."
+```
+
+Kata prerequisites are documented inline in
+[`examples/k8s/runtimeclass.yaml`](../../examples/k8s/runtimeclass.yaml).
+The RuntimeClass's `scheduling.nodeSelector` and any
+`--k8s-node-selector` the run supplies are merged by Kubernetes into the
+effective node selection.
+
+## Per-tenant RuntimeClass selection
+
+`executor.runtime` maps directly to the Pod `RuntimeClassName`, so a
+multi-tenant orchestrator selects the isolation level per run by setting
+the field. A cluster can register the full set and route each tenant to
+the appropriate class:
+
+- Low-trust / untrusted prompts → `gvisor` or a `kata-*` backend.
+- Trusted internal workloads → `runc` (or leave empty for the cluster
+  default, accepting the isolation warning the executor logs).
+
+An empty `executor.runtime` leaves `RuntimeClassName` unset, which
+selects the cluster-default RuntimeClass — often plain `runc` with no
+sandbox isolation. The executor logs a warning in that case so the
+opt-out is visible; a run wanting guaranteed isolation must set the
+field explicitly.
+
+Node isolation for sandbox runtimes is a `taint`/`toleration` pattern,
+documented (but **not yet implemented** by the executor — it does not
+inject tolerations) in
+[`examples/k8s/taint-and-toleration.yaml`](../../examples/k8s/taint-and-toleration.yaml).
+
+## Egress
+
+The `k8s` executor's network posture comes from `executor.network.mode`,
+and the matching `NetworkPolicy` is installed before the Pod exists.
+
+### Mode `none` — deny all egress
+
+A deny-all egress `NetworkPolicy` (an `Egress` policy type with no egress
+rules) selects the Pod and permits no outbound traffic. No proxy and no
+proxy env vars are involved.
+
+### Mode `allowlist` — proxy + DNS
+
+The policy permits egress only to (a) DNS (UDP/TCP 53) and (b) the
+in-cluster egress proxy (`app=stirrup-egress-proxy` on TCP 8080).
+Everything else is forced through the proxy, where the FQDN allowlist
+applies. The executor injects:
+
+```
+HTTP_PROXY  = <k8sEgressProxyUrl>
+HTTPS_PROXY = <k8sEgressProxyUrl>
+NO_PROXY    = localhost,127.0.0.1,::1
+```
+
+The `NetworkPolicy` intentionally does **not** encode the FQDN allowlist
+— NetworkPolicy operates on IPs/ports/selectors, not hostnames. The
+hostname allowlist lives in the proxy. The policy's job is the
+complementary half: guarantee the Pod cannot reach the network except
+via the proxy.
+
+### The egress proxy
+
+The proxy is the same allowlist proxy the `container` executor runs
+in-process, deployed as a long-lived in-cluster Deployment many sandbox
+Pods share (a Pod cannot start its own host-side proxy). Deploy it from
+[`examples/k8s/egress-proxy/`](../../examples/k8s/egress-proxy/), or run
+it standalone with the `stirrup egress-proxy` subcommand:
+
+```sh
+stirrup egress-proxy --listen :8080 \
+  --allowlist api.anthropic.com --allowlist '*.github.com:443'
+# or read the allowlist from a file:
+stirrup egress-proxy --listen :8080 --allowlist-file ./allowlist.txt
+```
+
+The proxy reads its allowlist once at startup (no hot reload); roll the
+Deployment to change it.
+
+**The proxy MUST run in the same namespace as the sandbox Pod.** The
+allowlist policy selects the proxy by a `PodSelector` with **no**
+`NamespaceSelector`, so a cross-namespace proxy is not matched: under an
+enforcing CNI the sandbox then gets *no* egress at all (a silent deny,
+not a bypass). Set `--k8s-namespace` and the proxy's namespace to the
+same value, and point `--k8s-egress-proxy-url` at the
+`<service>.<namespace>.svc` name — for example
+`http://stirrup-egress-proxy.stirrup-sandbox.svc:8080`. The
+top-level `examples/k8s/` manifests use `stirrup-sandbox` while
+`egress-proxy/` ships `default`; align them before applying (see the
+[examples README](../../examples/k8s/README.md#namespace-alignment--required-before-applying-the-egress-proxy)).
+
+### Enforcement caveat — kindnet does not enforce NetworkPolicy
+
+`NetworkPolicy` is enforced only by a CNI that implements it. **kindnet,
+the default CNI for `kind`, accepts NetworkPolicy objects but does not
+enforce them.** On a stock kind cluster the deny-all and allowlist
+policies are inert, and a sandbox Pod retains cluster-default egress.
+The confinement holds only on a NetworkPolicy-enforcing CNI such as
+[Cilium](https://cilium.io/) or
+[Calico](https://www.tigera.io/project-calico/).
+
+Treat a kind-based test as proof of *manifest shape* — the objects are
+created with the right selectors, ports, and env — not as proof that
+egress is actually confined. This mirrors the `container` executor's
+honest fail-open note around `host.docker.internal`.
+
+## Safety rings on Kubernetes
+
+The five [safety rings](../safety-rings.md) map onto the `k8s` executor
+as follows. The full per-ring detail is in
+[`docs/safety-rings.md`](../safety-rings.md#safety-rings-on-kubernetes);
+the K8s-specific mapping is:
+
+| Ring | On Kubernetes |
+|---|---|
+| **1 — Runtime class** | `executor.runtime` is the Pod `RuntimeClassName`, not a host OCI runtime. `gvisor` / `kata-*` give kernel/VM isolation; empty selects the cluster default (warned). The hardened `securityContext` (drop ALL, runAsNonRoot, seccomp RuntimeDefault) is applied unconditionally beneath the runtime choice. |
+| **2 — Egress proxy** | A per-Pod `NetworkPolicy` plus the in-cluster proxy Deployment, instead of an in-process host proxy. Enforcement depends on a NetworkPolicy-enforcing CNI. |
+| **3 — Cedar policy** | Unchanged — per tool-call authorization runs in the orchestrator before the executor acts, identically across executor types. |
+| **4 — Rule of Two** | Unchanged — a pre-flight invariant on the `RunConfig`. A non-`none` `network.mode` counts toward `canCommunicateExternally` exactly as for other executors. |
+| **5 — Code scanner** | Unchanged — post-edit content check, executor-agnostic. |
+
+Defence-in-depth on K8s additionally relies on cluster-level controls the
+reference manifests configure: the sandbox namespace enforces the
+`restricted` Pod Security Standard (pinned to a version, not `latest`),
+and the orchestrator's RBAC is the minimal `pods` / `pods/exec` /
+`networkpolicies` verb set. The sandbox Pod has no API access of its own
+(`automountServiceAccountToken: false`).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `RuntimeClass "<name>" was rejected by the cluster` | The named RuntimeClass is not registered or not permitted. | `kubectl get runtimeclass`; apply [`runtimeclass.yaml`](../../examples/k8s/runtimeclass.yaml) for the handlers actually installed, or pick a registered runtime. |
+| `executor.k8sNamespace is required for executor.type="k8s"` | `--k8s-namespace` / `executor.k8sNamespace` unset. | Set the namespace. |
+| `executor.k8sEgressProxyUrl is required when ... "allowlist"` | `network.mode: allowlist` without a proxy URL. | Set `--k8s-egress-proxy-url`, or use `network.mode: none`. |
+| `executor.k8sEgressProxyUrl is only valid when ... "allowlist"` | A proxy URL set while `network.mode` is `none`. | Remove the URL, or switch to `allowlist`. |
+| `executor.network is required for executor.type="k8s"` | No `network` block. | Set `executor.network.mode` to `none` or `allowlist`. |
+| `not in cluster and KUBECONFIG is unset` | No in-cluster config, no kubeconfig. | Set `--k8s-kubeconfig` or `$KUBECONFIG`, or run in-cluster. |
+| Pod scheduling fails / pending forever | RuntimeClass `nodeSelector` matches no node, or the handler is missing. | Label the node for the runtime; confirm the handler is installed. |
+| Egress not actually confined on `kind` | kindnet does not enforce NetworkPolicy. | Use a NetworkPolicy-enforcing CNI (Cilium, Calico) for real confinement. |
+| `pod ... not ready` after 60s | Image lacks `/bin/sh`, or the runtime cannot start the Pod. | Use an image shipping `/bin/sh`, `tar`, `ls`; check `kubectl describe pod`. |
+| Exec/file I/O fails with API errors | The orchestrator lacks `pods/exec` create. | Apply [`rbac.yaml`](../../examples/k8s/rbac.yaml) (or grant the verb). |
+
+## See also
+
+- [`examples/k8s/`](../../examples/k8s/) — reference manifests
+  (namespace, RBAC, RuntimeClasses, sample Pod, egress proxy).
+- [`scripts/dev/`](../../scripts/dev/) — local `kind` cluster with
+  gVisor for development (`just kind-up` / `kind-smoke` / `kind-down`).
+- [`docs/safety-rings.md`](../safety-rings.md) — the five-ring model.
+- [`docs/configuration.md`](../configuration.md) — full CLI/RunConfig
+  reference.

--- a/docs/safety-rings.md
+++ b/docs/safety-rings.md
@@ -461,9 +461,17 @@ is no silent fallback to `runc`.
 
 ### Kubernetes deployment
 
-On Kubernetes, set `runtimeClassName` on the pod spec rather than
-threading the runtime through stirrup. `--container-runtime` is for
-the local Docker/Podman container executor.
+For the `k8s` executor, `--container-runtime` (`executor.runtime`) maps
+to the sandbox Pod's `spec.runtimeClassName` — the same flag, a
+different closed set (`runc`, `gvisor`, `kata-qemu`, `kata-fc`,
+`kata-clh`; note `gvisor`, not the host OCI name `runsc`). The executor
+sets `runtimeClassName` on the Pod it creates, so the runtime is
+threaded through stirrup rather than hand-set on a static spec. Empty
+selects the cluster-default RuntimeClass and logs an isolation warning.
+See [`docs/executors/k8s.md`](executors/k8s.md#safety-rings-on-kubernetes)
+for the full ring mapping on Kubernetes, and
+[Safety rings on Kubernetes](#safety-rings-on-kubernetes) below for the
+in-document summary.
 
 ## Ring 2 — Egress allowlist proxy (network isolation)
 

--- a/docs/safety-rings.md
+++ b/docs/safety-rings.md
@@ -800,6 +800,90 @@ The `editStrategy` field is set out of habit but inert here — no
 the strategy never runs. Leaving it set keeps the config copy-paste
 compatible with the other postures.
 
+## Safety rings on Kubernetes
+
+The `k8s` executor runs the agent in a sandbox Pod rather than a host
+container. The five rings still apply, but Rings 1 and 2 are realised
+through Kubernetes primitives. The operator reference for the executor
+is [`docs/executors/k8s.md`](executors/k8s.md); this section is the
+ring-by-ring mapping.
+
+### Ring 1 — runtime class becomes a Pod RuntimeClass
+
+On `k8s`, `executor.runtime` (`--container-runtime`) maps to the Pod's
+`spec.runtimeClassName` rather than a host OCI runtime. The accepted set
+differs because the values name different things: a host OCI runtime for
+the `container` executor versus a registered `RuntimeClass` name for
+`k8s`. The closed `k8s` set is:
+
+| Value | RuntimeClass / isolation | Cluster prerequisite |
+|---|---|---|
+| `""` (default) | cluster-default RuntimeClass — often plain `runc`, **no** sandbox isolation (the executor logs a warning) | none |
+| `runc` | vanilla runc — process isolation only | none |
+| `gvisor` | [gVisor](https://gvisor.dev) user-space kernel (handler `runsc`) | install gVisor on the nodes; register a `gvisor` RuntimeClass |
+| `kata-qemu` | [Kata](https://katacontainers.io) Containers, QEMU VM | install Kata; KVM on the nodes |
+| `kata-fc` | Kata, Firecracker VM | install Kata + a devmapper snapshotter; KVM |
+| `kata-clh` | Kata, Cloud Hypervisor VM | install Kata for Cloud Hypervisor; KVM |
+
+Note the runtime name is `gvisor` (the conventional RuntimeClass name),
+not the OCI runtime name `runsc` used by the `container` executor.
+`ValidateRunConfig` rejects values outside the set, and an unregistered
+or impermissible RuntimeClass surfaces a friendly Pod-create error
+rather than an opaque admission rejection.
+
+Beneath the runtime choice, the executor applies a fixed hardened
+`securityContext` to every sandbox Pod regardless of config:
+`allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`,
+`runAsNonRoot: true`, `runAsUser: 65532`, and `seccompProfile.type:
+RuntimeDefault`. `automountServiceAccountToken` is always `false`, so the
+sandbox has no Kubernetes API access of its own. These are the
+process-level equivalents of the `container` executor's unconditional
+`CapDrop: ALL` + `no-new-privileges`, and they satisfy the `restricted`
+Pod Security Standard the reference namespace enforces.
+
+### Ring 2 — egress proxy becomes a NetworkPolicy + proxy Deployment
+
+A sandbox Pod cannot start its own host-side proxy, so the network ring
+is split: a per-Pod `NetworkPolicy` confines the Pod's egress, and the
+allowlist proxy runs as a separate in-cluster Deployment many Pods
+share. The executor installs the policy **before** the Pod is created,
+so there is no window in which a Running Pod has cluster-default egress.
+
+- `network.mode: none` installs a deny-all egress policy.
+- `network.mode: allowlist` installs a policy permitting egress only to
+  DNS and the proxy (`app=stirrup-egress-proxy` on TCP 8080), and
+  injects `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` pointing at
+  `executor.k8sEgressProxyUrl`. The proxy enforces the FQDN allowlist,
+  exactly as in the `container` case — the NetworkPolicy guarantees the
+  proxy is the Pod's only route off-cluster, while the proxy decides
+  which destinations are reachable.
+
+The proxy MUST run in the **same namespace** as the sandbox Pod: the
+policy selects it by a `PodSelector` with no `NamespaceSelector`, so a
+cross-namespace proxy is denied (more restrictive, not a bypass). Deploy
+it from [`examples/k8s/egress-proxy/`](../examples/k8s/egress-proxy/) or
+run it standalone with `stirrup egress-proxy`.
+
+> **Enforcement depends on the CNI.** kindnet — the default CNI for
+> `kind` — accepts `NetworkPolicy` objects but does **not** enforce
+> them, so on a stock kind cluster the deny/allowlist policy is inert
+> and the Pod keeps cluster-default egress. The confinement holds only
+> on a NetworkPolicy-enforcing CNI such as
+> [Cilium](https://cilium.io/) or
+> [Calico](https://www.tigera.io/project-calico/). This is the K8s
+> analogue of the `container` executor's honest fail-open note around
+> `host.docker.internal`: a kind smoke test proves manifest shape, not
+> that egress is confined.
+
+### Rings 3, 4, 5 are unchanged
+
+Rings 3 (Cedar policy), 4 (Rule of Two), and 5 (code scanner) are
+executor-agnostic and behave identically on `k8s`. Cedar authorization
+and the Rule-of-Two pre-flight run in the orchestrator before the
+executor acts; the code scanner runs around the edit strategy. A
+non-`none` `network.mode` counts toward `canCommunicateExternally` for
+the Rule of Two exactly as it does for the other executors.
+
 ## What these don't catch
 
 Honest list of out-of-scope risks. The rings exist *because* these

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -37,6 +37,40 @@ nodes — a RuntimeClass whose handler is missing makes Pod scheduling fail. The
 egress-proxy objects are applied separately and only when running in network
 mode `allowlist`; see [`egress-proxy/README.md`](egress-proxy/README.md).
 
+### Namespace alignment — required before applying the egress proxy
+
+The files in this directory place the sandbox in the `stirrup-sandbox`
+namespace, but the `egress-proxy/` manifests ship with `namespace: default`
+(they are written to stand alone). **These two halves MUST share one namespace.**
+The allowlist NetworkPolicy the executor installs selects the proxy by a
+`PodSelector` with no `NamespaceSelector`, so a proxy in a different namespace is
+not matched: under an enforcing CNI the sandbox then gets *no* egress at all (a
+silent deny, not a bypass).
+
+Before applying `egress-proxy/` for use with this sandbox, edit the
+`namespace:` field in each of its four manifests (deployment, service,
+network-policy, configmap) from `default` to `stirrup-sandbox`, then apply and
+point `--k8s-egress-proxy-url` at the matching name:
+
+```sh
+# After editing the egress-proxy manifests' namespace to stirrup-sandbox:
+kubectl apply -f examples/k8s/egress-proxy/configmap.yaml
+kubectl apply -f examples/k8s/egress-proxy/deployment.yaml
+kubectl apply -f examples/k8s/egress-proxy/service.yaml
+kubectl apply -f examples/k8s/egress-proxy/network-policy.yaml
+
+# …and point the executor at the proxy in that namespace:
+#   --k8s-egress-proxy-url http://stirrup-egress-proxy.stirrup-sandbox.svc:8080
+```
+
+The `namespace:` fields in `egress-proxy/` are set explicitly to `default`, so a
+`kubectl apply -n stirrup-sandbox` override does NOT work — kubectl rejects an
+`-n` that disagrees with the object's own `metadata.namespace`. Edit the field
+in the file (or delete it and supply `-n` on apply). Either way, the proxy and
+the sandbox Pods must end up in the same namespace.
+`sample-sandbox-pod.yaml` already shows the proxy URL in the `stirrup-sandbox`
+namespace to match this workflow.
+
 ## How the pieces fit together
 
 The executor authenticates as `stirrup-orchestrator` (`rbac.yaml`), creates a

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -1,0 +1,68 @@
+# Kubernetes reference manifests
+
+A working operator starting point for running the stirrup k8s executor, and an
+inline record of what the executor expects from the cluster. These are reference
+manifests: apply the standing objects, adapt the namespace and image to the
+cluster, and let the executor create sandbox Pods at runtime.
+
+The executor itself is documented in
+[`harness/internal/executor/k8s.go`](../../harness/internal/executor/k8s.go);
+every field shown here is cross-checked against it.
+
+## Files
+
+| File | Kind | Apply? | Purpose |
+|---|---|---|---|
+| `namespace.yaml` | Namespace | yes | The `stirrup-sandbox` namespace with sandbox/monitoring labels and `restricted` PodSecurity. |
+| `rbac.yaml` | ServiceAccount + Role + RoleBinding | yes | The `stirrup-orchestrator` identity and the pod / pods/exec / networkpolicy verbs the executor's lifecycle needs. |
+| `runtimeclass.yaml` | RuntimeClass ×5 | yes (per available runtime) | The closed set `runc / gvisor / kata-qemu / kata-fc / kata-clh`, with per-class node prerequisites. |
+| `taint-and-toleration.yaml` | (doc only) | no | The pattern for isolating sandbox nodes — and the note that the executor does not yet inject tolerations. |
+| `sample-sandbox-pod.yaml` | (doc only) | no | The exact Pod the executor produces, annotated field-by-field. The reference for "what a real sandbox Pod looks like". |
+| `egress-proxy/` | Deployment + Service + ConfigMap + NetworkPolicy | yes (allowlist mode) | The shared egress allowlist proxy. See its own [README](egress-proxy/README.md). |
+
+`sample-sandbox-pod.yaml` and `taint-and-toleration.yaml` are documentation, not
+appliable objects: the executor creates Pods at runtime, so a static Pod manifest
+would not be one the executor manages.
+
+## Applying the standing objects
+
+```sh
+kubectl apply -f examples/k8s/namespace.yaml
+kubectl apply -f examples/k8s/rbac.yaml
+kubectl apply -f examples/k8s/runtimeclass.yaml   # registered handlers only
+```
+
+Register only the RuntimeClasses whose handlers are actually installed on the
+nodes — a RuntimeClass whose handler is missing makes Pod scheduling fail. The
+egress-proxy objects are applied separately and only when running in network
+mode `allowlist`; see [`egress-proxy/README.md`](egress-proxy/README.md).
+
+## How the pieces fit together
+
+The executor authenticates as `stirrup-orchestrator` (`rbac.yaml`), creates a
+sandbox Pod (`sample-sandbox-pod.yaml`) in the `stirrup-sandbox` namespace
+(`namespace.yaml`) with the RuntimeClass named by `executor.runtime`
+(`runtimeclass.yaml`), and installs a per-Pod egress NetworkPolicy before the
+Pod starts. In network mode `allowlist`, that policy confines the Pod to DNS and
+the egress proxy (`egress-proxy/`), and the executor injects `HTTP_PROXY` /
+`HTTPS_PROXY` pointing at the proxy.
+
+The label contract knits these together: sandbox Pods carry
+`stirrup-sandbox=true` and `stirrup.dev/pod=<name>`, and the egress policy
+selects the proxy by `app=stirrup-egress-proxy` on TCP 8080. These labels are
+fixed in the executor (`k8s_netpol.go`); the manifests here and under
+`egress-proxy/` must keep them in sync.
+
+## Enforcement caveat
+
+NetworkPolicy is only enforced by a CNI that implements it. kindnet — the
+default CNI for `kind` — accepts NetworkPolicy objects but does not enforce
+them, so on a stock kind cluster the sandbox retains cluster-default egress. A
+NetworkPolicy-enforcing CNI (Cilium, Calico) is required for the confinement to
+hold. See [`egress-proxy/README.md`](egress-proxy/README.md) for the full note.
+
+## Out of scope
+
+Automated application (a Helm chart is tracked separately), HA for the egress
+proxy, the CNI installation itself, and node-level RuntimeClass setup. This
+directory is the minimal, readable starting point those build on.

--- a/examples/k8s/namespace.yaml
+++ b/examples/k8s/namespace.yaml
@@ -30,4 +30,11 @@ metadata:
     # admission rejects any Pod that does not — a defence-in-depth backstop
     # for anything scheduled into this namespace by mistake.
     pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: latest
+    # The version is PINNED rather than set to `latest`. `latest` tracks the
+    # apiserver's newest PSS revision, so a cluster upgrade can silently tighten
+    # the policy (start rejecting fields) with no manifest change. Pinning makes
+    # the enforced ruleset explicit and changes only on a deliberate bump; set
+    # this to a version at or below the cluster's Kubernetes minor. Operators who
+    # prefer to always track the newest standard may set it to `latest` instead,
+    # accepting the upgrade-time tightening that comes with it.
+    pod-security.kubernetes.io/enforce-version: v1.30

--- a/examples/k8s/namespace.yaml
+++ b/examples/k8s/namespace.yaml
@@ -1,0 +1,33 @@
+# Sandbox namespace for stirrup k8s-executor runs.
+#
+# Every sandbox Pod the executor creates carries the stirrup-sandbox=true
+# label (see sample-sandbox-pod.yaml), so a dedicated namespace lets an
+# operator scope RBAC, NetworkPolicy, ResourceQuota, and PodSecurity
+# admission to sandbox workloads without touching the rest of the cluster.
+#
+# The namespace name here is `stirrup-sandbox`. The executor's --k8s-namespace
+# flag (executor.k8sNamespace in a RunConfig) MUST point at whichever namespace
+# is used; the egress-proxy manifests under examples/k8s/egress-proxy/ default
+# to `default`, so adjust either the proxy manifests or this file so the proxy
+# and the sandbox Pods share one namespace — the allowlist NetworkPolicy selects
+# the proxy by PodSelector with no NamespaceSelector and will not cross a
+# namespace boundary.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stirrup-sandbox
+  labels:
+    # Marks the namespace as holding stirrup sandbox workloads. Operator
+    # tooling (quotas, admission, dashboards) can select on this.
+    stirrup-sandbox: "true"
+    # Opt the namespace into kube-state-metrics / Prometheus scraping. This is
+    # a widely used convention rather than an API-enforced label; adjust to
+    # match the cluster's monitoring stack if it selects on a different key.
+    monitoring: "true"
+    # Enforce the restricted Pod Security Standard. The sandbox Pod the
+    # executor produces (runAsNonRoot, drop ALL capabilities, no privilege
+    # escalation, seccomp RuntimeDefault) already satisfies `restricted`, so
+    # admission rejects any Pod that does not — a defence-in-depth backstop
+    # for anything scheduled into this namespace by mistake.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/examples/k8s/rbac.yaml
+++ b/examples/k8s/rbac.yaml
@@ -39,6 +39,9 @@ metadata:
 # token on its own Pod) rather than relying on an ambient mount.
 automountServiceAccountToken: false
 ---
+# The ServiceAccount above is core/v1; the Role and RoleBinding below are
+# rbac.authorization.k8s.io/v1 — they live in different API groups, which is why
+# the apiVersion changes across the three documents.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/examples/k8s/rbac.yaml
+++ b/examples/k8s/rbac.yaml
@@ -1,0 +1,88 @@
+# RBAC for the stirrup orchestrator (the process running the k8s executor).
+#
+# The orchestrator is the harness binary holding the kubeconfig / in-cluster
+# ServiceAccount that NewK8sExecutor authenticates as. It is NOT the sandbox
+# Pod: sandbox Pods run with automountServiceAccountToken=false and have no API
+# access of their own. This ServiceAccount is for whatever runs the harness
+# (a CI runner, a controller, an operator's shell).
+#
+# The verbs below are derived from the executor's clientset calls in
+# harness/internal/executor/k8s.go and k8s_netpol.go:
+#
+#   pods                  create  — NewK8sExecutor creates the sandbox Pod
+#                         get     — waitForPodReady polls Pod status
+#                         delete  — Close() / best-effort cleanup paths
+#   pods/exec             create  — Exec + tar-based file I/O POST to the
+#                                   pods/exec subresource (streamExec)
+#   pods/log              get     — NOT used by the executor today; granted so
+#                                   an operator can `kubectl logs` a sandbox Pod
+#                                   for debugging. Drop this verb to tighten the
+#                                   Role to exactly what the executor needs.
+#   networkpolicies       create  — the egress policy is installed BEFORE the
+#                         delete    Pod and removed on Close(); without these
+#                                   two verbs construction fails fail-closed,
+#                                   because a Pod whose egress cannot be
+#                                   confined must never be created.
+#
+# The Role is intentionally namespaced (not a ClusterRole): the orchestrator
+# operates within a single sandbox namespace. Bind one Role per namespace if
+# runs span several.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stirrup-orchestrator
+  namespace: stirrup-sandbox
+  labels:
+    stirrup-sandbox: "true"
+# Refuse a default token automount on the ServiceAccount object itself; the
+# orchestrator is given credentials explicitly (kubeconfig or a projected
+# token on its own Pod) rather than relying on an ambient mount.
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: stirrup-orchestrator
+  namespace: stirrup-sandbox
+  labels:
+    stirrup-sandbox: "true"
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - create
+      - get
+      - delete
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups: [""]
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: stirrup-orchestrator
+  namespace: stirrup-sandbox
+  labels:
+    stirrup-sandbox: "true"
+subjects:
+  - kind: ServiceAccount
+    name: stirrup-orchestrator
+    namespace: stirrup-sandbox
+roleRef:
+  kind: Role
+  name: stirrup-orchestrator
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/k8s/runtimeclass.yaml
+++ b/examples/k8s/runtimeclass.yaml
@@ -1,0 +1,97 @@
+# RuntimeClass objects for the stirrup k8s executor.
+#
+# The executor maps executor.runtime (the --container-runtime flag, shared with
+# the container executor) onto the Pod's spec.runtimeClassName. The accepted
+# names are a CLOSED set, enforced in types/runconfig.go (validK8sRuntimes):
+#
+#   runc | gvisor | kata-qemu | kata-fc | kata-clh
+#
+# An empty runtime leaves runtimeClassName unset, selecting the cluster-default
+# RuntimeClass — which may be plain runc with no sandbox isolation. The executor
+# logs a warning in that case (see NewK8sExecutor). Set executor.runtime
+# explicitly (e.g. gvisor) for guaranteed isolation.
+#
+# A RuntimeClass is only usable if its `handler` is installed and registered
+# with the container runtime (containerd/CRI-O) on the nodes that will run the
+# Pod. Registering a RuntimeClass object whose handler is absent makes Pod
+# scheduling fail with a RuntimeClass-not-found admission error — which the
+# executor surfaces with a friendlier message (classifyPodCreateError).
+#
+# The handler names below (`runc`, `runsc`, `kata-qemu`, …) are the conventional
+# CRI handler identifiers; confirm them against the node's containerd config
+# (`/etc/containerd/config.toml`, the `[plugins."io.containerd.grpc.v1.cri".
+# containerd.runtimes.<handler>]` stanzas) — handler naming is cluster-specific.
+#
+# The gvisor and kata classes pin scheduling to nodes labelled for that runtime
+# via `scheduling.nodeSelector`. Label the capable nodes to match, e.g.:
+#   kubectl label node <node> stirrup.dev/runtime-gvisor=true
+#   kubectl label node <node> stirrup.dev/runtime-kata=true
+# Sandbox runtimes typically need node-level setup (a gVisor or Kata install,
+# and for Kata nested-virt or bare metal), so they should not land on arbitrary
+# nodes. runc has no nodeSelector — every node can run it.
+---
+# runc — the default OCI runtime. NO additional isolation beyond standard
+# Linux namespaces/cgroups. Prerequisite: none; runc ships with every
+# conformant container runtime. Use this only when node-level sandboxing is
+# provided some other way, or for non-hostile workloads.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runc
+handler: runc
+---
+# gvisor — gVisor's user-space kernel (the runsc handler). Intercepts syscalls
+# in user space, presenting a much smaller kernel attack surface than runc.
+# Prerequisite: install gVisor (runsc + the containerd-shim-runsc-v1 shim) on
+# the target nodes and register a `runsc` handler in the containerd config.
+# See https://gvisor.dev/docs/user_guide/install/ and the Kubernetes guide at
+# https://gvisor.dev/docs/user_guide/quick_start/kubernetes/.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+scheduling:
+  nodeSelector:
+    stirrup.dev/runtime-gvisor: "true"
+---
+# kata-qemu — Kata Containers with the QEMU hypervisor. Runs each Pod in a
+# lightweight VM, giving hardware-virtualization isolation. The most broadly
+# compatible Kata backend. Prerequisite: install Kata Containers and register a
+# `kata-qemu` handler; nodes need KVM (bare metal or nested virtualization).
+# See https://github.com/kata-containers/kata-containers/blob/main/docs/install/.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu
+handler: kata-qemu
+scheduling:
+  nodeSelector:
+    stirrup.dev/runtime-kata: "true"
+---
+# kata-fc — Kata Containers with the Firecracker hypervisor. Minimal device
+# model and very fast VM boot, at the cost of fewer device features than QEMU.
+# Prerequisite: install Kata Containers configured for Firecracker, register a
+# `kata-fc` handler, and provide a devmapper snapshotter (Firecracker requires a
+# block-device rootfs) plus KVM on the nodes.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-fc
+handler: kata-fc
+scheduling:
+  nodeSelector:
+    stirrup.dev/runtime-kata: "true"
+---
+# kata-clh — Kata Containers with the Cloud Hypervisor (CLH) backend. A modern
+# Rust VMM aimed at cloud workloads. Prerequisite: install Kata Containers
+# configured for Cloud Hypervisor, register a `kata-clh` handler, and provide
+# KVM on the nodes.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-clh
+handler: kata-clh
+scheduling:
+  nodeSelector:
+    stirrup.dev/runtime-kata: "true"

--- a/examples/k8s/runtimeclass.yaml
+++ b/examples/k8s/runtimeclass.yaml
@@ -23,9 +23,15 @@
 # containerd.runtimes.<handler>]` stanzas) — handler naming is cluster-specific.
 #
 # The gvisor and kata classes pin scheduling to nodes labelled for that runtime
-# via `scheduling.nodeSelector`. Label the capable nodes to match, e.g.:
+# via `scheduling.nodeSelector`. Each class uses a DISTINCT label, because the
+# three Kata variants are NOT interchangeable on one node — kata-fc needs a
+# devmapper snapshotter, kata-clh a different VMM — and a node with only one
+# handler installed would fail admission (handler-not-found) for the others.
+# Label each node only for the handler(s) it actually has, e.g.:
 #   kubectl label node <node> stirrup.dev/runtime-gvisor=true
-#   kubectl label node <node> stirrup.dev/runtime-kata=true
+#   kubectl label node <node> stirrup.dev/runtime-kata-qemu=true
+#   kubectl label node <node> stirrup.dev/runtime-kata-fc=true
+#   kubectl label node <node> stirrup.dev/runtime-kata-clh=true
 # Sandbox runtimes typically need node-level setup (a gVisor or Kata install,
 # and for Kata nested-virt or bare metal), so they should not land on arbitrary
 # nodes. runc has no nodeSelector — every node can run it.
@@ -67,7 +73,7 @@ metadata:
 handler: kata-qemu
 scheduling:
   nodeSelector:
-    stirrup.dev/runtime-kata: "true"
+    stirrup.dev/runtime-kata-qemu: "true"
 ---
 # kata-fc — Kata Containers with the Firecracker hypervisor. Minimal device
 # model and very fast VM boot, at the cost of fewer device features than QEMU.
@@ -81,7 +87,7 @@ metadata:
 handler: kata-fc
 scheduling:
   nodeSelector:
-    stirrup.dev/runtime-kata: "true"
+    stirrup.dev/runtime-kata-fc: "true"
 ---
 # kata-clh — Kata Containers with the Cloud Hypervisor (CLH) backend. A modern
 # Rust VMM aimed at cloud workloads. Prerequisite: install Kata Containers
@@ -94,4 +100,4 @@ metadata:
 handler: kata-clh
 scheduling:
   nodeSelector:
-    stirrup.dev/runtime-kata: "true"
+    stirrup.dev/runtime-kata-clh: "true"

--- a/examples/k8s/sample-sandbox-pod.yaml
+++ b/examples/k8s/sample-sandbox-pod.yaml
@@ -52,9 +52,15 @@ spec:
   # cluster-default RuntimeClass and logs an isolation warning. gvisor is shown
   # here as the recommended sandbox runtime — see examples/k8s/runtimeclass.yaml.
   runtimeClassName: gvisor
-  # nodeSelector from --k8s-node-selector / executor.k8sNodeSelector. Empty
-  # (omitted) unless the operator sets one. The gvisor/kata RuntimeClasses also
-  # contribute their own scheduling.nodeSelector, which is merged in.
+  # nodeSelector from --k8s-node-selector / executor.k8sNodeSelector. It is
+  # OMITTED in this example because no --k8s-node-selector is configured; the
+  # executor leaves spec.nodeSelector unset, so the Pod is unconstrained beyond
+  # what the RuntimeClass contributes. The gvisor/kata RuntimeClasses carry their
+  # own scheduling.nodeSelector (see runtimeclass.yaml), which Kubernetes merges
+  # into the effective node selection. With a flag such as
+  # --k8s-node-selector disktype=ssd the executor would emit:
+  #   nodeSelector:
+  #     disktype: ssd
   containers:
     - # The container name is the constant "agent" (k8sAgentContainer). Exec and
       # file I/O target this container by name over the pods/exec subresource, so

--- a/examples/k8s/sample-sandbox-pod.yaml
+++ b/examples/k8s/sample-sandbox-pod.yaml
@@ -1,0 +1,122 @@
+# Reference: what a real stirrup sandbox Pod looks like.
+#
+# This is DOCUMENTATION, not a manifest to apply. The k8s executor CREATES this
+# Pod at runtime (NewK8sExecutor in harness/internal/executor/k8s.go); applying
+# this file by hand would create a static Pod the executor does not manage, with
+# a name it cannot guess. The value of the file is the annotated, field-by-field
+# record of the exact spec the executor produces, so an operator can reason about
+# RBAC, NetworkPolicy, PodSecurity, and RuntimeClass against a concrete object.
+#
+# Every field below is cross-checked against k8s.go / k8s_netpol.go. Where the
+# executor derives a value (the Pod name, proxy env, resources, runtimeClassName)
+# the source is called out inline. The shape shown is the network "allowlist"
+# mode (the proxy env vars are present); under mode "none" the env block is empty
+# and a deny-all NetworkPolicy replaces the allowlist policy.
+apiVersion: v1
+kind: Pod
+metadata:
+  # Generated as "stirrup-<12 hex chars>" by generatePodName(). Client-side
+  # deterministic (ObjectMeta.Name, not GenerateName) so the per-Pod
+  # NetworkPolicy can target it before the Pod exists. Shown here with a
+  # placeholder suffix.
+  name: stirrup-0a1b2c3d4e5f
+  # The namespace from --k8s-namespace / executor.k8sNamespace. Must match the
+  # egress proxy's namespace (see examples/k8s/egress-proxy/) — the allowlist
+  # NetworkPolicy selects the proxy with no NamespaceSelector.
+  namespace: stirrup-sandbox
+  labels:
+    # podLabels() in k8s_netpol.go applies exactly these two labels:
+    #   stirrup-sandbox=true  — the stable marker every sandbox Pod carries;
+    #                           operator policies and the namespace baseline
+    #                           NetworkPolicy select on it.
+    #   stirrup.dev/pod=<name> — the per-Pod label the runtime NetworkPolicy
+    #                           binds to (metadata.name is not selectable by a
+    #                           LabelSelector, so the name is mirrored here).
+    stirrup-sandbox: "true"
+    stirrup.dev/pod: stirrup-0a1b2c3d4e5f
+spec:
+  # RestartPolicy: Never (corev1.RestartPolicyNever). The Pod is a one-shot
+  # sandbox; the executor deletes it on Close().
+  restartPolicy: Never
+  # serviceAccountName from --k8s-service-account / executor.k8sServiceAccount,
+  # or "default" when unset. The sandbox needs NO API access — see the token
+  # mount below — so the account is effectively just an identity.
+  serviceAccountName: default
+  # ALWAYS false (ptr.To(false) in NewK8sExecutor, even when a ServiceAccount is
+  # named). A sandbox Pod must not be able to reach the Kubernetes API, so the
+  # token is never mounted. Do not rely on the orchestrator's RBAC leaking in.
+  automountServiceAccountToken: false
+  # runtimeClassName from executor.runtime, mapped through the closed set
+  # {runc, gvisor, kata-qemu, kata-fc, kata-clh}. OMITTED entirely when runtime
+  # is empty (optionalRuntimeClassName returns nil), which selects the
+  # cluster-default RuntimeClass and logs an isolation warning. gvisor is shown
+  # here as the recommended sandbox runtime — see examples/k8s/runtimeclass.yaml.
+  runtimeClassName: gvisor
+  # nodeSelector from --k8s-node-selector / executor.k8sNodeSelector. Empty
+  # (omitted) unless the operator sets one. The gvisor/kata RuntimeClasses also
+  # contribute their own scheduling.nodeSelector, which is merged in.
+  containers:
+    - # The container name is the constant "agent" (k8sAgentContainer). Exec and
+      # file I/O target this container by name over the pods/exec subresource, so
+      # the name is load-bearing, not cosmetic.
+      name: agent
+      # image from --image / executor.image. MUST ship /bin/sh, tar, and ls:
+      # Exec runs `/bin/sh -c`, file I/O streams tar, and ListDirectory runs ls.
+      # A shell-less distroless static image will not work.
+      image: ghcr.io/rxbynerd/stirrup-sandbox:latest
+      # The executor holds the container open with a sleep; all real work runs
+      # via subsequent exec calls, not as the entrypoint.
+      command: ["/bin/sh", "-c", "sleep infinity"]
+      # workingDir is the constant "/workspace" (k8sWorkspace). ResolvePath
+      # confines all file I/O beneath it.
+      workingDir: /workspace
+      # env is populated by proxyEnvFor ONLY in network mode "allowlist".
+      # HTTP_PROXY/HTTPS_PROXY are the --k8s-egress-proxy-url value; NO_PROXY is
+      # the fixed loopback set. Under mode "none" this whole block is absent.
+      env:
+        - name: HTTP_PROXY
+          value: http://stirrup-egress-proxy.stirrup-sandbox.svc:8080
+        - name: HTTPS_PROXY
+          value: http://stirrup-egress-proxy.stirrup-sandbox.svc:8080
+        - name: NO_PROXY
+          value: localhost,127.0.0.1,::1
+      # securityContext — every field below is fixed by NewK8sExecutor and does
+      # not vary with config. This is the hardened posture the namespace's
+      # `restricted` PodSecurity admission also expects.
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        # 65532 (k8sRunAsUserUID), the distroless "nonroot" UID. An explicit UID
+        # lets runAsNonRoot be enforced without the image declaring its own USER.
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      # resources from resourcesToPodResources(executor.resources). OMITTED when
+      # resources is nil/all-zero (the Pod then inherits namespace defaults).
+      # Mapping, when set:
+      #   cpus     -> requests.cpu AND limits.cpu (whole cores "2", fractional
+      #               cores milli "500m")
+      #   memoryMB -> requests.memory AND limits.memory (Mi)
+      #   diskMB   -> limits.ephemeral-storage ONLY (Mi); no request
+      #   pids     -> logged and IGNORED (per-Pod PID limits are a kubelet flag,
+      #               not a container resource field)
+      # The values shown are illustrative of a resources block with cpus=2,
+      # memoryMB=2048, diskMB=4096.
+      resources:
+        requests:
+          cpu: "2"
+          memory: 2048Mi
+        limits:
+          cpu: "2"
+          memory: 2048Mi
+          ephemeral-storage: 4096Mi
+# The egress side of this Pod is enforced by a per-Pod NetworkPolicy the
+# executor installs BEFORE the Pod (named "<pod-name>-egress"), plus optionally
+# the standing namespace baseline in examples/k8s/egress-proxy/network-policy.yaml.
+# In mode "allowlist" that policy permits egress only to DNS (53/UDP+TCP) and to
+# the proxy Pod (app=stirrup-egress-proxy) on TCP 8080; in mode "none" it permits
+# no egress at all. See examples/k8s/egress-proxy/ for the proxy Deployment whose
+# `app=stirrup-egress-proxy` label these policies select.

--- a/examples/k8s/taint-and-toleration.yaml
+++ b/examples/k8s/taint-and-toleration.yaml
@@ -1,0 +1,58 @@
+# Isolating sandbox Pods onto dedicated nodes with a taint + toleration.
+#
+# A taint on a node repels every Pod that does not carry a matching toleration.
+# Tainting a pool of nodes for sandbox use keeps untrusted sandbox workloads off
+# the nodes that run trusted/system workloads — a useful blast-radius control to
+# pair with a sandbox RuntimeClass (gvisor/kata) and the egress NetworkPolicy.
+#
+# ──────────────────────────────────────────────────────────────────────────
+# IMPORTANT — the executor does NOT add tolerations.
+#
+# NewK8sExecutor builds the Pod spec with no spec.tolerations field (see
+# harness/internal/executor/k8s.go). A sandbox Pod therefore tolerates nothing
+# beyond the cluster defaults and will NOT schedule onto a tainted node. Tainting
+# nodes is purely an operator concern, and there is currently no executor flag or
+# RunConfig field to inject a toleration. Until one exists, this is a documented
+# follow-up: tainting sandbox nodes is only viable once the executor can emit the
+# matching toleration. The manifest below shows the intended pattern so the shape
+# is settled when that wiring lands.
+# ──────────────────────────────────────────────────────────────────────────
+#
+# This file is documentation, not a directly-appliable object: a Pod is not a
+# standing manifest (the executor creates Pods at runtime), and the taint is
+# applied with `kubectl taint`, not `kubectl apply`. The Node stanza is shown
+# only to illustrate the matching key/value/effect.
+
+# 1. Taint the sandbox node pool. Apply with kubectl, not kubectl apply:
+#
+#      kubectl taint nodes <node> stirrup.dev/sandbox=true:NoSchedule
+#
+#    NoSchedule refuses new Pods without the toleration but leaves already
+#    running Pods in place. Use NoExecute instead to also evict running Pods
+#    that do not tolerate the taint. The taint a node carries looks like:
+#
+#    apiVersion: v1
+#    kind: Node
+#    metadata:
+#      name: <node>
+#    spec:
+#      taints:
+#        - key: stirrup.dev/sandbox
+#          value: "true"
+#          effect: NoSchedule
+
+# 2. The matching toleration the sandbox Pod would need. This is the field the
+#    executor must learn to inject (see the note above); it is shown here as the
+#    fragment that would be merged into the sandbox Pod's spec.tolerations:
+#
+#    tolerations:
+#      - key: stirrup.dev/sandbox
+#        operator: Equal
+#        value: "true"
+#        effect: NoSchedule
+#
+#    Pair the toleration with a nodeSelector / nodeAffinity (e.g. the
+#    stirrup.dev/runtime-gvisor label from runtimeclass.yaml) so the Pod is not
+#    only PERMITTED on the sandbox nodes but ATTRACTED to them: a toleration
+#    alone lets a Pod schedule onto a tainted node but does not prevent it from
+#    landing on an untainted one.


### PR DESCRIPTION
## Summary

Closes #84. Fourth link in the stacked K8s executor chain (#78/#79 → #80–82 → #178/#83 → **#84** → #85).

**Stacked on #398 (`feat/issue-178-83-k8s-egress`).** Based on that branch, not `main`; review only the commits unique to this branch. Retargets to `main` as the bases merge.

## What changed

Greenfield reference manifests under `examples/k8s/` — a working operator starting point and an inline record of the cluster contract the K8s executor depends on:

- **`namespace.yaml`** — the `stirrup-sandbox` namespace with `stirrup-sandbox`/`monitoring` labels and `restricted` PodSecurity (enforce-version pinned to `v1.30`, not `latest`).
- **`rbac.yaml`** — a `stirrup-orchestrator` ServiceAccount + namespaced Role (pods create/get/delete, pods/exec create, networkpolicies create/delete — derived from the executor's actual clientset calls) + RoleBinding. `pods/log get` is granted as a documented operator-convenience over-grant with a drop instruction.
- **`runtimeclass.yaml`** — the five RuntimeClasses (`runc`/`gvisor`/`kata-qemu`/`kata-fc`/`kata-clh`, matching the `validK8sRuntimes` closed set exactly), each with prerequisite header comments and a **distinct** per-variant nodeSelector (the Kata backends are not interchangeable on one node).
- **`taint-and-toleration.yaml`** — a documented node-isolation pattern, explicitly noting the executor does **not** auto-inject tolerations (operator follow-up).
- **`sample-sandbox-pod.yaml`** — an annotated, doc-only reference Pod whose every field was cross-checked against `NewK8sExecutor`'s output (labels, securityContext, container, proxy env, resources, runtimeClassName).
- **`README.md`** — index tying the set together, the kindnet enforcement caveat, and a required namespace-alignment step for the egress-proxy manifests.

## Verification

The sample Pod was asserted field-by-field against the executor (18/18 — labels `stirrup-sandbox=true`/`stirrup.dev/pod=<name>`, `runAsNonRoot`/uid 65532/cap-drop ALL/seccomp RuntimeDefault/no-priv-escalation, `automountServiceAccountToken: false`, container `agent` + `/bin/sh -c sleep infinity` + `/workspace`, `restartPolicy: Never`, proxy env incl. `NO_PROXY=localhost,127.0.0.1,::1`, cpu/mem on requests+limits, ephemeral-storage limit-only). RuntimeClass names match the executor's closed set. All manifests parse cleanly. `just build`/`just test`/`just lint` unchanged (0 issues; no Go touched).

## Caveat (accepted)

`kubectl --dry-run` requires a reachable cluster (none available), so validation is structural/offline. The reviewer-confirmed contract is that an operator applying the set must align the egress-proxy manifests' namespace with the sandbox namespace (documented in the README) — under an enforcing CNI a mismatch silently denies egress.

## Review

One reviewer wave (spec + code/consistency), fully remediated. Spec confirmed the sample Pod matches the executor field-for-field; the RBAC is least-privilege. The namespace-alignment footgun, collapsed Kata nodeSelectors, and the `latest` PSS pin were all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)