### PR TITLE
types, proto, eval: add ruleOfTwo.runtime config surface

### DIFF
--- a/eval/spec/runconfig.go
+++ b/eval/spec/runconfig.go
@@ -368,7 +368,7 @@ func runConfigSpecToType(s *runConfigSpec) *types.RunConfig {
 			out.RuleOfTwo.Runtime = &types.RuleOfTwoRuntimeConfig{
 				Classifier:    s.RuleOfTwo.Runtime.Classifier,
 				OnDetect:      s.RuleOfTwo.Runtime.OnDetect,
-				GuardCriteria: s.RuleOfTwo.Runtime.GuardCriteria,
+				GuardCriteria: append([]string(nil), s.RuleOfTwo.Runtime.GuardCriteria...),
 			}
 		}
 	}

--- a/eval/spec/runconfig.go
+++ b/eval/spec/runconfig.go
@@ -218,7 +218,14 @@ type toolsSpec struct {
 }
 
 type ruleOfTwoSpec struct {
-	Enforce *bool `hcl:"enforce,optional"`
+	Enforce *bool                 `hcl:"enforce,optional"`
+	Runtime *ruleOfTwoRuntimeSpec `hcl:"runtime,block"`
+}
+
+type ruleOfTwoRuntimeSpec struct {
+	Classifier    string   `hcl:"classifier,optional"`
+	OnDetect      string   `hcl:"on_detect,optional"`
+	GuardCriteria []string `hcl:"guard_criteria,optional"`
 }
 
 type codeScannerSpec struct {
@@ -357,6 +364,13 @@ func runConfigSpecToType(s *runConfigSpec) *types.RunConfig {
 	}
 	if s.RuleOfTwo != nil {
 		out.RuleOfTwo = &types.RuleOfTwoConfig{Enforce: s.RuleOfTwo.Enforce}
+		if s.RuleOfTwo.Runtime != nil {
+			out.RuleOfTwo.Runtime = &types.RuleOfTwoRuntimeConfig{
+				Classifier:    s.RuleOfTwo.Runtime.Classifier,
+				OnDetect:      s.RuleOfTwo.Runtime.OnDetect,
+				GuardCriteria: s.RuleOfTwo.Runtime.GuardCriteria,
+			}
+		}
 	}
 	if s.CodeScanner != nil {
 		out.CodeScanner = &types.CodeScannerConfig{

--- a/eval/spec/runconfig_test.go
+++ b/eval/spec/runconfig_test.go
@@ -672,6 +672,16 @@ suite "s" {
       block_on_warn = true
     }
 
+    rule_of_two {
+      enforce = true
+
+      runtime {
+        classifier     = "patterns"
+        on_detect      = "block-external"
+        guard_criteria = ["sensitive_data", "pii"]
+      }
+    }
+
     guard_rail {
       type = "composite"
 
@@ -747,6 +757,18 @@ suite "s" {
 	}
 	if rc.CodeScanner == nil || !rc.CodeScanner.BlockOnWarn {
 		t.Errorf("CodeScanner = %#v, want BlockOnWarn=true", rc.CodeScanner)
+	}
+	if rc.RuleOfTwo == nil || rc.RuleOfTwo.Enforce == nil || !*rc.RuleOfTwo.Enforce {
+		t.Errorf("RuleOfTwo = %#v, want Enforce=&true", rc.RuleOfTwo)
+	}
+	if rc.RuleOfTwo == nil || rc.RuleOfTwo.Runtime == nil {
+		t.Fatalf("RuleOfTwo.Runtime should be non-nil, got %#v", rc.RuleOfTwo)
+	}
+	if rc.RuleOfTwo.Runtime.Classifier != "patterns" || rc.RuleOfTwo.Runtime.OnDetect != "block-external" {
+		t.Errorf("RuleOfTwo.Runtime = %#v, want {Classifier:patterns OnDetect:block-external}", rc.RuleOfTwo.Runtime)
+	}
+	if got := rc.RuleOfTwo.Runtime.GuardCriteria; len(got) != 2 || got[0] != "sensitive_data" || got[1] != "pii" {
+		t.Errorf("RuleOfTwo.Runtime.GuardCriteria = %v, want [sensitive_data pii]", got)
 	}
 	if rc.GuardRail == nil || rc.GuardRail.Type != "composite" {
 		t.Errorf("GuardRail = %#v, want composite", rc.GuardRail)

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -1078,6 +1078,11 @@ func (x *RuleOfTwoConfig) GetRuntime() *RuleOfTwoRuntimeConfig {
 // detects sensitive content. The other two legs are static
 // capabilities computable at config time; sensitivity is a content
 // property only knowable at runtime.
+//
+// NOTE: Only the configuration surface ships in this message. The
+// detector, latch, and enforcement gate land in follow-up changes.
+// Fields are validated but have no runtime effect until that change
+// lands.
 type RuleOfTwoRuntimeConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The detector implementation.

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -1020,7 +1020,11 @@ type RuleOfTwoConfig struct {
 	// serialise an empty `RuleOfTwoConfig{}` identically to
 	// `RuleOfTwoConfig{enforce: false}`, silently disabling enforcement
 	// for any control plane that includes the sub-message at all.
-	Enforce       *bool `protobuf:"varint,1,opt,name=enforce,proto3,oneof" json:"enforce,omitempty"`
+	Enforce *bool `protobuf:"varint,1,opt,name=enforce,proto3,oneof" json:"enforce,omitempty"`
+	// Optional. Runtime sensitive-data classifier configuration. An
+	// absent sub-message leaves arming to the harness factory's
+	// defaults; the validator never synthesises one.
+	Runtime       *RuleOfTwoRuntimeConfig `protobuf:"bytes,2,opt,name=runtime,proto3" json:"runtime,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1062,6 +1066,97 @@ func (x *RuleOfTwoConfig) GetEnforce() bool {
 	return false
 }
 
+func (x *RuleOfTwoConfig) GetRuntime() *RuleOfTwoRuntimeConfig {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+// RuleOfTwoRuntimeConfig selects the runtime sensitive-data classifier
+// for the Rule-of-Two sensitive-data leg and the action taken when it
+// detects sensitive content. The other two legs are static
+// capabilities computable at config time; sensitivity is a content
+// property only knowable at runtime.
+type RuleOfTwoRuntimeConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The detector implementation.
+	// Valid values:
+	//
+	//	""         — automatic (the factory decides from the static
+	//	              Rule-of-Two state).
+	//	"patterns" — deterministic regex+checksum pattern pack.
+	//	"none"     — disable runtime classification entirely.
+	Classifier string `protobuf:"bytes,1,opt,name=classifier,proto3" json:"classifier,omitempty"`
+	// The action once the classifier trips. Empty defaults to
+	// "block-external".
+	// Valid values: "block-external" (revoke external-communication
+	// tools for the rest of the run), "ask-upstream" (route
+	// external-communication calls through the upstream permission
+	// channel; requires transport=grpc), "redact" (rewrite matched
+	// spans), "abort" (terminate the run), "warn" (events and metrics
+	// only).
+	OnDetect string `protobuf:"bytes,2,opt,name=on_detect,json=onDetect,proto3" json:"on_detect,omitempty"`
+	// Guard Decision.Criterion values that also trip the sensitive-data
+	// latch (one-way — a guard can tighten the rule, never loosen it).
+	// Entries must be snake_case identifiers, matching the constraint
+	// on GuardRailConfig.custom_criteria keys.
+	GuardCriteria []string `protobuf:"bytes,3,rep,name=guard_criteria,json=guardCriteria,proto3" json:"guard_criteria,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RuleOfTwoRuntimeConfig) Reset() {
+	*x = RuleOfTwoRuntimeConfig{}
+	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RuleOfTwoRuntimeConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RuleOfTwoRuntimeConfig) ProtoMessage() {}
+
+func (x *RuleOfTwoRuntimeConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RuleOfTwoRuntimeConfig.ProtoReflect.Descriptor instead.
+func (*RuleOfTwoRuntimeConfig) Descriptor() ([]byte, []int) {
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RuleOfTwoRuntimeConfig) GetClassifier() string {
+	if x != nil {
+		return x.Classifier
+	}
+	return ""
+}
+
+func (x *RuleOfTwoRuntimeConfig) GetOnDetect() string {
+	if x != nil {
+		return x.OnDetect
+	}
+	return ""
+}
+
+func (x *RuleOfTwoRuntimeConfig) GetGuardCriteria() []string {
+	if x != nil {
+		return x.GuardCriteria
+	}
+	return nil
+}
+
 // CodeScannerConfig selects the static-analysis pass run after every
 // successful file edit.
 type CodeScannerConfig struct {
@@ -1098,7 +1193,7 @@ type CodeScannerConfig struct {
 
 func (x *CodeScannerConfig) Reset() {
 	*x = CodeScannerConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	mi := &file_harness_v1_harness_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1110,7 +1205,7 @@ func (x *CodeScannerConfig) String() string {
 func (*CodeScannerConfig) ProtoMessage() {}
 
 func (x *CodeScannerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	mi := &file_harness_v1_harness_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1123,7 +1218,7 @@ func (x *CodeScannerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeScannerConfig.ProtoReflect.Descriptor instead.
 func (*CodeScannerConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{7}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CodeScannerConfig) GetType() string {
@@ -1224,7 +1319,7 @@ type GuardRailConfig struct {
 
 func (x *GuardRailConfig) Reset() {
 	*x = GuardRailConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[8]
+	mi := &file_harness_v1_harness_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1236,7 +1331,7 @@ func (x *GuardRailConfig) String() string {
 func (*GuardRailConfig) ProtoMessage() {}
 
 func (x *GuardRailConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[8]
+	mi := &file_harness_v1_harness_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1249,7 +1344,7 @@ func (x *GuardRailConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GuardRailConfig.ProtoReflect.Descriptor instead.
 func (*GuardRailConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{8}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GuardRailConfig) GetType() string {
@@ -1363,7 +1458,7 @@ type ObservabilityConfig struct {
 
 func (x *ObservabilityConfig) Reset() {
 	*x = ObservabilityConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[9]
+	mi := &file_harness_v1_harness_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1375,7 +1470,7 @@ func (x *ObservabilityConfig) String() string {
 func (*ObservabilityConfig) ProtoMessage() {}
 
 func (x *ObservabilityConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[9]
+	mi := &file_harness_v1_harness_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1388,7 +1483,7 @@ func (x *ObservabilityConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObservabilityConfig.ProtoReflect.Descriptor instead.
 func (*ObservabilityConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{9}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ObservabilityConfig) GetEnvironment() string {
@@ -1443,7 +1538,7 @@ type RunTrace struct {
 
 func (x *RunTrace) Reset() {
 	*x = RunTrace{}
-	mi := &file_harness_v1_harness_proto_msgTypes[10]
+	mi := &file_harness_v1_harness_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1455,7 +1550,7 @@ func (x *RunTrace) String() string {
 func (*RunTrace) ProtoMessage() {}
 
 func (x *RunTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[10]
+	mi := &file_harness_v1_harness_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1468,7 +1563,7 @@ func (x *RunTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTrace.ProtoReflect.Descriptor instead.
 func (*RunTrace) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{10}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RunTrace) GetRunId() string {
@@ -1618,7 +1713,7 @@ type ProviderConfig struct {
 
 func (x *ProviderConfig) Reset() {
 	*x = ProviderConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[11]
+	mi := &file_harness_v1_harness_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1630,7 +1725,7 @@ func (x *ProviderConfig) String() string {
 func (*ProviderConfig) ProtoMessage() {}
 
 func (x *ProviderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[11]
+	mi := &file_harness_v1_harness_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1643,7 +1738,7 @@ func (x *ProviderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderConfig.ProtoReflect.Descriptor instead.
 func (*ProviderConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{11}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ProviderConfig) GetType() string {
@@ -1786,7 +1881,7 @@ type BatchProviderConfig struct {
 
 func (x *BatchProviderConfig) Reset() {
 	*x = BatchProviderConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	mi := &file_harness_v1_harness_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1798,7 +1893,7 @@ func (x *BatchProviderConfig) String() string {
 func (*BatchProviderConfig) ProtoMessage() {}
 
 func (x *BatchProviderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	mi := &file_harness_v1_harness_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1811,7 +1906,7 @@ func (x *BatchProviderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchProviderConfig.ProtoReflect.Descriptor instead.
 func (*BatchProviderConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{12}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *BatchProviderConfig) GetEnabled() bool {
@@ -1987,7 +2082,7 @@ type CredentialConfig struct {
 
 func (x *CredentialConfig) Reset() {
 	*x = CredentialConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[13]
+	mi := &file_harness_v1_harness_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1999,7 +2094,7 @@ func (x *CredentialConfig) String() string {
 func (*CredentialConfig) ProtoMessage() {}
 
 func (x *CredentialConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[13]
+	mi := &file_harness_v1_harness_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2012,7 +2107,7 @@ func (x *CredentialConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CredentialConfig.ProtoReflect.Descriptor instead.
 func (*CredentialConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{13}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CredentialConfig) GetType() string {
@@ -2158,7 +2253,7 @@ type TokenSourceConfig struct {
 
 func (x *TokenSourceConfig) Reset() {
 	*x = TokenSourceConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[14]
+	mi := &file_harness_v1_harness_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2170,7 +2265,7 @@ func (x *TokenSourceConfig) String() string {
 func (*TokenSourceConfig) ProtoMessage() {}
 
 func (x *TokenSourceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[14]
+	mi := &file_harness_v1_harness_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2183,7 +2278,7 @@ func (x *TokenSourceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TokenSourceConfig.ProtoReflect.Descriptor instead.
 func (*TokenSourceConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{14}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *TokenSourceConfig) GetType() string {
@@ -2251,7 +2346,7 @@ type GeminiSafetySetting struct {
 
 func (x *GeminiSafetySetting) Reset() {
 	*x = GeminiSafetySetting{}
-	mi := &file_harness_v1_harness_proto_msgTypes[15]
+	mi := &file_harness_v1_harness_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2263,7 +2358,7 @@ func (x *GeminiSafetySetting) String() string {
 func (*GeminiSafetySetting) ProtoMessage() {}
 
 func (x *GeminiSafetySetting) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[15]
+	mi := &file_harness_v1_harness_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2276,7 +2371,7 @@ func (x *GeminiSafetySetting) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GeminiSafetySetting.ProtoReflect.Descriptor instead.
 func (*GeminiSafetySetting) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{15}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GeminiSafetySetting) GetCategory() string {
@@ -2318,7 +2413,7 @@ type ProviderRetryConfig struct {
 
 func (x *ProviderRetryConfig) Reset() {
 	*x = ProviderRetryConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[16]
+	mi := &file_harness_v1_harness_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2330,7 +2425,7 @@ func (x *ProviderRetryConfig) String() string {
 func (*ProviderRetryConfig) ProtoMessage() {}
 
 func (x *ProviderRetryConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[16]
+	mi := &file_harness_v1_harness_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2343,7 +2438,7 @@ func (x *ProviderRetryConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderRetryConfig.ProtoReflect.Descriptor instead.
 func (*ProviderRetryConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{16}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ProviderRetryConfig) GetMaxAttempts() int32 {
@@ -2417,7 +2512,7 @@ type ModelRouterConfig struct {
 
 func (x *ModelRouterConfig) Reset() {
 	*x = ModelRouterConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[17]
+	mi := &file_harness_v1_harness_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2429,7 +2524,7 @@ func (x *ModelRouterConfig) String() string {
 func (*ModelRouterConfig) ProtoMessage() {}
 
 func (x *ModelRouterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[17]
+	mi := &file_harness_v1_harness_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2442,7 +2537,7 @@ func (x *ModelRouterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelRouterConfig.ProtoReflect.Descriptor instead.
 func (*ModelRouterConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{17}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ModelRouterConfig) GetType() string {
@@ -2540,7 +2635,7 @@ type PromptBuilderConfig struct {
 
 func (x *PromptBuilderConfig) Reset() {
 	*x = PromptBuilderConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[18]
+	mi := &file_harness_v1_harness_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2552,7 +2647,7 @@ func (x *PromptBuilderConfig) String() string {
 func (*PromptBuilderConfig) ProtoMessage() {}
 
 func (x *PromptBuilderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[18]
+	mi := &file_harness_v1_harness_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2565,7 +2660,7 @@ func (x *PromptBuilderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromptBuilderConfig.ProtoReflect.Descriptor instead.
 func (*PromptBuilderConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{18}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PromptBuilderConfig) GetType() string {
@@ -2604,7 +2699,7 @@ type ContextStrategyConfig struct {
 
 func (x *ContextStrategyConfig) Reset() {
 	*x = ContextStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[19]
+	mi := &file_harness_v1_harness_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2616,7 +2711,7 @@ func (x *ContextStrategyConfig) String() string {
 func (*ContextStrategyConfig) ProtoMessage() {}
 
 func (x *ContextStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[19]
+	mi := &file_harness_v1_harness_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2629,7 +2724,7 @@ func (x *ContextStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContextStrategyConfig.ProtoReflect.Descriptor instead.
 func (*ContextStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{19}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ContextStrategyConfig) GetType() string {
@@ -2702,7 +2797,7 @@ type ExecutorConfig struct {
 
 func (x *ExecutorConfig) Reset() {
 	*x = ExecutorConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[20]
+	mi := &file_harness_v1_harness_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2714,7 +2809,7 @@ func (x *ExecutorConfig) String() string {
 func (*ExecutorConfig) ProtoMessage() {}
 
 func (x *ExecutorConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[20]
+	mi := &file_harness_v1_harness_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2727,7 +2822,7 @@ func (x *ExecutorConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorConfig.ProtoReflect.Descriptor instead.
 func (*ExecutorConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{20}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ExecutorConfig) GetType() string {
@@ -2832,7 +2927,7 @@ type VcsBackendConfig struct {
 
 func (x *VcsBackendConfig) Reset() {
 	*x = VcsBackendConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[21]
+	mi := &file_harness_v1_harness_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2844,7 +2939,7 @@ func (x *VcsBackendConfig) String() string {
 func (*VcsBackendConfig) ProtoMessage() {}
 
 func (x *VcsBackendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[21]
+	mi := &file_harness_v1_harness_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2857,7 +2952,7 @@ func (x *VcsBackendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VcsBackendConfig.ProtoReflect.Descriptor instead.
 func (*VcsBackendConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{21}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *VcsBackendConfig) GetType() string {
@@ -2905,7 +3000,7 @@ type NetworkConfig struct {
 
 func (x *NetworkConfig) Reset() {
 	*x = NetworkConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[22]
+	mi := &file_harness_v1_harness_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2917,7 +3012,7 @@ func (x *NetworkConfig) String() string {
 func (*NetworkConfig) ProtoMessage() {}
 
 func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[22]
+	mi := &file_harness_v1_harness_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2930,7 +3025,7 @@ func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkConfig.ProtoReflect.Descriptor instead.
 func (*NetworkConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{22}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *NetworkConfig) GetMode() string {
@@ -2964,7 +3059,7 @@ type ResourceLimits struct {
 
 func (x *ResourceLimits) Reset() {
 	*x = ResourceLimits{}
-	mi := &file_harness_v1_harness_proto_msgTypes[23]
+	mi := &file_harness_v1_harness_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2976,7 +3071,7 @@ func (x *ResourceLimits) String() string {
 func (*ResourceLimits) ProtoMessage() {}
 
 func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[23]
+	mi := &file_harness_v1_harness_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2989,7 +3084,7 @@ func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceLimits.ProtoReflect.Descriptor instead.
 func (*ResourceLimits) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{23}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ResourceLimits) GetCpus() float64 {
@@ -3044,7 +3139,7 @@ type EditStrategyConfig struct {
 
 func (x *EditStrategyConfig) Reset() {
 	*x = EditStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[24]
+	mi := &file_harness_v1_harness_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3056,7 +3151,7 @@ func (x *EditStrategyConfig) String() string {
 func (*EditStrategyConfig) ProtoMessage() {}
 
 func (x *EditStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[24]
+	mi := &file_harness_v1_harness_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3069,7 +3164,7 @@ func (x *EditStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditStrategyConfig.ProtoReflect.Descriptor instead.
 func (*EditStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{24}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *EditStrategyConfig) GetType() string {
@@ -3117,7 +3212,7 @@ type VerifierConfig struct {
 
 func (x *VerifierConfig) Reset() {
 	*x = VerifierConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[25]
+	mi := &file_harness_v1_harness_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3129,7 +3224,7 @@ func (x *VerifierConfig) String() string {
 func (*VerifierConfig) ProtoMessage() {}
 
 func (x *VerifierConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[25]
+	mi := &file_harness_v1_harness_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3142,7 +3237,7 @@ func (x *VerifierConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifierConfig.ProtoReflect.Descriptor instead.
 func (*VerifierConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{25}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *VerifierConfig) GetType() string {
@@ -3239,7 +3334,7 @@ type PermissionPolicyConfig struct {
 
 func (x *PermissionPolicyConfig) Reset() {
 	*x = PermissionPolicyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[26]
+	mi := &file_harness_v1_harness_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3251,7 +3346,7 @@ func (x *PermissionPolicyConfig) String() string {
 func (*PermissionPolicyConfig) ProtoMessage() {}
 
 func (x *PermissionPolicyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[26]
+	mi := &file_harness_v1_harness_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3264,7 +3359,7 @@ func (x *PermissionPolicyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PermissionPolicyConfig.ProtoReflect.Descriptor instead.
 func (*PermissionPolicyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{26}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PermissionPolicyConfig) GetType() string {
@@ -3311,7 +3406,7 @@ type GitStrategyConfig struct {
 
 func (x *GitStrategyConfig) Reset() {
 	*x = GitStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[27]
+	mi := &file_harness_v1_harness_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3323,7 +3418,7 @@ func (x *GitStrategyConfig) String() string {
 func (*GitStrategyConfig) ProtoMessage() {}
 
 func (x *GitStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[27]
+	mi := &file_harness_v1_harness_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3336,7 +3431,7 @@ func (x *GitStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitStrategyConfig.ProtoReflect.Descriptor instead.
 func (*GitStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{27}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GitStrategyConfig) GetType() string {
@@ -3408,7 +3503,7 @@ type TraceEmitterConfig struct {
 
 func (x *TraceEmitterConfig) Reset() {
 	*x = TraceEmitterConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[28]
+	mi := &file_harness_v1_harness_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3420,7 +3515,7 @@ func (x *TraceEmitterConfig) String() string {
 func (*TraceEmitterConfig) ProtoMessage() {}
 
 func (x *TraceEmitterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[28]
+	mi := &file_harness_v1_harness_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3433,7 +3528,7 @@ func (x *TraceEmitterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceEmitterConfig.ProtoReflect.Descriptor instead.
 func (*TraceEmitterConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{28}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *TraceEmitterConfig) GetType() string {
@@ -3530,7 +3625,7 @@ type ToolsConfig struct {
 
 func (x *ToolsConfig) Reset() {
 	*x = ToolsConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[29]
+	mi := &file_harness_v1_harness_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3542,7 +3637,7 @@ func (x *ToolsConfig) String() string {
 func (*ToolsConfig) ProtoMessage() {}
 
 func (x *ToolsConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[29]
+	mi := &file_harness_v1_harness_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3555,7 +3650,7 @@ func (x *ToolsConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolsConfig.ProtoReflect.Descriptor instead.
 func (*ToolsConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{29}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ToolsConfig) GetBuiltIn() []string {
@@ -3590,7 +3685,7 @@ type MCPServerConfig struct {
 
 func (x *MCPServerConfig) Reset() {
 	*x = MCPServerConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[30]
+	mi := &file_harness_v1_harness_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3602,7 +3697,7 @@ func (x *MCPServerConfig) String() string {
 func (*MCPServerConfig) ProtoMessage() {}
 
 func (x *MCPServerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[30]
+	mi := &file_harness_v1_harness_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3615,7 +3710,7 @@ func (x *MCPServerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerConfig.ProtoReflect.Descriptor instead.
 func (*MCPServerConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{30}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *MCPServerConfig) GetName() string {
@@ -3725,11 +3820,18 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\x05value\x18\x01 \x01(\tR\x05value\x12\x1c\n" +
 	"\tsensitive\x18\x02 \x01(\bR\tsensitive\"7\n" +
 	"\x12ToolDispatchConfig\x12!\n" +
-	"\fmax_parallel\x18\x01 \x01(\x05R\vmaxParallel\"<\n" +
+	"\fmax_parallel\x18\x01 \x01(\x05R\vmaxParallel\"\x82\x01\n" +
 	"\x0fRuleOfTwoConfig\x12\x1d\n" +
-	"\aenforce\x18\x01 \x01(\bH\x00R\aenforce\x88\x01\x01B\n" +
+	"\aenforce\x18\x01 \x01(\bH\x00R\aenforce\x88\x01\x01\x12D\n" +
+	"\aruntime\x18\x02 \x01(\v2*.stirrup.harness.v1.RuleOfTwoRuntimeConfigR\aruntimeB\n" +
 	"\n" +
-	"\b_enforce\"\x97\x01\n" +
+	"\b_enforce\"|\n" +
+	"\x16RuleOfTwoRuntimeConfig\x12\x1e\n" +
+	"\n" +
+	"classifier\x18\x01 \x01(\tR\n" +
+	"classifier\x12\x1b\n" +
+	"\ton_detect\x18\x02 \x01(\tR\bonDetect\x12%\n" +
+	"\x0eguard_criteria\x18\x03 \x03(\tR\rguardCriteria\"\x97\x01\n" +
 	"\x11CodeScannerConfig\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1a\n" +
 	"\bscanners\x18\x02 \x03(\tR\bscanners\x12\"\n" +
@@ -3945,7 +4047,7 @@ func file_harness_v1_harness_proto_rawDescGZIP() []byte {
 	return file_harness_v1_harness_proto_rawDescData
 }
 
-var file_harness_v1_harness_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_harness_v1_harness_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_harness_v1_harness_proto_goTypes = []any{
 	(*HarnessEvent)(nil),           // 0: stirrup.harness.v1.HarnessEvent
 	(*ControlEvent)(nil),           // 1: stirrup.harness.v1.ControlEvent
@@ -3954,86 +4056,88 @@ var file_harness_v1_harness_proto_goTypes = []any{
 	(*DynamicContextValue)(nil),    // 4: stirrup.harness.v1.DynamicContextValue
 	(*ToolDispatchConfig)(nil),     // 5: stirrup.harness.v1.ToolDispatchConfig
 	(*RuleOfTwoConfig)(nil),        // 6: stirrup.harness.v1.RuleOfTwoConfig
-	(*CodeScannerConfig)(nil),      // 7: stirrup.harness.v1.CodeScannerConfig
-	(*GuardRailConfig)(nil),        // 8: stirrup.harness.v1.GuardRailConfig
-	(*ObservabilityConfig)(nil),    // 9: stirrup.harness.v1.ObservabilityConfig
-	(*RunTrace)(nil),               // 10: stirrup.harness.v1.RunTrace
-	(*ProviderConfig)(nil),         // 11: stirrup.harness.v1.ProviderConfig
-	(*BatchProviderConfig)(nil),    // 12: stirrup.harness.v1.BatchProviderConfig
-	(*CredentialConfig)(nil),       // 13: stirrup.harness.v1.CredentialConfig
-	(*TokenSourceConfig)(nil),      // 14: stirrup.harness.v1.TokenSourceConfig
-	(*GeminiSafetySetting)(nil),    // 15: stirrup.harness.v1.GeminiSafetySetting
-	(*ProviderRetryConfig)(nil),    // 16: stirrup.harness.v1.ProviderRetryConfig
-	(*ModelRouterConfig)(nil),      // 17: stirrup.harness.v1.ModelRouterConfig
-	(*PromptBuilderConfig)(nil),    // 18: stirrup.harness.v1.PromptBuilderConfig
-	(*ContextStrategyConfig)(nil),  // 19: stirrup.harness.v1.ContextStrategyConfig
-	(*ExecutorConfig)(nil),         // 20: stirrup.harness.v1.ExecutorConfig
-	(*VcsBackendConfig)(nil),       // 21: stirrup.harness.v1.VcsBackendConfig
-	(*NetworkConfig)(nil),          // 22: stirrup.harness.v1.NetworkConfig
-	(*ResourceLimits)(nil),         // 23: stirrup.harness.v1.ResourceLimits
-	(*EditStrategyConfig)(nil),     // 24: stirrup.harness.v1.EditStrategyConfig
-	(*VerifierConfig)(nil),         // 25: stirrup.harness.v1.VerifierConfig
-	(*PermissionPolicyConfig)(nil), // 26: stirrup.harness.v1.PermissionPolicyConfig
-	(*GitStrategyConfig)(nil),      // 27: stirrup.harness.v1.GitStrategyConfig
-	(*TraceEmitterConfig)(nil),     // 28: stirrup.harness.v1.TraceEmitterConfig
-	(*ToolsConfig)(nil),            // 29: stirrup.harness.v1.ToolsConfig
-	(*MCPServerConfig)(nil),        // 30: stirrup.harness.v1.MCPServerConfig
-	nil,                            // 31: stirrup.harness.v1.RunConfig.DynamicContextEntry
-	nil,                            // 32: stirrup.harness.v1.RunConfig.ProvidersEntry
-	nil,                            // 33: stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
-	nil,                            // 34: stirrup.harness.v1.ProviderConfig.QueryParamsEntry
-	nil,                            // 35: stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
-	nil,                            // 36: stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
-	nil,                            // 37: stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
+	(*RuleOfTwoRuntimeConfig)(nil), // 7: stirrup.harness.v1.RuleOfTwoRuntimeConfig
+	(*CodeScannerConfig)(nil),      // 8: stirrup.harness.v1.CodeScannerConfig
+	(*GuardRailConfig)(nil),        // 9: stirrup.harness.v1.GuardRailConfig
+	(*ObservabilityConfig)(nil),    // 10: stirrup.harness.v1.ObservabilityConfig
+	(*RunTrace)(nil),               // 11: stirrup.harness.v1.RunTrace
+	(*ProviderConfig)(nil),         // 12: stirrup.harness.v1.ProviderConfig
+	(*BatchProviderConfig)(nil),    // 13: stirrup.harness.v1.BatchProviderConfig
+	(*CredentialConfig)(nil),       // 14: stirrup.harness.v1.CredentialConfig
+	(*TokenSourceConfig)(nil),      // 15: stirrup.harness.v1.TokenSourceConfig
+	(*GeminiSafetySetting)(nil),    // 16: stirrup.harness.v1.GeminiSafetySetting
+	(*ProviderRetryConfig)(nil),    // 17: stirrup.harness.v1.ProviderRetryConfig
+	(*ModelRouterConfig)(nil),      // 18: stirrup.harness.v1.ModelRouterConfig
+	(*PromptBuilderConfig)(nil),    // 19: stirrup.harness.v1.PromptBuilderConfig
+	(*ContextStrategyConfig)(nil),  // 20: stirrup.harness.v1.ContextStrategyConfig
+	(*ExecutorConfig)(nil),         // 21: stirrup.harness.v1.ExecutorConfig
+	(*VcsBackendConfig)(nil),       // 22: stirrup.harness.v1.VcsBackendConfig
+	(*NetworkConfig)(nil),          // 23: stirrup.harness.v1.NetworkConfig
+	(*ResourceLimits)(nil),         // 24: stirrup.harness.v1.ResourceLimits
+	(*EditStrategyConfig)(nil),     // 25: stirrup.harness.v1.EditStrategyConfig
+	(*VerifierConfig)(nil),         // 26: stirrup.harness.v1.VerifierConfig
+	(*PermissionPolicyConfig)(nil), // 27: stirrup.harness.v1.PermissionPolicyConfig
+	(*GitStrategyConfig)(nil),      // 28: stirrup.harness.v1.GitStrategyConfig
+	(*TraceEmitterConfig)(nil),     // 29: stirrup.harness.v1.TraceEmitterConfig
+	(*ToolsConfig)(nil),            // 30: stirrup.harness.v1.ToolsConfig
+	(*MCPServerConfig)(nil),        // 31: stirrup.harness.v1.MCPServerConfig
+	nil,                            // 32: stirrup.harness.v1.RunConfig.DynamicContextEntry
+	nil,                            // 33: stirrup.harness.v1.RunConfig.ProvidersEntry
+	nil,                            // 34: stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
+	nil,                            // 35: stirrup.harness.v1.ProviderConfig.QueryParamsEntry
+	nil,                            // 36: stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
+	nil,                            // 37: stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
+	nil,                            // 38: stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
 }
 var file_harness_v1_harness_proto_depIdxs = []int32{
-	10, // 0: stirrup.harness.v1.HarnessEvent.trace:type_name -> stirrup.harness.v1.RunTrace
+	11, // 0: stirrup.harness.v1.HarnessEvent.trace:type_name -> stirrup.harness.v1.RunTrace
 	3,  // 1: stirrup.harness.v1.ControlEvent.task:type_name -> stirrup.harness.v1.RunConfig
 	2,  // 2: stirrup.harness.v1.ControlEvent.allowed:type_name -> stirrup.harness.v1.OptionalBool
 	2,  // 3: stirrup.harness.v1.ControlEvent.is_error:type_name -> stirrup.harness.v1.OptionalBool
-	31, // 4: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
-	11, // 5: stirrup.harness.v1.RunConfig.provider:type_name -> stirrup.harness.v1.ProviderConfig
-	32, // 6: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
-	17, // 7: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
-	18, // 8: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
-	19, // 9: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
-	20, // 10: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
-	24, // 11: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
-	25, // 12: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
-	26, // 13: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
-	27, // 14: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
-	28, // 15: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
-	29, // 16: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
+	32, // 4: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
+	12, // 5: stirrup.harness.v1.RunConfig.provider:type_name -> stirrup.harness.v1.ProviderConfig
+	33, // 6: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
+	18, // 7: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
+	19, // 8: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
+	20, // 9: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
+	21, // 10: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
+	25, // 11: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
+	26, // 12: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
+	27, // 13: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
+	28, // 14: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
+	29, // 15: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
+	30, // 16: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
 	6,  // 17: stirrup.harness.v1.RunConfig.rule_of_two:type_name -> stirrup.harness.v1.RuleOfTwoConfig
-	7,  // 18: stirrup.harness.v1.RunConfig.code_scanner:type_name -> stirrup.harness.v1.CodeScannerConfig
-	8,  // 19: stirrup.harness.v1.RunConfig.guard_rail:type_name -> stirrup.harness.v1.GuardRailConfig
-	9,  // 20: stirrup.harness.v1.RunConfig.observability:type_name -> stirrup.harness.v1.ObservabilityConfig
+	8,  // 18: stirrup.harness.v1.RunConfig.code_scanner:type_name -> stirrup.harness.v1.CodeScannerConfig
+	9,  // 19: stirrup.harness.v1.RunConfig.guard_rail:type_name -> stirrup.harness.v1.GuardRailConfig
+	10, // 20: stirrup.harness.v1.RunConfig.observability:type_name -> stirrup.harness.v1.ObservabilityConfig
 	5,  // 21: stirrup.harness.v1.RunConfig.tool_dispatch:type_name -> stirrup.harness.v1.ToolDispatchConfig
-	8,  // 22: stirrup.harness.v1.GuardRailConfig.stages:type_name -> stirrup.harness.v1.GuardRailConfig
-	33, // 23: stirrup.harness.v1.GuardRailConfig.custom_criteria:type_name -> stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
-	13, // 24: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
-	34, // 25: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
-	15, // 26: stirrup.harness.v1.ProviderConfig.gemini_safety_settings:type_name -> stirrup.harness.v1.GeminiSafetySetting
-	16, // 27: stirrup.harness.v1.ProviderConfig.retry:type_name -> stirrup.harness.v1.ProviderRetryConfig
-	12, // 28: stirrup.harness.v1.ProviderConfig.batch:type_name -> stirrup.harness.v1.BatchProviderConfig
-	14, // 29: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
-	35, // 30: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
-	21, // 31: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
-	22, // 32: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
-	23, // 33: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
-	36, // 34: stirrup.harness.v1.ExecutorConfig.k8s_node_selector:type_name -> stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
-	25, // 35: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
-	37, // 36: stirrup.harness.v1.TraceEmitterConfig.headers:type_name -> stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
-	30, // 37: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
-	4,  // 38: stirrup.harness.v1.RunConfig.DynamicContextEntry.value:type_name -> stirrup.harness.v1.DynamicContextValue
-	11, // 39: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
-	0,  // 40: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
-	1,  // 41: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
-	41, // [41:42] is the sub-list for method output_type
-	40, // [40:41] is the sub-list for method input_type
-	40, // [40:40] is the sub-list for extension type_name
-	40, // [40:40] is the sub-list for extension extendee
-	0,  // [0:40] is the sub-list for field type_name
+	7,  // 22: stirrup.harness.v1.RuleOfTwoConfig.runtime:type_name -> stirrup.harness.v1.RuleOfTwoRuntimeConfig
+	9,  // 23: stirrup.harness.v1.GuardRailConfig.stages:type_name -> stirrup.harness.v1.GuardRailConfig
+	34, // 24: stirrup.harness.v1.GuardRailConfig.custom_criteria:type_name -> stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
+	14, // 25: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
+	35, // 26: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
+	16, // 27: stirrup.harness.v1.ProviderConfig.gemini_safety_settings:type_name -> stirrup.harness.v1.GeminiSafetySetting
+	17, // 28: stirrup.harness.v1.ProviderConfig.retry:type_name -> stirrup.harness.v1.ProviderRetryConfig
+	13, // 29: stirrup.harness.v1.ProviderConfig.batch:type_name -> stirrup.harness.v1.BatchProviderConfig
+	15, // 30: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
+	36, // 31: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
+	22, // 32: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
+	23, // 33: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
+	24, // 34: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
+	37, // 35: stirrup.harness.v1.ExecutorConfig.k8s_node_selector:type_name -> stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
+	26, // 36: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
+	38, // 37: stirrup.harness.v1.TraceEmitterConfig.headers:type_name -> stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
+	31, // 38: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
+	4,  // 39: stirrup.harness.v1.RunConfig.DynamicContextEntry.value:type_name -> stirrup.harness.v1.DynamicContextValue
+	12, // 40: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
+	0,  // 41: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
+	1,  // 42: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
+	42, // [42:43] is the sub-list for method output_type
+	41, // [41:42] is the sub-list for method input_type
+	41, // [41:41] is the sub-list for extension type_name
+	41, // [41:41] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_harness_v1_harness_proto_init() }
@@ -4043,17 +4147,17 @@ func file_harness_v1_harness_proto_init() {
 	}
 	file_harness_v1_harness_proto_msgTypes[3].OneofWrappers = []any{}
 	file_harness_v1_harness_proto_msgTypes[6].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[8].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[11].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[9].OneofWrappers = []any{}
 	file_harness_v1_harness_proto_msgTypes[12].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[24].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[13].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[25].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_harness_v1_harness_proto_rawDesc), len(file_harness_v1_harness_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   38,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -163,7 +163,7 @@ func runConfigFromProto(pc *pb.RunConfig) types.RunConfig {
 			rc.RuleOfTwo.Runtime = &types.RuleOfTwoRuntimeConfig{
 				Classifier:    pc.RuleOfTwo.Runtime.Classifier,
 				OnDetect:      pc.RuleOfTwo.Runtime.OnDetect,
-				GuardCriteria: pc.RuleOfTwo.Runtime.GuardCriteria,
+				GuardCriteria: append([]string(nil), pc.RuleOfTwo.Runtime.GuardCriteria...),
 			}
 		}
 	}

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -155,6 +155,17 @@ func runConfigFromProto(pc *pb.RunConfig) types.RunConfig {
 		// the unset/false distinction here — the validator depends on it
 		// to apply the secure default (enforce) when the field is omitted.
 		rc.RuleOfTwo = &types.RuleOfTwoConfig{Enforce: pc.RuleOfTwo.Enforce}
+		// Runtime mirrors the same nil-vs-present distinction: an absent
+		// sub-message stays nil so the factory's default arming applies,
+		// rather than a synthesised empty block masquerading as an
+		// operator declaration.
+		if pc.RuleOfTwo.Runtime != nil {
+			rc.RuleOfTwo.Runtime = &types.RuleOfTwoRuntimeConfig{
+				Classifier:    pc.RuleOfTwo.Runtime.Classifier,
+				OnDetect:      pc.RuleOfTwo.Runtime.OnDetect,
+				GuardCriteria: pc.RuleOfTwo.Runtime.GuardCriteria,
+			}
+		}
 	}
 	if pc.SensitiveData != nil {
 		// proto3 `optional bool`, generated as *bool. Preserve the

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -133,36 +133,37 @@ func TestRuleOfTwoProto_RuntimeTranslation(t *testing.T) {
 		}
 	})
 
-	t.Run("populated runtime round-trips through the wire", func(t *testing.T) {
-		original := &pb.RuleOfTwoConfig{
-			Runtime: &pb.RuleOfTwoRuntimeConfig{
-				Classifier:    "patterns",
-				OnDetect:      "block-external",
-				GuardCriteria: []string{"sensitive_data", "pii"},
+	t.Run("populated runtime translates fields", func(t *testing.T) {
+		src := &pb.RunConfig{
+			RuleOfTwo: &pb.RuleOfTwoConfig{
+				Runtime: &pb.RuleOfTwoRuntimeConfig{
+					Classifier:    "patterns",
+					OnDetect:      "block-external",
+					GuardCriteria: []string{"sensitive_data", "pii"},
+				},
 			},
 		}
-		bytes, err := proto.Marshal(original)
-		if err != nil {
-			t.Fatalf("marshal: %v", err)
-		}
-		var decoded pb.RuleOfTwoConfig
-		if err := proto.Unmarshal(bytes, &decoded); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-
-		rc := runConfigFromProto(&pb.RunConfig{RuleOfTwo: &decoded})
+		rc := runConfigFromProto(src)
 		rt := rc.RuleOfTwo.Runtime
 		if rt == nil {
-			t.Fatal("expected Runtime non-nil after wire round-trip")
+			t.Fatal("expected Runtime non-nil")
 		}
 		if rt.Classifier != "patterns" {
-			t.Errorf("Classifier = %q, want patterns", rt.Classifier)
+			t.Errorf("Classifier: got %q, want %q", rt.Classifier, "patterns")
 		}
 		if rt.OnDetect != "block-external" {
-			t.Errorf("OnDetect = %q, want block-external", rt.OnDetect)
+			t.Errorf("OnDetect: got %q, want %q", rt.OnDetect, "block-external")
 		}
 		if len(rt.GuardCriteria) != 2 || rt.GuardCriteria[0] != "sensitive_data" || rt.GuardCriteria[1] != "pii" {
-			t.Errorf("GuardCriteria = %v, want [sensitive_data pii]", rt.GuardCriteria)
+			t.Errorf("GuardCriteria: got %v", rt.GuardCriteria)
+		}
+		// Mutation isolation: the proto message owns its backing array; on
+		// a long-lived gRPC server a shared slice would let writes to one
+		// decoded payload corrupt another run's criteria list. Modifying
+		// the source after translation must not reach the translated copy.
+		src.RuleOfTwo.Runtime.GuardCriteria[0] = "mutated"
+		if rt.GuardCriteria[0] != "sensitive_data" {
+			t.Error("GuardCriteria shares backing array with proto source")
 		}
 	})
 }

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -105,6 +105,68 @@ func TestRuleOfTwoProto_EmptyMessageDoesNotDisableEnforcement(t *testing.T) {
 	})
 }
 
+// TestRuleOfTwoProto_RuntimeTranslation pins the runtime sub-message
+// translation. The nil-vs-present distinction matters the same way it
+// does for enforce: an absent proto Runtime must stay nil on the
+// internal config so the factory's default arming applies, while a
+// present-but-empty one must surface as a present-but-empty block.
+func TestRuleOfTwoProto_RuntimeTranslation(t *testing.T) {
+	t.Run("absent runtime stays nil", func(t *testing.T) {
+		rc := runConfigFromProto(&pb.RunConfig{RuleOfTwo: &pb.RuleOfTwoConfig{}})
+		if rc.RuleOfTwo == nil {
+			t.Fatal("expected RuleOfTwo non-nil when proto sub-message present")
+		}
+		if rc.RuleOfTwo.Runtime != nil {
+			t.Fatalf("expected Runtime nil when proto runtime absent, got %+v", rc.RuleOfTwo.Runtime)
+		}
+	})
+
+	t.Run("empty runtime surfaces as present-but-empty", func(t *testing.T) {
+		rc := runConfigFromProto(&pb.RunConfig{
+			RuleOfTwo: &pb.RuleOfTwoConfig{Runtime: &pb.RuleOfTwoRuntimeConfig{}},
+		})
+		if rc.RuleOfTwo == nil || rc.RuleOfTwo.Runtime == nil {
+			t.Fatalf("expected present-but-empty Runtime, got %+v", rc.RuleOfTwo)
+		}
+		if rc.RuleOfTwo.Runtime.Classifier != "" || rc.RuleOfTwo.Runtime.OnDetect != "" || rc.RuleOfTwo.Runtime.GuardCriteria != nil {
+			t.Errorf("expected zero-valued Runtime, got %+v", rc.RuleOfTwo.Runtime)
+		}
+	})
+
+	t.Run("populated runtime round-trips through the wire", func(t *testing.T) {
+		original := &pb.RuleOfTwoConfig{
+			Runtime: &pb.RuleOfTwoRuntimeConfig{
+				Classifier:    "patterns",
+				OnDetect:      "block-external",
+				GuardCriteria: []string{"sensitive_data", "pii"},
+			},
+		}
+		bytes, err := proto.Marshal(original)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded pb.RuleOfTwoConfig
+		if err := proto.Unmarshal(bytes, &decoded); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		rc := runConfigFromProto(&pb.RunConfig{RuleOfTwo: &decoded})
+		rt := rc.RuleOfTwo.Runtime
+		if rt == nil {
+			t.Fatal("expected Runtime non-nil after wire round-trip")
+		}
+		if rt.Classifier != "patterns" {
+			t.Errorf("Classifier = %q, want patterns", rt.Classifier)
+		}
+		if rt.OnDetect != "block-external" {
+			t.Errorf("OnDetect = %q, want block-external", rt.OnDetect)
+		}
+		if len(rt.GuardCriteria) != 2 || rt.GuardCriteria[0] != "sensitive_data" || rt.GuardCriteria[1] != "pii" {
+			t.Errorf("GuardCriteria = %v, want [sensitive_data pii]", rt.GuardCriteria)
+		}
+	})
+}
+
 // TestRunConfigFromProto_TranslatesNewSafetyFields confirms that proto
 // fields added in #42 (executor.runtime, ruleOfTwo, codeScanner,
 // permissionPolicy.policy_file/fallback) are populated on the internal

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -494,6 +494,42 @@ message RuleOfTwoConfig {
   // `RuleOfTwoConfig{enforce: false}`, silently disabling enforcement
   // for any control plane that includes the sub-message at all.
   optional bool enforce = 1;
+
+  // Optional. Runtime sensitive-data classifier configuration. An
+  // absent sub-message leaves arming to the harness factory's
+  // defaults; the validator never synthesises one.
+  RuleOfTwoRuntimeConfig runtime = 2;
+}
+
+// RuleOfTwoRuntimeConfig selects the runtime sensitive-data classifier
+// for the Rule-of-Two sensitive-data leg and the action taken when it
+// detects sensitive content. The other two legs are static
+// capabilities computable at config time; sensitivity is a content
+// property only knowable at runtime.
+message RuleOfTwoRuntimeConfig {
+  // The detector implementation.
+  // Valid values:
+  //   ""         — automatic (the factory decides from the static
+  //                 Rule-of-Two state).
+  //   "patterns" — deterministic regex+checksum pattern pack.
+  //   "none"     — disable runtime classification entirely.
+  string classifier = 1;
+
+  // The action once the classifier trips. Empty defaults to
+  // "block-external".
+  // Valid values: "block-external" (revoke external-communication
+  // tools for the rest of the run), "ask-upstream" (route
+  // external-communication calls through the upstream permission
+  // channel; requires transport=grpc), "redact" (rewrite matched
+  // spans), "abort" (terminate the run), "warn" (events and metrics
+  // only).
+  string on_detect = 2;
+
+  // Guard Decision.Criterion values that also trip the sensitive-data
+  // latch (one-way — a guard can tighten the rule, never loosen it).
+  // Entries must be snake_case identifiers, matching the constraint
+  // on GuardRailConfig.custom_criteria keys.
+  repeated string guard_criteria = 3;
 }
 
 // CodeScannerConfig selects the static-analysis pass run after every

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -506,6 +506,11 @@ message RuleOfTwoConfig {
 // detects sensitive content. The other two legs are static
 // capabilities computable at config time; sensitivity is a content
 // property only knowable at runtime.
+//
+// NOTE: Only the configuration surface ships in this message. The
+// detector, latch, and enforcement gate land in follow-up changes.
+// Fields are validated but have no runtime effect until that change
+// lands.
 message RuleOfTwoRuntimeConfig {
   // The detector implementation.
   // Valid values:

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -332,6 +332,47 @@ func (rc *RunConfig) EffectiveToolDispatchMaxParallel() int {
 // equivalent to leaving the field unset.
 type RuleOfTwoConfig struct {
 	Enforce *bool `json:"enforce,omitempty"`
+
+	// Runtime configures the runtime sensitive-data classifier. The
+	// untrusted-input and external-communication legs are static
+	// capabilities computable at config time; sensitivity is a content
+	// property — the declarative signals (SensitiveData, per-entry
+	// Sensitive flags) cannot see sensitive content that first arrives
+	// mid-run via tool results. The runtime classifier makes the
+	// sensitive-data leg dynamic by scanning content as it enters the
+	// conversation. Nil leaves arming to the factory; validation never
+	// injects a Runtime block, so the Redact()-persisted config always
+	// reflects exactly what the operator declared.
+	Runtime *RuleOfTwoRuntimeConfig `json:"runtime,omitempty"`
+}
+
+// RuleOfTwoRuntimeConfig selects the runtime sensitive-data classifier
+// and the action taken when it detects sensitive content. Only the
+// config surface and its validation ship today; the detector, monitor,
+// and enforcement semantics land in follow-up changes.
+type RuleOfTwoRuntimeConfig struct {
+	// Classifier selects the detector implementation. Valid values:
+	// "" (automatic — the factory decides from the static Rule-of-Two
+	// state), "patterns" (deterministic regex+checksum pack), "none"
+	// (disable runtime classification entirely).
+	Classifier string `json:"classifier,omitempty"`
+
+	// OnDetect selects the action once the classifier trips. Empty
+	// defaults to "block-external" (revoke external-communication
+	// tools for the rest of the run). Other values: "ask-upstream"
+	// (route external-communication calls through the upstream
+	// permission channel; requires transport=grpc), "redact" (rewrite
+	// matched spans), "abort" (terminate the run), "warn" (events and
+	// metrics only).
+	OnDetect string `json:"onDetect,omitempty"`
+
+	// GuardCriteria lists guard Decision.Criterion values that also
+	// trip the sensitive-data latch, so an LLM guard flagging e.g.
+	// "sensitive_data" can tighten the rule mid-run (one-way — a guard
+	// can never loosen it). Entries follow the same snake_case
+	// constraint as guardRail customCriteria keys. Empty defers to the
+	// factory default of ["sensitive_data", "pii"].
+	GuardCriteria []string `json:"guardCriteria,omitempty"`
 }
 
 // CodeScannerConfig selects the static-analysis pass run after every
@@ -1967,6 +2008,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	}
 
 	validateRuleOfTwo(config, &errs)
+	validateRuleOfTwoRuntime(config, &errs)
 	validateCodeScannerConfig(config.CodeScanner, &errs)
 	validateGuardRailConfig(config.GuardRail, "guardRail", false, &errs)
 	validateObservabilityConfig(config.Observability, &errs)
@@ -2131,6 +2173,47 @@ func validateRuleOfTwo(config *RunConfig, errs *[]string) {
 	}
 	*errs = append(*errs,
 		"all three of {untrusted-input, sensitive-data, external-communication} cannot simultaneously hold without the ask-upstream permission policy (Rule of Two)")
+}
+
+var validRuleOfTwoClassifiers = map[string]bool{
+	"":         true,
+	"patterns": true,
+	"none":     true,
+}
+
+var validRuleOfTwoOnDetectActions = map[string]bool{
+	"":               true,
+	"block-external": true,
+	"ask-upstream":   true,
+	"redact":         true,
+	"abort":          true,
+	"warn":           true,
+}
+
+// validateRuleOfTwoRuntime enforces the closed sets and cross-field
+// invariants on RuleOfTwo.Runtime. Unlike applyCodeScannerDefault, it
+// deliberately never injects or defaults a Runtime block: default
+// arming is factory behaviour, and an injected block would alter the
+// Redact()-persisted config operators audit against.
+func validateRuleOfTwoRuntime(config *RunConfig, errs *[]string) {
+	if config.RuleOfTwo == nil || config.RuleOfTwo.Runtime == nil {
+		return
+	}
+	rt := config.RuleOfTwo.Runtime
+	if !validRuleOfTwoClassifiers[rt.Classifier] {
+		*errs = append(*errs, fmt.Sprintf("unsupported ruleOfTwo.runtime.classifier %q", rt.Classifier))
+	}
+	if !validRuleOfTwoOnDetectActions[rt.OnDetect] {
+		*errs = append(*errs, fmt.Sprintf("unsupported ruleOfTwo.runtime.onDetect %q", rt.OnDetect))
+	}
+	if rt.OnDetect == "ask-upstream" && config.Transport.Type != "grpc" {
+		*errs = append(*errs, "ruleOfTwo.runtime.onDetect \"ask-upstream\" requires transport=grpc (stdio has no upstream control plane to answer permission requests)")
+	}
+	for i, criterion := range rt.GuardCriteria {
+		if !guardRailCustomCriterionPattern.MatchString(criterion) {
+			*errs = append(*errs, fmt.Sprintf("ruleOfTwo.runtime.guardCriteria[%d] %q must match %s", i, criterion, guardRailCustomCriterionPattern.String()))
+		}
+	}
 }
 
 // ruleOfTwoUntrustedInput reports whether the run can ingest content

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -370,8 +370,7 @@ type RuleOfTwoRuntimeConfig struct {
 	// trip the sensitive-data latch, so an LLM guard flagging e.g.
 	// "sensitive_data" can tighten the rule mid-run (one-way — a guard
 	// can never loosen it). Entries follow the same snake_case
-	// constraint as guardRail customCriteria keys. Empty defers to the
-	// factory default of ["sensitive_data", "pii"].
+	// constraint as guardRail customCriteria keys.
 	GuardCriteria []string `json:"guardCriteria,omitempty"`
 }
 
@@ -2203,10 +2202,16 @@ func validateRuleOfTwoRuntime(config *RunConfig, errs *[]string) {
 	if !validRuleOfTwoClassifiers[rt.Classifier] {
 		*errs = append(*errs, fmt.Sprintf("unsupported ruleOfTwo.runtime.classifier %q", rt.Classifier))
 	}
+	// Reject dead configuration: "none" disables the detector, so any
+	// onDetect action would be stored and validated but never fire — an
+	// operator who sets {classifier: "none", onDetect: "abort"} believing
+	// they have a safety net in fact has none.
+	if rt.Classifier == "none" && rt.OnDetect != "" {
+		*errs = append(*errs, `ruleOfTwo.runtime.onDetect has no effect when classifier="none": the detector is disabled and will never fire`)
+	}
 	if !validRuleOfTwoOnDetectActions[rt.OnDetect] {
 		*errs = append(*errs, fmt.Sprintf("unsupported ruleOfTwo.runtime.onDetect %q", rt.OnDetect))
-	}
-	if rt.OnDetect == "ask-upstream" && config.Transport.Type != "grpc" {
+	} else if rt.OnDetect == "ask-upstream" && config.Transport.Type != "grpc" {
 		*errs = append(*errs, "ruleOfTwo.runtime.onDetect \"ask-upstream\" requires transport=grpc (stdio has no upstream control plane to answer permission requests)")
 	}
 	for i, criterion := range rt.GuardCriteria {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -2774,6 +2774,192 @@ func TestValidateRunConfig_RuleOfTwo_ToolListReflectsActualBuiltIn(t *testing.T)
 	}
 }
 
+// --- RuleOfTwoRuntimeConfig ---
+
+func TestValidateRunConfig_RuleOfTwoRuntime_ClassifierClosedSet(t *testing.T) {
+	cases := []struct {
+		name       string
+		classifier string
+		wantErr    bool
+	}{
+		{"empty_is_auto", "", false},
+		{"patterns", "patterns", false},
+		{"none", "none", false},
+		{"unknown", "regex", true},
+		{"case_sensitive", "Patterns", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{Classifier: tc.classifier}}
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for classifier %q, got nil", tc.classifier)
+				}
+				if !strings.Contains(err.Error(), "ruleOfTwo.runtime.classifier") {
+					t.Errorf("error should name ruleOfTwo.runtime.classifier, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("classifier %q should pass, got: %v", tc.classifier, err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_RuleOfTwoRuntime_OnDetectClosedSet(t *testing.T) {
+	cases := []struct {
+		name     string
+		onDetect string
+		wantErr  bool
+	}{
+		{"empty_defaults_to_block_external", "", false},
+		{"block_external", "block-external", false},
+		{"redact", "redact", false},
+		{"abort", "abort", false},
+		{"warn", "warn", false},
+		{"unknown", "deny", true},
+		{"case_sensitive", "Warn", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{OnDetect: tc.onDetect}}
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for onDetect %q, got nil", tc.onDetect)
+				}
+				if !strings.Contains(err.Error(), "ruleOfTwo.runtime.onDetect") {
+					t.Errorf("error should name ruleOfTwo.runtime.onDetect, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("onDetect %q should pass, got: %v", tc.onDetect, err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_RuleOfTwoRuntime_AskUpstreamRequiresGRPC pins the
+// cross-field invariant: onDetect "ask-upstream" routes external-comm
+// permission requests upstream, which only exists on the gRPC transport.
+// A stdio (or defaulted-empty) transport has no control plane to answer
+// the request, so the combination must fail at validation time rather
+// than as a 60-second timeout per tool call at runtime.
+func TestValidateRunConfig_RuleOfTwoRuntime_AskUpstreamRequiresGRPC(t *testing.T) {
+	cases := []struct {
+		name      string
+		transport string
+		wantErr   bool
+	}{
+		{"grpc_passes", "grpc", false},
+		{"stdio_fails", "stdio", true},
+		{"empty_transport_fails", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			c.Transport = TransportConfig{Type: tc.transport}
+			c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{OnDetect: "ask-upstream"}}
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for ask-upstream with transport %q, got nil", tc.transport)
+				}
+				if !strings.Contains(err.Error(), "requires transport=grpc") {
+					t.Errorf("error should mention requires transport=grpc, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ask-upstream with grpc transport should pass, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_RuleOfTwoRuntime_GuardCriteriaPattern(t *testing.T) {
+	cases := []struct {
+		name     string
+		criteria []string
+		wantErr  bool
+	}{
+		{"snake_case_passes", []string{"sensitive_data", "pii"}, false},
+		{"uppercase_fails", []string{"PII"}, true},
+		{"leading_digit_fails", []string{"4data"}, true},
+		{"hyphen_fails", []string{"sensitive-data"}, true},
+		{"empty_entry_fails", []string{""}, true},
+		{"mixed_reports_offender", []string{"sensitive_data", "Bad Entry"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{GuardCriteria: tc.criteria}}
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for guardCriteria %v, got nil", tc.criteria)
+				}
+				if !strings.Contains(err.Error(), "ruleOfTwo.runtime.guardCriteria") {
+					t.Errorf("error should name ruleOfTwo.runtime.guardCriteria, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("guardCriteria %v should pass, got: %v", tc.criteria, err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_RuleOfTwoRuntime_NilPassthrough pins the
+// no-injection invariant: validation must neither reject nor mutate a
+// config with a nil RuleOfTwo or nil Runtime. Default arming is factory
+// behaviour — an injected Runtime block would alter the
+// Redact()-persisted config operators audit against (contrast
+// applyCodeScannerDefault, which deliberately does mutate).
+func TestValidateRunConfig_RuleOfTwoRuntime_NilPassthrough(t *testing.T) {
+	t.Run("nil RuleOfTwo", func(t *testing.T) {
+		c := validConfig()
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("nil RuleOfTwo should pass, got: %v", err)
+		}
+		if c.RuleOfTwo != nil {
+			t.Fatalf("validation must not inject a RuleOfTwo block, got: %+v", c.RuleOfTwo)
+		}
+	})
+	t.Run("nil Runtime", func(t *testing.T) {
+		c := validConfig()
+		c.RuleOfTwo = &RuleOfTwoConfig{Enforce: boolRef(true)}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("nil Runtime should pass, got: %v", err)
+		}
+		if c.RuleOfTwo.Runtime != nil {
+			t.Fatalf("validation must not inject a Runtime block, got: %+v", c.RuleOfTwo.Runtime)
+		}
+	})
+}
+
+func TestValidateRunConfig_RuleOfTwoRuntime_ValidFullBlockPasses(t *testing.T) {
+	c := validConfig()
+	c.Transport = TransportConfig{Type: "grpc"}
+	c.RuleOfTwo = &RuleOfTwoConfig{
+		Enforce: boolRef(true),
+		Runtime: &RuleOfTwoRuntimeConfig{
+			Classifier:    "patterns",
+			OnDetect:      "ask-upstream",
+			GuardCriteria: []string{"sensitive_data", "pii"},
+		},
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("fully-populated valid runtime block should pass, got: %v", err)
+	}
+}
+
 // --- GuardRailConfig ---
 
 // TestValidateGuardRailConfig is a table-driven exercise of every

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -2811,21 +2811,24 @@ func TestValidateRunConfig_RuleOfTwoRuntime_ClassifierClosedSet(t *testing.T) {
 
 func TestValidateRunConfig_RuleOfTwoRuntime_OnDetectClosedSet(t *testing.T) {
 	cases := []struct {
-		name     string
-		onDetect string
-		wantErr  bool
+		name      string
+		onDetect  string
+		transport string
+		wantErr   bool
 	}{
-		{"empty_defaults_to_block_external", "", false},
-		{"block_external", "block-external", false},
-		{"redact", "redact", false},
-		{"abort", "abort", false},
-		{"warn", "warn", false},
-		{"unknown", "deny", true},
-		{"case_sensitive", "Warn", true},
+		{"empty_defaults_to_block_external", "", "", false},
+		{"block_external", "block-external", "", false},
+		{"ask_upstream_valid_value", "ask-upstream", "grpc", false}, // cross-field check exercised separately
+		{"redact", "redact", "", false},
+		{"abort", "abort", "", false},
+		{"warn", "warn", "", false},
+		{"unknown", "deny", "", true},
+		{"case_sensitive", "Warn", "", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := validConfig()
+			c.Transport = TransportConfig{Type: tc.transport}
 			c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{OnDetect: tc.onDetect}}
 			err := ValidateRunConfig(c)
 			if tc.wantErr {
@@ -2842,6 +2845,31 @@ func TestValidateRunConfig_RuleOfTwoRuntime_OnDetectClosedSet(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateRunConfig_RuleOfTwoRuntime_NoneClassifierCrossField pins
+// the dead-config rejection: classifier "none" disables the detector,
+// so a non-empty onDetect would be stored and validated but never fire
+// — an operator who sets it believing they have a safety net has none.
+func TestValidateRunConfig_RuleOfTwoRuntime_NoneClassifierCrossField(t *testing.T) {
+	t.Run("none with onDetect rejected", func(t *testing.T) {
+		c := validConfig()
+		c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{Classifier: "none", OnDetect: "abort"}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected rejection for classifier=none with onDetect=abort, got nil")
+		}
+		if !strings.Contains(err.Error(), "has no effect") {
+			t.Errorf("error should mention has no effect, got: %v", err)
+		}
+	})
+	t.Run("none with empty onDetect passes", func(t *testing.T) {
+		c := validConfig()
+		c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{Classifier: "none"}}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("classifier=none alone should pass, got: %v", err)
+		}
+	})
 }
 
 // TestValidateRunConfig_RuleOfTwoRuntime_AskUpstreamRequiresGRPC pins the


### PR DESCRIPTION
## Summary

Wave 1 of 5 making the Rule of Two's sensitive-data leg dynamic (Ring 4, `docs/safety-rings.md`). This PR is **config plumbing only — no behaviour change**:

- `RuleOfTwoRuntimeConfig` (`classifier`, `onDetect`, `guardCriteria`) nested under `ruleOfTwo.runtime` in `types/runconfig.go`, with `validateRuleOfTwoRuntime` (closed value sets, `ask-upstream` ⇒ grpc transport, `guardCriteria` validated against the existing guard-criterion pattern, `classifier:"none"` + `onDetect` cross-field rejection).
- Proto `RuleOfTwoRuntimeConfig` message + `runtime = 2` on `RuleOfTwoConfig`; `runConfigFromProto` mapping with defensive slice copies; regenerated `gen/` via `buf generate` (no hand edits).
- `rule_of_two { runtime { ... } }` block in the eval HCL grammar.

Context: the sensitive-data leg today is a static operator declaration that detects nothing (`ruleOfTwoSensitiveData`, introduced in #73 after the #51 heuristic degraded the rule to "rule of one"). The follow-up waves add a deterministic pattern detector (Wave 2), a run-scoped one-way latch + loop wiring shipping observe-only (Wave 3), enforcement incl. egress revocation (Wave 4), and docs/evals (Wave 5). Plan agreed with the operator before implementation.

## One-way decisions

- **Wire shape is frozen on merge**: proto field numbers (`classifier=1`, `on_detect=2`, `guard_criteria=3`, `runtime=2`) and the JSON names (`classifier`, `onDetect`, `guardCriteria`) become compatibility surface for control planes.
- **Closed value sets**: `classifier ∈ {"", "patterns", "none"}`, `onDetect ∈ {"", "block-external", "ask-upstream", "redact", "abort", "warn"}`. Adding values later is cheap; renaming/removing is breaking.
- **No CLI flag**, matching the existing `ruleOfTwo.enforce` rule: the override must live in a reviewable RunConfig file, not shell history.
- **The validator never injects a `runtime` default.** Default-arming is factory behaviour (Wave 3) so the `Redact()`-persisted config stays exactly operator-authored. Tests pin config non-mutation.

## Assumptions

- gRPC translation is **fromProto-only**: the transport has no types→proto RunConfig direction anywhere, so none was added.
- `onDetect: "ask-upstream"` is rejected for stdio (and empty/defaulted) transport at validation time — stdio has no upstream control plane to answer permission requests; failing fast beats a 60 s timeout per tool call at runtime.
- Semantics documented in code comments are deliberately scoped to "config surface only; enforcement not yet shipped" (both Go and proto carry the caveat) so nobody reads protection into a flag that does not act yet.

## Review

One wave of three parallel reviews (code, security, spec-compliance) was synthesized and remediated before opening: proto/HCL slice aliasing fixed with defensive copies, overpromising doc comment removed, `classifier:"none"`+`onDetect` cross-check added, ask-upstream check restructured to `else if`, direct (non-marshalling) translation test replacing the proto-library round-trip, closed-set test rows extended.

## Testing

- `just` (build + full test) green; `just lint` 0 issues.
- New: `TestValidateRunConfig_RuleOfTwoRuntime_*` (closed sets, cross-field, nil passthrough, non-mutation), `TestRuleOfTwoProto_RuntimeTranslation` (absent→nil, empty→present, populated, mutation isolation), eval HCL deep-block parse coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)