### PR TITLE
feat: transport sub-agent spawner + start-and-detach sessions (#54, #71)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -442,6 +442,27 @@ The `SubAgentSpawner` function type in `tool/builtins` decouples the
 tool from the `core` package, avoiding circular imports. The factory
 provides the concrete closure.
 
+The `subAgent` config block widens this in two ways
+([configuration.md](configuration.md#sub-agent-spawning-and-sessions)).
+`spawner: transport` dispatches the spawn over the gRPC transport
+instead of running it in-process — the control plane materialises the
+sub-agent (for example as a separate `stirrup job`) and returns its
+result over the existing `tool_result_request` / `tool_result_response`
+async-tool round-trip, so no spawn-specific wire message is needed.
+`sessions: true` registers the start-and-detach tools (`start_session`,
+`check_session`, `wait_session`, `terminate_session`), which let the
+agent kick off a sub-agent and collect its result later instead of
+blocking. Both ride a `SessionManager` (`core/session.go`) that models a
+detached session as a non-awaited async round-trip: `start_session`
+emits the request and returns the request id as a session handle, and
+`wait_session` / `check_session` resolve it via the transport
+`Correlator`'s buffered retained entries. Blocking `spawn_agent` is the
+same machinery with start and wait fused. A new fire-and-forget
+`session_terminate` event lets the harness ask the control plane to stop
+a detached sub-agent job. Sub-agents receive neither `spawn_agent` nor
+the session tools, so the recursion and concurrency guards hold one
+level down.
+
 ## Permission policies
 
 Four implementations gate side-effecting tool calls:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -607,6 +607,41 @@ did not resolve to a known tool under a non-default profile". The active
 `tools.profile` is recorded in the trace's attached `RunConfig`, so the
 two cases are distinguishable by reading it alongside the record.
 
+## Sub-agent spawning and sessions
+
+The `subAgent` block configures how `spawn_agent` and the start-and-detach
+session tools materialise sub-agents. The zero value preserves the
+historical behaviour: `spawn_agent` runs a child loop in-process and the
+session tools are absent.
+
+| Field | Values | Default | Effect |
+|---|---|---|---|
+| `spawner` | `local`, `transport` | `local` | `local` runs the sub-agent in-process. `transport` dispatches the spawn over the gRPC transport to the control plane, which materialises the sub-agent (for example as a separate `stirrup job`) and returns the result. |
+| `sessions` | `true`, `false` | `false` | When `true`, registers `start_session`, `check_session`, `wait_session`, and `terminate_session` alongside `spawn_agent`. |
+| `sessionTimeout` | 1–3600 s | 300 s | The per-wait timeout applied to a blocking result wait (`spawn_agent`'s implicit wait, or `wait_session` without an explicit timeout). |
+| `maxConcurrentSessions` | 1–256 | 16 | The cap on simultaneously-running detached sessions. `start_session` fails once the cap is reached; terminal sessions do not count against it. |
+
+`spawn_agent` blocks until the sub-agent returns. The session tools split
+that into a lifecycle: `start_session` dispatches a sub-agent and returns a
+session id immediately, `check_session` polls without blocking,
+`wait_session` blocks for the result, and `terminate_session` stops a
+session. A session whose result arrives before any wait is buffered, so a
+later `check_session`/`wait_session` still observes it. The blocking
+`spawn_agent` is `start_session` + `wait_session` fused over the same
+machinery, so the two paths share one wire shape (`tool_result_request` /
+`tool_result_response`).
+
+The `transport` spawner requires a live control-plane transport.
+Selecting it on a run whose transport cannot deliver responses (a
+`NullTransport`) fails at construction rather than blocking on the first
+spawn. Sub-agents themselves never receive `spawn_agent` or the session
+tools, so a sub-agent cannot recurse or open its own detached sessions.
+
+`start_session` carries the same `RequiresApproval` gate as `spawn_agent`
+— it is the budget-consuming spawn. The `check_session`, `wait_session`,
+and `terminate_session` tools manage an already-approved session and are
+not separately gated.
+
 ## Limits and budgets
 
 `ValidateRunConfig` enforces hard caps on values that could otherwise

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -522,17 +522,63 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		ownedClosers: ownedClosers,
 	}
 
+	// Build the sub-agent session manager when the run uses the transport
+	// spawner (#54) or enables the start-and-detach session tools (#71).
+	// The common case — the local spawner with sessions off — needs no
+	// manager: spawn_agent runs SpawnSubAgent in-process exactly as before,
+	// so a bare run pays nothing for this feature.
+	useTransportSpawner := config.SubAgent.UsesTransportSpawner()
+	spawnEnabled := toolEnabled(config.Tools.BuiltIn, "spawn_agent")
+	var sessionMgr *SessionManager
+	if config.SubAgent.Sessions || (spawnEnabled && useTransportSpawner) {
+		// A detached session must not outlive the run; bound a single
+		// transport await by the run timeout when one is set.
+		var maxLifetime time.Duration
+		if config.Timeout != nil && *config.Timeout > 0 {
+			maxLifetime = time.Duration(*config.Timeout) * time.Second
+		}
+		mgr, mgrErr := NewSessionManager(SessionManagerOptions{
+			UseTransport:  useTransportSpawner,
+			Transport:     tp,
+			Parent:        loop,
+			ParentConfig:  config,
+			MaxConcurrent: config.SubAgent.EffectiveMaxConcurrentSessions(),
+			DefaultWait:   time.Duration(config.SubAgent.EffectiveSessionTimeoutSeconds()) * time.Second,
+			MaxLifetime:   maxLifetime,
+			Logger:        logger,
+		})
+		if mgrErr != nil {
+			cleanup()
+			return nil, fmt.Errorf("build sub-agent session manager: %w", mgrErr)
+		}
+		sessionMgr = mgr
+		// Close the manager (tearing down any live sessions) before the
+		// transport closes: appended last, it runs first in Close's reverse
+		// walk. Keep loop.ownedClosers in sync with the local slice so both
+		// the success path (loop.Close) and the failure path (cleanup) cover
+		// it.
+		ownedClosers = append(ownedClosers, mgr)
+		loop.ownedClosers = ownedClosers
+	}
+
 	// Register spawn_agent after loop construction. The tool needs a
 	// reference to the loop (chicken-and-egg), so we close over the loop
 	// pointer here. The spawner closure captures the loop and config so
-	// the tool can call SpawnSubAgent without a circular import.
-	if toolEnabled(config.Tools.BuiltIn, "spawn_agent") {
+	// the tool can call SpawnSubAgent without a circular import. With the
+	// transport spawner the same call is dispatched over the wire and
+	// awaited (Start+Wait fused) instead of run in-process.
+	if spawnEnabled {
 		spawner := func(ctx context.Context, prompt, mode string, maxTurns int) (json.RawMessage, error) {
-			result, err := SpawnSubAgent(ctx, loop, config, SubAgentConfig{
-				Prompt:   prompt,
-				Mode:     mode,
-				MaxTurns: maxTurns,
-			})
+			cfg := SubAgentConfig{Prompt: prompt, Mode: mode, MaxTurns: maxTurns}
+			var (
+				result *SubAgentResult
+				err    error
+			)
+			if sessionMgr != nil && useTransportSpawner {
+				result, err = sessionMgr.SpawnAndWait(ctx, cfg, time.Duration(config.SubAgent.EffectiveSessionTimeoutSeconds())*time.Second)
+			} else {
+				result, err = SpawnSubAgent(ctx, loop, config, cfg)
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -550,6 +596,24 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		// the wrapper's pass-through first before falling back to a
 		// direct type assertion.
 		addApprovalTool(pp, "spawn_agent")
+	}
+
+	// Register the start-and-detach session tools (#71) when enabled. They
+	// share the session manager backend with the transport spawner. The
+	// sub-agent recursion guard in SpawnSubAgent withholds these (and
+	// spawn_agent) from spawned children so a sub-agent cannot open its own
+	// detached sessions.
+	if config.SubAgent.Sessions {
+		ctrl := newSessionController(sessionMgr)
+		registry.Register(builtins.StartSessionTool(ctrl))
+		registry.Register(builtins.CheckSessionTool(ctrl))
+		registry.Register(builtins.WaitSessionTool(ctrl))
+		registry.Register(builtins.TerminateSessionTool(ctrl))
+		// start_session is the budget-consuming spawn in the family, so it
+		// carries the same upstream-approval gate as spawn_agent. The
+		// poll/wait/terminate tools manage an already-approved session and
+		// are not separately gated.
+		addApprovalTool(pp, "start_session")
 	}
 
 	// Apply the toolset-profile presentation (issue #234) last, after every

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -1655,6 +1655,112 @@ func TestBuildLoopWithTransport_AllToolsRegisteredByDefault(t *testing.T) {
 			t.Errorf("expected tool %q to be registered", name)
 		}
 	}
+	// The session tools are off unless SubAgent.Sessions opts in.
+	for _, name := range []string{"start_session", "check_session", "wait_session", "terminate_session"} {
+		if loop.Tools.Resolve(name) != nil {
+			t.Errorf("session tool %q registered without SubAgent.Sessions", name)
+		}
+	}
+}
+
+// TestBuildLoopWithTransport_SessionToolsRegistered pins the #71 wiring:
+// SubAgent.Sessions registers the four detached-session tools, and
+// start_session joins the ask-upstream approval set (the budget-consuming
+// spawn) while the management tools do not.
+func TestBuildLoopWithTransport_SessionToolsRegistered(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-sessions",
+		Mode:             "execution",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "ask-upstream", Timeout: 60},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		MaxTurns:         2,
+		Timeout:          &timeout,
+		SubAgent:         types.SubAgentRunConfig{Sessions: true},
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	for _, name := range []string{"start_session", "check_session", "wait_session", "terminate_session"} {
+		if loop.Tools.Resolve(name) == nil {
+			t.Errorf("expected session tool %q to be registered", name)
+		}
+	}
+
+	ask, ok := permission.Unwrap(loop.Permissions).(*permission.AskUpstreamPolicy)
+	if !ok {
+		t.Fatalf("expected AskUpstreamPolicy, got %T", loop.Permissions)
+	}
+	approval := make(map[string]bool)
+	for _, name := range ask.ApprovalToolNames() {
+		approval[name] = true
+	}
+	if !approval["start_session"] {
+		t.Errorf("start_session missing from approval set; got %v", approval)
+	}
+	for _, name := range []string{"check_session", "wait_session", "terminate_session"} {
+		if approval[name] {
+			t.Errorf("management tool %q should not require approval", name)
+		}
+	}
+}
+
+// TestBuildLoopWithTransport_TransportSpawnerRequiresLiveTransport pins the
+// #54 misconfiguration guard: selecting the transport spawner on a loop
+// whose transport cannot deliver responses (NullTransport) fails at
+// construction rather than blocking on the first spawn.
+func TestBuildLoopWithTransport_TransportSpawnerRequiresLiveTransport(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-transport-spawner",
+		Mode:             "execution",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+		SubAgent:         types.SubAgentRunConfig{Spawner: "transport"},
+	}
+
+	// Inject a NullTransport (cannot deliver control-plane responses).
+	_, err := BuildLoopWithTransport(context.Background(), config, &transport.NullTransport{})
+	if err == nil {
+		t.Fatal("expected error for transport spawner on NullTransport")
+	}
+	if !strings.Contains(err.Error(), "session manager") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // TestBuildLoopWithTransport_TraceEmitterHeaderResolutionError pins

--- a/harness/internal/core/session.go
+++ b/harness/internal/core/session.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rxbynerd/stirrup/harness/internal/security"
@@ -36,6 +38,13 @@ const (
 	SessionTerminated SessionState = "terminated"
 	SessionNotFound   SessionState = "not_found"
 )
+
+// sessionRetentionFactor multiplies MaxConcurrent to bound the total
+// number of sessions retained in the registry (running plus terminal).
+// Terminal sessions are kept for later inspection but evicted oldest-first
+// once the registry reaches MaxConcurrent * sessionRetentionFactor, so a
+// run that starts and forgets many sessions cannot grow it without bound.
+const sessionRetentionFactor = 8
 
 // SessionStatus is the snapshot returned by Status/Wait and serialised to
 // the model by the session tools. Result is populated once the session
@@ -74,18 +83,27 @@ var subAgentExcludedTools = []string{
 
 // session is one entry in the SessionManager's registry. state/result are
 // guarded by mu; done is closed exactly once when the session reaches a
-// terminal state, unblocking Wait. cancel stops the backend's work (local
-// backend only).
+// terminal state, unblocking Wait. id and seq are set once at construction
+// (before the backend starts, so a terminate racing the start sees them)
+// and never mutated, so they are read without the lock. terminal is an
+// atomic mirror of "state != running" that the manager's eviction sweep
+// reads without taking mu (avoiding an mu->s.mu lock-order inversion).
+// onTerminal fires exactly once when the session first leaves the running
+// state; the manager uses it to release the concurrency slot. cancel stops
+// the backend's work (local backend only).
 type session struct {
-	id   string
-	seq  int
-	mu   sync.Mutex
-	done chan struct{}
+	id  string
+	seq int
+	mu  sync.Mutex
+
+	done     chan struct{}
+	terminal atomic.Bool
 
 	state  SessionState
 	result *SubAgentResult
 
-	cancel context.CancelFunc
+	onTerminal func()
+	cancel     context.CancelFunc
 }
 
 func (s *session) status() SessionStatus {
@@ -95,19 +113,18 @@ func (s *session) status() SessionStatus {
 }
 
 func (s *session) isTerminal() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.state != SessionRunning
+	return s.terminal.Load()
 }
 
 // complete transitions a running session to its terminal state. A no-op if
 // the session is already terminal (e.g. terminated while a late backend
 // result was in flight), so the backend goroutine never panics on a double
-// close.
+// close. onTerminal is invoked after the lock is released to keep the
+// s.mu -> m.mu ordering one-directional.
 func (s *session) complete(result *SubAgentResult) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.state != SessionRunning {
+		s.mu.Unlock()
 		return
 	}
 	s.result = result
@@ -116,21 +133,36 @@ func (s *session) complete(result *SubAgentResult) {
 	} else {
 		s.state = SessionDone
 	}
+	s.terminal.Store(true)
 	close(s.done)
+	onTerminal := s.onTerminal
+	s.mu.Unlock()
+
+	if onTerminal != nil {
+		onTerminal()
+	}
 }
 
 // markTerminated transitions a running session to terminated. Returns true
 // if it made the transition (false if already terminal). The backend's
-// terminate signal is sent by the caller only on a true return.
+// terminate signal is sent by the caller only on a true return. onTerminal
+// fires (once) after the lock is released, as in complete.
 func (s *session) markTerminated() bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.state != SessionRunning {
+		s.mu.Unlock()
 		return false
 	}
 	s.state = SessionTerminated
 	s.result = &SubAgentResult{Outcome: "terminated"}
+	s.terminal.Store(true)
 	close(s.done)
+	onTerminal := s.onTerminal
+	s.mu.Unlock()
+
+	if onTerminal != nil {
+		onTerminal()
+	}
 	return true
 }
 
@@ -139,10 +171,10 @@ func (s *session) markTerminated() bool {
 // correlates the response; the local backend runs SpawnSubAgent in a
 // goroutine.
 type sessionBackend interface {
-	// start kicks off the sub-agent for sess, arranging for sess.complete
-	// to be called when it finishes. It must not block on the result. The
-	// returned id becomes the session's public handle.
-	start(sess *session, cfg SubAgentConfig) (id string, err error)
+	// start kicks off the sub-agent for sess under the manager-allocated
+	// id, arranging for sess.complete to be called when it finishes. It
+	// must not block on the result.
+	start(sess *session, cfg SubAgentConfig, id string) error
 	// terminate signals the backend to stop sess's in-flight work.
 	terminate(sess *session)
 }
@@ -155,13 +187,19 @@ type sessionBackend interface {
 type SessionManager struct {
 	backend       sessionBackend
 	maxConcurrent int
+	maxTotal      int
 	defaultWait   time.Duration
 	logger        *slog.Logger
 
 	bgCtx  context.Context
 	cancel context.CancelFunc
 
-	mu       sync.Mutex
+	mu sync.Mutex
+	// running is the count of sessions still in the running state. It is
+	// the authoritative concurrency gauge — reserved under mu in Start
+	// before the backend dispatches (so concurrent Starts cannot both pass
+	// the cap) and released exactly once per session via onTerminal.
+	running  int
 	sessions map[string]*session
 	seq      int
 }
@@ -219,11 +257,16 @@ func NewSessionManager(opts SessionManagerOptions) (*SessionManager, error) {
 
 	m := &SessionManager{
 		maxConcurrent: maxConcurrent,
-		defaultWait:   defaultWait,
-		logger:        logger,
-		bgCtx:         bgCtx,
-		cancel:        cancel,
-		sessions:      make(map[string]*session),
+		// Retain up to a small multiple of the live cap so terminal
+		// sessions stay inspectable, but evict oldest-first past the
+		// ceiling so a long run that starts (and forgets) many sessions
+		// cannot grow the registry without bound.
+		maxTotal:    maxConcurrent * sessionRetentionFactor,
+		defaultWait: defaultWait,
+		logger:      logger,
+		bgCtx:       bgCtx,
+		cancel:      cancel,
+		sessions:    make(map[string]*session),
 	}
 
 	if opts.UseTransport {
@@ -249,7 +292,6 @@ func NewSessionManager(opts SessionManagerOptions) (*SessionManager, error) {
 			parent:       opts.Parent,
 			parentConfig: opts.ParentConfig,
 			bgCtx:        bgCtx,
-			nextID:       m.nextLocalID,
 		}
 	}
 
@@ -276,9 +318,11 @@ func (m *SessionManager) Close() error {
 }
 
 // Start dispatches a new detached session and returns its handle. It
-// enforces the live-session cap. The session persists in the registry
-// until the manager is Closed, so a later Status/Wait can observe its
-// result.
+// reserves a concurrency slot atomically (so concurrent Starts cannot both
+// pass a full cap), allocates an unguessable id, dispatches the backend,
+// and registers the session. The session persists in the registry until it
+// is evicted or the manager is Closed, so a later Status/Wait can observe
+// its result.
 func (m *SessionManager) Start(cfg SubAgentConfig) (string, error) {
 	if cfg.Prompt == "" {
 		return "", errors.New("session prompt must not be empty")
@@ -287,37 +331,83 @@ func (m *SessionManager) Start(cfg SubAgentConfig) (string, error) {
 		return "", err
 	}
 
-	sess := &session{done: make(chan struct{}), state: SessionRunning}
-	id, err := m.backend.start(sess, cfg)
-	if err != nil {
+	id := newSessionID()
+	// onTerminal releases the slot exactly once, when the session first
+	// leaves the running state (via complete or markTerminated).
+	sess := &session{id: id, done: make(chan struct{}), state: SessionRunning, onTerminal: m.releaseSlot}
+
+	if err := m.backend.start(sess, cfg, id); err != nil {
+		// Roll back the reserved slot: the session never started, so its
+		// onTerminal will never fire.
+		m.releaseSlot()
 		return "", err
 	}
-	sess.id = id
 
 	m.mu.Lock()
 	m.seq++
 	sess.seq = m.seq
+	m.evictLocked()
 	m.sessions[id] = sess
 	m.mu.Unlock()
 	return id, nil
 }
 
-// reserveSlot fails when the number of running sessions has reached the
-// configured cap. Terminal sessions (done/error/terminated) do not count
-// against the cap — they are kept only for later inspection.
+// reserveSlot claims a running-session slot, failing when the cap is
+// already reached. Terminal sessions do not hold a slot (it is released in
+// onTerminal), so the cap bounds concurrency, not total retention.
 func (m *SessionManager) reserveSlot() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	running := 0
-	for _, s := range m.sessions {
-		if !s.isTerminal() {
-			running++
-		}
+	if m.running >= m.maxConcurrent {
+		return fmt.Errorf("session limit reached: %d concurrent sessions already running (max %d)", m.running, m.maxConcurrent)
 	}
-	if running >= m.maxConcurrent {
-		return fmt.Errorf("session limit reached: %d concurrent sessions already running (max %d)", running, m.maxConcurrent)
-	}
+	m.running++
 	return nil
+}
+
+// releaseSlot returns a running-session slot to the pool. Called exactly
+// once per reserved slot: from onTerminal when a session reaches a terminal
+// state, or directly from Start to roll back a backend that failed to
+// dispatch.
+func (m *SessionManager) releaseSlot() {
+	m.mu.Lock()
+	if m.running > 0 {
+		m.running--
+	}
+	m.mu.Unlock()
+}
+
+// evictLocked drops oldest-first terminal sessions while the registry is at
+// or above its retention ceiling. Caller holds m.mu. It reads each
+// session's terminal flag atomically rather than taking s.mu, so it cannot
+// invert the s.mu -> m.mu order that onTerminal relies on. Running sessions
+// are never evicted; since running is capped below maxTotal there is always
+// a terminal victim when the ceiling is hit.
+func (m *SessionManager) evictLocked() {
+	for len(m.sessions) >= m.maxTotal {
+		victimID := ""
+		victimSeq := int(^uint(0) >> 1) // max int
+		for id, s := range m.sessions {
+			if s.isTerminal() && s.seq < victimSeq {
+				victimID, victimSeq = id, s.seq
+			}
+		}
+		if victimID == "" {
+			return
+		}
+		delete(m.sessions, victimID)
+	}
+}
+
+// newSessionID returns an unguessable session handle. The random suffix
+// stops a prompt-injected model from iterating session-N ids to interfere
+// with sibling sessions it did not start. crypto/rand.Read never fails on
+// supported platforms; a read error degrades to a still-unique but
+// lower-entropy id rather than aborting the spawn.
+func newSessionID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "session-" + hex.EncodeToString(b[:])
 }
 
 // Status returns a non-blocking snapshot of a session. An unknown id
@@ -393,7 +483,12 @@ func (m *SessionManager) SpawnAndWait(ctx context.Context, cfg SubAgentConfig, t
 		}
 		return &SubAgentResult{Outcome: string(st.State)}, nil
 	default:
-		// Still running after the wait timed out.
+		// Still running after the wait timed out. A blocking spawn that
+		// times out has no later wait to collect the result, so terminate
+		// the session to stop the backend's work — otherwise the
+		// control-plane job (or local goroutine) would run on, orphaned,
+		// until its own lifetime cap.
+		_ = m.Terminate(id)
 		return &SubAgentResult{
 			Outcome: "timeout",
 			Output:  fmt.Sprintf("spawn_agent timed out after %s waiting for the sub-agent result", timeout),
@@ -413,14 +508,7 @@ func (m *SessionManager) forget(id string) {
 	m.mu.Unlock()
 }
 
-func (m *SessionManager) nextLocalID() string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.seq++
-	return fmt.Sprintf("session-%d", m.seq)
-}
-
-// --- transport backend -----------------------------------------------------
+// transport backend.
 
 type transportSessionBackend struct {
 	transport   transport.Transport
@@ -430,27 +518,28 @@ type transportSessionBackend struct {
 	complete    func(payload any) *SubAgentResult
 }
 
-func (b *transportSessionBackend) start(sess *session, cfg SubAgentConfig) (string, error) {
+func (b *transportSessionBackend) start(sess *session, cfg SubAgentConfig, id string) error {
 	input, err := json.Marshal(cfg)
 	if err != nil {
-		return "", fmt.Errorf("marshal sub-agent config: %w", err)
+		return fmt.Errorf("marshal sub-agent config: %w", err)
 	}
 
-	id, err := b.correlator.StartPending(func(requestID string) error {
+	if err := b.correlator.StartPendingWithID(id, func(requestID string) error {
 		return b.transport.Emit(types.HarnessEvent{
 			Type:      "tool_result_request",
 			RequestID: requestID,
 			ToolName:  "spawn_agent",
 			Input:     input,
 		})
-	})
-	if err != nil {
-		return "", err
+	}); err != nil {
+		return err
 	}
 
 	// Await the control-plane response on the manager's background context
-	// so the session survives the turn that spawned it. The entry is
-	// Forgotten once resolved — the durable result lives on the session.
+	// so the session survives the turn that spawned it. Forget on every
+	// exit so a terminated/timed-out session's correlator entry is dropped
+	// promptly (Forget also unblocks a parked AwaitID); the durable result
+	// lives on the session, not the correlator.
 	go func() {
 		defer b.correlator.Forget(id)
 		payload, awaitErr := b.correlator.AwaitID(b.bgCtx, id, b.maxLifetime)
@@ -460,7 +549,7 @@ func (b *transportSessionBackend) start(sess *session, cfg SubAgentConfig) (stri
 		}
 		sess.complete(b.complete(payload))
 	}()
-	return id, nil
+	return nil
 }
 
 func (b *transportSessionBackend) terminate(sess *session) {
@@ -475,8 +564,14 @@ func (b *transportSessionBackend) terminate(sess *session) {
 }
 
 // completeFromAsyncResult translates a correlator payload (always an
-// asyncToolResult from extractAsyncToolResult) into a SubAgentResult. On a
-// successful response the content is the control plane's serialised
+// asyncToolResult from extractAsyncToolResult) into a SubAgentResult.
+//
+// The control plane is partially trusted: it could embed secret-shaped
+// strings in a response. Every content path is scrubbed before it becomes
+// the SubAgentResult.Output, because that value flows into the model
+// context and the JSONL trace before the outbound transport scrub can act —
+// matching dispatchAsyncToolCall's point-of-entry scrub on the error path.
+// On a successful response the content is the control plane's serialised
 // SubAgentResult JSON; if it does not parse, the raw content is surfaced
 // as the output so nothing is silently lost.
 func completeFromAsyncResult(payload any) *SubAgentResult {
@@ -489,17 +584,21 @@ func completeFromAsyncResult(payload any) *SubAgentResult {
 	}
 	var sr SubAgentResult
 	if err := json.Unmarshal([]byte(res.content), &sr); err != nil || sr.Outcome == "" {
-		return &SubAgentResult{Outcome: "done", Output: res.content}
+		return &SubAgentResult{Outcome: "done", Output: security.Scrub(res.content)}
 	}
+	sr.Output = security.Scrub(sr.Output)
 	return &sr
 }
 
 // sessionResultFromAwaitErr maps a correlator await error onto a distinct
 // SubAgentResult.Outcome, mirroring dispatchAsyncToolCall so the failure
-// vocabulary is identical across the blocking and detached paths.
+// vocabulary is identical across the blocking and detached paths. The
+// default arm treats any unrecognised correlator failure as a timeout —
+// the conservative choice for the model, which then knows the result did
+// not arrive.
 func sessionResultFromAwaitErr(err error) *SubAgentResult {
 	switch {
-	case strings.Contains(err.Error(), "emit failed"):
+	case errors.Is(err, transport.ErrEmitFailed):
 		return &SubAgentResult{Outcome: "transport_disconnect", Output: err.Error()}
 	case errors.Is(err, context.DeadlineExceeded):
 		return &SubAgentResult{Outcome: "timeout", Output: err.Error()}
@@ -510,20 +609,27 @@ func sessionResultFromAwaitErr(err error) *SubAgentResult {
 	}
 }
 
-// --- local backend ---------------------------------------------------------
+// local backend.
 
 type localSessionBackend struct {
 	parent       *AgenticLoop
 	parentConfig *types.RunConfig
 	bgCtx        context.Context
-	nextID       func() string
 }
 
-func (b *localSessionBackend) start(sess *session, cfg SubAgentConfig) (string, error) {
-	id := b.nextID()
+// start runs the sub-agent in a background goroutine. SpawnSubAgent reuses
+// the parent loop's Provider, Executor, Edit and Tools while giving the
+// child its own message history, context strategy, transport, and (for
+// Cedar) a cloned permission policy. Those reused components are the same
+// ones the parallel async-tool dispatch path (#184) already drives
+// concurrently via multiple in-flight spawn_agent calls, so concurrent use
+// here is on the same footing — detached sessions only widen the window,
+// they do not introduce a new sharing pattern. cancel is stored for
+// Terminate / manager Close.
+func (b *localSessionBackend) start(sess *session, cfg SubAgentConfig, _ string) error {
 	// Derive from the manager's background context, not the spawning tool
 	// call's ctx, so a detached session keeps running after the call that
-	// started it returns. cancel is stored for Terminate.
+	// started it returns.
 	childCtx, cancel := context.WithCancel(b.bgCtx)
 	sess.cancel = cancel
 
@@ -536,7 +642,7 @@ func (b *localSessionBackend) start(sess *session, cfg SubAgentConfig) (string, 
 		}
 		sess.complete(result)
 	}()
-	return id, nil
+	return nil
 }
 
 func (b *localSessionBackend) terminate(sess *session) {
@@ -545,7 +651,7 @@ func (b *localSessionBackend) terminate(sess *session) {
 	}
 }
 
-// --- builtins.SessionController adapter ------------------------------------
+// builtins.SessionController adapter.
 
 // sessionController adapts *SessionManager to builtins.SessionController,
 // marshalling typed SessionStatus snapshots to JSON at the package boundary
@@ -558,6 +664,11 @@ func newSessionController(mgr *SessionManager) sessionController {
 	return sessionController{mgr: mgr}
 }
 
+// Start ignores the tool-call context deliberately: a detached session
+// must outlive the call that started it, so the underlying work derives
+// from the manager's background context (cancelled on run end), not from
+// the per-call ctx. Wait, by contrast, threads ctx through so a blocking
+// wait unblocks on run cancellation.
 func (c sessionController) Start(_ context.Context, prompt, mode string, maxTurns int) (string, error) {
 	return c.mgr.Start(SubAgentConfig{Prompt: prompt, Mode: mode, MaxTurns: maxTurns})
 }

--- a/harness/internal/core/session.go
+++ b/harness/internal/core/session.go
@@ -1,0 +1,545 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// SessionState is the lifecycle state of a sub-agent session (issue #71).
+//
+//   - running    — the sub-agent has been dispatched; no result yet.
+//   - done       — the sub-agent finished with a non-error outcome.
+//   - error      — the sub-agent finished with an error outcome (child
+//     failure, upstream control-plane error, transport disconnect, or
+//     timeout). The accompanying SubAgentResult.Outcome distinguishes them.
+//   - terminated — the session was explicitly terminated by the agent
+//     before it finished.
+//   - not_found  — returned for a lookup against an unknown session id; it
+//     is never stored on a live session.
+type SessionState string
+
+const (
+	SessionRunning    SessionState = "running"
+	SessionDone       SessionState = "done"
+	SessionError      SessionState = "error"
+	SessionTerminated SessionState = "terminated"
+	SessionNotFound   SessionState = "not_found"
+)
+
+// SessionStatus is the snapshot returned by Status/Wait and serialised to
+// the model by the session tools. Result is populated once the session
+// reaches a terminal state (done/error/terminated).
+type SessionStatus struct {
+	SessionID string          `json:"sessionId"`
+	State     SessionState    `json:"state"`
+	Result    *SubAgentResult `json:"result,omitempty"`
+}
+
+// errorOutcomes are the SubAgentResult.Outcome values that map a terminal
+// session to SessionError rather than SessionDone. The transport failure
+// outcomes mirror dispatchAsyncToolCall's error taxonomy so a session and
+// a blocking async tool surface the same vocabulary.
+var errorOutcomes = map[string]bool{
+	"error":                true,
+	"upstream_error":       true,
+	"transport_disconnect": true,
+	"timeout":              true,
+	"cancelled":            true,
+}
+
+// subAgentExcludedTools is the set of tool IDs withheld from a spawned
+// sub-agent's registry. spawn_agent prevents unbounded recursion; the
+// session tools prevent a sub-agent from opening its own detached
+// sessions (which would escape the parent's concurrency cap and lifetime
+// management). Kept as one list so the recursion guard cannot drift
+// between the blocking and detached spawn paths.
+var subAgentExcludedTools = []string{
+	"spawn_agent",
+	"start_session",
+	"check_session",
+	"wait_session",
+	"terminate_session",
+}
+
+// session is one entry in the SessionManager's registry. state/result are
+// guarded by mu; done is closed exactly once when the session reaches a
+// terminal state, unblocking Wait. cancel stops the backend's work (local
+// backend only).
+type session struct {
+	id   string
+	seq  int
+	mu   sync.Mutex
+	done chan struct{}
+
+	state  SessionState
+	result *SubAgentResult
+
+	cancel context.CancelFunc
+}
+
+func (s *session) status() SessionStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return SessionStatus{SessionID: s.id, State: s.state, Result: s.result}
+}
+
+func (s *session) isTerminal() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state != SessionRunning
+}
+
+// complete transitions a running session to its terminal state. A no-op if
+// the session is already terminal (e.g. terminated while a late backend
+// result was in flight), so the backend goroutine never panics on a double
+// close.
+func (s *session) complete(result *SubAgentResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != SessionRunning {
+		return
+	}
+	s.result = result
+	if result != nil && errorOutcomes[result.Outcome] {
+		s.state = SessionError
+	} else {
+		s.state = SessionDone
+	}
+	close(s.done)
+}
+
+// markTerminated transitions a running session to terminated. Returns true
+// if it made the transition (false if already terminal). The backend's
+// terminate signal is sent by the caller only on a true return.
+func (s *session) markTerminated() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != SessionRunning {
+		return false
+	}
+	s.state = SessionTerminated
+	s.result = &SubAgentResult{Outcome: "terminated"}
+	close(s.done)
+	return true
+}
+
+// sessionBackend produces a sub-agent result into a session and stops its
+// work on terminate. The transport backend dispatches over the wire and
+// correlates the response; the local backend runs SpawnSubAgent in a
+// goroutine.
+type sessionBackend interface {
+	// start kicks off the sub-agent for sess, arranging for sess.complete
+	// to be called when it finishes. It must not block on the result. The
+	// returned id becomes the session's public handle.
+	start(sess *session, cfg SubAgentConfig) (id string, err error)
+	// terminate signals the backend to stop sess's in-flight work.
+	terminate(sess *session)
+}
+
+// SessionManager owns the registry of sub-agent sessions for one run and
+// brokers the start/wait/status/terminate lifecycle behind whichever
+// backend the run's spawner selects. It backs both the start-and-detach
+// session tools (#71) and the blocking transport spawn_agent (#54), which
+// is Start+Wait fused.
+type SessionManager struct {
+	backend       sessionBackend
+	maxConcurrent int
+	defaultWait   time.Duration
+	logger        *slog.Logger
+
+	bgCtx  context.Context
+	cancel context.CancelFunc
+
+	mu       sync.Mutex
+	sessions map[string]*session
+	seq      int
+}
+
+// SessionManagerOptions configures NewSessionManager.
+type SessionManagerOptions struct {
+	// UseTransport selects the transport backend (spawner=="transport").
+	// When false the local in-process backend is used.
+	UseTransport bool
+
+	// Transport is the live control-plane transport. Required (and must
+	// not be a NullTransport) when UseTransport is true.
+	Transport transport.Transport
+
+	// Parent and ParentConfig are required by the local backend to run
+	// SpawnSubAgent. The transport backend ignores Parent.
+	Parent       *AgenticLoop
+	ParentConfig *types.RunConfig
+
+	// MaxConcurrent caps simultaneously-running detached sessions.
+	MaxConcurrent int
+
+	// DefaultWait is the per-wait timeout applied when a caller passes a
+	// non-positive timeout.
+	DefaultWait time.Duration
+
+	// MaxLifetime bounds how long the transport backend waits for a single
+	// session's response before resolving it as a timeout. Sessions are
+	// also torn down when the manager is Closed (run end).
+	MaxLifetime time.Duration
+
+	Logger *slog.Logger
+}
+
+// NewSessionManager constructs a SessionManager. It returns an error when
+// the transport backend is requested without a transport that can deliver
+// control-plane responses — the config-time analogue of
+// dispatchAsyncToolCall's fast-fail, surfaced here so the misconfiguration
+// is caught at factory construction rather than on the first spawn.
+func NewSessionManager(opts SessionManagerOptions) (*SessionManager, error) {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	defaultWait := opts.DefaultWait
+	if defaultWait <= 0 {
+		defaultWait = DefaultAsyncToolTimeout
+	}
+	maxConcurrent := opts.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = types.DefaultMaxConcurrentSessions
+	}
+
+	bgCtx, cancel := context.WithCancel(context.Background())
+
+	m := &SessionManager{
+		maxConcurrent: maxConcurrent,
+		defaultWait:   defaultWait,
+		logger:        logger,
+		bgCtx:         bgCtx,
+		cancel:        cancel,
+		sessions:      make(map[string]*session),
+	}
+
+	if opts.UseTransport {
+		if opts.Transport == nil || transport.IsNull(opts.Transport) {
+			cancel()
+			return nil, errors.New("session manager: transport spawner requires a live control-plane transport, but the loop has none")
+		}
+		maxLifetime := opts.MaxLifetime
+		if maxLifetime <= 0 {
+			maxLifetime = time.Hour
+		}
+		correlator := transport.NewCorrelator("session")
+		correlator.AttachTo(opts.Transport, extractAsyncToolResult)
+		m.backend = &transportSessionBackend{
+			transport:   opts.Transport,
+			correlator:  correlator,
+			bgCtx:       bgCtx,
+			maxLifetime: maxLifetime,
+			complete:    completeFromAsyncResult,
+		}
+	} else {
+		m.backend = &localSessionBackend{
+			parent:       opts.Parent,
+			parentConfig: opts.ParentConfig,
+			bgCtx:        bgCtx,
+			nextID:       m.nextLocalID,
+		}
+	}
+
+	return m, nil
+}
+
+// Close cancels every live session and releases the manager's background
+// context. Idempotent. Wired into the loop's owned closers so sessions do
+// not outlive the run.
+func (m *SessionManager) Close() error {
+	m.cancel()
+	m.mu.Lock()
+	live := make([]*session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		live = append(live, s)
+	}
+	m.mu.Unlock()
+	for _, s := range live {
+		if s.markTerminated() {
+			m.backend.terminate(s)
+		}
+	}
+	return nil
+}
+
+// Start dispatches a new detached session and returns its handle. It
+// enforces the live-session cap. The session persists in the registry
+// until the manager is Closed, so a later Status/Wait can observe its
+// result.
+func (m *SessionManager) Start(cfg SubAgentConfig) (string, error) {
+	if cfg.Prompt == "" {
+		return "", errors.New("session prompt must not be empty")
+	}
+	if err := m.reserveSlot(); err != nil {
+		return "", err
+	}
+
+	sess := &session{done: make(chan struct{}), state: SessionRunning}
+	id, err := m.backend.start(sess, cfg)
+	if err != nil {
+		return "", err
+	}
+	sess.id = id
+
+	m.mu.Lock()
+	m.seq++
+	sess.seq = m.seq
+	m.sessions[id] = sess
+	m.mu.Unlock()
+	return id, nil
+}
+
+// reserveSlot fails when the number of running sessions has reached the
+// configured cap. Terminal sessions (done/error/terminated) do not count
+// against the cap — they are kept only for later inspection.
+func (m *SessionManager) reserveSlot() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	running := 0
+	for _, s := range m.sessions {
+		if !s.isTerminal() {
+			running++
+		}
+	}
+	if running >= m.maxConcurrent {
+		return fmt.Errorf("session limit reached: %d concurrent sessions already running (max %d)", running, m.maxConcurrent)
+	}
+	return nil
+}
+
+// Status returns a non-blocking snapshot of a session. An unknown id
+// yields a not_found status rather than an error so the model gets a
+// structured answer it can reason about.
+func (m *SessionManager) Status(id string) SessionStatus {
+	sess := m.get(id)
+	if sess == nil {
+		return SessionStatus{SessionID: id, State: SessionNotFound}
+	}
+	return sess.status()
+}
+
+// Wait blocks until the session reaches a terminal state, the timeout
+// elapses, or ctx is cancelled, then returns the current snapshot. A
+// timeout is not an error: the returned status simply still reads
+// "running", and the caller may wait again. An unknown id yields
+// not_found.
+func (m *SessionManager) Wait(ctx context.Context, id string, timeout time.Duration) SessionStatus {
+	sess := m.get(id)
+	if sess == nil {
+		return SessionStatus{SessionID: id, State: SessionNotFound}
+	}
+	if timeout <= 0 {
+		timeout = m.defaultWait
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-sess.done:
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+	return sess.status()
+}
+
+// Terminate stops a session's in-flight work and marks it terminated.
+// Unknown ids return an error so the model learns the handle was invalid.
+func (m *SessionManager) Terminate(id string) error {
+	sess := m.get(id)
+	if sess == nil {
+		return fmt.Errorf("unknown session %q", id)
+	}
+	if sess.markTerminated() {
+		m.backend.terminate(sess)
+	}
+	return nil
+}
+
+// SpawnAndWait is the blocking transport spawn_agent path (#54): Start +
+// Wait fused, with the session removed from the registry on return so a
+// one-shot blocking spawn does not linger as a detached session or count
+// against the concurrency cap beyond its own lifetime.
+func (m *SessionManager) SpawnAndWait(ctx context.Context, cfg SubAgentConfig, timeout time.Duration) (*SubAgentResult, error) {
+	id, err := m.Start(cfg)
+	if err != nil {
+		// A start failure (emit/transport) is surfaced as a result, not a
+		// Go error, so spawn_agent behaves like its in-process sibling,
+		// which encodes failure in the result rather than failing the tool.
+		return &SubAgentResult{Outcome: "transport_disconnect", Output: err.Error()}, nil
+	}
+	defer m.forget(id)
+
+	if timeout <= 0 {
+		timeout = m.defaultWait
+	}
+	st := m.Wait(ctx, id, timeout)
+	switch st.State {
+	case SessionDone, SessionError, SessionTerminated:
+		if st.Result != nil {
+			return st.Result, nil
+		}
+		return &SubAgentResult{Outcome: string(st.State)}, nil
+	default:
+		// Still running after the wait timed out.
+		return &SubAgentResult{
+			Outcome: "timeout",
+			Output:  fmt.Sprintf("spawn_agent timed out after %s waiting for the sub-agent result", timeout),
+		}, nil
+	}
+}
+
+func (m *SessionManager) get(id string) *session {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sessions[id]
+}
+
+func (m *SessionManager) forget(id string) {
+	m.mu.Lock()
+	delete(m.sessions, id)
+	m.mu.Unlock()
+}
+
+func (m *SessionManager) nextLocalID() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.seq++
+	return fmt.Sprintf("session-%d", m.seq)
+}
+
+// --- transport backend -----------------------------------------------------
+
+type transportSessionBackend struct {
+	transport   transport.Transport
+	correlator  *transport.Correlator
+	bgCtx       context.Context
+	maxLifetime time.Duration
+	complete    func(payload any) *SubAgentResult
+}
+
+func (b *transportSessionBackend) start(sess *session, cfg SubAgentConfig) (string, error) {
+	input, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("marshal sub-agent config: %w", err)
+	}
+
+	id, err := b.correlator.StartPending(func(requestID string) error {
+		return b.transport.Emit(types.HarnessEvent{
+			Type:      "tool_result_request",
+			RequestID: requestID,
+			ToolName:  "spawn_agent",
+			Input:     input,
+		})
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Await the control-plane response on the manager's background context
+	// so the session survives the turn that spawned it. The entry is
+	// Forgotten once resolved — the durable result lives on the session.
+	go func() {
+		defer b.correlator.Forget(id)
+		payload, awaitErr := b.correlator.AwaitID(b.bgCtx, id, b.maxLifetime)
+		if awaitErr != nil {
+			sess.complete(sessionResultFromAwaitErr(awaitErr))
+			return
+		}
+		sess.complete(b.complete(payload))
+	}()
+	return id, nil
+}
+
+func (b *transportSessionBackend) terminate(sess *session) {
+	// Best-effort: tell the control plane to stop the sub-agent job, then
+	// drop the correlator entry so the awaiting goroutine unwinds.
+	if err := b.transport.Emit(types.HarnessEvent{Type: "session_terminate", RequestID: sess.id}); err != nil {
+		// The transport is gone; the awaiting goroutine will resolve via
+		// the background context. Nothing more to do.
+		_ = err
+	}
+	b.correlator.Forget(sess.id)
+}
+
+// completeFromAsyncResult translates a correlator payload (always an
+// asyncToolResult from extractAsyncToolResult) into a SubAgentResult. On a
+// successful response the content is the control plane's serialised
+// SubAgentResult JSON; if it does not parse, the raw content is surfaced
+// as the output so nothing is silently lost.
+func completeFromAsyncResult(payload any) *SubAgentResult {
+	res, ok := payload.(asyncToolResult)
+	if !ok {
+		return &SubAgentResult{Outcome: "error", Output: fmt.Sprintf("unexpected session payload type %T", payload)}
+	}
+	if res.isError {
+		return &SubAgentResult{Outcome: "upstream_error", Output: security.Scrub(res.content)}
+	}
+	var sr SubAgentResult
+	if err := json.Unmarshal([]byte(res.content), &sr); err != nil || sr.Outcome == "" {
+		return &SubAgentResult{Outcome: "done", Output: res.content}
+	}
+	return &sr
+}
+
+// sessionResultFromAwaitErr maps a correlator await error onto a distinct
+// SubAgentResult.Outcome, mirroring dispatchAsyncToolCall so the failure
+// vocabulary is identical across the blocking and detached paths.
+func sessionResultFromAwaitErr(err error) *SubAgentResult {
+	switch {
+	case strings.Contains(err.Error(), "emit failed"):
+		return &SubAgentResult{Outcome: "transport_disconnect", Output: err.Error()}
+	case errors.Is(err, context.DeadlineExceeded):
+		return &SubAgentResult{Outcome: "timeout", Output: err.Error()}
+	case errors.Is(err, context.Canceled):
+		return &SubAgentResult{Outcome: "cancelled", Output: err.Error()}
+	default:
+		return &SubAgentResult{Outcome: "timeout", Output: err.Error()}
+	}
+}
+
+// --- local backend ---------------------------------------------------------
+
+type localSessionBackend struct {
+	parent       *AgenticLoop
+	parentConfig *types.RunConfig
+	bgCtx        context.Context
+	nextID       func() string
+}
+
+func (b *localSessionBackend) start(sess *session, cfg SubAgentConfig) (string, error) {
+	id := b.nextID()
+	// Derive from the manager's background context, not the spawning tool
+	// call's ctx, so a detached session keeps running after the call that
+	// started it returns. cancel is stored for Terminate.
+	childCtx, cancel := context.WithCancel(b.bgCtx)
+	sess.cancel = cancel
+
+	go func() {
+		defer cancel()
+		result, err := SpawnSubAgent(childCtx, b.parent, b.parentConfig, cfg)
+		if err != nil {
+			sess.complete(&SubAgentResult{Outcome: "error", Output: err.Error()})
+			return
+		}
+		sess.complete(result)
+	}()
+	return id, nil
+}
+
+func (b *localSessionBackend) terminate(sess *session) {
+	if sess.cancel != nil {
+		sess.cancel()
+	}
+}

--- a/harness/internal/core/session.go
+++ b/harness/internal/core/session.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool/builtins"
 	"github.com/rxbynerd/stirrup/harness/internal/transport"
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -542,4 +543,36 @@ func (b *localSessionBackend) terminate(sess *session) {
 	if sess.cancel != nil {
 		sess.cancel()
 	}
+}
+
+// --- builtins.SessionController adapter ------------------------------------
+
+// sessionController adapts *SessionManager to builtins.SessionController,
+// marshalling typed SessionStatus snapshots to JSON at the package boundary
+// so the builtins package stays free of a core import.
+type sessionController struct{ mgr *SessionManager }
+
+var _ builtins.SessionController = sessionController{}
+
+func newSessionController(mgr *SessionManager) sessionController {
+	return sessionController{mgr: mgr}
+}
+
+func (c sessionController) Start(_ context.Context, prompt, mode string, maxTurns int) (string, error) {
+	return c.mgr.Start(SubAgentConfig{Prompt: prompt, Mode: mode, MaxTurns: maxTurns})
+}
+
+func (c sessionController) Status(sessionID string) (json.RawMessage, error) {
+	return json.Marshal(c.mgr.Status(sessionID))
+}
+
+func (c sessionController) Wait(ctx context.Context, sessionID string, timeoutSeconds int) (json.RawMessage, error) {
+	return json.Marshal(c.mgr.Wait(ctx, sessionID, time.Duration(timeoutSeconds)*time.Second))
+}
+
+func (c sessionController) Terminate(sessionID string) (json.RawMessage, error) {
+	if err := c.mgr.Terminate(sessionID); err != nil {
+		return nil, err
+	}
+	return json.Marshal(c.mgr.Status(sessionID))
 }

--- a/harness/internal/core/session_integration_test.go
+++ b/harness/internal/core/session_integration_test.go
@@ -1,0 +1,198 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	pb "github.com/rxbynerd/stirrup/gen/harness/v1"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+)
+
+// stubControlPlane is a minimal HarnessService server for session
+// integration tests. When respond is set it echoes every tool_result_request
+// back as a tool_result_response carrying replyContent; it records the
+// request ids of any session_terminate events it receives.
+type stubControlPlane struct {
+	pb.UnimplementedHarnessServiceServer
+
+	respond      bool
+	replyContent string
+
+	mu          sync.Mutex
+	requestIDs  []string
+	terminateCh chan string
+}
+
+func (s *stubControlPlane) RunTask(stream pb.HarnessService_RunTaskServer) error {
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			return nil
+		}
+		switch ev.Type {
+		case "tool_result_request":
+			s.mu.Lock()
+			s.requestIDs = append(s.requestIDs, ev.RequestId)
+			s.mu.Unlock()
+			if s.respond {
+				_ = stream.Send(&pb.ControlEvent{
+					Type:      "tool_result_response",
+					RequestId: ev.RequestId,
+					Content:   s.replyContent,
+				})
+			}
+		case "session_terminate":
+			select {
+			case s.terminateCh <- ev.RequestId:
+			default:
+			}
+		}
+	}
+}
+
+func newSessionIntegrationTransport(t *testing.T, srv *stubControlPlane) *transport.GRPCTransport {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	pb.RegisterHarnessServiceServer(grpcServer, srv)
+	go func() { _ = grpcServer.Serve(lis) }()
+
+	tr, err := transport.NewGRPCTransport(context.Background(), "passthrough:///bufconn",
+		transport.WithDialOptions(
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+	)
+	if err != nil {
+		grpcServer.Stop()
+		t.Fatalf("NewGRPCTransport: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = tr.Close()
+		grpcServer.Stop()
+	})
+	return tr
+}
+
+// TestSessionIntegration_BlockingSpawn exercises the #54 transport spawner
+// end-to-end over a real gRPC transport: SpawnAndWait dispatches a
+// spawn-shaped tool_result_request and blocks on the control plane's
+// serialised SubAgentResult.
+func TestSessionIntegration_BlockingSpawn(t *testing.T) {
+	body, _ := json.Marshal(SubAgentResult{Outcome: "completed", Output: "from control plane", Turns: 2})
+	srv := &stubControlPlane{respond: true, replyContent: string(body), terminateCh: make(chan string, 1)}
+	tr := newSessionIntegrationTransport(t, srv)
+
+	mgr, err := NewSessionManager(SessionManagerOptions{
+		UseTransport: true,
+		Transport:    tr,
+		MaxConcurrent: 4,
+		DefaultWait:   5 * time.Second,
+		MaxLifetime:   5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	res, err := mgr.SpawnAndWait(context.Background(), SubAgentConfig{Prompt: "audit the redaction path", Mode: "research"}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("SpawnAndWait: %v", err)
+	}
+	if res.Outcome != "completed" || res.Output != "from control plane" || res.Turns != 2 {
+		t.Fatalf("result = %#v, want {completed, from control plane, 2}", res)
+	}
+}
+
+// TestSessionIntegration_DetachedLifecycle exercises the #71 start-and-detach
+// flow end-to-end: start returns immediately, the control plane later
+// responds, and wait collects the result.
+func TestSessionIntegration_DetachedLifecycle(t *testing.T) {
+	body, _ := json.Marshal(SubAgentResult{Outcome: "completed", Output: "findings packet", Turns: 6})
+	srv := &stubControlPlane{respond: true, replyContent: string(body), terminateCh: make(chan string, 1)}
+	tr := newSessionIntegrationTransport(t, srv)
+
+	mgr, err := NewSessionManager(SessionManagerOptions{
+		UseTransport: true,
+		Transport:    tr,
+		MaxConcurrent: 4,
+		DefaultWait:   5 * time.Second,
+		MaxLifetime:   5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	id, err := mgr.Start(SubAgentConfig{Prompt: "investigate flaky test"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait collects the result the control plane returned. (The stub
+	// responds immediately, so by the time Wait returns the session is
+	// terminal — the precise running->done transition is covered by the
+	// fake-transport unit tests, which can gate the response.)
+	st := mgr.Wait(context.Background(), id, 5*time.Second)
+	if st.State != SessionDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.Result == nil || st.Result.Output != "findings packet" {
+		t.Fatalf("result = %#v, want findings packet", st.Result)
+	}
+
+	// A subsequent check still observes the cached terminal result.
+	if again := mgr.Status(id); again.State != SessionDone {
+		t.Fatalf("re-check state = %q, want done", again.State)
+	}
+}
+
+// TestSessionIntegration_Terminate confirms that terminating a detached
+// session emits a session_terminate event the control plane receives.
+func TestSessionIntegration_Terminate(t *testing.T) {
+	// respond=false: the session stays running so we can terminate it.
+	srv := &stubControlPlane{respond: false, terminateCh: make(chan string, 1)}
+	tr := newSessionIntegrationTransport(t, srv)
+
+	mgr, err := NewSessionManager(SessionManagerOptions{
+		UseTransport: true,
+		Transport:    tr,
+		MaxConcurrent: 4,
+		DefaultWait:   2 * time.Second,
+		MaxLifetime:   5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	id, err := mgr.Start(SubAgentConfig{Prompt: "long running"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := mgr.Terminate(id); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if st := mgr.Status(id); st.State != SessionTerminated {
+		t.Fatalf("state = %q, want terminated", st.State)
+	}
+
+	select {
+	case got := <-srv.terminateCh:
+		if got != id {
+			t.Fatalf("session_terminate requestID = %q, want %q", got, id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("control plane did not receive session_terminate")
+	}
+}

--- a/harness/internal/core/session_integration_test.go
+++ b/harness/internal/core/session_integration_test.go
@@ -94,8 +94,8 @@ func TestSessionIntegration_BlockingSpawn(t *testing.T) {
 	tr := newSessionIntegrationTransport(t, srv)
 
 	mgr, err := NewSessionManager(SessionManagerOptions{
-		UseTransport: true,
-		Transport:    tr,
+		UseTransport:  true,
+		Transport:     tr,
 		MaxConcurrent: 4,
 		DefaultWait:   5 * time.Second,
 		MaxLifetime:   5 * time.Second,
@@ -123,8 +123,8 @@ func TestSessionIntegration_DetachedLifecycle(t *testing.T) {
 	tr := newSessionIntegrationTransport(t, srv)
 
 	mgr, err := NewSessionManager(SessionManagerOptions{
-		UseTransport: true,
-		Transport:    tr,
+		UseTransport:  true,
+		Transport:     tr,
 		MaxConcurrent: 4,
 		DefaultWait:   5 * time.Second,
 		MaxLifetime:   5 * time.Second,
@@ -165,8 +165,8 @@ func TestSessionIntegration_Terminate(t *testing.T) {
 	tr := newSessionIntegrationTransport(t, srv)
 
 	mgr, err := NewSessionManager(SessionManagerOptions{
-		UseTransport: true,
-		Transport:    tr,
+		UseTransport:  true,
+		Transport:     tr,
 		MaxConcurrent: 4,
 		DefaultWait:   2 * time.Second,
 		MaxLifetime:   5 * time.Second,

--- a/harness/internal/core/session_remediation_test.go
+++ b/harness/internal/core/session_remediation_test.go
@@ -1,0 +1,407 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// blockingBackend never completes its sessions and shares no state, so the
+// concurrency-cap hammer test can drive it under -race.
+type blockingBackend struct{}
+
+func (blockingBackend) start(_ *session, _ SubAgentConfig, _ string) error { return nil }
+func (blockingBackend) terminate(_ *session)                               {}
+
+// --- P0-B: concurrency cap under contention --------------------------------
+
+func TestSessionManager_ConcurrencyCap_Concurrent(t *testing.T) {
+	const limit = 3
+	m := newTestManager(blockingBackend{}, limit)
+
+	const goroutines = limit + 12
+	var ok, failed atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all at once to maximise contention
+			if _, err := m.Start(SubAgentConfig{Prompt: "x"}); err != nil {
+				failed.Add(1)
+			} else {
+				ok.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if ok.Load() != limit {
+		t.Fatalf("successful Starts = %d, want exactly %d (cap)", ok.Load(), limit)
+	}
+	if failed.Load() != goroutines-limit {
+		t.Fatalf("failed Starts = %d, want %d", failed.Load(), goroutines-limit)
+	}
+}
+
+// --- P0-A / P1-E: completeFromAsyncResult ----------------------------------
+
+func TestCompleteFromAsyncResult_ScrubsSuccessPath(t *testing.T) {
+	// A control plane returning a SubAgentResult whose Output embeds a
+	// secret-shaped string must be scrubbed before it becomes the result.
+	body, _ := json.Marshal(SubAgentResult{Outcome: "completed", Output: "leak: sk-ant-abc123_DEF-456"})
+	got := completeFromAsyncResult(asyncToolResult{content: string(body)})
+	if got.Outcome != "completed" {
+		t.Fatalf("outcome = %q, want completed", got.Outcome)
+	}
+	if want := security.Scrub("leak: sk-ant-abc123_DEF-456"); got.Output != want {
+		t.Fatalf("output = %q, want scrubbed %q", got.Output, want)
+	}
+	if got.Output == "leak: sk-ant-abc123_DEF-456" {
+		t.Fatal("success-path output was not scrubbed")
+	}
+}
+
+func TestCompleteFromAsyncResult_ScrubsRawFallback(t *testing.T) {
+	// Non-SubAgentResult JSON falls back to surfacing the raw content, which
+	// must also be scrubbed.
+	got := completeFromAsyncResult(asyncToolResult{content: "plain sk-ant-abc123_DEF-456 text"})
+	if got.Outcome != "done" {
+		t.Fatalf("outcome = %q, want done", got.Outcome)
+	}
+	if got.Output == "plain sk-ant-abc123_DEF-456 text" {
+		t.Fatal("fallback output was not scrubbed")
+	}
+}
+
+func TestCompleteFromAsyncResult_UpstreamErrorScrubbed(t *testing.T) {
+	got := completeFromAsyncResult(asyncToolResult{content: "boom sk-ant-abc123_DEF-456", isError: true})
+	if got.Outcome != "upstream_error" {
+		t.Fatalf("outcome = %q, want upstream_error", got.Outcome)
+	}
+	if got.Output == "boom sk-ant-abc123_DEF-456" {
+		t.Fatal("upstream error output was not scrubbed")
+	}
+}
+
+func TestCompleteFromAsyncResult_WrongType(t *testing.T) {
+	got := completeFromAsyncResult("not an asyncToolResult")
+	if got.Outcome != "error" {
+		t.Fatalf("outcome = %q, want error", got.Outcome)
+	}
+}
+
+func TestCompleteFromAsyncResult_MalformedJSON(t *testing.T) {
+	got := completeFromAsyncResult(asyncToolResult{content: "{not valid json"})
+	if got.Outcome != "done" {
+		t.Fatalf("outcome = %q, want done (raw fallback)", got.Outcome)
+	}
+	if got.Output != "{not valid json" {
+		t.Fatalf("output = %q, want raw content", got.Output)
+	}
+}
+
+// --- P1-A: failure-outcome taxonomy ----------------------------------------
+
+func TestSessionResultFromAwaitErr_Outcomes(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"emit failure", fmt.Errorf("%w: boom", transport.ErrEmitFailed), "transport_disconnect"},
+		{"deadline", fmt.Errorf("wrap: %w", context.DeadlineExceeded), "timeout"},
+		{"canceled", fmt.Errorf("wrap: %w", context.Canceled), "cancelled"},
+		{"unknown", errors.New("correlator: unknown request id"), "timeout"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionResultFromAwaitErr(tc.err); got.Outcome != tc.want {
+				t.Fatalf("outcome = %q, want %q", got.Outcome, tc.want)
+			}
+		})
+	}
+}
+
+// --- P0-C: SessionController adapter ----------------------------------------
+
+func TestSessionController_RoundTrip(t *testing.T) {
+	fb := &fakeSessionBackend{}
+	m := newTestManager(fb, 4)
+	ctrl := newSessionController(m)
+
+	id, err := ctrl.Start(context.Background(), "do work", "research", 5)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	statusJSON, err := ctrl.Status(id)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	var st SessionStatus
+	if err := json.Unmarshal(statusJSON, &st); err != nil {
+		t.Fatalf("Status JSON: %v", err)
+	}
+	if st.SessionID != id || st.State != SessionRunning {
+		t.Fatalf("status = %#v, want running %q", st, id)
+	}
+
+	// Terminate returns the post-terminate snapshot.
+	termJSON, err := ctrl.Terminate(id)
+	if err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if err := json.Unmarshal(termJSON, &st); err != nil {
+		t.Fatalf("Terminate JSON: %v", err)
+	}
+	if st.State != SessionTerminated {
+		t.Fatalf("post-terminate state = %q, want terminated", st.State)
+	}
+
+	// Terminate on an unknown id is an error surfaced to the caller.
+	if _, err := ctrl.Terminate("session-unknown"); err == nil {
+		t.Fatal("Terminate unknown: err = nil, want error")
+	}
+
+	// Wait on a terminal session returns immediately with the snapshot.
+	waitJSON, err := ctrl.Wait(context.Background(), id, 1)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := json.Unmarshal(waitJSON, &st); err != nil {
+		t.Fatalf("Wait JSON: %v", err)
+	}
+	if st.State != SessionTerminated {
+		t.Fatalf("wait state = %q, want terminated", st.State)
+	}
+}
+
+// --- P0-C: local backend ---------------------------------------------------
+
+func TestSessionManager_LocalBackend_StartAndComplete(t *testing.T) {
+	prov := &mockProvider{events: []types.StreamEvent{
+		{Type: "text_delta", Text: "local sub-agent output"},
+		{Type: "message_complete", StopReason: "end_turn"},
+	}}
+	parent := buildSubAgentTestLoop(prov)
+	parentConfig := buildTestConfig()
+
+	m, err := NewSessionManager(SessionManagerOptions{
+		UseTransport:  false,
+		Parent:        parent,
+		ParentConfig:  parentConfig,
+		MaxConcurrent: 4,
+		DefaultWait:   2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	id, err := m.Start(SubAgentConfig{Prompt: "do a local subtask"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	st := m.Wait(context.Background(), id, 2*time.Second)
+	if st.State != SessionDone {
+		t.Fatalf("state = %q, want done; result=%#v", st.State, st.Result)
+	}
+	if st.Result == nil || st.Result.Output != "local sub-agent output" {
+		t.Fatalf("result = %#v, want output 'local sub-agent output'", st.Result)
+	}
+}
+
+func TestSessionManager_LocalBackend_Terminate(t *testing.T) {
+	// slowProvider blocks until its context is cancelled, so the session
+	// stays running until Terminate cancels the child context.
+	parent := buildSubAgentTestLoop(&mockProvider{})
+	parent.Provider = &slowProvider{}
+	parentConfig := buildTestConfig()
+
+	m, err := NewSessionManager(SessionManagerOptions{
+		UseTransport:  false,
+		Parent:        parent,
+		ParentConfig:  parentConfig,
+		MaxConcurrent: 4,
+		DefaultWait:   time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	id, err := m.Start(SubAgentConfig{Prompt: "long local task"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := m.Terminate(id); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if st := m.Status(id); st.State != SessionTerminated {
+		t.Fatalf("state = %q, want terminated", st.State)
+	}
+}
+
+// --- P1-F: Wait honours context cancellation -------------------------------
+
+func TestSessionManager_Wait_CtxCancelled(t *testing.T) {
+	fb := &fakeSessionBackend{onStart: func(*session) {}} // never completes
+	m := newTestManager(fb, 4)
+	id, _ := m.Start(SubAgentConfig{Prompt: "x"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	// Long timeout: the only way Wait returns promptly is via ctx.
+	st := m.Wait(ctx, id, 10*time.Second)
+	if st.State != SessionRunning {
+		t.Fatalf("state = %q, want running (cancelled while in flight)", st.State)
+	}
+}
+
+// --- P1-C: out-of-order transport responses at the manager layer -----------
+
+func TestSessionManager_Transport_OutOfOrder(t *testing.T) {
+	tr := newAsyncTestTransport()
+	m := newTransportManager(t, tr)
+	defer func() { _ = m.Close() }()
+
+	id1, _ := m.Start(SubAgentConfig{Prompt: "one"})
+	id2, _ := m.Start(SubAgentConfig{Prompt: "two"})
+	if id1 == id2 {
+		t.Fatalf("session ids collided: %q", id1)
+	}
+
+	b1, _ := json.Marshal(SubAgentResult{Outcome: "completed", Output: "result-one"})
+	b2, _ := json.Marshal(SubAgentResult{Outcome: "completed", Output: "result-two"})
+	// Respond to the second session first.
+	tr.FireControl(types.ControlEvent{Type: "tool_result_response", RequestID: id2, Content: string(b2)})
+	tr.FireControl(types.ControlEvent{Type: "tool_result_response", RequestID: id1, Content: string(b1)})
+
+	st1 := m.Wait(context.Background(), id1, time.Second)
+	st2 := m.Wait(context.Background(), id2, time.Second)
+	if st1.Result == nil || st1.Result.Output != "result-one" {
+		t.Fatalf("id1 result = %#v, want result-one", st1.Result)
+	}
+	if st2.Result == nil || st2.Result.Output != "result-two" {
+		t.Fatalf("id2 result = %#v, want result-two", st2.Result)
+	}
+}
+
+// --- P1-G: terminate when the transport emit fails -------------------------
+
+func TestSessionManager_Transport_TerminateAfterTransportFail(t *testing.T) {
+	tr := newAsyncTestTransport()
+	m := newTransportManager(t, tr)
+	defer func() { _ = m.Close() }()
+
+	id, err := m.Start(SubAgentConfig{Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// The transport dies before terminate is emitted; terminate must still
+	// mark the session terminated without surfacing an error.
+	tr.emitErr = errors.New("stream closed")
+	if err := m.Terminate(id); err != nil {
+		t.Fatalf("Terminate after transport fail: %v", err)
+	}
+	if st := m.Status(id); st.State != SessionTerminated {
+		t.Fatalf("state = %q, want terminated", st.State)
+	}
+}
+
+// --- P0-D: Close tears down live sessions; goroutines unwind ----------------
+
+func TestSessionManager_Close_TerminatesLiveSessions(t *testing.T) {
+	fb := &fakeSessionBackend{onStart: func(*session) {}} // never complete
+	m := newTestManager(fb, 8)
+	id1, _ := m.Start(SubAgentConfig{Prompt: "a"})
+	id2, _ := m.Start(SubAgentConfig{Prompt: "b"})
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	for _, id := range []string{id1, id2} {
+		if st := m.Status(id); st.State != SessionTerminated {
+			t.Fatalf("session %s state after Close = %q, want terminated", id, st.State)
+		}
+	}
+	if fb.startedCount() != 2 {
+		t.Fatalf("started = %d, want 2", fb.startedCount())
+	}
+}
+
+func TestSessionManager_Transport_Close_UnwindsGoroutine(t *testing.T) {
+	tr := newAsyncTestTransport()
+	m := newTransportManager(t, tr)
+
+	id, err := m.Start(SubAgentConfig{Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	be := m.backend.(*transportSessionBackend)
+	if be.correlator.RetainedCount() != 1 {
+		t.Fatalf("RetainedCount before Close = %d, want 1", be.correlator.RetainedCount())
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if st := m.Status(id); st.State != SessionTerminated {
+		t.Fatalf("state after Close = %q, want terminated", st.State)
+	}
+	// The awaiting goroutine forgets its correlator entry as it unwinds.
+	waitForCondition(t, time.Second, func() bool { return be.correlator.RetainedCount() == 0 })
+}
+
+// --- P1-B: terminal sessions are evicted past the retention ceiling --------
+
+func TestSessionManager_EvictsTerminalSessionsPastCeiling(t *testing.T) {
+	// cap=1 -> maxTotal = sessionRetentionFactor. Each session completes
+	// immediately (onStart), so only terminal sessions accumulate; the map
+	// must never exceed maxTotal.
+	fb := &fakeSessionBackend{onStart: func(s *session) {
+		s.complete(&SubAgentResult{Outcome: "completed"})
+	}}
+	m := newTestManager(fb, 1)
+
+	for i := 0; i < sessionRetentionFactor*3; i++ {
+		if _, err := m.Start(SubAgentConfig{Prompt: "x"}); err != nil {
+			t.Fatalf("Start #%d: %v", i, err)
+		}
+	}
+	m.mu.Lock()
+	n := len(m.sessions)
+	m.mu.Unlock()
+	if n > m.maxTotal {
+		t.Fatalf("retained sessions = %d, want <= maxTotal %d", n, m.maxTotal)
+	}
+}
+
+func waitForCondition(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !cond() {
+		t.Fatal("condition not met within deadline")
+	}
+}

--- a/harness/internal/core/session_test.go
+++ b/harness/internal/core/session_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/harness/internal/transport"
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -313,5 +314,28 @@ func TestNewSessionManager_TransportOnNull(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("NewSessionManager(transport, NullTransport): err = nil, want misconfiguration error")
+	}
+}
+
+// TestSubAgentExcludedTools_RecursionGuard pins that a spawned sub-agent's
+// tool registry withholds spawn_agent AND every session tool, so a
+// sub-agent can neither recurse via spawn_agent nor open its own detached
+// sessions outside the parent's concurrency cap and lifetime management.
+func TestSubAgentExcludedTools_RecursionGuard(t *testing.T) {
+	parent := tool.NewRegistry()
+	keep := &tool.Tool{Name: "read_file", Handler: func(context.Context, json.RawMessage) (string, error) { return "", nil }}
+	parent.Register(keep)
+	for _, name := range subAgentExcludedTools {
+		parent.Register(&tool.Tool{Name: name, Handler: func(context.Context, json.RawMessage) (string, error) { return "", nil }})
+	}
+
+	child := filterToolRegistry(parent, subAgentExcludedTools...)
+	if child.Resolve("read_file") == nil {
+		t.Error("read_file should survive the sub-agent filter")
+	}
+	for _, name := range subAgentExcludedTools {
+		if child.Resolve(name) != nil {
+			t.Errorf("excluded tool %q leaked into the sub-agent registry", name)
+		}
 	}
 }

--- a/harness/internal/core/session_test.go
+++ b/harness/internal/core/session_test.go
@@ -205,8 +205,8 @@ func TestSessionManager_SpawnAndWait_StartFailure(t *testing.T) {
 func newTransportManager(t *testing.T, tr transport.Transport) *SessionManager {
 	t.Helper()
 	m, err := NewSessionManager(SessionManagerOptions{
-		UseTransport: true,
-		Transport:    tr,
+		UseTransport:  true,
+		Transport:     tr,
 		MaxConcurrent: 4,
 		DefaultWait:   time.Second,
 		MaxLifetime:   2 * time.Second,

--- a/harness/internal/core/session_test.go
+++ b/harness/internal/core/session_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,30 +16,40 @@ import (
 
 // fakeSessionBackend drives the SessionManager state machine without a real
 // sub-agent. onStart, when set, is invoked synchronously during start so a
-// test can complete (or not) the session deterministically.
+// test can complete (or not) the session deterministically. The slices are
+// mutex-guarded so the concurrency tests can hammer Start under -race.
 type fakeSessionBackend struct {
-	idCounter  int
-	startErr   error
-	onStart    func(sess *session)
+	startErr error
+	onStart  func(sess *session)
+
+	mu         sync.Mutex
 	started    []*session
 	terminated []*session
 }
 
-func (b *fakeSessionBackend) start(sess *session, _ SubAgentConfig) (string, error) {
+func (b *fakeSessionBackend) start(sess *session, _ SubAgentConfig, _ string) error {
 	if b.startErr != nil {
-		return "", b.startErr
+		return b.startErr
 	}
-	b.idCounter++
-	id := "session-" + strconv.Itoa(b.idCounter)
+	b.mu.Lock()
 	b.started = append(b.started, sess)
+	b.mu.Unlock()
 	if b.onStart != nil {
 		b.onStart(sess)
 	}
-	return id, nil
+	return nil
 }
 
 func (b *fakeSessionBackend) terminate(sess *session) {
+	b.mu.Lock()
 	b.terminated = append(b.terminated, sess)
+	b.mu.Unlock()
+}
+
+func (b *fakeSessionBackend) startedCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.started)
 }
 
 func newTestManager(b sessionBackend, maxConcurrent int) *SessionManager {
@@ -47,6 +57,7 @@ func newTestManager(b sessionBackend, maxConcurrent int) *SessionManager {
 	return &SessionManager{
 		backend:       b,
 		maxConcurrent: maxConcurrent,
+		maxTotal:      maxConcurrent * sessionRetentionFactor,
 		defaultWait:   50 * time.Millisecond,
 		logger:        slog.Default(),
 		bgCtx:         bg,

--- a/harness/internal/core/session_test.go
+++ b/harness/internal/core/session_test.go
@@ -1,0 +1,317 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeSessionBackend drives the SessionManager state machine without a real
+// sub-agent. onStart, when set, is invoked synchronously during start so a
+// test can complete (or not) the session deterministically.
+type fakeSessionBackend struct {
+	idCounter  int
+	startErr   error
+	onStart    func(sess *session)
+	started    []*session
+	terminated []*session
+}
+
+func (b *fakeSessionBackend) start(sess *session, _ SubAgentConfig) (string, error) {
+	if b.startErr != nil {
+		return "", b.startErr
+	}
+	b.idCounter++
+	id := "session-" + strconv.Itoa(b.idCounter)
+	b.started = append(b.started, sess)
+	if b.onStart != nil {
+		b.onStart(sess)
+	}
+	return id, nil
+}
+
+func (b *fakeSessionBackend) terminate(sess *session) {
+	b.terminated = append(b.terminated, sess)
+}
+
+func newTestManager(b sessionBackend, maxConcurrent int) *SessionManager {
+	bg, cancel := context.WithCancel(context.Background())
+	return &SessionManager{
+		backend:       b,
+		maxConcurrent: maxConcurrent,
+		defaultWait:   50 * time.Millisecond,
+		logger:        slog.Default(),
+		bgCtx:         bg,
+		cancel:        cancel,
+		sessions:      make(map[string]*session),
+	}
+}
+
+func TestSessionManager_StartStatusComplete(t *testing.T) {
+	fb := &fakeSessionBackend{}
+	m := newTestManager(fb, 4)
+
+	id, err := m.Start(SubAgentConfig{Prompt: "do a thing"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if st := m.Status(id); st.State != SessionRunning {
+		t.Fatalf("state after Start = %q, want running", st.State)
+	}
+
+	// Complete via the captured session, as a backend would.
+	fb.started[0].complete(&SubAgentResult{Outcome: "completed", Output: "ok", Turns: 3})
+
+	st := m.Status(id)
+	if st.State != SessionDone {
+		t.Fatalf("state after complete = %q, want done", st.State)
+	}
+	if st.Result == nil || st.Result.Output != "ok" || st.Result.Turns != 3 {
+		t.Fatalf("result = %#v, want {completed ok 3}", st.Result)
+	}
+
+	// Wait returns the terminal snapshot without blocking.
+	if w := m.Wait(context.Background(), id, time.Second); w.State != SessionDone {
+		t.Fatalf("Wait state = %q, want done", w.State)
+	}
+}
+
+func TestSessionManager_StartEmptyPrompt(t *testing.T) {
+	m := newTestManager(&fakeSessionBackend{}, 4)
+	if _, err := m.Start(SubAgentConfig{Prompt: ""}); err == nil {
+		t.Fatal("Start with empty prompt: err = nil, want error")
+	}
+}
+
+func TestSessionManager_ConcurrencyCap(t *testing.T) {
+	fb := &fakeSessionBackend{}
+	m := newTestManager(fb, 1)
+
+	id1, err := m.Start(SubAgentConfig{Prompt: "first"})
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if _, err := m.Start(SubAgentConfig{Prompt: "second"}); err == nil {
+		t.Fatal("second Start: err = nil, want session-limit error")
+	}
+
+	// Completing the first frees the slot.
+	fb.started[0].complete(&SubAgentResult{Outcome: "completed"})
+	if st := m.Status(id1); st.State != SessionDone {
+		t.Fatalf("id1 state = %q, want done", st.State)
+	}
+	if _, err := m.Start(SubAgentConfig{Prompt: "third"}); err != nil {
+		t.Fatalf("third Start after slot freed: %v", err)
+	}
+}
+
+func TestSessionManager_Terminate(t *testing.T) {
+	fb := &fakeSessionBackend{}
+	m := newTestManager(fb, 4)
+
+	id, _ := m.Start(SubAgentConfig{Prompt: "long task"})
+	if err := m.Terminate(id); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	st := m.Status(id)
+	if st.State != SessionTerminated {
+		t.Fatalf("state after Terminate = %q, want terminated", st.State)
+	}
+	if len(fb.terminated) != 1 {
+		t.Fatalf("backend.terminate calls = %d, want 1", len(fb.terminated))
+	}
+	// Terminating again (already terminal) does not re-signal the backend.
+	_ = m.Terminate(id)
+	if len(fb.terminated) != 1 {
+		t.Fatalf("backend.terminate calls after second Terminate = %d, want 1", len(fb.terminated))
+	}
+}
+
+func TestSessionManager_TerminateUnknown(t *testing.T) {
+	m := newTestManager(&fakeSessionBackend{}, 4)
+	if err := m.Terminate("session-404"); err == nil {
+		t.Fatal("Terminate unknown: err = nil, want error")
+	}
+}
+
+func TestSessionManager_StatusAndWaitNotFound(t *testing.T) {
+	m := newTestManager(&fakeSessionBackend{}, 4)
+	if st := m.Status("nope"); st.State != SessionNotFound {
+		t.Fatalf("Status unknown = %q, want not_found", st.State)
+	}
+	if st := m.Wait(context.Background(), "nope", 10*time.Millisecond); st.State != SessionNotFound {
+		t.Fatalf("Wait unknown = %q, want not_found", st.State)
+	}
+}
+
+func TestSessionManager_SpawnAndWait_Happy(t *testing.T) {
+	fb := &fakeSessionBackend{onStart: func(s *session) {
+		s.complete(&SubAgentResult{Outcome: "completed", Output: "result text", Turns: 2})
+	}}
+	m := newTestManager(fb, 4)
+
+	res, err := m.SpawnAndWait(context.Background(), SubAgentConfig{Prompt: "go"}, time.Second)
+	if err != nil {
+		t.Fatalf("SpawnAndWait: %v", err)
+	}
+	if res.Outcome != "completed" || res.Output != "result text" {
+		t.Fatalf("result = %#v, want {completed result text}", res)
+	}
+	// The one-shot spawn is forgotten, leaving no lingering session.
+	if len(m.sessions) != 0 {
+		t.Fatalf("sessions after SpawnAndWait = %d, want 0", len(m.sessions))
+	}
+}
+
+func TestSessionManager_SpawnAndWait_Timeout(t *testing.T) {
+	// Backend never completes the session.
+	fb := &fakeSessionBackend{onStart: func(*session) {}}
+	m := newTestManager(fb, 4)
+
+	res, err := m.SpawnAndWait(context.Background(), SubAgentConfig{Prompt: "go"}, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("SpawnAndWait: %v", err)
+	}
+	if res.Outcome != "timeout" {
+		t.Fatalf("outcome = %q, want timeout", res.Outcome)
+	}
+	if len(m.sessions) != 0 {
+		t.Fatalf("sessions after timed-out SpawnAndWait = %d, want 0 (forgotten)", len(m.sessions))
+	}
+}
+
+func TestSessionManager_SpawnAndWait_StartFailure(t *testing.T) {
+	fb := &fakeSessionBackend{startErr: errors.New("correlator: emit failed: boom")}
+	m := newTestManager(fb, 4)
+	res, err := m.SpawnAndWait(context.Background(), SubAgentConfig{Prompt: "go"}, time.Second)
+	if err != nil {
+		t.Fatalf("SpawnAndWait: %v", err)
+	}
+	if res.Outcome != "transport_disconnect" {
+		t.Fatalf("outcome = %q, want transport_disconnect", res.Outcome)
+	}
+}
+
+// --- transport backend (real backend over a fake transport) ----------------
+
+func newTransportManager(t *testing.T, tr transport.Transport) *SessionManager {
+	t.Helper()
+	m, err := NewSessionManager(SessionManagerOptions{
+		UseTransport: true,
+		Transport:    tr,
+		MaxConcurrent: 4,
+		DefaultWait:   time.Second,
+		MaxLifetime:   2 * time.Second,
+		Logger:        slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	return m
+}
+
+func TestSessionManager_Transport_RoundTrip(t *testing.T) {
+	tr := newAsyncTestTransport()
+	m := newTransportManager(t, tr)
+	defer func() { _ = m.Close() }()
+
+	id, err := m.Start(SubAgentConfig{Prompt: "investigate", Mode: "research", MaxTurns: 5})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// The start dispatched a tool_result_request shaped like a spawn.
+	ev := tr.Events()
+	if len(ev) != 1 || ev[0].Type != "tool_result_request" || ev[0].ToolName != "spawn_agent" {
+		t.Fatalf("emitted events = %#v, want one tool_result_request for spawn_agent", ev)
+	}
+	var sent SubAgentConfig
+	if err := json.Unmarshal(ev[0].Input, &sent); err != nil || sent.Prompt != "investigate" || sent.Mode != "research" {
+		t.Fatalf("emitted input = %s, want the SubAgentConfig", string(ev[0].Input))
+	}
+	if st := m.Status(id); st.State != SessionRunning {
+		t.Fatalf("state before response = %q, want running", st.State)
+	}
+
+	// Control plane echoes a serialised SubAgentResult.
+	body, _ := json.Marshal(SubAgentResult{Outcome: "completed", Output: "findings", Turns: 4})
+	tr.FireControl(types.ControlEvent{Type: "tool_result_response", RequestID: id, Content: string(body)})
+
+	st := m.Wait(context.Background(), id, time.Second)
+	if st.State != SessionDone {
+		t.Fatalf("state after response = %q, want done", st.State)
+	}
+	if st.Result == nil || st.Result.Output != "findings" || st.Result.Turns != 4 {
+		t.Fatalf("result = %#v, want {completed findings 4}", st.Result)
+	}
+}
+
+func TestSessionManager_Transport_UpstreamError(t *testing.T) {
+	tr := newAsyncTestTransport()
+	m := newTransportManager(t, tr)
+	defer func() { _ = m.Close() }()
+
+	id, _ := m.Start(SubAgentConfig{Prompt: "x"})
+	isErr := true
+	tr.FireControl(types.ControlEvent{Type: "tool_result_response", RequestID: id, Content: "kaboom", IsError: &isErr})
+
+	st := m.Wait(context.Background(), id, time.Second)
+	if st.State != SessionError {
+		t.Fatalf("state = %q, want error", st.State)
+	}
+	if st.Result == nil || st.Result.Outcome != "upstream_error" {
+		t.Fatalf("result = %#v, want upstream_error", st.Result)
+	}
+}
+
+func TestSessionManager_Transport_Terminate(t *testing.T) {
+	tr := newAsyncTestTransport()
+	m := newTransportManager(t, tr)
+	defer func() { _ = m.Close() }()
+
+	id, _ := m.Start(SubAgentConfig{Prompt: "x"})
+	if err := m.Terminate(id); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if st := m.Status(id); st.State != SessionTerminated {
+		t.Fatalf("state = %q, want terminated", st.State)
+	}
+	if rid := tr.lastRequestID("session_terminate"); rid != id {
+		t.Fatalf("session_terminate requestID = %q, want %q", rid, id)
+	}
+}
+
+func TestSessionManager_Transport_EmitFailure(t *testing.T) {
+	tr := newAsyncTestTransport()
+	tr.emitErr = errors.New("stream closed")
+	m := newTransportManager(t, tr)
+	defer func() { _ = m.Close() }()
+
+	if _, err := m.Start(SubAgentConfig{Prompt: "x"}); err == nil {
+		t.Fatal("Start with failing transport: err = nil, want error")
+	}
+	res, err := m.SpawnAndWait(context.Background(), SubAgentConfig{Prompt: "x"}, time.Second)
+	if err != nil {
+		t.Fatalf("SpawnAndWait: %v", err)
+	}
+	if res.Outcome != "transport_disconnect" {
+		t.Fatalf("outcome = %q, want transport_disconnect", res.Outcome)
+	}
+}
+
+func TestNewSessionManager_TransportOnNull(t *testing.T) {
+	_, err := NewSessionManager(SessionManagerOptions{
+		UseTransport: true,
+		Transport:    &transport.NullTransport{},
+	})
+	if err == nil {
+		t.Fatal("NewSessionManager(transport, NullTransport): err = nil, want misconfiguration error")
+	}
+}

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -79,7 +79,7 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 	// would only arise from an alias collision the parent already resolved,
 	// so fall back to the unaliased child registry rather than aborting the
 	// spawn.
-	var childTools tool.ToolRegistry = filterToolRegistry(parent.Tools, "spawn_agent")
+	var childTools tool.ToolRegistry = filterToolRegistry(parent.Tools, subAgentExcludedTools...)
 	if presenter, err := tool.NewPresenter(childTools, parent.ToolProfile); err == nil {
 		childTools = presenter
 	} else {

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -268,7 +268,12 @@ func capSubAgentMaxTurns(requested, parentMaxTurns int) int {
 	if maxTurns > maxSubAgentMaxTurns {
 		maxTurns = maxSubAgentMaxTurns
 	}
-	if maxTurns > parentMaxTurns {
+	// Cap at the parent's budget, but only when the parent actually has
+	// one: a zero parentMaxTurns (a test-built or not-yet-validated config)
+	// would otherwise silently floor the child to 0 turns, which never
+	// runs. ValidateRunConfig rejects a non-positive MaxTurns for real
+	// runs, so this guard only matters off the validated path.
+	if parentMaxTurns > 0 && maxTurns > parentMaxTurns {
 		maxTurns = parentMaxTurns
 	}
 	return maxTurns

--- a/harness/internal/tool/builtins/builtins_test.go
+++ b/harness/internal/tool/builtins/builtins_test.go
@@ -812,6 +812,10 @@ func TestBuiltinInputExamples_MatchDescription(t *testing.T) {
 		GitShowTool(mock),
 		WebFetchTool(),
 		SpawnAgentTool(nil),
+		StartSessionTool(nil),
+		CheckSessionTool(nil),
+		WaitSessionTool(nil),
+		TerminateSessionTool(nil),
 	}
 	for _, tl := range tools {
 		t.Run(tl.Name, func(t *testing.T) {

--- a/harness/internal/tool/builtins/session.go
+++ b/harness/internal/tool/builtins/session.go
@@ -1,0 +1,229 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+)
+
+// SessionController is the interface the start-and-detach session tools use
+// to drive the run's SessionManager. It is declared here, returning JSON
+// and primitives rather than core types, so the builtins package does not
+// import core (which would be a cycle — core registers these tools). The
+// factory wires a core-backed adapter (issue #71).
+type SessionController interface {
+	// Start dispatches a detached sub-agent and returns its session id.
+	Start(ctx context.Context, prompt, mode string, maxTurns int) (sessionID string, err error)
+	// Status returns a non-blocking snapshot of a session as JSON.
+	Status(sessionID string) (json.RawMessage, error)
+	// Wait blocks until the session is terminal, the timeout elapses, or
+	// the context is cancelled, then returns the snapshot as JSON. A
+	// non-positive timeout selects the configured default.
+	Wait(ctx context.Context, sessionID string, timeoutSeconds int) (json.RawMessage, error)
+	// Terminate stops a session and returns the resulting snapshot as JSON.
+	Terminate(sessionID string) (json.RawMessage, error)
+}
+
+var startSessionSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"prompt": {
+			"type": "string",
+			"description": "The task for the detached sub-agent to perform. Be specific and self-contained — the sub-agent has no access to the parent conversation history."
+		},
+		"mode": {
+			"type": "string",
+			"description": "Run mode for the sub-agent. Defaults to the parent's mode.",
+			"enum": ["execution", "planning", "review", "research", "toil"]
+		},
+		"max_turns": {
+			"type": "integer",
+			"description": "Maximum turns for the sub-agent (1-20, defaults to 10).",
+			"minimum": 1,
+			"maximum": 20
+		}
+	},
+	"required": ["prompt"],
+	"additionalProperties": false
+}`)
+
+var sessionIDSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"session_id": {
+			"type": "string",
+			"description": "The session id returned by start_session."
+		}
+	},
+	"required": ["session_id"],
+	"additionalProperties": false
+}`)
+
+var waitSessionSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"session_id": {
+			"type": "string",
+			"description": "The session id returned by start_session."
+		},
+		"timeout_seconds": {
+			"type": "integer",
+			"description": "Maximum seconds to block waiting for the session to finish. When the timeout elapses the session keeps running and the returned state is still \"running\"; call wait_session or check_session again later. Defaults to the run's configured session timeout.",
+			"minimum": 1
+		}
+	},
+	"required": ["session_id"],
+	"additionalProperties": false
+}`)
+
+// StartSessionTool returns the start_session tool: it dispatches a sub-agent
+// the same way spawn_agent does but returns immediately with a session id
+// instead of blocking on the result. Use it to fan out investigative
+// threads ("whilst I'm here" work) and collect their findings later with
+// wait_session / check_session, or to kick off a thread and forget it.
+func StartSessionTool(ctrl SessionController) *tool.Tool {
+	return &tool.Tool{
+		Name: "start_session",
+		Description: "Start a detached sub-agent session and return immediately with a session id, instead of blocking on the result like spawn_agent does. " +
+			"Use this to kick off independent investigative threads, parallel exploration, or 'whilst I'm here' work that you can collect later — call wait_session to block for a result, check_session to poll without blocking, or terminate_session to stop it. You may also simply forget a session you no longer care about. " +
+			"The sub-agent shares the workspace and inherits the parent's permission policy, security GuardRail, and code scanner — detaching is a high-privilege delegation, not a sandbox. " +
+			"The prompt must be specific and self-contained because the sub-agent cannot see the parent's history. mode defaults to the parent's mode; max_turns bounds the sub-agent at 1-20 turns (default 10). " +
+			"Returns {\"sessionId\": \"...\", \"state\": \"running\"}. " +
+			"Example: {\"prompt\": \"Audit every call site of RunConfig.Redact and report any that log the raw config.\", \"mode\": \"research\", \"max_turns\": 8}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"prompt": "Audit every call site of RunConfig.Redact and report any that log the raw config.", "mode": "research", "max_turns": 8}`)},
+		InputSchema:       startSessionSchema,
+		WorkspaceMutating: false,
+		// start_session is the budget-consuming operation in the session
+		// family (it spawns), so it carries the same upstream-approval gate
+		// as spawn_agent. check/wait/terminate manage an already-approved
+		// session and are not separately gated.
+		RequiresApproval: true,
+		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
+			var params struct {
+				Prompt   string `json:"prompt"`
+				Mode     string `json:"mode"`
+				MaxTurns int    `json:"max_turns"`
+			}
+			if err := json.Unmarshal(input, &params); err != nil {
+				return "", fmt.Errorf("parse start_session input: %w", err)
+			}
+			id, err := ctrl.Start(ctx, params.Prompt, params.Mode, params.MaxTurns)
+			if err != nil {
+				return "", err
+			}
+			out, err := json.Marshal(struct {
+				SessionID string `json:"sessionId"`
+				State     string `json:"state"`
+			}{SessionID: id, State: "running"})
+			if err != nil {
+				return "", fmt.Errorf("marshal start_session result: %w", err)
+			}
+			return string(out), nil
+		},
+	}
+}
+
+// CheckSessionTool returns the check_session tool: a non-blocking poll of a
+// session's state. Returns running while in flight, or a terminal state
+// (done / error / terminated) with the sub-agent's result once finished.
+func CheckSessionTool(ctrl SessionController) *tool.Tool {
+	return &tool.Tool{
+		Name: "check_session",
+		Description: "Check the status of a detached session started with start_session, without blocking. " +
+			"Returns the current state — \"running\" while the sub-agent is still working, or a terminal state (\"done\", \"error\", \"terminated\") with the sub-agent's result once it has finished. An unknown session id returns state \"not_found\". " +
+			"Use this to poll progress while you do other work; use wait_session when you are ready to block for the result. " +
+			"Example: {\"session_id\": \"session-3\"}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"session_id": "session-3"}`)},
+		InputSchema:       sessionIDSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
+		Handler: func(_ context.Context, input json.RawMessage) (string, error) {
+			id, err := parseSessionID(input, "check_session")
+			if err != nil {
+				return "", err
+			}
+			status, err := ctrl.Status(id)
+			if err != nil {
+				return "", err
+			}
+			return string(status), nil
+		},
+	}
+}
+
+// WaitSessionTool returns the wait_session tool: block until a session
+// finishes (or the timeout elapses) and return its result.
+func WaitSessionTool(ctrl SessionController) *tool.Tool {
+	return &tool.Tool{
+		Name: "wait_session",
+		Description: "Block until a detached session started with start_session reaches a terminal state, then return its result. " +
+			"If the optional timeout_seconds elapses first, the session keeps running and the returned state is still \"running\" — call wait_session again to keep waiting, or move on. An unknown session id returns state \"not_found\". " +
+			"Use this to collect a result you previously kicked off; use spawn_agent instead when you want to delegate and block in a single step. " +
+			"Example: {\"session_id\": \"session-3\", \"timeout_seconds\": 120}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"session_id": "session-3", "timeout_seconds": 120}`)},
+		InputSchema:       waitSessionSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
+		Handler: func(ctx context.Context, input json.RawMessage) (string, error) {
+			var params struct {
+				SessionID      string `json:"session_id"`
+				TimeoutSeconds int    `json:"timeout_seconds"`
+			}
+			if err := json.Unmarshal(input, &params); err != nil {
+				return "", fmt.Errorf("parse wait_session input: %w", err)
+			}
+			if params.SessionID == "" {
+				return "", fmt.Errorf("wait_session requires a session_id")
+			}
+			status, err := ctrl.Wait(ctx, params.SessionID, params.TimeoutSeconds)
+			if err != nil {
+				return "", err
+			}
+			return string(status), nil
+		},
+	}
+}
+
+// TerminateSessionTool returns the terminate_session tool: stop a detached
+// session and discard its in-flight work.
+func TerminateSessionTool(ctrl SessionController) *tool.Tool {
+	return &tool.Tool{
+		Name: "terminate_session",
+		Description: "Terminate a detached session started with start_session, stopping the sub-agent and discarding its in-flight work. " +
+			"Returns the session with state \"terminated\". An unknown session id is an error. " +
+			"Use this to cancel a thread you no longer need; a session you simply stop referencing is also fine to leave running until the run ends. " +
+			"Example: {\"session_id\": \"session-3\"}",
+		InputExamples:     []json.RawMessage{json.RawMessage(`{"session_id": "session-3"}`)},
+		InputSchema:       sessionIDSchema,
+		WorkspaceMutating: false,
+		RequiresApproval:  false,
+		Handler: func(_ context.Context, input json.RawMessage) (string, error) {
+			id, err := parseSessionID(input, "terminate_session")
+			if err != nil {
+				return "", err
+			}
+			status, err := ctrl.Terminate(id)
+			if err != nil {
+				return "", err
+			}
+			return string(status), nil
+		},
+	}
+}
+
+// parseSessionID unmarshals the {session_id} input shared by check_session
+// and terminate_session.
+func parseSessionID(input json.RawMessage, toolName string) (string, error) {
+	var params struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return "", fmt.Errorf("parse %s input: %w", toolName, err)
+	}
+	if params.SessionID == "" {
+		return "", fmt.Errorf("%s requires a session_id", toolName)
+	}
+	return params.SessionID, nil
+}

--- a/harness/internal/tool/builtins/session.go
+++ b/harness/internal/tool/builtins/session.go
@@ -8,6 +8,11 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 )
 
+// maxWaitSessionSeconds bounds wait_session's timeout_seconds, mirroring the
+// JSON schema's maximum. It guards against a value that bypasses schema
+// validation overflowing time.Duration in the controller.
+const maxWaitSessionSeconds = 3600
+
 // SessionController is the interface the start-and-detach session tools use
 // to drive the run's SessionManager. It is declared here, returning JSON
 // and primitives rather than core types, so the builtins package does not
@@ -71,7 +76,8 @@ var waitSessionSchema = json.RawMessage(`{
 		"timeout_seconds": {
 			"type": "integer",
 			"description": "Maximum seconds to block waiting for the session to finish. When the timeout elapses the session keeps running and the returned state is still \"running\"; call wait_session or check_session again later. Defaults to the run's configured session timeout.",
-			"minimum": 1
+			"minimum": 1,
+			"maximum": 3600
 		}
 	},
 	"required": ["session_id"],
@@ -177,7 +183,12 @@ func WaitSessionTool(ctrl SessionController) *tool.Tool {
 			if params.SessionID == "" {
 				return "", fmt.Errorf("wait_session requires a session_id")
 			}
-			status, err := ctrl.Wait(ctx, params.SessionID, params.TimeoutSeconds)
+			// Defence in depth against a value that bypasses the schema's
+			// maximum: clamp to [0, maxWaitSessionSeconds] so a huge timeout
+			// cannot overflow time.Duration (negative -> fires immediately)
+			// or block a dispatch goroutine for an unreasonable span.
+			timeout := max(0, min(params.TimeoutSeconds, maxWaitSessionSeconds))
+			status, err := ctrl.Wait(ctx, params.SessionID, timeout)
 			if err != nil {
 				return "", err
 			}

--- a/harness/internal/tool/builtins/session_test.go
+++ b/harness/internal/tool/builtins/session_test.go
@@ -1,0 +1,186 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeSessionController records calls and returns canned results.
+type fakeSessionController struct {
+	startID     string
+	startErr    error
+	gotPrompt   string
+	gotMode     string
+	gotMaxTurns int
+
+	statusJSON json.RawMessage
+	statusErr  error
+
+	waitJSON      json.RawMessage
+	waitErr       error
+	gotWaitID     string
+	gotWaitTimout int
+
+	terminateJSON json.RawMessage
+	terminateErr  error
+	gotTerminate  string
+}
+
+func (f *fakeSessionController) Start(_ context.Context, prompt, mode string, maxTurns int) (string, error) {
+	f.gotPrompt, f.gotMode, f.gotMaxTurns = prompt, mode, maxTurns
+	return f.startID, f.startErr
+}
+
+func (f *fakeSessionController) Status(string) (json.RawMessage, error) {
+	return f.statusJSON, f.statusErr
+}
+
+func (f *fakeSessionController) Wait(_ context.Context, id string, timeoutSeconds int) (json.RawMessage, error) {
+	f.gotWaitID, f.gotWaitTimout = id, timeoutSeconds
+	return f.waitJSON, f.waitErr
+}
+
+func (f *fakeSessionController) Terminate(id string) (json.RawMessage, error) {
+	f.gotTerminate = id
+	return f.terminateJSON, f.terminateErr
+}
+
+func TestStartSessionTool_Dispatch(t *testing.T) {
+	f := &fakeSessionController{startID: "session-7"}
+	tl := StartSessionTool(f)
+
+	out, err := tl.Handler(context.Background(), json.RawMessage(`{"prompt":"go","mode":"research","max_turns":5}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if f.gotPrompt != "go" || f.gotMode != "research" || f.gotMaxTurns != 5 {
+		t.Fatalf("controller got (%q,%q,%d), want (go,research,5)", f.gotPrompt, f.gotMode, f.gotMaxTurns)
+	}
+	var got struct {
+		SessionID string `json:"sessionId"`
+		State     string `json:"state"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output not JSON: %v (%s)", err, out)
+	}
+	if got.SessionID != "session-7" || got.State != "running" {
+		t.Fatalf("output = %#v, want {session-7 running}", got)
+	}
+	if !tl.RequiresApproval {
+		t.Error("start_session should require approval (it spawns)")
+	}
+	if tl.WorkspaceMutating {
+		t.Error("start_session should not be workspace-mutating")
+	}
+}
+
+func TestStartSessionTool_ControllerError(t *testing.T) {
+	f := &fakeSessionController{startErr: errors.New("session limit reached")}
+	tl := StartSessionTool(f)
+	if _, err := tl.Handler(context.Background(), json.RawMessage(`{"prompt":"go"}`)); err == nil {
+		t.Fatal("Handler err = nil, want controller error surfaced")
+	}
+}
+
+func TestCheckSessionTool_Dispatch(t *testing.T) {
+	f := &fakeSessionController{statusJSON: json.RawMessage(`{"sessionId":"session-1","state":"running"}`)}
+	tl := CheckSessionTool(f)
+	out, err := tl.Handler(context.Background(), json.RawMessage(`{"session_id":"session-1"}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if out != `{"sessionId":"session-1","state":"running"}` {
+		t.Fatalf("output = %s", out)
+	}
+	if tl.RequiresApproval {
+		t.Error("check_session should not require approval (read-only poll)")
+	}
+}
+
+func TestCheckSessionTool_MissingID(t *testing.T) {
+	tl := CheckSessionTool(&fakeSessionController{})
+	if _, err := tl.Handler(context.Background(), json.RawMessage(`{}`)); err == nil {
+		t.Fatal("Handler err = nil, want missing session_id error")
+	}
+}
+
+func TestWaitSessionTool_Dispatch(t *testing.T) {
+	f := &fakeSessionController{waitJSON: json.RawMessage(`{"sessionId":"session-2","state":"done"}`)}
+	tl := WaitSessionTool(f)
+	out, err := tl.Handler(context.Background(), json.RawMessage(`{"session_id":"session-2","timeout_seconds":30}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if f.gotWaitID != "session-2" || f.gotWaitTimout != 30 {
+		t.Fatalf("controller got (%q,%d), want (session-2,30)", f.gotWaitID, f.gotWaitTimout)
+	}
+	if !strings.Contains(out, `"state":"done"`) {
+		t.Fatalf("output = %s", out)
+	}
+}
+
+func TestWaitSessionTool_MissingID(t *testing.T) {
+	tl := WaitSessionTool(&fakeSessionController{})
+	if _, err := tl.Handler(context.Background(), json.RawMessage(`{"timeout_seconds":5}`)); err == nil {
+		t.Fatal("Handler err = nil, want missing session_id error")
+	}
+}
+
+func TestTerminateSessionTool_Dispatch(t *testing.T) {
+	f := &fakeSessionController{terminateJSON: json.RawMessage(`{"sessionId":"session-3","state":"terminated"}`)}
+	tl := TerminateSessionTool(f)
+	out, err := tl.Handler(context.Background(), json.RawMessage(`{"session_id":"session-3"}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if f.gotTerminate != "session-3" {
+		t.Fatalf("controller got %q, want session-3", f.gotTerminate)
+	}
+	if !strings.Contains(out, `"terminated"`) {
+		t.Fatalf("output = %s", out)
+	}
+}
+
+func TestTerminateSessionTool_ControllerError(t *testing.T) {
+	f := &fakeSessionController{terminateErr: errors.New("unknown session")}
+	tl := TerminateSessionTool(f)
+	if _, err := tl.Handler(context.Background(), json.RawMessage(`{"session_id":"nope"}`)); err == nil {
+		t.Fatal("Handler err = nil, want controller error surfaced")
+	}
+}
+
+// TestSessionTools_EnrichedShape mirrors TestBuiltinDescriptions_EnrichedShape
+// for the factory-registered session tools, which RegisterBuiltins does not
+// cover.
+func TestSessionTools_EnrichedShape(t *testing.T) {
+	defs := []struct {
+		name string
+		desc string
+	}{
+		{"start_session", StartSessionTool(nil).Description},
+		{"check_session", CheckSessionTool(nil).Description},
+		{"wait_session", WaitSessionTool(nil).Description},
+		{"terminate_session", TerminateSessionTool(nil).Description},
+	}
+	for _, d := range defs {
+		t.Run(d.name, func(t *testing.T) {
+			if len(d.desc) > maxToolDescriptionLen {
+				t.Errorf("description length %d exceeds cap %d", len(d.desc), maxToolDescriptionLen)
+			}
+			if !hasPositiveUseThis(d.desc) {
+				t.Errorf("description missing positive when-to-use guidance")
+			}
+			example, ok := extractJSONExample(d.desc)
+			if !ok {
+				t.Fatalf("description missing JSON example after Example marker")
+			}
+			var probe map[string]any
+			if err := json.Unmarshal([]byte(example), &probe); err != nil {
+				t.Errorf("example is not valid JSON: %v\n%s", err, example)
+			}
+		})
+	}
+}

--- a/harness/internal/tool/builtins/session_test.go
+++ b/harness/internal/tool/builtins/session_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 )
 
 // fakeSessionController records calls and returns canned results.
@@ -183,4 +185,67 @@ func TestSessionTools_EnrichedShape(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSessionTools_UnmarshalErrors(t *testing.T) {
+	ctrl := &fakeSessionController{startID: "session-1"}
+	tools := map[string]*tool.Tool{
+		"start_session":     StartSessionTool(ctrl),
+		"check_session":     CheckSessionTool(ctrl),
+		"wait_session":      WaitSessionTool(ctrl),
+		"terminate_session": TerminateSessionTool(ctrl),
+	}
+	for name, tl := range tools {
+		t.Run(name, func(t *testing.T) {
+			if _, err := tl.Handler(context.Background(), json.RawMessage(`{not json`)); err == nil {
+				t.Fatalf("%s: err = nil for malformed input, want parse error", name)
+			}
+		})
+	}
+}
+
+func TestSessionTools_ControllerErrorPropagation(t *testing.T) {
+	t.Run("check_session", func(t *testing.T) {
+		ctrl := &fakeSessionController{statusErr: errors.New("boom")}
+		if _, err := CheckSessionTool(ctrl).Handler(context.Background(), json.RawMessage(`{"session_id":"s"}`)); err == nil {
+			t.Fatal("err = nil, want controller error")
+		}
+	})
+	t.Run("wait_session", func(t *testing.T) {
+		ctrl := &fakeSessionController{waitErr: errors.New("boom")}
+		if _, err := WaitSessionTool(ctrl).Handler(context.Background(), json.RawMessage(`{"session_id":"s"}`)); err == nil {
+			t.Fatal("err = nil, want controller error")
+		}
+	})
+	t.Run("terminate_session", func(t *testing.T) {
+		ctrl := &fakeSessionController{terminateErr: errors.New("boom")}
+		if _, err := TerminateSessionTool(ctrl).Handler(context.Background(), json.RawMessage(`{"session_id":"s"}`)); err == nil {
+			t.Fatal("err = nil, want controller error")
+		}
+	})
+}
+
+func TestWaitSessionTool_ClampsTimeout(t *testing.T) {
+	t.Run("oversized clamps to max", func(t *testing.T) {
+		ctrl := &fakeSessionController{waitJSON: json.RawMessage(`{}`)}
+		_, err := WaitSessionTool(ctrl).Handler(context.Background(),
+			json.RawMessage(`{"session_id":"s","timeout_seconds":999999999999}`))
+		if err != nil {
+			t.Fatalf("Handler: %v", err)
+		}
+		if ctrl.gotWaitTimout != maxWaitSessionSeconds {
+			t.Fatalf("clamped timeout = %d, want %d", ctrl.gotWaitTimout, maxWaitSessionSeconds)
+		}
+	})
+	t.Run("negative clamps to zero", func(t *testing.T) {
+		ctrl := &fakeSessionController{waitJSON: json.RawMessage(`{}`)}
+		_, err := WaitSessionTool(ctrl).Handler(context.Background(),
+			json.RawMessage(`{"session_id":"s","timeout_seconds":-5}`))
+		if err != nil {
+			t.Fatalf("Handler: %v", err)
+		}
+		if ctrl.gotWaitTimout != 0 {
+			t.Fatalf("clamped timeout = %d, want 0", ctrl.gotWaitTimout)
+		}
+	})
 }

--- a/harness/internal/transport/correlator.go
+++ b/harness/internal/transport/correlator.go
@@ -44,6 +44,23 @@ type Correlator struct {
 	mu      sync.Mutex
 	nextID  int
 	pending map[string]chan any
+
+	// retained holds entries registered via StartPending — the
+	// emit-now / await-or-poll-later path used by detached sub-agent
+	// sessions (#71). Unlike pending (one-shot Await), a retained entry
+	// is NOT removed on delivery: its payload is buffered until a caller
+	// Polls/AwaitIDs it, and only Forget removes it. This lets a response
+	// that arrives before any waiter be observed rather than dropped.
+	retained map[string]*retainedEntry
+}
+
+// retainedEntry buffers the response to a StartPending request. delivered
+// and payload are guarded by Correlator.mu; done is closed exactly once
+// (under mu) when the response arrives, unblocking any AwaitID waiter.
+type retainedEntry struct {
+	done      chan struct{}
+	delivered bool
+	payload   any
 }
 
 // NewCorrelator constructs a Correlator. The idPrefix is used to format
@@ -56,6 +73,7 @@ func NewCorrelator(idPrefix string) *Correlator {
 	return &Correlator{
 		idPrefix: idPrefix,
 		pending:  make(map[string]chan any),
+		retained: make(map[string]*retainedEntry),
 	}
 }
 
@@ -90,6 +108,16 @@ func (c *Correlator) deliver(id string, payload any) {
 	ch, ok := c.pending[id]
 	if ok {
 		delete(c.pending, id)
+	}
+	// Retained (StartPending) path: record the payload once and signal
+	// any AwaitID waiter, but do NOT remove the entry — the buffered
+	// payload must survive until Poll/AwaitID reads it or Forget discards
+	// it. A given id lives in at most one map (pending and retained draw
+	// from the same monotonic counter), so at most one branch fires.
+	if entry, rok := c.retained[id]; rok && !entry.delivered {
+		entry.delivered = true
+		entry.payload = payload
+		close(entry.done)
 	}
 	c.mu.Unlock()
 
@@ -152,6 +180,114 @@ func (c *Correlator) Await(
 		c.cancel(requestID)
 		return nil, fmt.Errorf("correlator: cancelled (requestId=%s): %w", requestID, ctx.Err())
 	}
+}
+
+// StartPending allocates a fresh request ID, registers a retained entry,
+// and invokes emit with that ID — the non-blocking counterpart to Await.
+// It returns as soon as emit succeeds, leaving the response to be picked
+// up later via Poll (non-blocking) or AwaitID (blocking). A response that
+// arrives before any such call is buffered in the entry rather than
+// dropped.
+//
+// On emit failure the entry is removed and the error returned wrapped.
+// The caller owns the returned request ID and must eventually Forget it
+// to release the buffered state.
+//
+// This backs the start-and-detach session model (#71): start_session
+// calls StartPending and returns the ID to the model as a session handle;
+// wait_session/check_session resolve it later.
+func (c *Correlator) StartPending(emit func(requestID string) error) (string, error) {
+	if emit == nil {
+		return "", errors.New("correlator: emit callback is required")
+	}
+
+	requestID := c.nextRequestID()
+	entry := &retainedEntry{done: make(chan struct{})}
+
+	c.mu.Lock()
+	c.retained[requestID] = entry
+	c.mu.Unlock()
+
+	if err := emit(requestID); err != nil {
+		c.Forget(requestID)
+		return "", fmt.Errorf("correlator: emit failed: %w", err)
+	}
+	return requestID, nil
+}
+
+// Poll reports whether the retained request identified by requestID has
+// received its response. When ready is true, payload carries the delivered
+// value; the value is cached, so repeated Polls and a later AwaitID all
+// observe it. ready is false when the request is unknown or still in
+// flight. Non-blocking.
+func (c *Correlator) Poll(requestID string) (payload any, ready bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.retained[requestID]
+	if !ok || !entry.delivered {
+		return nil, false
+	}
+	return entry.payload, true
+}
+
+// AwaitID blocks until the retained request identified by requestID
+// receives its response, the timeout elapses, or ctx is cancelled.
+//
+// Unlike Await, the entry is NOT removed on return: the same id may be
+// AwaitID'd or Poll'd again and still observe the cached payload until
+// Forget is called. A non-positive timeout is replaced with
+// DefaultCorrelatorTimeout. Returns an error if requestID is unknown
+// (never registered via StartPending, or already Forgotten).
+func (c *Correlator) AwaitID(ctx context.Context, requestID string, timeout time.Duration) (any, error) {
+	if timeout <= 0 {
+		timeout = DefaultCorrelatorTimeout
+	}
+
+	c.mu.Lock()
+	entry, ok := c.retained[requestID]
+	c.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("correlator: unknown request id %q", requestID)
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-entry.done:
+		return c.retainedPayload(entry), nil
+	case <-timer.C:
+		return nil, fmt.Errorf("correlator: timed out after %s waiting for response (requestId=%s)", timeout, requestID)
+	case <-ctx.Done():
+		return nil, fmt.Errorf("correlator: cancelled (requestId=%s): %w", requestID, ctx.Err())
+	}
+}
+
+// retainedPayload reads an entry's delivered payload under the lock. Only
+// called after observing entry.done closed, so delivered is guaranteed
+// true; the lock is taken purely for the memory barrier on payload.
+func (c *Correlator) retainedPayload(entry *retainedEntry) any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return entry.payload
+}
+
+// Forget removes a retained entry and any buffered payload. Idempotent:
+// safe to call when the entry is already absent. Use it to release a
+// session's state once its result has been consumed, or to abandon a
+// detached session that the agent has chosen to forget.
+func (c *Correlator) Forget(requestID string) {
+	c.mu.Lock()
+	delete(c.retained, requestID)
+	c.mu.Unlock()
+}
+
+// RetainedCount returns the number of live retained entries. Intended for
+// tests and diagnostics (e.g. enforcing a live-session cap).
+func (c *Correlator) RetainedCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.retained)
 }
 
 // cancel removes a pending entry. Safe to call when the entry has already

--- a/harness/internal/transport/correlator.go
+++ b/harness/internal/transport/correlator.go
@@ -14,6 +14,11 @@ import (
 // caller passes a non-positive timeout to Correlator.Await.
 const DefaultCorrelatorTimeout = 60 * time.Second
 
+// ErrEmitFailed wraps any error returned by the emit callback of Await or
+// StartPending. Callers can match it with errors.Is rather than scraping
+// the message, while the underlying transport error stays in the chain.
+var ErrEmitFailed = errors.New("correlator: emit failed")
+
 // HasOnControl is the minimal Transport surface the correlator needs. It is
 // declared in this package so the helper can be reused without a circular
 // import via consumers (e.g. permission, tool dispatch) that define the same
@@ -57,8 +62,12 @@ type Correlator struct {
 // retainedEntry buffers the response to a StartPending request. delivered
 // and payload are guarded by Correlator.mu; done is closed exactly once
 // (under mu) when the response arrives, unblocking any AwaitID waiter.
+// forgotten is closed (once, under mu) by Forget so a parked AwaitID
+// unwinds promptly instead of waiting out its timeout when the session is
+// abandoned or terminated.
 type retainedEntry struct {
 	done      chan struct{}
+	forgotten chan struct{}
 	delivered bool
 	payload   any
 }
@@ -163,7 +172,7 @@ func (c *Correlator) Await(
 
 	if err := emit(requestID); err != nil {
 		c.cancel(requestID)
-		return nil, fmt.Errorf("correlator: emit failed: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrEmitFailed, err)
 	}
 
 	timer := time.NewTimer(timeout)
@@ -182,37 +191,56 @@ func (c *Correlator) Await(
 	}
 }
 
-// StartPending allocates a fresh request ID, registers a retained entry,
-// and invokes emit with that ID — the non-blocking counterpart to Await.
-// It returns as soon as emit succeeds, leaving the response to be picked
-// up later via Poll (non-blocking) or AwaitID (blocking). A response that
-// arrives before any such call is buffered in the entry rather than
+// StartPending allocates a fresh request ID and registers a retained entry
+// via StartPendingWithID. It is the auto-id counterpart to Await; callers
+// that need an externally-chosen id (e.g. an unguessable session handle)
+// use StartPendingWithID directly.
+func (c *Correlator) StartPending(emit func(requestID string) error) (string, error) {
+	requestID := c.nextRequestID()
+	if err := c.StartPendingWithID(requestID, emit); err != nil {
+		return "", err
+	}
+	return requestID, nil
+}
+
+// StartPendingWithID registers a retained entry under the caller-supplied
+// requestID and invokes emit with it — the non-blocking counterpart to
+// Await. It returns as soon as emit succeeds, leaving the response to be
+// picked up later via Poll (non-blocking) or AwaitID (blocking). A response
+// that arrives before any such call is buffered in the entry rather than
 // dropped.
 //
-// On emit failure the entry is removed and the error returned wrapped.
-// The caller owns the returned request ID and must eventually Forget it
-// to release the buffered state.
+// The requestID must be unique among live retained entries; a collision is
+// rejected. On emit failure the entry is removed and the error returned
+// wrapped in ErrEmitFailed. The caller owns the id and must eventually
+// Forget it to release the buffered state.
 //
-// This backs the start-and-detach session model (#71): start_session
-// calls StartPending and returns the ID to the model as a session handle;
-// wait_session/check_session resolve it later.
-func (c *Correlator) StartPending(emit func(requestID string) error) (string, error) {
+// This backs the start-and-detach session model (#71): the SessionManager
+// supplies an unguessable id, emits a tool_result_request under it, and
+// resolves it later via AwaitID/Poll.
+func (c *Correlator) StartPendingWithID(requestID string, emit func(requestID string) error) error {
 	if emit == nil {
-		return "", errors.New("correlator: emit callback is required")
+		return errors.New("correlator: emit callback is required")
+	}
+	if requestID == "" {
+		return errors.New("correlator: requestID is required")
 	}
 
-	requestID := c.nextRequestID()
-	entry := &retainedEntry{done: make(chan struct{})}
+	entry := &retainedEntry{done: make(chan struct{}), forgotten: make(chan struct{})}
 
 	c.mu.Lock()
+	if _, exists := c.retained[requestID]; exists {
+		c.mu.Unlock()
+		return fmt.Errorf("correlator: request id %q already pending", requestID)
+	}
 	c.retained[requestID] = entry
 	c.mu.Unlock()
 
 	if err := emit(requestID); err != nil {
 		c.Forget(requestID)
-		return "", fmt.Errorf("correlator: emit failed: %w", err)
+		return fmt.Errorf("%w: %w", ErrEmitFailed, err)
 	}
-	return requestID, nil
+	return nil
 }
 
 // Poll reports whether the retained request identified by requestID has
@@ -256,6 +284,8 @@ func (c *Correlator) AwaitID(ctx context.Context, requestID string, timeout time
 	select {
 	case <-entry.done:
 		return c.retainedPayload(entry), nil
+	case <-entry.forgotten:
+		return nil, fmt.Errorf("correlator: request %q forgotten before response", requestID)
 	case <-timer.C:
 		return nil, fmt.Errorf("correlator: timed out after %s waiting for response (requestId=%s)", timeout, requestID)
 	case <-ctx.Done():
@@ -272,13 +302,19 @@ func (c *Correlator) retainedPayload(entry *retainedEntry) any {
 	return entry.payload
 }
 
-// Forget removes a retained entry and any buffered payload. Idempotent:
+// Forget removes a retained entry and any buffered payload, unblocking any
+// parked AwaitID for that id (it returns a "forgotten" error). Idempotent:
 // safe to call when the entry is already absent. Use it to release a
 // session's state once its result has been consumed, or to abandon a
 // detached session that the agent has chosen to forget.
 func (c *Correlator) Forget(requestID string) {
 	c.mu.Lock()
-	delete(c.retained, requestID)
+	if entry, ok := c.retained[requestID]; ok {
+		delete(c.retained, requestID)
+		// Closed exactly once: the entry is removed under the same lock,
+		// so a second Forget finds nothing and cannot double-close.
+		close(entry.forgotten)
+	}
 	c.mu.Unlock()
 }
 

--- a/harness/internal/transport/correlator_test.go
+++ b/harness/internal/transport/correlator_test.go
@@ -574,3 +574,57 @@ func TestCorrelator_StartPending_NilEmit(t *testing.T) {
 		t.Fatal("StartPending(nil) err = nil, want error")
 	}
 }
+
+func TestCorrelator_Forget_UnblocksAwaitID(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	id, err := c.StartPending(func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("StartPending: %v", err)
+	}
+
+	parked := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(parked) // about to block in AwaitID
+		_, err := c.AwaitID(context.Background(), id, 5*time.Second)
+		done <- err
+	}()
+
+	// Let the goroutine reach AwaitID's select, then forget the entry.
+	<-parked
+	time.Sleep(20 * time.Millisecond)
+	c.Forget(id)
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "forgotten") {
+			t.Fatalf("AwaitID err = %v, want a 'forgotten' error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AwaitID did not unblock after Forget (goroutine leak)")
+	}
+	if c.RetainedCount() != 0 {
+		t.Errorf("RetainedCount after Forget = %d, want 0", c.RetainedCount())
+	}
+}
+
+func TestCorrelator_StartPendingWithID_Duplicate(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	if err := c.StartPendingWithID("session-x", func(string) error { return nil }); err != nil {
+		t.Fatalf("first StartPendingWithID: %v", err)
+	}
+	if err := c.StartPendingWithID("session-x", func(string) error { return nil }); err == nil {
+		t.Fatal("duplicate StartPendingWithID: err = nil, want collision error")
+	}
+}
+
+func TestCorrelator_StartPending_EmitFailure_WrapsSentinel(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	_, err := c.StartPending(func(string) error { return errors.New("boom") })
+	if err == nil || !errors.Is(err, ErrEmitFailed) {
+		t.Fatalf("err = %v, want errors.Is(ErrEmitFailed)", err)
+	}
+}

--- a/harness/internal/transport/correlator_test.go
+++ b/harness/internal/transport/correlator_test.go
@@ -396,3 +396,181 @@ func TestCorrelator_NewIsEmpty(t *testing.T) {
 	// Avoid unused-import lint on fmt by referencing it in a tiny check.
 	_ = fmt.Sprintf("ok-%d", c.PendingCount())
 }
+
+// --- Retained (StartPending / Poll / AwaitID / Forget) path: issue #71 ---
+
+const sessionRespType = "tool_result_response"
+
+func TestCorrelator_StartPending_PollThenAwait(t *testing.T) {
+	t.Parallel()
+	fc := &fakeOnControl{}
+	c := NewCorrelator("session")
+	c.AttachTo(fc, extractByType(sessionRespType))
+
+	id, err := c.StartPending(func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("StartPending: %v", err)
+	}
+	if id != "session-1" {
+		t.Errorf("id = %q, want session-1", id)
+	}
+	if c.RetainedCount() != 1 {
+		t.Errorf("RetainedCount = %d, want 1", c.RetainedCount())
+	}
+
+	// Not ready before delivery.
+	if _, ready := c.Poll(id); ready {
+		t.Error("Poll ready before delivery, want not ready")
+	}
+
+	fc.simulate(types.ControlEvent{Type: sessionRespType, RequestID: id, Content: "done"})
+
+	// Ready after delivery; payload cached across repeated reads.
+	for i := 0; i < 2; i++ {
+		payload, ready := c.Poll(id)
+		if !ready {
+			t.Fatalf("Poll #%d not ready after delivery", i)
+		}
+		if ev, ok := payload.(types.ControlEvent); !ok || ev.Content != "done" {
+			t.Fatalf("Poll #%d payload = %#v, want ControlEvent{Content:done}", i, payload)
+		}
+	}
+
+	// AwaitID returns the same cached payload immediately.
+	payload, err := c.AwaitID(context.Background(), id, time.Second)
+	if err != nil {
+		t.Fatalf("AwaitID: %v", err)
+	}
+	if ev, ok := payload.(types.ControlEvent); !ok || ev.Content != "done" {
+		t.Fatalf("AwaitID payload = %#v, want ControlEvent{Content:done}", payload)
+	}
+
+	// Entry survives until Forget.
+	if c.RetainedCount() != 1 {
+		t.Errorf("RetainedCount before Forget = %d, want 1", c.RetainedCount())
+	}
+	c.Forget(id)
+	if c.RetainedCount() != 0 {
+		t.Errorf("RetainedCount after Forget = %d, want 0", c.RetainedCount())
+	}
+}
+
+func TestCorrelator_StartPending_DeliverBeforeAwait(t *testing.T) {
+	t.Parallel()
+	fc := &fakeOnControl{}
+	c := NewCorrelator("session")
+	c.AttachTo(fc, extractByType(sessionRespType))
+
+	id, err := c.StartPending(func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("StartPending: %v", err)
+	}
+
+	// Deliver before anyone awaits; the payload must be buffered.
+	fc.simulate(types.ControlEvent{Type: sessionRespType, RequestID: id, Content: "early"})
+
+	payload, err := c.AwaitID(context.Background(), id, time.Second)
+	if err != nil {
+		t.Fatalf("AwaitID: %v", err)
+	}
+	if ev, ok := payload.(types.ControlEvent); !ok || ev.Content != "early" {
+		t.Fatalf("payload = %#v, want ControlEvent{Content:early}", payload)
+	}
+}
+
+func TestCorrelator_StartPending_OutOfOrder(t *testing.T) {
+	t.Parallel()
+	fc := &fakeOnControl{}
+	c := NewCorrelator("session")
+	c.AttachTo(fc, extractByType(sessionRespType))
+
+	id1, _ := c.StartPending(func(string) error { return nil })
+	id2, _ := c.StartPending(func(string) error { return nil })
+	if id1 == id2 {
+		t.Fatalf("ids collided: %q", id1)
+	}
+
+	// Respond to the second first.
+	fc.simulate(types.ControlEvent{Type: sessionRespType, RequestID: id2, Content: "two"})
+	fc.simulate(types.ControlEvent{Type: sessionRespType, RequestID: id1, Content: "one"})
+
+	p1, _ := c.Poll(id1)
+	p2, _ := c.Poll(id2)
+	if ev := p1.(types.ControlEvent); ev.Content != "one" {
+		t.Errorf("id1 payload = %q, want one", ev.Content)
+	}
+	if ev := p2.(types.ControlEvent); ev.Content != "two" {
+		t.Errorf("id2 payload = %q, want two", ev.Content)
+	}
+}
+
+func TestCorrelator_AwaitID_Timeout(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	id, err := c.StartPending(func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("StartPending: %v", err)
+	}
+	_, err = c.AwaitID(context.Background(), id, 25*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("AwaitID err = %v, want timeout", err)
+	}
+	// A timed-out wait does NOT discard the entry — a later wait can still
+	// observe a late-arriving result.
+	if c.RetainedCount() != 1 {
+		t.Errorf("RetainedCount after timeout = %d, want 1 (entry retained)", c.RetainedCount())
+	}
+}
+
+func TestCorrelator_AwaitID_ContextCancel(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	id, _ := c.StartPending(func(string) error { return nil })
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { cancel() }()
+	_, err := c.AwaitID(ctx, id, time.Second)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("AwaitID err = %v, want context.Canceled", err)
+	}
+}
+
+func TestCorrelator_AwaitID_UnknownID(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	_, err := c.AwaitID(context.Background(), "session-404", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "unknown request id") {
+		t.Fatalf("AwaitID err = %v, want unknown request id", err)
+	}
+}
+
+func TestCorrelator_StartPending_EmitFailure(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	_, err := c.StartPending(func(string) error { return errors.New("boom") })
+	if err == nil || !strings.Contains(err.Error(), "emit failed") {
+		t.Fatalf("StartPending err = %v, want emit failed", err)
+	}
+	if c.RetainedCount() != 0 {
+		t.Errorf("RetainedCount after emit failure = %d, want 0 (entry rolled back)", c.RetainedCount())
+	}
+}
+
+func TestCorrelator_Forget_Idempotent(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	c.Forget("never-existed") // must not panic
+	id, _ := c.StartPending(func(string) error { return nil })
+	c.Forget(id)
+	c.Forget(id) // double Forget is safe
+	if c.RetainedCount() != 0 {
+		t.Errorf("RetainedCount = %d, want 0", c.RetainedCount())
+	}
+}
+
+func TestCorrelator_StartPending_NilEmit(t *testing.T) {
+	t.Parallel()
+	c := NewCorrelator("session")
+	if _, err := c.StartPending(nil); err == nil {
+		t.Fatal("StartPending(nil) err = nil, want error")
+	}
+}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -103,12 +103,20 @@ service HarnessService {
 //     (Best-effort signal; the control plane should call the provider's
 //     batch-cancel endpoint. The harness does not retry or block on a
 //     response — cancellation is fire-and-forget.)
+//
+//   "session_terminate"
+//     - request_id: the originating "tool_result_request" request_id of a
+//                   detached sub-agent session (#71).
+//     (Best-effort signal; the control plane should stop the matching
+//     sub-agent job. The harness does not retry or block on a response —
+//     termination is fire-and-forget. Reuses the generic async-tool
+//     round-trip's request_id, so no session-specific message is needed.)
 message HarnessEvent {
   // Required. The event type discriminator.
   // Valid values: "text_delta", "tool_call", "tool_result", "done", "error",
   //              "warning", "heartbeat", "ready", "permission_request",
   //              "tool_result_request", "batch_submission", "batch_waiting",
-  //              "batch_cancel_request".
+  //              "batch_cancel_request", "session_terminate".
   string type = 1;
 
   // Incremental text fragment from the model. Set on "text_delta" events.

--- a/types/events.go
+++ b/types/events.go
@@ -299,6 +299,11 @@ func Float64Ptr(v float64) *float64 {
 //     cancels or its wall-clock cap fires and the operator opted into
 //     CancelBundleOnRunCancel; RequestID echoes the submission so the
 //     control plane can cancel the matching provider-side batch entry.
+//   - "session_terminate"    — emitted by the SessionManager when the agent
+//     terminates (or the run tears down) a detached sub-agent session
+//     (#71); RequestID echoes the originating "tool_result_request" so the
+//     control plane can stop the matching sub-agent job. Fire-and-forget:
+//     no response is correlated back.
 type HarnessEvent struct {
 	Type           string          `json:"type"`
 	Text           string          `json:"text,omitempty"`

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -219,6 +219,12 @@ type RunConfig struct {
 	// ToolChoiceEscalationConfig for the per-knob semantics and the
 	// mode-aware policy that decides when a no-tool answer is suspicious.
 	ToolChoiceEscalation *ToolChoiceEscalationConfig `json:"toolChoiceEscalation,omitempty"`
+
+	// SubAgent configures how spawn_agent and the start-and-detach
+	// session tools materialise sub-agents (issues #54, #71). The zero
+	// value selects the in-process spawner with the session tools
+	// disabled, so a bare run is byte-for-byte unchanged.
+	SubAgent SubAgentRunConfig `json:"subAgent,omitempty"`
 }
 
 // ObservabilityConfig carries operator-supplied labels that are promoted to
@@ -963,6 +969,112 @@ type ResourceLimits struct {
 // ValidateRunConfig.
 type ToolDispatchConfig struct {
 	MaxParallel int `json:"maxParallel,omitempty"`
+}
+
+// Sub-agent spawning / session defaults (issues #54, #71).
+const (
+	// DefaultSessionTimeout is the per-wait timeout, in seconds, applied
+	// to a blocking sub-agent result wait (spawn_agent's implicit wait,
+	// or an explicit wait_session) when SubAgentRunConfig.SessionTimeout
+	// is unset.
+	DefaultSessionTimeout = 300
+
+	// maxSessionTimeout bounds SubAgentRunConfig.SessionTimeout. It mirrors
+	// the run-level timeout ceiling: a per-wait timeout longer than the
+	// longest a run may live is meaningless.
+	maxSessionTimeout = 3600
+
+	// DefaultMaxConcurrentSessions caps simultaneously-live detached
+	// sessions a single run may hold open when
+	// SubAgentRunConfig.MaxConcurrentSessions is unset.
+	DefaultMaxConcurrentSessions = 16
+
+	// maxConcurrentSessionsCeiling is the hard upper bound on
+	// SubAgentRunConfig.MaxConcurrentSessions regardless of what an
+	// operator requests, bounding the registry's memory footprint.
+	maxConcurrentSessionsCeiling = 256
+)
+
+// SubAgentRunConfig configures how spawn_agent and the start-and-detach
+// session tools materialise sub-agents (issues #54, #71).
+//
+// The zero value selects the in-process ("local") spawner with the
+// session tools disabled — a bare run keeps the pre-existing behaviour
+// where spawn_agent runs a child loop synchronously in the calling
+// goroutine.
+type SubAgentRunConfig struct {
+	// Spawner selects how a sub-agent is materialised:
+	//
+	//   "local"  (default) — run the child loop in-process in the calling
+	//                        harness, synchronously (the historical path).
+	//   "transport"        — dispatch the spawn over the gRPC transport to
+	//                        the control plane, which materialises the
+	//                        sub-agent (e.g. a separate `stirrup job`) and
+	//                        returns its result.
+	//
+	// The transport spawner needs a live control-plane transport: the
+	// factory refuses to construct it on a NullTransport rather than
+	// letting every spawn block until the per-call timeout.
+	Spawner string `json:"spawner,omitempty"`
+
+	// Sessions, when true, registers the start-and-detach session tools
+	// (start_session, check_session, wait_session, terminate_session)
+	// alongside the blocking spawn_agent tool. The session tools share the
+	// Spawner backend. Default false: a bare run exposes only spawn_agent.
+	Sessions bool `json:"sessions,omitempty"`
+
+	// SessionTimeout bounds, in seconds, how long a blocking result wait
+	// (spawn_agent's implicit wait or an explicit wait_session) blocks on a
+	// sub-agent result before returning a "timeout" outcome. Nil selects
+	// DefaultSessionTimeout. A detached session that times out on one wait
+	// is not terminated — a later wait_session/check_session can still
+	// observe its result.
+	SessionTimeout *int `json:"sessionTimeout,omitempty"`
+
+	// MaxConcurrentSessions caps the number of simultaneously-live detached
+	// sessions a single run may hold. Nil selects
+	// DefaultMaxConcurrentSessions. start_session fails loudly once the cap
+	// is reached rather than growing the registry without bound.
+	MaxConcurrentSessions *int `json:"maxConcurrentSessions,omitempty"`
+}
+
+// SpawnerOrDefault returns the configured spawner, defaulting the empty
+// (unset) value to "local" so call sites need not special-case the zero
+// value.
+func (c SubAgentRunConfig) SpawnerOrDefault() string {
+	if c.Spawner == "" {
+		return "local"
+	}
+	return c.Spawner
+}
+
+// UsesTransportSpawner reports whether the configured spawner dispatches
+// over the transport rather than running in-process.
+func (c SubAgentRunConfig) UsesTransportSpawner() bool {
+	return c.SpawnerOrDefault() == "transport"
+}
+
+// EffectiveSessionTimeoutSeconds resolves the per-wait timeout, falling
+// back to DefaultSessionTimeout when unset or non-positive.
+func (c SubAgentRunConfig) EffectiveSessionTimeoutSeconds() int {
+	if c.SessionTimeout == nil || *c.SessionTimeout <= 0 {
+		return DefaultSessionTimeout
+	}
+	return *c.SessionTimeout
+}
+
+// EffectiveMaxConcurrentSessions resolves the live-session cap, falling
+// back to DefaultMaxConcurrentSessions when unset or non-positive.
+func (c SubAgentRunConfig) EffectiveMaxConcurrentSessions() int {
+	if c.MaxConcurrentSessions == nil || *c.MaxConcurrentSessions <= 0 {
+		return DefaultMaxConcurrentSessions
+	}
+	return *c.MaxConcurrentSessions
+}
+
+var validSpawnerTypes = map[string]bool{
+	"local":     true,
+	"transport": true,
 }
 
 // ToolChoiceEscalationConfig configures the missed-tool recovery (#230).
@@ -1918,11 +2030,27 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateToolDispatchConfig(config.ToolDispatch, &errs)
 	validateToolChoiceEscalationConfig(config.ToolChoiceEscalation, &errs)
 	validateBatchConfig(config, &errs)
+	validateSubAgentConfig(config.SubAgent, &errs)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("RunConfig validation failed: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// validateSubAgentConfig enforces the sub-agent spawning / session knobs
+// (issues #54, #71). The spawner enum, the session timeout, and the
+// concurrency cap are all bounded here; the NullTransport-vs-transport
+// misconfiguration is caught later at factory construction, where the
+// resolved transport is known.
+func validateSubAgentConfig(c SubAgentRunConfig, errs *[]string) {
+	validateOptionalType("subAgent.spawner", c.Spawner, validSpawnerTypes, errs)
+	if c.SessionTimeout != nil && (*c.SessionTimeout <= 0 || *c.SessionTimeout > maxSessionTimeout) {
+		*errs = append(*errs, fmt.Sprintf("subAgent.sessionTimeout must be > 0 and <= %d seconds", maxSessionTimeout))
+	}
+	if c.MaxConcurrentSessions != nil && (*c.MaxConcurrentSessions <= 0 || *c.MaxConcurrentSessions > maxConcurrentSessionsCeiling) {
+		*errs = append(*errs, fmt.Sprintf("subAgent.maxConcurrentSessions must be > 0 and <= %d", maxConcurrentSessionsCeiling))
+	}
 }
 
 func validateRequiredType(name, value string, valid map[string]bool, errs *[]string) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -309,6 +309,69 @@ func TestValidateRunConfig_ReadOnlyModeWithAllowAll(t *testing.T) {
 	}
 }
 
+func TestValidateRunConfig_SubAgent(t *testing.T) {
+	ptr := func(i int) *int { return &i }
+	cases := []struct {
+		name    string
+		mutate  func(*RunConfig)
+		wantErr string // substring; empty means expect success
+	}{
+		{"default zero value", func(c *RunConfig) {}, ""},
+		{"spawner local", func(c *RunConfig) { c.SubAgent.Spawner = "local" }, ""},
+		{"spawner transport", func(c *RunConfig) { c.SubAgent.Spawner = "transport" }, ""},
+		{"spawner invalid", func(c *RunConfig) { c.SubAgent.Spawner = "remote" }, "subAgent.spawner"},
+		{"sessions enabled", func(c *RunConfig) { c.SubAgent.Sessions = true }, ""},
+		{"timeout valid", func(c *RunConfig) { c.SubAgent.SessionTimeout = ptr(120) }, ""},
+		{"timeout zero", func(c *RunConfig) { c.SubAgent.SessionTimeout = ptr(0) }, "subAgent.sessionTimeout"},
+		{"timeout too large", func(c *RunConfig) { c.SubAgent.SessionTimeout = ptr(maxSessionTimeout + 1) }, "subAgent.sessionTimeout"},
+		{"maxConcurrent valid", func(c *RunConfig) { c.SubAgent.MaxConcurrentSessions = ptr(8) }, ""},
+		{"maxConcurrent zero", func(c *RunConfig) { c.SubAgent.MaxConcurrentSessions = ptr(0) }, "subAgent.maxConcurrentSessions"},
+		{"maxConcurrent too large", func(c *RunConfig) { c.SubAgent.MaxConcurrentSessions = ptr(maxConcurrentSessionsCeiling + 1) }, "subAgent.maxConcurrentSessions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			tc.mutate(c)
+			err := ValidateRunConfig(c)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected success, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestSubAgentRunConfig_Effective(t *testing.T) {
+	ptr := func(i int) *int { return &i }
+	var zero SubAgentRunConfig
+	if got := zero.SpawnerOrDefault(); got != "local" {
+		t.Errorf("SpawnerOrDefault zero = %q, want local", got)
+	}
+	if zero.UsesTransportSpawner() {
+		t.Error("UsesTransportSpawner zero = true, want false")
+	}
+	if got := (SubAgentRunConfig{Spawner: "transport"}); !got.UsesTransportSpawner() {
+		t.Error("UsesTransportSpawner transport = false, want true")
+	}
+	if got := zero.EffectiveSessionTimeoutSeconds(); got != DefaultSessionTimeout {
+		t.Errorf("EffectiveSessionTimeoutSeconds zero = %d, want %d", got, DefaultSessionTimeout)
+	}
+	if got := (SubAgentRunConfig{SessionTimeout: ptr(45)}).EffectiveSessionTimeoutSeconds(); got != 45 {
+		t.Errorf("EffectiveSessionTimeoutSeconds = %d, want 45", got)
+	}
+	if got := zero.EffectiveMaxConcurrentSessions(); got != DefaultMaxConcurrentSessions {
+		t.Errorf("EffectiveMaxConcurrentSessions zero = %d, want %d", got, DefaultMaxConcurrentSessions)
+	}
+	if got := (SubAgentRunConfig{MaxConcurrentSessions: ptr(3)}).EffectiveMaxConcurrentSessions(); got != 3 {
+		t.Errorf("EffectiveMaxConcurrentSessions = %d, want 3", got)
+	}
+}
+
 func TestValidateRunConfig_ReadOnlyModeWithDenySideEffects(t *testing.T) {
 	c := validConfig()
 	c.Mode = "review"


### PR DESCRIPTION
## Summary

Implements **#54** (transport-backed sub-agent spawner) and **#71**
(start-and-detach sessions) together, per the recast on #54 and #71's
"land in one pass" steer. Closes #54, closes #71.

### Design — Hybrid (confirmed with the maintainer before implementing)

A detached session is modelled as a **non-awaited async tool round-trip**:
one wire shape, one correlation primitive, no duplicate subsystem.

- `spawn_agent` blocking over the transport = `Start` + `Wait` fused.
- `start_session` emits the existing `tool_result_request` and returns its
  request id as the session handle; `wait_session` / `check_session`
  resolve it later via the extended `transport.Correlator`'s buffered
  retained entries; `terminate_session` stops it.
- Reuses `tool_result_request` / `tool_result_response` — **no proto
  regeneration**. The only protocol addition is a documented
  fire-and-forget `session_terminate` event (a new `type` string on the
  existing `HarnessEvent` envelope; `request_id` reused).

### What's included

| Layer | Change |
|---|---|
| `types` | `RunConfig.SubAgent{ spawner: local\|transport, sessions, sessionTimeout, maxConcurrentSessions }` + validation. Zero value = today's behaviour. |
| `transport` | `Correlator` gains an emit-now / await-or-poll-later path (`StartPending(WithID)` / `Poll` / `AwaitID` / `Forget`); the one-shot `Await` path is unchanged. |
| `core` | `SessionManager` (transport + local backends), state machine, bounded concurrency + retention, failure-outcome taxonomy, recursion guard. |
| `tool/builtins` | `SessionController` + `start_session` / `check_session` / `wait_session` / `terminate_session`. |
| `core/factory` | Wires the manager; transport `spawn_agent` variant; `NullTransport` misconfiguration guard; sub-agents excluded from all session tools. |
| docs/proto | `docs/configuration.md`, `docs/architecture.md`, and `session_terminate` documented. |

### Safety properties

- **In-process default is byte-for-byte unchanged** for a bare run.
- `transport` spawner on a `NullTransport` fails at construction.
- Sub-agents get neither `spawn_agent` nor any session tool (recursion guard).
- `start_session` carries the `spawn_agent` approval gate; management tools do not.
- Control-plane content is scrubbed at the point of entry (success and error paths).
- Unguessable `crypto/rand` session ids; concurrency cap enforced under contention; registry bounded with oldest-terminal eviction; detached/timed-out sessions are torn down (no orphaned jobs or leaked goroutines).

## Testing

`just build`, `just test`, and `just lint` (0 issues) all pass.
Unit tests for the correlator retained path, the session state machine
(fake + transport + local backends), the tool surface, and config
validation; plus an end-to-end gRPC integration test with a stub control
plane (blocking spawn, detached lifecycle, terminate). Concurrency-critical
paths are exercised under `-race`.

## Review

Implemented via a coordinated agent review wave (code, security,
spec-compliance, consistency, test-coverage) → synthesized remediation
brief → one full remediation round (all P0/P1 fixed: TOCTOU concurrency
cap, success-path scrubbing, goroutine/orphaned-job teardown, unguessable
ids, registry bounding, `errors.Is` taxonomy, local-backend + adapter
coverage) → verification pass confirming the fixes with no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
