### PR TITLE
mcp: log a display-safe server uri to avoid leaking embedded credentials

### DIFF
--- a/harness/internal/mcp/client.go
+++ b/harness/internal/mcp/client.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -354,10 +355,15 @@ func (c *Client) filterAllowedTools(config types.MCPServerConfig, tools []mcpToo
 
 // serverSession holds per-server connection state.
 type serverSession struct {
-	name      string // operator-supplied logical name, for log attribution
-	uri       string
-	token     string // bearer token, empty if no auth
-	sessionID string // Mcp-Session-Id from server
+	name string // operator-supplied logical name, for log attribution
+	uri  string
+	// displayURI is uri with userinfo and query string stripped. Logs and
+	// returned errors must use this rather than uri: an operator may embed
+	// credentials in the URI (https://user:pass@host or ?api_key=...), and
+	// RunConfig.Redact() does not cover this path (CWE-532).
+	displayURI string
+	token      string // bearer token, empty if no auth
+	sessionID  string // Mcp-Session-Id from server
 }
 
 const mcpClientTimeout = 30 * time.Second
@@ -491,7 +497,30 @@ func newSession(ctx context.Context, config types.MCPServerConfig, secrets secur
 		}
 	}
 
-	return &serverSession{name: config.Name, uri: config.URI, token: token}, nil
+	return &serverSession{
+		name:       config.Name,
+		uri:        config.URI,
+		displayURI: displaySafeURI(config.URI),
+		token:      token,
+	}, nil
+}
+
+// displaySafeURI strips userinfo and the query string from a URI so it can be
+// logged or returned in an error without leaking credentials an operator may
+// have embedded (https://user:pass@host or ?api_key=...). The full URI is kept
+// on serverSession.uri for the actual request. On a parse failure it returns a
+// fixed sentinel rather than the raw input — validateMCPHost has already
+// rejected unparseable URIs by the time a session is built, so this branch is
+// defence in depth and must not echo the original string.
+func displaySafeURI(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<unparseable mcp uri>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
 }
 
 // Close releases resources held by the client. Currently a no-op since
@@ -786,7 +815,16 @@ func (c *Client) call(ctx context.Context, sess *serverSession, method string, p
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("HTTP request to %s: %w", sess.uri, err)
+		// *url.Error embeds the full request URL — including any credential
+		// query string, which Go does NOT redact (it only masks userinfo) — in
+		// its message. Unwrap to the transport-level cause so the dial failure
+		// is still reported without leaking the credentialed URI (CWE-532).
+		cause := err
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			cause = urlErr.Err
+		}
+		return nil, fmt.Errorf("HTTP request to %s: %w", sess.displayURI, cause)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -806,7 +844,7 @@ func (c *Client) call(ctx context.Context, sess *serverSession, method string, p
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, sess.uri, string(respBody))
+		return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, sess.displayURI, string(respBody))
 	}
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxMCPResponseSize))

--- a/harness/internal/mcp/client_test.go
+++ b/harness/internal/mcp/client_test.go
@@ -1182,3 +1182,106 @@ func TestConnect_LocalhostNameDefaultTransport(t *testing.T) {
 		t.Fatalf("tool result = %q, want pong", out.Text)
 	}
 }
+
+// credentialedURI rewrites base (e.g. an httptest server URL) to embed
+// userinfo and a secret query parameter, matching the CWE-532 leak scenario in
+// issue #395: an operator who puts credentials directly in the MCP server URI.
+func credentialedURI(t *testing.T, base string) string {
+	t.Helper()
+	u, err := url.Parse(base)
+	if err != nil {
+		t.Fatalf("parse base URL %q: %v", base, err)
+	}
+	u.User = url.UserPassword("user", "pass")
+	u.RawQuery = "api_key=supersecret"
+	return u.String()
+}
+
+// assertNoSecret fails if either the embedded credential or the secret query
+// value appears in s.
+func assertNoSecret(t *testing.T, where, s string) {
+	t.Helper()
+	if strings.Contains(s, "user:pass") {
+		t.Errorf("%s leaked userinfo: %q", where, s)
+	}
+	if strings.Contains(s, "supersecret") {
+		t.Errorf("%s leaked query secret: %q", where, s)
+	}
+}
+
+// TestCall_NonOKError_DoesNotLeakCredentials drives the non-200 error site in
+// call(): the returned error must report a display-safe URI, never the raw
+// credentialed one.
+func TestCall_NonOKError_DoesNotLeakCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream is sad", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	uri := credentialedURI(t, srv.URL)
+	sess, err := newSession(context.Background(),
+		types.MCPServerConfig{Name: "leaky", URI: uri},
+		&stubSecretStore{secrets: map[string]string{}})
+	if err != nil {
+		t.Fatalf("newSession: %v", err)
+	}
+	if strings.Contains(sess.displayURI, "user:pass") || strings.Contains(sess.displayURI, "supersecret") {
+		t.Fatalf("displayURI itself leaked credentials: %q", sess.displayURI)
+	}
+
+	client := NewClient(tool.NewRegistry(), srv.Client())
+	_, err = client.call(context.Background(), sess, "tools/list", nil)
+	if err == nil {
+		t.Fatal("expected error from non-200 response")
+	}
+	assertNoSecret(t, "non-200 error", err.Error())
+}
+
+// TestCall_TransportError_DoesNotLeakCredentials drives the transport-error
+// site in call(): a dial failure against a credentialed loopback URI must not
+// surface the credentials.
+func TestCall_TransportError_DoesNotLeakCredentials(t *testing.T) {
+	// Bind then immediately close a listener to obtain a port that refuses
+	// connections, keeping the host loopback so the SSRF dial guard allows it.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closedURL := srv.URL
+	srv.Close()
+
+	uri := credentialedURI(t, closedURL)
+	sess, err := newSession(context.Background(),
+		types.MCPServerConfig{Name: "leaky", URI: uri},
+		&stubSecretStore{secrets: map[string]string{}})
+	if err != nil {
+		t.Fatalf("newSession: %v", err)
+	}
+
+	client := NewClient(tool.NewRegistry(), nil) // default transport: real dial
+	_, err = client.call(context.Background(), sess, "tools/list", nil)
+	if err == nil {
+		t.Fatal("expected transport error from closed port")
+	}
+	assertNoSecret(t, "transport error", err.Error())
+}
+
+func TestDisplaySafeURI(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"userinfo and query", "https://user:pass@host.example/path?api_key=supersecret", "https://host.example/path"},
+		{"query only", "https://host.example/mcp?token=abc", "https://host.example/mcp"},
+		{"fragment", "https://host.example/mcp#frag", "https://host.example/mcp"},
+		{"clean uri unchanged", "https://host.example/mcp", "https://host.example/mcp"},
+		{"unparseable", "ht!tp://\x7f", "<unparseable mcp uri>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := displaySafeURI(tt.in)
+			if got != tt.want {
+				t.Errorf("displaySafeURI(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			assertNoSecret(t, "displaySafeURI", got)
+		})
+	}
+}


### PR DESCRIPTION
## What
Stops MCP server URIs with embedded credentials from leaking into slog/error output (CWE-532), per #395.

## Fix
- New `displaySafeURI` helper + `displayURI` field on `serverSession`, derived once in `newSession` (clears userinfo, query, and fragment). The raw URI is still used for the actual HTTP request.
- Both `call()`-site error logs now use the display-safe URI.
- The transport-error site additionally unwraps `*url.Error` to its transport cause before wrapping: Go redacts userinfo in a `*url.Error` message but **not** the query string, so `?api_key=...` would otherwise still leak through the `%w` wrap.

## Verification
New tests assert a credentialed URI (`user:pass`, `?api_key=...`) never appears in emitted error text; `just test` and `just lint` green.

Closes #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
