### PR TITLE
security, provider, webfetch, guard: unwrap url.Error to stop credentialed-URL leaks

### DIFF
--- a/harness/internal/guard/graniteguardian.go
+++ b/harness/internal/guard/graniteguardian.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 )
 
 // Granite Guardian adapter for the OpenAI-compatible chat-completions API
@@ -406,7 +408,11 @@ func (g *GraniteGuardian) Check(ctx context.Context, in Input) (*Decision, error
 
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("granite-guardian: do request: %w", err)
+		// g.endpoint is an operator-supplied URL that composeGraniteURL
+		// preserves verbatim (userinfo and query string included); unwrap the
+		// transport *url.Error so an embedded credential cannot leak into the
+		// returned error (CWE-532).
+		return nil, fmt.Errorf("granite-guardian: do request: %w", security.UnwrapURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -520,7 +521,10 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, params types.StreamParams
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
 		a.recordLatency(ctx, start, metricAttrs)
-		return nil, fmt.Errorf("execute request: %w", err)
+		// a.baseURL is operator-configurable and may carry a credential in
+		// its query string; unwrap the *url.Error so its embedded URL (which
+		// Go does not query-redact) never reaches a log or caller (CWE-532).
+		return nil, fmt.Errorf("execute request: %w", security.UnwrapURLError(err))
 	}
 
 	// Record HTTP-level metadata on the span from context (the provider.stream

--- a/harness/internal/provider/anthropic_test.go
+++ b/harness/internal/provider/anthropic_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -210,6 +211,44 @@ func TestAnthropicAdapter_HTTPErrorBodyTruncated(t *testing.T) {
 	}
 	if !strings.Contains(errMsg, "400") {
 		t.Errorf("expected status code in error, got: %v", err)
+	}
+}
+
+// TestAnthropicAdapter_TransportError_DoesNotLeakCredentials drives the
+// transport-error path with a credentialed baseURL pointed at a closed port.
+// An operator may put credentials directly in a custom baseURL (userinfo or a
+// gateway api_key query param); the *url.Error Go returns from Do embeds that
+// URL and does not redact the query string, so the wrapped error must report
+// only the dial-level cause (CWE-532, follow-up to #395).
+func TestAnthropicAdapter_TransportError_DoesNotLeakCredentials(t *testing.T) {
+	// A closed loopback port yields a connection-refused dial error.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closed := srv.URL
+	srv.Close()
+
+	u, err := url.Parse(closed)
+	if err != nil {
+		t.Fatalf("parse closed URL %q: %v", closed, err)
+	}
+	u.User = url.UserPassword("user", "pass")
+	u.RawQuery = "api_key=supersecret"
+
+	adapter := NewAnthropicAdapter(staticBearer("key"), AuthModeAPIKey)
+	adapter.baseURL = u.String()
+
+	_, err = adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: 1024,
+	})
+	if err == nil {
+		t.Fatal("expected a transport error dialing a closed port")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "supersecret") {
+		t.Errorf("transport error leaked the query secret: %q", msg)
+	}
+	if strings.Contains(msg, "user:pass") {
+		t.Errorf("transport error leaked userinfo: %q", msg)
 	}
 }
 

--- a/harness/internal/provider/batchpoll.go
+++ b/harness/internal/provider/batchpoll.go
@@ -368,7 +368,7 @@ func (c *harnessPollingBatchClient) submitAnthropic(ctx context.Context, entry B
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("submit batch: %w", err)
+		return "", fmt.Errorf("submit batch: %w", security.UnwrapURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -514,7 +514,7 @@ func (c *harnessPollingBatchClient) pollOnce(ctx context.Context, batchID string
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("poll batch: %w", err)
+		return nil, fmt.Errorf("poll batch: %w", security.UnwrapURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -549,7 +549,10 @@ func (c *harnessPollingBatchClient) fetchResults(ctx context.Context, resultsURL
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch batch results: %w", err)
+		// resultsURL is provider-returned and is frequently a presigned
+		// download URL whose signature lives in the query string; unwrap
+		// the *url.Error so it cannot leak into this error (CWE-532).
+		return nil, fmt.Errorf("fetch batch results: %w", security.UnwrapURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -646,7 +649,10 @@ func (c *harnessPollingBatchClient) bestEffortCancel(batchID string) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if c.logger != nil {
-			c.logger.Warn("batch cancel: send", "batchID", batchID, "error", err, "keyRef", c.apiKeyRef)
+			// Unwrap the transport *url.Error before logging: its embedded
+			// cancelURL is built from c.baseURL, which may carry a credential
+			// query string Go does not redact (CWE-532).
+			c.logger.Warn("batch cancel: send", "batchID", batchID, "error", security.UnwrapURLError(err), "keyRef", c.apiKeyRef)
 		}
 		return
 	}
@@ -887,7 +893,7 @@ func (c *harnessPollingBatchClient) submitOpenAI(ctx context.Context, entry Batc
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("submit openai batch: %w", err)
+		return "", fmt.Errorf("submit openai batch: %w", security.UnwrapURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -946,7 +952,7 @@ func (c *harnessPollingBatchClient) uploadOpenAIBatchFile(ctx context.Context, j
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("upload openai batch file: %w", err)
+		return "", fmt.Errorf("upload openai batch file: %w", security.UnwrapURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -1064,7 +1070,7 @@ func (c *harnessPollingBatchClient) pollOnceOpenAI(ctx context.Context, batchID 
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("poll openai batch: %w", err)
+		return nil, fmt.Errorf("poll openai batch: %w", security.UnwrapURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -1233,7 +1239,7 @@ func (c *harnessPollingBatchClient) downloadOpenAIFile(ctx context.Context, file
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("download openai file: %w", err)
+		return nil, fmt.Errorf("download openai file: %w", security.UnwrapURLError(err))
 	}
 	if resp.StatusCode != http.StatusOK {
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -1030,7 +1031,10 @@ func (o *OpenAICompatibleAdapter) Stream(ctx context.Context, params types.Strea
 	})
 	if err != nil {
 		o.recordLatency(ctx, start, metricAttrs)
-		return nil, fmt.Errorf("execute request: %w", err)
+		// DoWithRetry surfaces the raw transport *url.Error, whose embedded
+		// URL (o.baseURL + o.queryParams) may carry a gateway credential Go
+		// does not query-redact; unwrap before wrapping (CWE-532).
+		return nil, fmt.Errorf("execute request: %w", security.UnwrapURLError(err))
 	}
 
 	// Record HTTP-level metadata on the span from context when OTel is enabled.

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -872,7 +873,10 @@ func (o *OpenAIResponsesAdapter) Stream(ctx context.Context, params types.Stream
 	resp, err := o.httpClient.Do(req)
 	if err != nil {
 		o.recordLatency(ctx, start, metricAttrs)
-		return nil, fmt.Errorf("execute request: %w", err)
+		// The composed URL carries o.baseURL and o.queryParams, either of
+		// which may hold a credential (e.g. a gateway api_key query param);
+		// unwrap the *url.Error so its embedded URL never leaks (CWE-532).
+		return nil, fmt.Errorf("execute request: %w", security.UnwrapURLError(err))
 	}
 
 	if o.Tracer != nil {

--- a/harness/internal/provider/openai_test.go
+++ b/harness/internal/provider/openai_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
-	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -1005,33 +1004,24 @@ func TestComposeOpenAIURL_TrimsAndAppends(t *testing.T) {
 	}
 }
 
-// TestOpenAIAdapter_HTTPDoErrorContainsURLAndIsScrubbed pins the F2
-// remediation from the issue #48 review: when httpClient.Do fails, Go
-// wraps the underlying transport error in *url.Error which embeds the
-// full request URL — including any QueryParams the operator configured.
-// Today's QueryParams (e.g. api-version=preview) are non-sensitive, but
-// the harness now accepts arbitrary user-controlled values there. OTel
-// span status messages bypass ScrubHandler (which only intercepts slog),
-// so loop.go scrubs streamErr.Error() before SetStatus to close the
-// architectural gap.
+// TestOpenAIAdapter_HTTPDoErrorDoesNotContainURL pins the #395 follow-up
+// remediation. When httpClient.Do fails, Go wraps the transport error in a
+// *url.Error whose Error() string embeds the full request URL — including any
+// QueryParams the operator configured. Go redacts userinfo but NOT the query
+// string, so an arbitrary user-controlled QueryParams value (the harness now
+// accepts these) would leak verbatim wherever the error is logged or returned.
 //
-// This test confirms two things in concert:
-//  1. An httpClient.Do failure produces a *url.Error whose string
-//     representation contains the request URL with QueryParams encoded.
-//     This is the channel by which a sensitive QueryParams value would
-//     reach an unscrubbed telemetry sink.
-//  2. security.Scrub strips known sensitive patterns from that string.
-//     We seed a scrubber-recognised secret into the URL via QueryParams
-//     to demonstrate the architectural fix actively redacts when fed a
-//     sensitive value, rather than relying on the current happy-path
-//     where QueryParams values do not happen to match any pattern.
+// The earlier issue #48 mitigation relied on security.Scrub stripping known
+// secret patterns from the error before it reached an OTel span; that left
+// arbitrary, non-pattern secrets (Azure SAS signatures, opaque gateway tokens)
+// exposed. The Stream adapter now unwraps the *url.Error to its transport cause
+// at the Do site, so the credentialed URL never enters the error chain at all —
+// a stronger guarantee that does not depend on pattern matching.
 //
-// The matching scrub call lives at harness/internal/core/loop.go in the
-// provider.stream span error path; verifying its presence directly via
-// the OTel test exporter requires standing up the full agentic loop, so
-// this test exercises the same security.Scrub call against the same
-// shape of error string that loop.go would receive.
-func TestOpenAIAdapter_HTTPDoErrorContainsURLAndIsScrubbed(t *testing.T) {
+// This test seeds an unmistakable secret into QueryParams and asserts it is
+// absent from the returned error string, and that the error no longer wraps a
+// *url.Error.
+func TestOpenAIAdapter_HTTPDoErrorDoesNotContainURL(t *testing.T) {
 	// httptest.Server with a Hijack handler that closes the underlying
 	// TCP connection mid-request. http.Client.Do returns a *url.Error
 	// wrapping the transport-layer failure with the request URL.
@@ -1048,16 +1038,13 @@ func TestOpenAIAdapter_HTTPDoErrorContainsURLAndIsScrubbed(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Seed a scrubber-recognised secret into QueryParams. The pattern
-	// must survive net/url's percent-encoding so it can still be matched
-	// in the *url.Error string — Anthropic and OpenAI API keys are
-	// alphanumeric (with `-` and `_`) so they pass through unchanged. We
-	// craft a synthetic `sk-ant-...` string here purely to give the
-	// scrubber something deterministic to match; this is not a real key.
-	const sensitive = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	// An opaque, non-pattern secret: security.Scrub would NOT catch this,
+	// which is exactly why the leak must be closed at the source rather than
+	// relying on downstream scrubbing.
+	const sensitive = "supersecretsignature"
 	queryParams := map[string]string{
 		"api-version": "preview",
-		"deployment":  sensitive, // crafted to match the anthropic_api_key pattern
+		"sig":         sensitive,
 	}
 
 	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{
@@ -1072,35 +1059,17 @@ func TestOpenAIAdapter_HTTPDoErrorContainsURLAndIsScrubbed(t *testing.T) {
 		t.Fatal("expected an error from connection-close, got nil")
 	}
 
-	// Step 1: the error must wrap *url.Error and the URL string must
-	// contain the encoded QueryParams. If this assertion fails the
-	// premise of F2 (URL leaks via *url.Error) no longer holds and the
-	// scrub mitigation can be reconsidered.
+	// The credentialed URL must not survive into the error chain.
 	var urlErr *url.Error
-	if !errors.As(err, &urlErr) {
-		t.Fatalf("expected error wrapping *url.Error, got %T: %v", err, err)
+	if errors.As(err, &urlErr) {
+		t.Fatalf("error still wraps *url.Error (URL leaks): %v", err)
 	}
 	rawMessage := err.Error()
-	if !strings.Contains(rawMessage, "api-version=preview") {
-		t.Errorf("expected raw error to contain encoded QueryParams, got: %s", rawMessage)
+	if strings.Contains(rawMessage, sensitive) {
+		t.Errorf("error leaked the sig QueryParams secret: %s", rawMessage)
 	}
-	// The sensitive value should be present pre-scrub (the very leak
-	// we are guarding against in OTel span status).
-	if !strings.Contains(rawMessage, url.QueryEscape(sensitive)) && !strings.Contains(rawMessage, sensitive) {
-		t.Errorf("expected raw error to contain sensitive QueryParams value, got: %s", rawMessage)
-	}
-
-	// Step 2: security.Scrub strips the secret-ref pattern. This is
-	// the same call the provider.stream span site in loop.go applies
-	// before passing the string to SetStatus.
-	scrubbed := security.Scrub(rawMessage)
-	if strings.Contains(scrubbed, sensitive) {
-		t.Errorf("scrubbed error still contains sensitive value: %s", scrubbed)
-	}
-	// Confirm scrub did something — the redacted placeholder is the
-	// canonical signal that a pattern fired.
-	if !strings.Contains(scrubbed, "[REDACTED]") {
-		t.Errorf("scrubbed error missing [REDACTED] marker: %s", scrubbed)
+	if strings.Contains(rawMessage, "api-version=preview") {
+		t.Errorf("error still embeds the encoded request URL: %s", rawMessage)
 	}
 }
 

--- a/harness/internal/provider/probe.go
+++ b/harness/internal/provider/probe.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 )
 
 // probeBodyLimit caps how much of a non-2xx probe response body is read
@@ -38,7 +39,10 @@ func (a *AnthropicAdapter) Probe(ctx context.Context) error {
 
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("execute request: %w", err)
+		// a.baseURL is operator-configurable and may carry a credential in
+		// its query string; unwrap the *url.Error so its embedded URL never
+		// leaks into the returned probe error (CWE-532).
+		return fmt.Errorf("execute request: %w", security.UnwrapURLError(err))
 	}
 	return checkProbeStatus("anthropic", resp)
 }
@@ -94,7 +98,10 @@ func probeOpenAIModels(
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("execute request: %w", err)
+		// The composed URL carries baseURL and queryParams, either of which
+		// may hold a gateway credential; unwrap the *url.Error so its
+		// embedded URL never leaks into the returned probe error (CWE-532).
+		return fmt.Errorf("execute request: %w", security.UnwrapURLError(err))
 	}
 	return checkProbeStatus(providerLabel, resp)
 }

--- a/harness/internal/security/urlerror.go
+++ b/harness/internal/security/urlerror.go
@@ -1,0 +1,24 @@
+package security
+
+import (
+	"errors"
+	"net/url"
+)
+
+// UnwrapURLError returns the transport-level cause of a *url.Error, or err
+// unchanged when err is not a *url.Error.
+//
+// http.Client.Do wraps every transport failure in a *url.Error whose Error()
+// string embeds the full request URL. Go redacts the userinfo component of
+// that URL (user:***) but does NOT redact the query string, so a request to a
+// credentialed URL (https://host/path?api_key=secret) leaks the secret
+// whenever the *url.Error is %w-wrapped into a returned or logged error
+// (CWE-532). Callers that interpolate a Do error into a message a credentialed
+// URL could reach must unwrap it here first.
+func UnwrapURLError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return urlErr.Err
+	}
+	return err
+}

--- a/harness/internal/security/urlerror_test.go
+++ b/harness/internal/security/urlerror_test.go
@@ -1,0 +1,52 @@
+package security
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestUnwrapURLError(t *testing.T) {
+	cause := errors.New("dial tcp 127.0.0.1:1: connect: connection refused")
+
+	t.Run("unwraps url.Error to transport cause", func(t *testing.T) {
+		wrapped := &url.Error{
+			Op:  "Get",
+			URL: "https://host.example/path?api_key=supersecret",
+			Err: cause,
+		}
+		// Sanity: the *url.Error message would itself leak the query secret.
+		if !strings.Contains(wrapped.Error(), "supersecret") {
+			t.Fatalf("test premise broken: url.Error did not embed the query secret: %q", wrapped.Error())
+		}
+		got := UnwrapURLError(wrapped)
+		if got != cause {
+			t.Fatalf("UnwrapURLError returned %v, want the transport cause", got)
+		}
+		if strings.Contains(got.Error(), "supersecret") {
+			t.Errorf("unwrapped error still leaks the query secret: %q", got.Error())
+		}
+	})
+
+	t.Run("returns non-url errors unchanged", func(t *testing.T) {
+		plain := errors.New("some other failure")
+		if got := UnwrapURLError(plain); got != plain {
+			t.Fatalf("UnwrapURLError(%v) = %v, want it unchanged", plain, got)
+		}
+	})
+
+	t.Run("finds a url.Error nested deeper in the chain", func(t *testing.T) {
+		wrapped := &url.Error{Op: "Post", URL: "https://host?token=abc", Err: cause}
+		chain := errors.Join(errors.New("context"), wrapped)
+		if got := UnwrapURLError(chain); got != cause {
+			t.Fatalf("UnwrapURLError on a joined chain = %v, want the transport cause", got)
+		}
+	})
+
+	t.Run("nil error is returned unchanged", func(t *testing.T) {
+		if got := UnwrapURLError(nil); got != nil {
+			t.Fatalf("UnwrapURLError(nil) = %v, want nil", got)
+		}
+	})
+}

--- a/harness/internal/tool/builtins/webfetch.go
+++ b/harness/internal/tool/builtins/webfetch.go
@@ -92,7 +92,13 @@ func newWebFetchTool(opts webFetchOptions) *tool.Tool {
 
 			resp, err := client.Do(req)
 			if err != nil {
-				return "", fmt.Errorf("fetch URL: %w", err)
+				// The fetched URL is arbitrary user input and frequently
+				// carries credentials in its query string (presigned S3/GCS
+				// URLs, ?api_key=...) or userinfo. The transport *url.Error
+				// embeds that URL and Go does not redact the query string, so
+				// unwrap to the dial-level cause before this error is returned
+				// to the model and logged (CWE-532).
+				return "", fmt.Errorf("fetch URL: %w", security.UnwrapURLError(err))
 			}
 			defer func() { _ = resp.Body.Close() }()
 

--- a/harness/internal/tool/builtins/webfetch_test.go
+++ b/harness/internal/tool/builtins/webfetch_test.go
@@ -1,0 +1,56 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// credentialedLoopbackURL closes an httptest server to obtain a loopback URL
+// whose port refuses connections, then rewrites it to embed userinfo and a
+// secret query parameter — the CWE-532 leak scenario for web_fetch, where a
+// user passes a presigned or otherwise credentialed URL that then fails to
+// dial. Loopback keeps the SSRF guard satisfiable via allowPrivateHosts.
+func credentialedLoopbackURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closed := srv.URL
+	srv.Close()
+
+	u, err := url.Parse(closed)
+	if err != nil {
+		t.Fatalf("parse closed URL %q: %v", closed, err)
+	}
+	u.User = url.UserPassword("user", "pass")
+	u.RawQuery = "api_key=supersecret"
+	return u.String()
+}
+
+// TestWebFetch_TransportError_DoesNotLeakCredentials drives the dial-failure
+// path: the returned error must not surface the userinfo or the secret query
+// parameter embedded in the fetched URL.
+func TestWebFetch_TransportError_DoesNotLeakCredentials(t *testing.T) {
+	uri := credentialedLoopbackURL(t)
+
+	tl := newWebFetchTool(webFetchOptions{allowPrivateHosts: true})
+	input, err := json.Marshal(map[string]string{"url": uri})
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+
+	_, err = tl.Handler(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected a transport error dialing a closed port")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "supersecret") {
+		t.Errorf("error leaked the query secret: %q", msg)
+	}
+	if strings.Contains(msg, "user:pass") {
+		t.Errorf("error leaked userinfo: %q", msg)
+	}
+}


### PR DESCRIPTION
## What
Follow-up remediation to #395 / PR #405. Closes the same `*url.Error` credentialed-URL leak class (CWE-532) across the remaining outbound-HTTP sites in production code. Surfaced and tracked while working #395; filed as a PR directly rather than a new issue.

## The leak class
When `http.Client.Do` fails it returns a `*url.Error` whose message embeds the full request URL. Go redacts userinfo (`user:***`) but **not** the query string, so `?api_key=...` or a presigned-URL signature leaks whenever that error is `%w`-wrapped into a returned/logged error. Pattern-based scrubbing only catches known key shapes, so opaque secrets slip through.

## Fix
- New shared primitive `security.UnwrapURLError` (one audited helper rather than per-site rewrites).
- Applied at every confirmed-leak site:
  - **provider**: anthropic, openai, openai_responses, probe (anthropic/openai), and batchpoll ×8 (submit/poll/**resultsURL — provider-returned, often presigned**/cancel/upload/download).
  - **tool/webfetch** (highest risk — fetches arbitrary user URLs that may carry userinfo, `?api_key=`, or presigned signatures; the error is returned to the model and logged).
  - **guard/graniteguardian** (operator endpoint stored verbatim, userinfo+query preserved).

## Confirmed NOT leaks (left unchanged, documented)
gemini + gemini-probe (fixed hosts, header auth), credential/* (secrets in bodies/headers), gcs upload, executor GitHub/container APIs, eval diffreview — header auth or creds-free URLs. `mcp/client.go` intentionally untouched (covered by PR #405).

## Tests
`security/urlerror_test.go` (proves a raw `*url.Error` contains the secret and the unwrapped one does not), `tool/builtins/webfetch_test.go` (credentialed loopback URL), an anthropic transport-error test, and a strengthened openai (#48) test asserting an opaque non-pattern query secret is absent and the error no longer wraps a `*url.Error`.

## Verification
`just build`, `just test` (all packages), and `just lint` (0 issues) green on this branch.

Conflict-free with the other open PRs (#404 egress-proxy, #405 mcp/client.go, #406 just recipes) — disjoint files.

Relates to #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
