### PR TITLE
proto: add explicit outcome field to HarnessEvent.RunTrace

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,7 +96,11 @@ IMDS, GitHub Actions OIDC). See
 7. **Done.** A final `HarnessEvent{type:"done", stop_reason, trace}`
    carries the run metrics and the reason the loop ended
    (`end_turn`, `max_turns`, `timeout`, `stalled`, `tool_failures`,
-   `cancelled`, `budget_exceeded`).
+   `cancelled`, `budget_exceeded`). The nested `trace.outcome` is the
+   canonical terminal status for downstream analytics — the full
+   `RunTrace.Outcome` set, which adds `success`, `verification_failed`,
+   `verification_error`, and `max_tokens` on top of the loop's stop
+   reasons. `trace.stop_reason` mirrors it for backward compatibility.
 8. **Follow-up grace** *(optional)*. If `STIRRUP_FOLLOWUP_GRACE > 0`,
    the stream stays open for that many seconds so the control plane
    can deliver `user_response` events that resume the loop.

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -1429,14 +1429,13 @@ type RunTrace struct {
 	// Canonical terminal status of the run, mirroring the Go-side
 	// types.RunTrace.Outcome. Unlike stop_reason (which on the loop's own
 	// events is one of 7 values and has no "success" concept), outcome is
-	// the authoritative field for downstream analytics and is one of:
+	// the authoritative field for downstream analytics: a wire-driven
+	// lakehouse writer can persist it directly without inferring it from
+	// stop_reason + verification_results + budget state.
+	// Values: "success", "error", "max_turns", "verification_failed",
 	//
-	//	"success" | "error" | "max_turns" | "verification_failed" |
-	//	"verification_error" | "budget_exceeded" | "stalled" |
-	//	"tool_failures" | "cancelled" | "timeout" | "max_tokens".
-	//
-	// A wire-driven lakehouse writer can persist this directly without
-	// inferring it from stop_reason + verification_results + budget state.
+	//	"verification_error", "budget_exceeded", "stalled",
+	//	"tool_failures", "cancelled", "timeout", "max_tokens".
 	Outcome       string `protobuf:"bytes,8,opt,name=outcome,proto3" json:"outcome,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -1421,10 +1421,23 @@ type RunTrace struct {
 	CostUsd float64 `protobuf:"fixed64,5,opt,name=cost_usd,json=costUsd,proto3" json:"cost_usd,omitempty"`
 	// Wall-clock duration of the run in milliseconds.
 	DurationMs int64 `protobuf:"varint,6,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
-	// Why the run ended. Same values as HarnessEvent.stop_reason:
-	// "end_turn", "max_turns", "timeout", "stalled", "tool_failures",
-	// "cancelled", "budget_exceeded".
-	StopReason    string `protobuf:"bytes,7,opt,name=stop_reason,json=stopReason,proto3" json:"stop_reason,omitempty"`
+	// Deprecated for analytics: retained for backward compatibility. This
+	// field has always carried the run outcome (see `outcome` below), not
+	// the narrower HarnessEvent.stop_reason set, so existing consumers
+	// reading it keep the same value. New consumers should read `outcome`.
+	StopReason string `protobuf:"bytes,7,opt,name=stop_reason,json=stopReason,proto3" json:"stop_reason,omitempty"`
+	// Canonical terminal status of the run, mirroring the Go-side
+	// types.RunTrace.Outcome. Unlike stop_reason (which on the loop's own
+	// events is one of 7 values and has no "success" concept), outcome is
+	// the authoritative field for downstream analytics and is one of:
+	//
+	//	"success" | "error" | "max_turns" | "verification_failed" |
+	//	"verification_error" | "budget_exceeded" | "stalled" |
+	//	"tool_failures" | "cancelled" | "timeout" | "max_tokens".
+	//
+	// A wire-driven lakehouse writer can persist this directly without
+	// inferring it from stop_reason + verification_results + budget state.
+	Outcome       string `protobuf:"bytes,8,opt,name=outcome,proto3" json:"outcome,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1504,6 +1517,13 @@ func (x *RunTrace) GetDurationMs() int64 {
 func (x *RunTrace) GetStopReason() string {
 	if x != nil {
 		return x.StopReason
+	}
+	return ""
+}
+
+func (x *RunTrace) GetOutcome() string {
+	if x != nil {
+		return x.Outcome
 	}
 	return ""
 }
@@ -3721,7 +3741,7 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\x06_think\"d\n" +
 	"\x13ObservabilityConfig\x12 \n" +
 	"\venvironment\x18\x01 \x01(\tR\venvironment\x12+\n" +
-	"\x11service_namespace\x18\x02 \x01(\tR\x10serviceNamespace\"\xdc\x01\n" +
+	"\x11service_namespace\x18\x02 \x01(\tR\x10serviceNamespace\"\xf6\x01\n" +
 	"\bRunTrace\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x14\n" +
 	"\x05turns\x18\x02 \x01(\x05R\x05turns\x12!\n" +
@@ -3731,7 +3751,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\vduration_ms\x18\x06 \x01(\x03R\n" +
 	"durationMs\x12\x1f\n" +
 	"\vstop_reason\x18\a \x01(\tR\n" +
-	"stopReason\"\x9e\x06\n" +
+	"stopReason\x12\x18\n" +
+	"\aoutcome\x18\b \x01(\tR\aoutcome\"\x9e\x06\n" +
 	"\x0eProviderConfig\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1e\n" +
 	"\vapi_key_ref\x18\x02 \x01(\tR\tapiKeyRef\x12\x16\n" +

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -62,17 +62,17 @@ func controlEventFromProto(pe *pb.ControlEvent) types.ControlEvent {
 // runTraceToProto translates the internal RunTrace to a simplified proto
 // wire format suitable for streaming back to the control plane.
 func runTraceToProto(t *types.RunTrace) *pb.RunTrace {
+	// Outcome is the canonical analytics field (#141). StopReason has always
+	// carried t.Outcome too; it keeps doing so for consumers predating the
+	// outcome field.
 	return &pb.RunTrace{
 		RunId:        t.ID,
 		Turns:        int32(t.Turns),
 		InputTokens:  int32(t.TokenUsage.Input),
 		OutputTokens: int32(t.TokenUsage.Output),
 		DurationMs:   t.CompletedAt.Sub(t.StartedAt).Milliseconds(),
-		// Outcome is the canonical analytics field (#141). StopReason
-		// carries the same value for backward compatibility with consumers
-		// predating the outcome field.
-		Outcome:    t.Outcome,
-		StopReason: t.Outcome,
+		Outcome:      t.Outcome,
+		StopReason:   t.Outcome,
 	}
 }
 

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -68,7 +68,11 @@ func runTraceToProto(t *types.RunTrace) *pb.RunTrace {
 		InputTokens:  int32(t.TokenUsage.Input),
 		OutputTokens: int32(t.TokenUsage.Output),
 		DurationMs:   t.CompletedAt.Sub(t.StartedAt).Milliseconds(),
-		StopReason:   t.Outcome,
+		// Outcome is the canonical analytics field (#141). StopReason
+		// carries the same value for backward compatibility with consumers
+		// predating the outcome field.
+		Outcome:    t.Outcome,
+		StopReason: t.Outcome,
 	}
 }
 

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -880,15 +880,32 @@ func TestRunConfigFromProto_TemperatureRoundTrip(t *testing.T) {
 
 // TestRunTraceToProto_OutcomePopulated pins #141: the canonical Outcome must
 // land on the proto outcome field verbatim, and stop_reason must mirror it so
-// pre-outcome consumers keep the value they have always read. The full
-// types.RunTrace.Outcome set is the 11-value superset of the loop's stop
-// reasons, so a representative sample including the proto-stop_reason-foreign
-// "success" and "verification_failed" values is exercised.
+// pre-outcome consumers keep the value they have always read. The case set is
+// the full 11-value types.RunTrace.Outcome superset of the loop's stop reasons
+// — including the proto-stop_reason-foreign "success", "verification_failed",
+// "verification_error", and "max_tokens" — plus the empty zero value. The
+// proto.Marshal/Unmarshal round-trip pins the field's wire tag (outcome = 8),
+// which a struct-copy assertion alone would not catch.
 func TestRunTraceToProto_OutcomePopulated(t *testing.T) {
-	for _, outcome := range []string{
-		"success", "verification_failed", "max_tokens", "budget_exceeded", "",
-	} {
-		t.Run(outcome, func(t *testing.T) {
+	cases := []struct {
+		name    string
+		outcome string
+	}{
+		{name: "success", outcome: "success"},
+		{name: "error", outcome: "error"},
+		{name: "max_turns", outcome: "max_turns"},
+		{name: "verification_failed", outcome: "verification_failed"},
+		{name: "verification_error", outcome: "verification_error"},
+		{name: "budget_exceeded", outcome: "budget_exceeded"},
+		{name: "stalled", outcome: "stalled"},
+		{name: "tool_failures", outcome: "tool_failures"},
+		{name: "cancelled", outcome: "cancelled"},
+		{name: "timeout", outcome: "timeout"},
+		{name: "max_tokens", outcome: "max_tokens"},
+		{name: "empty", outcome: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			start := time.Unix(1700000000, 0)
 			tr := &types.RunTrace{
 				ID:          "run-141",
@@ -896,14 +913,14 @@ func TestRunTraceToProto_OutcomePopulated(t *testing.T) {
 				TokenUsage:  types.TokenUsage{Input: 120, Output: 45},
 				StartedAt:   start,
 				CompletedAt: start.Add(2500 * time.Millisecond),
-				Outcome:     outcome,
+				Outcome:     tc.outcome,
 			}
 			pt := runTraceToProto(tr)
-			if pt.Outcome != outcome {
-				t.Errorf("Outcome: got %q, want %q", pt.Outcome, outcome)
+			if pt.Outcome != tc.outcome {
+				t.Errorf("Outcome: got %q, want %q", pt.Outcome, tc.outcome)
 			}
-			if pt.StopReason != outcome {
-				t.Errorf("StopReason should mirror Outcome: got %q, want %q", pt.StopReason, outcome)
+			if pt.StopReason != tc.outcome {
+				t.Errorf("StopReason should mirror Outcome: got %q, want %q", pt.StopReason, tc.outcome)
 			}
 			if pt.RunId != "run-141" {
 				t.Errorf("RunId: got %q, want run-141", pt.RunId)
@@ -916,6 +933,21 @@ func TestRunTraceToProto_OutcomePopulated(t *testing.T) {
 			}
 			if pt.DurationMs != 2500 {
 				t.Errorf("DurationMs: got %d, want 2500", pt.DurationMs)
+			}
+
+			raw, err := proto.Marshal(pt)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded pb.RunTrace
+			if err := proto.Unmarshal(raw, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if decoded.Outcome != tc.outcome {
+				t.Errorf("outcome did not survive wire round-trip: got %q, want %q", decoded.Outcome, tc.outcome)
+			}
+			if decoded.StopReason != tc.outcome {
+				t.Errorf("stop_reason did not survive wire round-trip: got %q, want %q", decoded.StopReason, tc.outcome)
 			}
 		})
 	}

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -2,10 +2,12 @@ package transport
 
 import (
 	"testing"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/rxbynerd/stirrup/gen/harness/v1"
+	"github.com/rxbynerd/stirrup/types"
 )
 
 // TestRunConfigFromProto_SessionNamePropagates ensures that a SessionName set
@@ -871,6 +873,49 @@ func TestRunConfigFromProto_TemperatureRoundTrip(t *testing.T) {
 				t.Fatalf("set-on-wire (%v) dropped to nil internal", *tc.set)
 			case tc.set != nil && *rc.Temperature != *tc.set:
 				t.Errorf("Temperature: got %v, want %v", *rc.Temperature, *tc.set)
+			}
+		})
+	}
+}
+
+// TestRunTraceToProto_OutcomePopulated pins #141: the canonical Outcome must
+// land on the proto outcome field verbatim, and stop_reason must mirror it so
+// pre-outcome consumers keep the value they have always read. The full
+// types.RunTrace.Outcome set is the 11-value superset of the loop's stop
+// reasons, so a representative sample including the proto-stop_reason-foreign
+// "success" and "verification_failed" values is exercised.
+func TestRunTraceToProto_OutcomePopulated(t *testing.T) {
+	for _, outcome := range []string{
+		"success", "verification_failed", "max_tokens", "budget_exceeded", "",
+	} {
+		t.Run(outcome, func(t *testing.T) {
+			start := time.Unix(1700000000, 0)
+			tr := &types.RunTrace{
+				ID:          "run-141",
+				Turns:       3,
+				TokenUsage:  types.TokenUsage{Input: 120, Output: 45},
+				StartedAt:   start,
+				CompletedAt: start.Add(2500 * time.Millisecond),
+				Outcome:     outcome,
+			}
+			pt := runTraceToProto(tr)
+			if pt.Outcome != outcome {
+				t.Errorf("Outcome: got %q, want %q", pt.Outcome, outcome)
+			}
+			if pt.StopReason != outcome {
+				t.Errorf("StopReason should mirror Outcome: got %q, want %q", pt.StopReason, outcome)
+			}
+			if pt.RunId != "run-141" {
+				t.Errorf("RunId: got %q, want run-141", pt.RunId)
+			}
+			if pt.Turns != 3 {
+				t.Errorf("Turns: got %d, want 3", pt.Turns)
+			}
+			if pt.InputTokens != 120 || pt.OutputTokens != 45 {
+				t.Errorf("tokens: got in=%d out=%d, want in=120 out=45", pt.InputTokens, pt.OutputTokens)
+			}
+			if pt.DurationMs != 2500 {
+				t.Errorf("DurationMs: got %d, want 2500", pt.DurationMs)
 			}
 		})
 	}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -648,10 +648,22 @@ message RunTrace {
   // Wall-clock duration of the run in milliseconds.
   int64 duration_ms = 6;
 
-  // Why the run ended. Same values as HarnessEvent.stop_reason:
-  // "end_turn", "max_turns", "timeout", "stalled", "tool_failures",
-  // "cancelled", "budget_exceeded".
+  // Deprecated for analytics: retained for backward compatibility. This
+  // field has always carried the run outcome (see `outcome` below), not
+  // the narrower HarnessEvent.stop_reason set, so existing consumers
+  // reading it keep the same value. New consumers should read `outcome`.
   string stop_reason = 7;
+
+  // Canonical terminal status of the run, mirroring the Go-side
+  // types.RunTrace.Outcome. Unlike stop_reason (which on the loop's own
+  // events is one of 7 values and has no "success" concept), outcome is
+  // the authoritative field for downstream analytics and is one of:
+  //   "success" | "error" | "max_turns" | "verification_failed" |
+  //   "verification_error" | "budget_exceeded" | "stalled" |
+  //   "tool_failures" | "cancelled" | "timeout" | "max_tokens".
+  // A wire-driven lakehouse writer can persist this directly without
+  // inferring it from stop_reason + verification_results + budget state.
+  string outcome = 8;
 }
 
 // ---------------------------------------------------------------------------

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -657,12 +657,12 @@ message RunTrace {
   // Canonical terminal status of the run, mirroring the Go-side
   // types.RunTrace.Outcome. Unlike stop_reason (which on the loop's own
   // events is one of 7 values and has no "success" concept), outcome is
-  // the authoritative field for downstream analytics and is one of:
-  //   "success" | "error" | "max_turns" | "verification_failed" |
-  //   "verification_error" | "budget_exceeded" | "stalled" |
-  //   "tool_failures" | "cancelled" | "timeout" | "max_tokens".
-  // A wire-driven lakehouse writer can persist this directly without
-  // inferring it from stop_reason + verification_results + budget state.
+  // the authoritative field for downstream analytics: a wire-driven
+  // lakehouse writer can persist it directly without inferring it from
+  // stop_reason + verification_results + budget state.
+  // Values: "success", "error", "max_turns", "verification_failed",
+  //         "verification_error", "budget_exceeded", "stalled",
+  //         "tool_failures", "cancelled", "timeout", "max_tokens".
   string outcome = 8;
 }
 


### PR DESCRIPTION
Closes #141.

## Problem

The proto `HarnessEvent.RunTrace` shipped run-terminal status only as `stop_reason` (field 7). The translator (`runTraceToProto`) already populated that field from the Go-side `types.RunTrace.Outcome` — an **11-value** set including `success`, `verification_failed`, `verification_error`, and `max_tokens` — while the proto documents `stop_reason` as the narrower **7-value** loop vocabulary with no `success` concept. A wire-driven lakehouse writer (control plane consuming `HarnessEvent` → BigQuery/ClickHouse, per #105) could not reconstruct the outcome losslessly without inferring it from `stop_reason` + `verification_results` + budget bookkeeping.

## Change

- **proto**: add `string outcome = 8` to `RunTrace` as the canonical analytics field, carrying the full `Outcome` set verbatim. Corrected the `stop_reason` doc to record that it has always mirrored the outcome and is retained for backward compatibility. Regenerated with `buf generate`.
- **transport**: `runTraceToProto` now sets `outcome` from `t.Outcome`. `stop_reason` keeps the same value, so consumers predating the field read exactly what they did before — the two diverge in intent, not value.
- **docs**: noted the canonical `trace.outcome` field and its superset values on the `deployment.md` gRPC contract.
- **test**: `TestRunTraceToProto_OutcomePopulated` exercises all 11 outcome values plus the empty zero value, and a `proto.Marshal`/`Unmarshal` round-trip pins the `outcome = 8` wire tag.

No wire behaviour change for existing consumers; `outcome` is purely additive.

## Reviewer pass

Ran spec-compliance, code, and consistency reviewers. Outcome:

- **Spec compliance: COMPLIANT** — all three substantive requirements met (field added at a non-colliding number, populated from the canonical value on completion, backward compat preserved).
- **Remediated**: reformatted the proto value-set comment to the sibling `// Values:` style; hoisted the translator rationale comment above the `return`; expanded the test from a 5-value sample to all 11 values in the file's struct-slice table idiom; added a wire round-trip assertion.
- **Rejected** (verified against `main`): a code-review claim that `stop_reason` was newly introduced by this PR and its backward-compat comment was "factually incorrect". `git show main:…/grpc_translate.go` confirms `StopReason: t.Outcome` predates this branch, so the comment is accurate. The spec reviewer corroborated this.

## Out of scope (pre-existing, noted for follow-up)

- `RunTrace.cost_usd` (proto field 5) is never populated by `runTraceToProto` because `types.RunTrace` has no cost field. Unchanged here.
- `duration_ms` is computed unconditionally from `CompletedAt - StartedAt`; a zero `CompletedAt` on an early-error path would yield a garbage value. Pre-existing and unchanged.

## Verification

`just build`, `just test` (`./harness/...` `./types/...` `./eval/...`), and `just lint` (golangci-lint v2) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)