### PR TITLE
docs: document the Kubernetes executor (k8s.md, README, CLAUDE.md, safety-rings)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,11 @@ docs are:
 - [`docs/security.md`](docs/security.md) and
   [`docs/safety-rings.md`](docs/safety-rings.md) — security
   foundations and the five operator-configurable rings.
+- [`docs/executors/k8s.md`](docs/executors/k8s.md) — the
+  Kubernetes (Pod-per-run) executor: architecture, config
+  reference, deployment recipes, and egress. Reference manifests
+  in [`examples/k8s/`](examples/k8s/); local `kind` cluster in
+  [`scripts/dev/`](scripts/dev/).
 - [`AGENTS.md`](AGENTS.md) — per-package map of `harness/internal/*`.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — build, test, lint,
   commit/PR conventions.
@@ -133,6 +138,9 @@ Quick map for "I need to change X" lookups:
 | Permission gating logic | `harness/internal/permission/<type>.go` |
 | Cedar policy semantics | `harness/internal/permission/policyengine.go` |
 | Container runtime / network mode wiring | `harness/internal/executor/container*.go` |
+| K8s executor (Pod-per-run) + egress NetworkPolicy | `harness/internal/executor/k8s.go`, `k8s_netpol.go` (operator doc: `docs/executors/k8s.md`) |
+| `--k8s-*` CLI flags (`--k8s-namespace`, `--k8s-kubeconfig`, `--k8s-node-selector`, `--k8s-service-account`, `--k8s-egress-proxy-url`) | `harness/cmd/stirrup/cmd/runconfigflags.go` (defs), `harness.go` (mapping) |
+| `stirrup egress-proxy` subcommand | `harness/cmd/stirrup/cmd/egress_proxy.go` |
 | Egress proxy | `harness/internal/executor/egressproxy/` |
 | Code scanner | `harness/internal/security/codescanner/` |
 | Result sink (RunResult payload) | `harness/internal/resultsink/` |

--- a/README.md
+++ b/README.md
@@ -74,6 +74,55 @@ config a flag-only invocation *would* have used — useful for
 post-mortem replays or pinning a stable configuration. See
 [`docs/configuration.md`](docs/configuration.md#building-runconfigs-interactively).
 
+### Executors
+
+The agent runs inside one of four executors, selected with
+`--executor` / `executor.type`:
+
+| Executor | Boundary | Notes |
+|---|---|---|
+| `local` | none (host process) | Trusted local iteration. |
+| `container` | a Docker/Podman container | Single-host sandbox with an in-process egress proxy. |
+| `k8s` | a Pod on a Kubernetes cluster | Pod-per-run with a hardened `securityContext`, per-tenant RuntimeClass, and `NetworkPolicy` egress. See [`docs/executors/k8s.md`](docs/executors/k8s.md). |
+| `api` | no shell (VCS-backed, read-only) | Reviews/plans against a Git host without a workspace. |
+
+The relevant executor flags are:
+
+| Flag | Notes |
+|---|---|
+| `--executor` | `local` (default), `container`, `k8s`, or `api`. |
+| `--image` | Sandbox container image (`container` / `k8s`). |
+| `--container-runtime` | OCI runtime (`container`) or Pod `RuntimeClassName` (`k8s`): `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh`, `runc`. |
+| `--k8s-namespace` | Namespace for the `k8s` sandbox Pod (required for `k8s`). |
+| `--k8s-kubeconfig` | Kubeconfig path; empty prefers in-cluster config then `$KUBECONFIG`. |
+| `--k8s-node-selector` | Repeatable `key=value` Pod `nodeSelector` constraint. |
+| `--k8s-service-account` | ServiceAccount name; the token is never automounted. |
+| `--k8s-egress-proxy-url` | Egress proxy URL (required in `allowlist` network mode). |
+
+#### Running on Kubernetes
+
+```sh
+# Apply the standing objects once per cluster (namespace, RBAC, RuntimeClasses):
+kubectl apply -f examples/k8s/namespace.yaml
+kubectl apply -f examples/k8s/rbac.yaml
+kubectl apply -f examples/k8s/runtimeclass.yaml
+
+# Run the agent in a sandbox Pod under gVisor:
+ANTHROPIC_API_KEY=... ./stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --container-runtime gvisor \
+  --mode execution \
+  --prompt "Fix the failing test in main_test.go"
+```
+
+Full reference manifests are under
+[`examples/k8s/`](examples/k8s/) and a local `kind` cluster under
+[`scripts/dev/`](scripts/dev/). The operator guide —
+architecture, config reference, deployment recipes, egress, and
+troubleshooting — is [`docs/executors/k8s.md`](docs/executors/k8s.md).
+
 `stirrup harness --output <text|json|none>` (alias `-o`) selects the
 post-run summary surface. `text` (default) prints today's stderr
 summary, `json` emits a single `STIRRUP_RESULT` line on stdout
@@ -94,6 +143,7 @@ See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.
 | Component model, agentic loop, deep dives | [`docs/architecture.md`](docs/architecture.md) |
 | CLI flags, `RunConfig` precedence, examples | [`docs/configuration.md`](docs/configuration.md) |
 | Production deployment via `stirrup job` (K8s, gRPC) | [`docs/deployment.md`](docs/deployment.md) |
+| Kubernetes executor (Pod-per-run sandbox) | [`docs/executors/k8s.md`](docs/executors/k8s.md) |
 | Running stirrup as a Google Cloud Run job | [`docs/cloud-run-jobs.md`](docs/cloud-run-jobs.md) |
 | Five safety rings (operator guide) | [`docs/safety-rings.md`](docs/safety-rings.md) |
 | In-harness security foundations | [`docs/security.md`](docs/security.md) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -367,14 +367,23 @@ Walkthrough: [`azure-workload-identity.md`](azure-workload-identity.md).
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--executor` | `local` | One of `local`, `container`, `api`. |
-| `--container-runtime` | (none) | OCI runtime: `runc`, `runsc` (gVisor), `kata`, `kata-qemu`, `kata-fc`. Empty = engine default. Requires the runtime to be registered with the host Docker/Podman daemon. |
+| `--executor` | `local` | One of `local`, `container`, `k8s`, `api`. |
+| `--container-runtime` | (none) | Per-`executor` closed set. For `container` (host OCI runtime): `runc`, `runsc` (gVisor), `kata`, `kata-qemu`, `kata-fc`, `kata-clh` — must be registered with the host Docker/Podman daemon. For `k8s` (Pod `RuntimeClassName`): `runc`, `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh` — note the name is `gvisor`, not `runsc`. Empty = engine default for `container`, cluster-default RuntimeClass for `k8s`. |
+| `--k8s-namespace` | (none) | Namespace for the `k8s` executor's sandbox Pod. Required when `--executor=k8s`. JSON path: `executor.k8sNamespace`. |
+| `--k8s-kubeconfig` | (none) | Path to a kubeconfig for the `k8s` executor. An explicit value wins even in-cluster; empty prefers in-cluster config, then `$KUBECONFIG`. JSON path: `executor.k8sKubeconfig`. |
+| `--k8s-node-selector` | (none) | Repeatable `key=value` `nodeSelector` constraining where the `k8s` Pod schedules (e.g. `--k8s-node-selector disktype=ssd`). JSON path: `executor.k8sNodeSelector`. |
+| `--k8s-service-account` | (none) | ServiceAccount name for the `k8s` Pod. Empty uses the namespace `default`. The token is never automounted regardless. JSON path: `executor.k8sServiceAccount`. |
+| `--k8s-egress-proxy-url` | (none) | URL the `k8s` sandbox Pod routes `HTTP_PROXY`/`HTTPS_PROXY` through. Required when `--executor=k8s` and the network mode is `allowlist`; rejected otherwise. JSON path: `executor.k8sEgressProxyUrl`. |
 | `--edit-strategy` | `multi` | One of `whole-file`, `search-replace`, `udiff`, `multi`. `composite` is reachable only via `--config`. |
 | `--verifier` | `none` | One of `none`, `test-runner`, `llm-judge`. `composite` is reachable only via `--config`. |
 | `--git-strategy` | `none` | One of `none`, `deterministic`. |
 | `--permission-policy-file` | (none) | Path to a Cedar policy file. When set and the policy type is unset elsewhere, implies `permissionPolicy.type=policy-engine`. Starters live under [`examples/policies/`](../examples/policies/). |
 | `--code-scanner` | (none) | One of `none`, `patterns`, `semgrep`. `composite` is accepted only via `--config` (it requires `codeScanner.scanners`). Empty defers to the mode-aware default (`patterns` for execution, `none` for read-only modes). |
 | `--tools-profile` | (none) | Model-facing toolset profile. Closed enum: `""`/`default` (no aliasing, internal tool names) or `coding-classic` (terse coding-CLI aliases). Changes only the names the model sees; dispatch identities and gating are unchanged. JSON path: `tools.profile`. See [Toolset profiles](#toolset-profiles). |
+
+See also: [`docs/executors/k8s.md`](executors/k8s.md) for the `k8s`
+executor's architecture, deployment recipes, egress model, and the full
+`executor.k8s*` field reference.
 
 ### Transport
 

--- a/docs/executors/k8s.md
+++ b/docs/executors/k8s.md
@@ -23,7 +23,7 @@ those files.
 - [Architecture](#architecture)
 - [Configuration reference](#configuration-reference)
 - [Deployment recipes](#deployment-recipes)
-- [Per-tenant RuntimeClass selection](#per-tenant-runtimeclass-selection)
+- [RuntimeClass selection per run](#runtimeclass-selection-per-run)
 - [Egress](#egress)
 - [Safety rings on Kubernetes](#safety-rings-on-kubernetes)
 - [Troubleshooting](#troubleshooting)
@@ -49,7 +49,7 @@ host proxy).
 ```mermaid
 flowchart LR
   subgraph Orchestrator["Orchestrator (harness binary)"]
-    SA[ServiceAccount<br/>stirrup-orchestrator]
+    SA[authenticates as<br/>stirrup-orchestrator SA]
   end
   subgraph NS["Sandbox namespace (PodSecurity: restricted)"]
     NP{{Per-Pod egress<br/>NetworkPolicy}}
@@ -67,14 +67,18 @@ flowchart LR
 The pieces and their lifecycle:
 
 - **The orchestrator** is whatever runs the harness (a CI runner, a
-  controller, an operator shell). It authenticates with the cluster via
-  the in-cluster ServiceAccount, the kubeconfig at
-  `executor.k8sKubeconfig`, or `$KUBECONFIG` — resolved in that order
-  (see [`buildRESTConfig`](../../harness/internal/executor/k8s.go)). It
-  holds the RBAC the executor's lifecycle needs:
+  controller, an operator shell). It authenticates with the cluster in
+  this order (see
+  [`buildRESTConfig`](../../harness/internal/executor/k8s.go)): an
+  explicit kubeconfig at `executor.k8sKubeconfig` if set (it wins even
+  when running in-cluster), then the in-cluster ServiceAccount, then
+  `$KUBECONFIG`. It holds the RBAC the executor's lifecycle needs:
   `pods` (create/get/delete), `pods/exec` (create), and
-  `networkpolicies` (create/delete). The reference Role is
-  [`examples/k8s/rbac.yaml`](../../examples/k8s/rbac.yaml).
+  `networkpolicies` (create/delete). The reference Role
+  ([`examples/k8s/rbac.yaml`](../../examples/k8s/rbac.yaml)) also grants
+  `pods/log` (get); the executor does not use it, so it is granted only
+  for operator `kubectl logs` debugging and may be dropped to tighten
+  the Role to the executor's minimum.
 
 - **The sandbox Pod** is created per run with a fixed, config-independent
   hardened `securityContext`: `allowPrivilegeEscalation: false`,
@@ -303,7 +307,7 @@ The RuntimeClass's `scheduling.nodeSelector` and any
 `--k8s-node-selector` the run supplies are merged by Kubernetes into the
 effective node selection.
 
-## Per-tenant RuntimeClass selection
+## RuntimeClass selection per run
 
 `executor.runtime` maps directly to the Pod `RuntimeClassName`, so a
 multi-tenant orchestrator selects the isolation level per run by setting
@@ -349,6 +353,9 @@ HTTPS_PROXY = <k8sEgressProxyUrl>
 NO_PROXY    = localhost,127.0.0.1,::1
 ```
 
+The `NO_PROXY` set (`localhost,127.0.0.1,::1`) is fixed in the executor
+and not flag-configurable.
+
 The `NetworkPolicy` intentionally does **not** encode the FQDN allowlist
 — NetworkPolicy operates on IPs/ports/selectors, not hostnames. The
 hostname allowlist lives in the proxy. The policy's job is the
@@ -371,7 +378,10 @@ stirrup egress-proxy --listen :8080 --allowlist-file ./allowlist.txt
 ```
 
 The proxy reads its allowlist once at startup (no hot reload); roll the
-Deployment to change it.
+Deployment to change it. During a rolling update, in-flight runs keep
+routing through the old Pod (and its old allowlist) until the new Pod is
+Ready; pause runs across the roll if that overlap window is
+unacceptable.
 
 **The proxy MUST run in the same namespace as the sandbox Pod.** The
 allowlist policy selects the proxy by a `PodSelector` with **no**
@@ -419,7 +429,9 @@ Defence-in-depth on K8s additionally relies on cluster-level controls the
 reference manifests configure: the sandbox namespace enforces the
 `restricted` Pod Security Standard (pinned to a version, not `latest`),
 and the orchestrator's RBAC is the minimal `pods` / `pods/exec` /
-`networkpolicies` verb set. The sandbox Pod has no API access of its own
+`networkpolicies` verb set the executor needs (the reference Role adds
+`pods/log` get for operator debugging only; drop it to reach the
+executor's exact minimum). The sandbox Pod has no API access of its own
 (`automountServiceAccountToken: false`).
 
 ## Troubleshooting
@@ -434,7 +446,7 @@ and the orchestrator's RBAC is the minimal `pods` / `pods/exec` /
 | `not in cluster and KUBECONFIG is unset` | No in-cluster config, no kubeconfig. | Set `--k8s-kubeconfig` or `$KUBECONFIG`, or run in-cluster. |
 | Pod scheduling fails / pending forever | RuntimeClass `nodeSelector` matches no node, or the handler is missing. | Label the node for the runtime; confirm the handler is installed. |
 | Egress not actually confined on `kind` | kindnet does not enforce NetworkPolicy. | Use a NetworkPolicy-enforcing CNI (Cilium, Calico) for real confinement. |
-| `pod ... not ready` after 60s | Image lacks `/bin/sh`, or the runtime cannot start the Pod. | Use an image shipping `/bin/sh`, `tar`, `ls`; check `kubectl describe pod`. |
+| `pod ... not ready` after the readiness timeout (default 60 s, or the caller context deadline if shorter) | Image lacks `/bin/sh`, or the runtime cannot start the Pod. | Use an image shipping `/bin/sh`, `tar`, `ls`; check `kubectl describe pod`. |
 | Exec/file I/O fails with API errors | The orchestrator lacks `pods/exec` create. | Apply [`rbac.yaml`](../../examples/k8s/rbac.yaml) (or grant the verb). |
 
 ## See also

--- a/docs/executors/k8s.md
+++ b/docs/executors/k8s.md
@@ -1,0 +1,448 @@
+# Kubernetes executor
+
+The `k8s` executor runs the agent inside a hardened, single-use
+**sandbox Pod** rather than a local Docker/Podman container. It is the
+executor for running stirrup *on* a Kubernetes cluster: an orchestrator
+process (the harness binary holding a kubeconfig or in-cluster
+ServiceAccount) creates one Pod per run, drives command execution and
+file I/O over the `pods/exec` subresource, confines the Pod's egress
+with a per-Pod `NetworkPolicy`, and deletes the Pod when the run ends.
+
+This document is the operator reference. The reference manifests it
+points at live under [`examples/k8s/`](../../examples/k8s/) and the
+local development cluster under [`scripts/dev/`](../../scripts/dev/).
+The executor implementation is
+[`harness/internal/executor/k8s.go`](../../harness/internal/executor/k8s.go)
+and [`k8s_netpol.go`](../../harness/internal/executor/k8s_netpol.go);
+every flag, field, and label documented here is cross-checked against
+those files.
+
+## Contents
+
+- [When to use it](#when-to-use-it)
+- [Architecture](#architecture)
+- [Configuration reference](#configuration-reference)
+- [Deployment recipes](#deployment-recipes)
+- [Per-tenant RuntimeClass selection](#per-tenant-runtimeclass-selection)
+- [Egress](#egress)
+- [Safety rings on Kubernetes](#safety-rings-on-kubernetes)
+- [Troubleshooting](#troubleshooting)
+
+## When to use it
+
+| Executor | Boundary | Use when |
+|---|---|---|
+| `local` | none (host process) | Trusted local iteration. |
+| `container` | a Docker/Podman container on the harness host | A single host with a container engine is the deployment target. |
+| `k8s` | a Pod on a Kubernetes cluster | The deployment target is a cluster; multi-tenant isolation, per-tenant RuntimeClass, and cluster-native NetworkPolicy egress are required. |
+
+The `k8s` executor is the cluster-native analogue of the `container`
+executor. The two share the `image`, `network`, `resources`, and
+`runtime` configuration surface; the differences are that the sandbox
+is a Pod (not a host container), the runtime maps to a Pod
+`RuntimeClassName` (not a host OCI runtime), and egress is enforced by
+a `NetworkPolicy` plus an in-cluster proxy Deployment (not an in-process
+host proxy).
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph Orchestrator["Orchestrator (harness binary)"]
+    SA[ServiceAccount<br/>stirrup-orchestrator]
+  end
+  subgraph NS["Sandbox namespace (PodSecurity: restricted)"]
+    NP{{Per-Pod egress<br/>NetworkPolicy}}
+    Pod[/"Sandbox Pod (agent)<br/>hardened securityContext<br/>RuntimeClass = runtime"/]
+    Proxy[Egress proxy<br/>Deployment]
+  end
+  SA -->|pods: create/get/delete| Pod
+  SA -->|pods/exec: create| Pod
+  SA -->|networkpolicies: create/delete| NP
+  NP -.->|binds| Pod
+  Pod -->|HTTP_PROXY allowlist mode| Proxy
+  Proxy -->|FQDN allowlist| Net([Internet])
+```
+
+The pieces and their lifecycle:
+
+- **The orchestrator** is whatever runs the harness (a CI runner, a
+  controller, an operator shell). It authenticates with the cluster via
+  the in-cluster ServiceAccount, the kubeconfig at
+  `executor.k8sKubeconfig`, or `$KUBECONFIG` — resolved in that order
+  (see [`buildRESTConfig`](../../harness/internal/executor/k8s.go)). It
+  holds the RBAC the executor's lifecycle needs:
+  `pods` (create/get/delete), `pods/exec` (create), and
+  `networkpolicies` (create/delete). The reference Role is
+  [`examples/k8s/rbac.yaml`](../../examples/k8s/rbac.yaml).
+
+- **The sandbox Pod** is created per run with a fixed, config-independent
+  hardened `securityContext`: `allowPrivilegeEscalation: false`,
+  `capabilities.drop: [ALL]`, `runAsNonRoot: true`, `runAsUser: 65532`
+  (the distroless "nonroot" UID), and `seccompProfile.type:
+  RuntimeDefault`. `automountServiceAccountToken` is **always** `false`,
+  so the sandbox itself has no Kubernetes API access regardless of the
+  ServiceAccount named. `restartPolicy` is `Never` (one-shot), the
+  container is named `agent`, the working directory is `/workspace`, and
+  the entrypoint is `/bin/sh -c "sleep infinity"` — all real work runs
+  through subsequent `exec` calls, not the entrypoint. The exact spec is
+  annotated field-by-field in
+  [`examples/k8s/sample-sandbox-pod.yaml`](../../examples/k8s/sample-sandbox-pod.yaml).
+
+- **Command execution and file I/O** both ride the `pods/exec`
+  subresource. `Exec` runs `/bin/sh -c`; `ReadFile`/`WriteFile` stream a
+  `tar` archive over exec; `ListDirectory` runs `ls -A1`. The image must
+  therefore ship a POSIX shell at `/bin/sh` plus `tar` and `ls` on
+  `PATH` — a shell-less distroless static image will not work. Output
+  and file payloads are capped at 10 MB (matching the container
+  executor).
+
+- **Egress** is enforced by a per-Pod `NetworkPolicy` the executor
+  installs *before* the Pod is created (closing the window in which a
+  Running Pod would otherwise have cluster-default egress). Mode `none`
+  installs a deny-all egress policy; mode `allowlist` installs a policy
+  permitting egress only to DNS and the in-cluster egress proxy, and
+  injects `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` into the container. See
+  [Egress](#egress).
+
+The label contract knits these together: every sandbox Pod carries
+`stirrup-sandbox: "true"` and `stirrup.dev/pod: <pod-name>`, and the
+allowlist policy selects the proxy by `app=stirrup-egress-proxy` on TCP
+8080. These labels are fixed in `k8s_netpol.go`; the manifests must keep
+them in sync.
+
+## Configuration reference
+
+The `k8s` executor is selected by `--executor k8s` /
+`executor.type: "k8s"`. It draws on the shared executor fields (`image`,
+`network`, `resources`, `runtime`) plus a set of `K8s*` fields. Every
+flag and field below is verified against
+[`runconfigflags.go`](../../harness/cmd/stirrup/cmd/runconfigflags.go),
+[`harness.go`](../../harness/cmd/stirrup/cmd/harness.go), and
+[`types/runconfig.go`](../../types/runconfig.go).
+
+### Flags and fields
+
+| CLI flag | RunConfig field | Required | Notes |
+|---|---|---|---|
+| `--executor k8s` | `executor.type: "k8s"` | yes | Selects the executor. |
+| `--image` | `executor.image` | yes for `k8s` | Pod container image. Must ship `/bin/sh`, `tar`, and `ls`. |
+| `--k8s-namespace` | `executor.k8sNamespace` | yes for `k8s` | Namespace the sandbox Pod (and its `NetworkPolicy`) is created in. |
+| `--k8s-kubeconfig` | `executor.k8sKubeconfig` | no | Path to a kubeconfig file. Empty prefers in-cluster config, then `$KUBECONFIG`. |
+| `--k8s-node-selector key=value` | `executor.k8sNodeSelector` | no | Repeatable `nodeSelector` constraint, e.g. `--k8s-node-selector disktype=ssd`. Merged with any `nodeSelector` the RuntimeClass contributes. |
+| `--k8s-service-account` | `executor.k8sServiceAccount` | no | ServiceAccount name for the Pod. Empty uses the namespace `default`. The token is never automounted regardless. |
+| `--k8s-egress-proxy-url` | `executor.k8sEgressProxyUrl` | conditional | Egress proxy URL the Pod's `HTTP_PROXY`/`HTTPS_PROXY` point at. Required when `network.mode` is `allowlist`; rejected otherwise. |
+| `--container-runtime` | `executor.runtime` | no | Pod `RuntimeClassName`. Closed set: `runc`, `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh`. Empty selects the cluster-default RuntimeClass (and logs an isolation warning). |
+| *(RunConfig only)* | `executor.network` | yes for `k8s` | Mode `none` or `allowlist`. A nil network is rejected at config load (fail closed). |
+| *(RunConfig only)* | `executor.resources` | no | CPU/memory/disk mapped onto the Pod container. See [Resource mapping](#resource-mapping). |
+
+`--container-runtime` is shared with the `container` executor, where it
+names a host OCI runtime. For `k8s` the same field names a Pod
+`RuntimeClassName`, which is **not** the same namespace of values: the
+closed set for `k8s` is `runc / gvisor / kata-qemu / kata-fc / kata-clh`
+(`gvisor`, not the OCI runtime name `runsc`). Shell completions list the
+container set only, so `gvisor` is valid but not offered by completion.
+
+### Validation rules
+
+`ValidateRunConfig` enforces the following for `executor.type: "k8s"`
+(see `validateK8sExecutor` / `validateK8sEgressProxy` /
+`validateExecutorRuntime` in
+[`types/runconfig.go`](../../types/runconfig.go)):
+
+- `executor.image` is **required**.
+- `executor.k8sNamespace` is **required**.
+- `executor.workspace` is **rejected** — the Pod workspace is fixed at
+  `/workspace`, not a mapped host directory.
+- `executor.network` is **required** (set `mode` to `none` or
+  `allowlist`). A nil network leaves egress posture undefined and is
+  surfaced at config-load time rather than at runtime.
+- `executor.k8sEgressProxyUrl` is **required** when `network.mode` is
+  `allowlist` and **rejected** when it is not.
+- `executor.runtime`, when non-empty, must be one of the closed set
+  `runc / gvisor / kata-qemu / kata-fc / kata-clh`; any other value is
+  rejected.
+- `executor.resources`, when set, must not carry negative values — a
+  negative bound would silently map to "no limit".
+
+### Resource mapping
+
+`executor.resources` maps onto the Pod container as follows
+(`resourcesToPodResources`):
+
+| Field | Pod mapping |
+|---|---|
+| `cpus` | `requests.cpu` **and** `limits.cpu`. Whole cores render as an integer (`"2"`), fractional cores as milli-CPU (`"500m"`). |
+| `memoryMb` | `requests.memory` **and** `limits.memory` (Mi). |
+| `diskMb` | `limits.ephemeral-storage` **only** (Mi) — the eviction ceiling. No request, so the scheduler is not forced to find a node with that much free scratch. |
+| `pids` | **Logged and ignored.** Per-Pod PID limits are a kubelet setting (`--pod-max-pids`), not a container resource field. |
+
+A nil or all-zero `resources` block leaves the Pod's requirements empty
+so it inherits namespace defaults.
+
+## Deployment recipes
+
+Each recipe below is a `kind`/cluster bring-up plus the run invocation.
+The standing objects (namespace, RBAC, RuntimeClasses) come from
+[`examples/k8s/`](../../examples/k8s/); apply them once per cluster:
+
+```sh
+kubectl apply -f examples/k8s/namespace.yaml
+kubectl apply -f examples/k8s/rbac.yaml
+kubectl apply -f examples/k8s/runtimeclass.yaml   # registered handlers only
+```
+
+Register only the RuntimeClasses whose handlers are actually installed
+on the nodes — a RuntimeClass whose handler is missing makes Pod
+scheduling fail. The recipes set `--mode execution` and a network mode;
+fill in the provider/model and prompt as for any run.
+
+### kind + runc (manifest-shape smoke test)
+
+A stock `kind` cluster runs every Pod under `runc` and does **not**
+enforce `NetworkPolicy` (its default CNI, kindnet, accepts policy objects
+but ignores them). This recipe proves the executor can create, exec
+into, and tear down a Pod — it does **not** prove egress confinement.
+
+```sh
+./scripts/dev/kind-up.sh        # or: just kind-up
+kubectl config use-context kind-stirrup-sandbox
+
+stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --mode execution \
+  --prompt "..."
+# network.mode comes from a RunConfig; use "none" for the smoke test.
+```
+
+### kind + gVisor (sandboxed runtime, unenforced egress)
+
+`scripts/dev/kind-up.sh` installs gVisor (`runsc` + the containerd shim)
+into the kind node and registers a `gvisor` RuntimeClass, so a Pod can
+schedule onto a kernel-isolated runtime. Egress is still unenforced on
+kindnet — combine gVisor with a real CNI for the full posture.
+
+```sh
+./scripts/dev/kind-up.sh        # installs gVisor + RuntimeClasses
+./scripts/dev/smoke-test.sh     # or: just kind-smoke — verifies gVisor runs
+
+stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --container-runtime gvisor \
+  --mode execution \
+  --prompt "..."
+```
+
+Kata backends are deliberately absent from the kind dev cluster: kind
+nodes are themselves containers and Kata needs nested KVM, which is not
+available inside a containerised host. Exercise Kata on a real cluster.
+
+### GKE Sandbox (gVisor on GKE)
+
+GKE Sandbox runs Pods under gVisor and exposes a `gvisor` RuntimeClass
+on Sandbox-enabled node pools. No node-level gVisor install is needed —
+GKE manages it. A NetworkPolicy-enforcing CNI is available on GKE
+(Dataplane V2 / Calico), so the egress policy is genuinely enforced.
+
+```sh
+# Create a node pool with GKE Sandbox enabled, then:
+stirrup harness \
+  --executor k8s \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox \
+  --container-runtime gvisor \
+  --k8s-node-selector sandbox.gke.io/runtime=gvisor \
+  --mode execution \
+  --prompt "..."
+```
+
+The `--k8s-node-selector` pins scheduling to the Sandbox node pool;
+adjust the label to the cluster's node pool labelling.
+
+### Kata Containers (kata-qemu / kata-fc / kata-clh)
+
+The three Kata backends give hardware-virtualization isolation: each Pod
+runs in a lightweight VM. They are **not** interchangeable on one node —
+`kata-fc` needs a devmapper snapshotter, `kata-clh` a different VMM — so
+[`examples/k8s/runtimeclass.yaml`](../../examples/k8s/runtimeclass.yaml)
+gives each a **distinct** `nodeSelector` label. Label each node only for
+the handler(s) it actually has:
+
+```sh
+kubectl label node <node> stirrup.dev/runtime-kata-qemu=true
+kubectl label node <node> stirrup.dev/runtime-kata-fc=true
+kubectl label node <node> stirrup.dev/runtime-kata-clh=true
+```
+
+Then select the matching runtime per run:
+
+```sh
+# kata-qemu — broadest compatibility, needs KVM (bare metal or nested virt)
+stirrup harness --executor k8s --container-runtime kata-qemu \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox --mode execution --prompt "..."
+
+# kata-fc — Firecracker, fast boot, needs a devmapper snapshotter + KVM
+stirrup harness --executor k8s --container-runtime kata-fc \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox --mode execution --prompt "..."
+
+# kata-clh — Cloud Hypervisor, needs KVM
+stirrup harness --executor k8s --container-runtime kata-clh \
+  --image ghcr.io/rxbynerd/stirrup-sandbox:latest \
+  --k8s-namespace stirrup-sandbox --mode execution --prompt "..."
+```
+
+Kata prerequisites are documented inline in
+[`examples/k8s/runtimeclass.yaml`](../../examples/k8s/runtimeclass.yaml).
+The RuntimeClass's `scheduling.nodeSelector` and any
+`--k8s-node-selector` the run supplies are merged by Kubernetes into the
+effective node selection.
+
+## Per-tenant RuntimeClass selection
+
+`executor.runtime` maps directly to the Pod `RuntimeClassName`, so a
+multi-tenant orchestrator selects the isolation level per run by setting
+the field. A cluster can register the full set and route each tenant to
+the appropriate class:
+
+- Low-trust / untrusted prompts → `gvisor` or a `kata-*` backend.
+- Trusted internal workloads → `runc` (or leave empty for the cluster
+  default, accepting the isolation warning the executor logs).
+
+An empty `executor.runtime` leaves `RuntimeClassName` unset, which
+selects the cluster-default RuntimeClass — often plain `runc` with no
+sandbox isolation. The executor logs a warning in that case so the
+opt-out is visible; a run wanting guaranteed isolation must set the
+field explicitly.
+
+Node isolation for sandbox runtimes is a `taint`/`toleration` pattern,
+documented (but **not yet implemented** by the executor — it does not
+inject tolerations) in
+[`examples/k8s/taint-and-toleration.yaml`](../../examples/k8s/taint-and-toleration.yaml).
+
+## Egress
+
+The `k8s` executor's network posture comes from `executor.network.mode`,
+and the matching `NetworkPolicy` is installed before the Pod exists.
+
+### Mode `none` — deny all egress
+
+A deny-all egress `NetworkPolicy` (an `Egress` policy type with no egress
+rules) selects the Pod and permits no outbound traffic. No proxy and no
+proxy env vars are involved.
+
+### Mode `allowlist` — proxy + DNS
+
+The policy permits egress only to (a) DNS (UDP/TCP 53) and (b) the
+in-cluster egress proxy (`app=stirrup-egress-proxy` on TCP 8080).
+Everything else is forced through the proxy, where the FQDN allowlist
+applies. The executor injects:
+
+```
+HTTP_PROXY  = <k8sEgressProxyUrl>
+HTTPS_PROXY = <k8sEgressProxyUrl>
+NO_PROXY    = localhost,127.0.0.1,::1
+```
+
+The `NetworkPolicy` intentionally does **not** encode the FQDN allowlist
+— NetworkPolicy operates on IPs/ports/selectors, not hostnames. The
+hostname allowlist lives in the proxy. The policy's job is the
+complementary half: guarantee the Pod cannot reach the network except
+via the proxy.
+
+### The egress proxy
+
+The proxy is the same allowlist proxy the `container` executor runs
+in-process, deployed as a long-lived in-cluster Deployment many sandbox
+Pods share (a Pod cannot start its own host-side proxy). Deploy it from
+[`examples/k8s/egress-proxy/`](../../examples/k8s/egress-proxy/), or run
+it standalone with the `stirrup egress-proxy` subcommand:
+
+```sh
+stirrup egress-proxy --listen :8080 \
+  --allowlist api.anthropic.com --allowlist '*.github.com:443'
+# or read the allowlist from a file:
+stirrup egress-proxy --listen :8080 --allowlist-file ./allowlist.txt
+```
+
+The proxy reads its allowlist once at startup (no hot reload); roll the
+Deployment to change it.
+
+**The proxy MUST run in the same namespace as the sandbox Pod.** The
+allowlist policy selects the proxy by a `PodSelector` with **no**
+`NamespaceSelector`, so a cross-namespace proxy is not matched: under an
+enforcing CNI the sandbox then gets *no* egress at all (a silent deny,
+not a bypass). Set `--k8s-namespace` and the proxy's namespace to the
+same value, and point `--k8s-egress-proxy-url` at the
+`<service>.<namespace>.svc` name — for example
+`http://stirrup-egress-proxy.stirrup-sandbox.svc:8080`. The
+top-level `examples/k8s/` manifests use `stirrup-sandbox` while
+`egress-proxy/` ships `default`; align them before applying (see the
+[examples README](../../examples/k8s/README.md#namespace-alignment--required-before-applying-the-egress-proxy)).
+
+### Enforcement caveat — kindnet does not enforce NetworkPolicy
+
+`NetworkPolicy` is enforced only by a CNI that implements it. **kindnet,
+the default CNI for `kind`, accepts NetworkPolicy objects but does not
+enforce them.** On a stock kind cluster the deny-all and allowlist
+policies are inert, and a sandbox Pod retains cluster-default egress.
+The confinement holds only on a NetworkPolicy-enforcing CNI such as
+[Cilium](https://cilium.io/) or
+[Calico](https://www.tigera.io/project-calico/).
+
+Treat a kind-based test as proof of *manifest shape* — the objects are
+created with the right selectors, ports, and env — not as proof that
+egress is actually confined. This mirrors the `container` executor's
+honest fail-open note around `host.docker.internal`.
+
+## Safety rings on Kubernetes
+
+The five [safety rings](../safety-rings.md) map onto the `k8s` executor
+as follows. The full per-ring detail is in
+[`docs/safety-rings.md`](../safety-rings.md#safety-rings-on-kubernetes);
+the K8s-specific mapping is:
+
+| Ring | On Kubernetes |
+|---|---|
+| **1 — Runtime class** | `executor.runtime` is the Pod `RuntimeClassName`, not a host OCI runtime. `gvisor` / `kata-*` give kernel/VM isolation; empty selects the cluster default (warned). The hardened `securityContext` (drop ALL, runAsNonRoot, seccomp RuntimeDefault) is applied unconditionally beneath the runtime choice. |
+| **2 — Egress proxy** | A per-Pod `NetworkPolicy` plus the in-cluster proxy Deployment, instead of an in-process host proxy. Enforcement depends on a NetworkPolicy-enforcing CNI. |
+| **3 — Cedar policy** | Unchanged — per tool-call authorization runs in the orchestrator before the executor acts, identically across executor types. |
+| **4 — Rule of Two** | Unchanged — a pre-flight invariant on the `RunConfig`. A non-`none` `network.mode` counts toward `canCommunicateExternally` exactly as for other executors. |
+| **5 — Code scanner** | Unchanged — post-edit content check, executor-agnostic. |
+
+Defence-in-depth on K8s additionally relies on cluster-level controls the
+reference manifests configure: the sandbox namespace enforces the
+`restricted` Pod Security Standard (pinned to a version, not `latest`),
+and the orchestrator's RBAC is the minimal `pods` / `pods/exec` /
+`networkpolicies` verb set. The sandbox Pod has no API access of its own
+(`automountServiceAccountToken: false`).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `RuntimeClass "<name>" was rejected by the cluster` | The named RuntimeClass is not registered or not permitted. | `kubectl get runtimeclass`; apply [`runtimeclass.yaml`](../../examples/k8s/runtimeclass.yaml) for the handlers actually installed, or pick a registered runtime. |
+| `executor.k8sNamespace is required for executor.type="k8s"` | `--k8s-namespace` / `executor.k8sNamespace` unset. | Set the namespace. |
+| `executor.k8sEgressProxyUrl is required when ... "allowlist"` | `network.mode: allowlist` without a proxy URL. | Set `--k8s-egress-proxy-url`, or use `network.mode: none`. |
+| `executor.k8sEgressProxyUrl is only valid when ... "allowlist"` | A proxy URL set while `network.mode` is `none`. | Remove the URL, or switch to `allowlist`. |
+| `executor.network is required for executor.type="k8s"` | No `network` block. | Set `executor.network.mode` to `none` or `allowlist`. |
+| `not in cluster and KUBECONFIG is unset` | No in-cluster config, no kubeconfig. | Set `--k8s-kubeconfig` or `$KUBECONFIG`, or run in-cluster. |
+| Pod scheduling fails / pending forever | RuntimeClass `nodeSelector` matches no node, or the handler is missing. | Label the node for the runtime; confirm the handler is installed. |
+| Egress not actually confined on `kind` | kindnet does not enforce NetworkPolicy. | Use a NetworkPolicy-enforcing CNI (Cilium, Calico) for real confinement. |
+| `pod ... not ready` after 60s | Image lacks `/bin/sh`, or the runtime cannot start the Pod. | Use an image shipping `/bin/sh`, `tar`, `ls`; check `kubectl describe pod`. |
+| Exec/file I/O fails with API errors | The orchestrator lacks `pods/exec` create. | Apply [`rbac.yaml`](../../examples/k8s/rbac.yaml) (or grant the verb). |
+
+## See also
+
+- [`examples/k8s/`](../../examples/k8s/) — reference manifests
+  (namespace, RBAC, RuntimeClasses, sample Pod, egress proxy).
+- [`scripts/dev/`](../../scripts/dev/) — local `kind` cluster with
+  gVisor for development (`just kind-up` / `kind-smoke` / `kind-down`).
+- [`docs/safety-rings.md`](../safety-rings.md) — the five-ring model.
+- [`docs/configuration.md`](../configuration.md) — full CLI/RunConfig
+  reference.

--- a/docs/safety-rings.md
+++ b/docs/safety-rings.md
@@ -461,9 +461,17 @@ is no silent fallback to `runc`.
 
 ### Kubernetes deployment
 
-On Kubernetes, set `runtimeClassName` on the pod spec rather than
-threading the runtime through stirrup. `--container-runtime` is for
-the local Docker/Podman container executor.
+For the `k8s` executor, `--container-runtime` (`executor.runtime`) maps
+to the sandbox Pod's `spec.runtimeClassName` — the same flag, a
+different closed set (`runc`, `gvisor`, `kata-qemu`, `kata-fc`,
+`kata-clh`; note `gvisor`, not the host OCI name `runsc`). The executor
+sets `runtimeClassName` on the Pod it creates, so the runtime is
+threaded through stirrup rather than hand-set on a static spec. Empty
+selects the cluster-default RuntimeClass and logs an isolation warning.
+See [`docs/executors/k8s.md`](executors/k8s.md#safety-rings-on-kubernetes)
+for the full ring mapping on Kubernetes, and
+[Safety rings on Kubernetes](#safety-rings-on-kubernetes) below for the
+in-document summary.
 
 ## Ring 2 — Egress allowlist proxy (network isolation)
 

--- a/docs/safety-rings.md
+++ b/docs/safety-rings.md
@@ -800,6 +800,90 @@ The `editStrategy` field is set out of habit but inert here — no
 the strategy never runs. Leaving it set keeps the config copy-paste
 compatible with the other postures.
 
+## Safety rings on Kubernetes
+
+The `k8s` executor runs the agent in a sandbox Pod rather than a host
+container. The five rings still apply, but Rings 1 and 2 are realised
+through Kubernetes primitives. The operator reference for the executor
+is [`docs/executors/k8s.md`](executors/k8s.md); this section is the
+ring-by-ring mapping.
+
+### Ring 1 — runtime class becomes a Pod RuntimeClass
+
+On `k8s`, `executor.runtime` (`--container-runtime`) maps to the Pod's
+`spec.runtimeClassName` rather than a host OCI runtime. The accepted set
+differs because the values name different things: a host OCI runtime for
+the `container` executor versus a registered `RuntimeClass` name for
+`k8s`. The closed `k8s` set is:
+
+| Value | RuntimeClass / isolation | Cluster prerequisite |
+|---|---|---|
+| `""` (default) | cluster-default RuntimeClass — often plain `runc`, **no** sandbox isolation (the executor logs a warning) | none |
+| `runc` | vanilla runc — process isolation only | none |
+| `gvisor` | [gVisor](https://gvisor.dev) user-space kernel (handler `runsc`) | install gVisor on the nodes; register a `gvisor` RuntimeClass |
+| `kata-qemu` | [Kata](https://katacontainers.io) Containers, QEMU VM | install Kata; KVM on the nodes |
+| `kata-fc` | Kata, Firecracker VM | install Kata + a devmapper snapshotter; KVM |
+| `kata-clh` | Kata, Cloud Hypervisor VM | install Kata for Cloud Hypervisor; KVM |
+
+Note the runtime name is `gvisor` (the conventional RuntimeClass name),
+not the OCI runtime name `runsc` used by the `container` executor.
+`ValidateRunConfig` rejects values outside the set, and an unregistered
+or impermissible RuntimeClass surfaces a friendly Pod-create error
+rather than an opaque admission rejection.
+
+Beneath the runtime choice, the executor applies a fixed hardened
+`securityContext` to every sandbox Pod regardless of config:
+`allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`,
+`runAsNonRoot: true`, `runAsUser: 65532`, and `seccompProfile.type:
+RuntimeDefault`. `automountServiceAccountToken` is always `false`, so the
+sandbox has no Kubernetes API access of its own. These are the
+process-level equivalents of the `container` executor's unconditional
+`CapDrop: ALL` + `no-new-privileges`, and they satisfy the `restricted`
+Pod Security Standard the reference namespace enforces.
+
+### Ring 2 — egress proxy becomes a NetworkPolicy + proxy Deployment
+
+A sandbox Pod cannot start its own host-side proxy, so the network ring
+is split: a per-Pod `NetworkPolicy` confines the Pod's egress, and the
+allowlist proxy runs as a separate in-cluster Deployment many Pods
+share. The executor installs the policy **before** the Pod is created,
+so there is no window in which a Running Pod has cluster-default egress.
+
+- `network.mode: none` installs a deny-all egress policy.
+- `network.mode: allowlist` installs a policy permitting egress only to
+  DNS and the proxy (`app=stirrup-egress-proxy` on TCP 8080), and
+  injects `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` pointing at
+  `executor.k8sEgressProxyUrl`. The proxy enforces the FQDN allowlist,
+  exactly as in the `container` case — the NetworkPolicy guarantees the
+  proxy is the Pod's only route off-cluster, while the proxy decides
+  which destinations are reachable.
+
+The proxy MUST run in the **same namespace** as the sandbox Pod: the
+policy selects it by a `PodSelector` with no `NamespaceSelector`, so a
+cross-namespace proxy is denied (more restrictive, not a bypass). Deploy
+it from [`examples/k8s/egress-proxy/`](../examples/k8s/egress-proxy/) or
+run it standalone with `stirrup egress-proxy`.
+
+> **Enforcement depends on the CNI.** kindnet — the default CNI for
+> `kind` — accepts `NetworkPolicy` objects but does **not** enforce
+> them, so on a stock kind cluster the deny/allowlist policy is inert
+> and the Pod keeps cluster-default egress. The confinement holds only
+> on a NetworkPolicy-enforcing CNI such as
+> [Cilium](https://cilium.io/) or
+> [Calico](https://www.tigera.io/project-calico/). This is the K8s
+> analogue of the `container` executor's honest fail-open note around
+> `host.docker.internal`: a kind smoke test proves manifest shape, not
+> that egress is confined.
+
+### Rings 3, 4, 5 are unchanged
+
+Rings 3 (Cedar policy), 4 (Rule of Two), and 5 (code scanner) are
+executor-agnostic and behave identically on `k8s`. Cedar authorization
+and the Rule-of-Two pre-flight run in the orchestrator before the
+executor acts; the code scanner runs around the edit strategy. A
+non-`none` `network.mode` counts toward `canCommunicateExternally` for
+the Rule of Two exactly as it does for the other executors.
+
 ## What these don't catch
 
 Honest list of out-of-scope risks. The rings exist *because* these


### PR DESCRIPTION
## Summary

Closes #85. Final link in the stacked K8s executor chain (#78/#79 → #80–82 → #178/#83 → #84 → **#85**).

**Stacked on #399 (`feat/issue-84-k8s-manifests`).** Based on that branch, not `main`; review only the commits unique to this branch. Retargets to `main` as the bases merge — and as the last in the chain, this is the one to merge last.

## What changed

- **NEW `docs/executors/k8s.md`** — the operator reference: architecture (orchestrator SA → Pod-per-run with hardened securityContext → exec/file-I/O over the `pods/exec` subresource → egress NetworkPolicy + optional egress proxy), a full config-reference table (every `--k8s-*` flag and `K8s*` RunConfig field with validation rules), deployment recipes (kind+runc, kind+gvisor, GKE Sandbox, kata-clh/qemu/fc), RuntimeClass selection per run, the egress story (none vs allowlist, the proxy, the NetworkPolicy), troubleshooting, and the five-ring security model on Kubernetes.
- **`README.md`** — an Executors subsection (four-executor list + the executor/k8s flag rows), a "Running on Kubernetes" quick start, and a doc-table row.
- **`CLAUDE.md`** — terse index entries only (canonical-doc link + "Where things live" rows for the executor, the `--k8s-*` flags, and the egress-proxy subcommand) — no knowledge duplicated.
- **`docs/safety-rings.md`** — a new "Safety rings on Kubernetes" section, and a corrected Ring 1 callout (`--container-runtime` now maps to the Pod `RuntimeClassName` for the k8s executor).
- **`docs/configuration.md`** — brought the canonical CLI-flag reference up to date: `k8s` added to `--executor`, `--container-runtime` documented as a per-Type closed set (`gvisor` for k8s, not `runsc`), the five `--k8s-*` rows added, and a see-also link to the new doc.

## Accuracy

Every documented flag was verified against `runconfigflags.go`/`harness.go`/`egress_proxy.go`, every RunConfig field against `types/runconfig.go`, validation rules against `validateK8sExecutor`/`validateK8sEgressProxy`/`validateExecutorRuntime`, the RuntimeClass set against `validK8sRuntimes` (exactly `runc/gvisor/kata-qemu/kata-fc/kata-clh`), the resource mapping against `resourcesToPodResources`, and the kubeconfig resolution order against `buildRESTConfig`. The kindnet-doesn't-enforce-NetworkPolicy caveat and the no-toleration-injection limitation are stated honestly. All cross-doc links and TOC anchors resolve. `just build`/`just test`/`just lint` unchanged (0 issues; docs-only).

## Review

Two reviewers: doc-tone (passed clean — impersonal voice held throughout) and technical-doc (verified against the code). Remediated: the kubeconfig resolution order, the omitted `pods/log` RBAC verb, the stale `configuration.md` flag reference, the now-incorrect safety-rings Ring 1 callout, and the readiness-timeout / NO_PROXY / rolling-update wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)