### PR TITLE
ruleoftwo, core: wire runtime sensitive-data monitor, observe-only

### DIFF
--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/provider/compat/zai"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
+	"github.com/rxbynerd/stirrup/harness/internal/ruleoftwo"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/security/codescanner"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
@@ -75,8 +76,12 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	// override (RuleOfTwo.Enforce: false) or the ask-upstream policy.
 	// Recording the event keeps the override auditable; the two-of-three
 	// warning surfaces a heads-up that future capability creep would
-	// trip the invariant.
-	emitRuleOfTwoEvents(config, secLogger)
+	// trip the invariant. The arming decision for the runtime
+	// sensitive-data monitor is computed once here — it feeds both the
+	// rule_of_two_runtime_armed audit event and the monitor built in
+	// step 10b below.
+	ruleOfTwoArmingState := resolveRuleOfTwoArming(config)
+	emitRuleOfTwoEvents(config, secLogger, ruleOfTwoArmingState)
 
 	// Secret store for resolving credential references. AutoSecretStore routes
 	// to SSM for "secret://ssm:///..." refs, falling back to env/file otherwise.
@@ -275,6 +280,14 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		cleanup()
 		return nil, fmt.Errorf("build guardrail: %w", err)
 	}
+
+	// 10b. Rule-of-Two runtime monitor, from the arming decision
+	// computed alongside the run-start audit events above. Noop when
+	// unarmed so the loop's call sites are unconditional. Observe-only
+	// this wave: enforcing/action flow into events only — no
+	// enforcement consumer exists until wave 4 lands the permission
+	// gate, redact, and abort paths.
+	rot := buildRuleOfTwoMonitor(ruleOfTwoArmingState)
 
 	// 11. Git strategy.
 	gs := buildGitStrategy(config.GitStrategy)
@@ -542,6 +555,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		Permissions:  pp,
 		Git:          gs,
 		GuardRail:    gr,
+		RuleOfTwo:    rot,
 		Escalation:   escalation,
 		Transport:    tp,
 		Trace:        te,
@@ -1054,8 +1068,110 @@ func editStrategyTool(es edit.EditStrategy, exec executor.Executor) *tool.Tool {
 	}
 }
 
-// emitRuleOfTwoEvents records two security events at run start:
+// defaultRuleOfTwoGuardCriteria is the guard-criteria set used when
+// ruleOfTwo.runtime.guardCriteria is unset: the two built-in criteria
+// an LLM guard is expected to name when it spots sensitive content.
+var defaultRuleOfTwoGuardCriteria = []string{"sensitive_data", "pii"}
+
+// defaultRuleOfTwoAction is the documented onDetect default. Inert this
+// wave (no enforcement consumer); it flows into events so the soak
+// shows the action wave 4 will start applying.
+const defaultRuleOfTwoAction = "block-external"
+
+// ruleOfTwoArming is the factory's arming decision for the Rule-of-Two
+// runtime monitor, computed once per run from the static Rule-of-Two
+// state and the operator's ruleOfTwo.runtime block. Default arming is
+// deliberately factory behaviour, not config mutation — the validator
+// never injects a Runtime block, so the Redact()-persisted config
+// reflects exactly what the operator declared.
+type ruleOfTwoArming struct {
+	armed           bool
+	enforcing       bool
+	action          string
+	criteria        []string
+	classifier      string
+	staticSensitive bool
+}
+
+// resolveRuleOfTwoArming computes the arming matrix. With u =
+// holdsUntrusted, e = canCommExternal, s = static sensitive declaration:
 //
+//   - runtime.classifier "none" disarms entirely.
+//   - u && e && !s with a non-ask-upstream policy and enforce != false
+//     arms enforcing (the dangerous two-of-three where a mid-run
+//     sensitive sighting completes the triad).
+//   - u && e otherwise (ask-upstream, enforce:false, or s already
+//     declared) arms observe-only: ask-upstream already gates egress,
+//     an explicit override must stay an override, and a declared-
+//     sensitive run was already adjudicated by the validator.
+//   - !u || !e stays unarmed — the triad cannot complete — unless the
+//     operator explicitly selected classifier "patterns" (observe-only
+//     detection telemetry on request).
+func resolveRuleOfTwoArming(config *types.RunConfig) ruleOfTwoArming {
+	if config == nil {
+		return ruleOfTwoArming{}
+	}
+	classifier := ""
+	action := defaultRuleOfTwoAction
+	criteria := defaultRuleOfTwoGuardCriteria
+	enforceOverridden := false
+	if config.RuleOfTwo != nil {
+		enforceOverridden = config.RuleOfTwo.Enforce != nil && !*config.RuleOfTwo.Enforce
+		if rt := config.RuleOfTwo.Runtime; rt != nil {
+			classifier = rt.Classifier
+			if rt.OnDetect != "" {
+				action = rt.OnDetect
+			}
+			if len(rt.GuardCriteria) > 0 {
+				criteria = rt.GuardCriteria
+			}
+		}
+	}
+	if classifier == "none" {
+		return ruleOfTwoArming{}
+	}
+	u, s, e := types.RuleOfTwoState(config)
+	switch {
+	case u && e:
+		enforcing := !s && config.PermissionPolicy.Type != "ask-upstream" && !enforceOverridden
+		return ruleOfTwoArming{
+			armed:           true,
+			enforcing:       enforcing,
+			action:          action,
+			criteria:        criteria,
+			classifier:      "patterns",
+			staticSensitive: s,
+		}
+	case classifier == "patterns":
+		return ruleOfTwoArming{
+			armed:           true,
+			enforcing:       false,
+			action:          action,
+			criteria:        criteria,
+			classifier:      "patterns",
+			staticSensitive: s,
+		}
+	default:
+		return ruleOfTwoArming{}
+	}
+}
+
+// buildRuleOfTwoMonitor maps an arming decision onto a Monitor. Noop
+// for unarmed runs so the loop's call sites stay unconditional.
+func buildRuleOfTwoMonitor(arming ruleOfTwoArming) ruleoftwo.Monitor {
+	if !arming.armed {
+		return ruleoftwo.NewNoop()
+	}
+	return ruleoftwo.NewPatternMonitor(arming.enforcing, arming.action, arming.criteria, arming.staticSensitive)
+}
+
+// emitRuleOfTwoEvents records the Rule-of-Two security events at run
+// start:
+//
+//   - rule_of_two_runtime_armed whenever the runtime monitor is armed,
+//     recording the resolved classifier, the effective on-detect action
+//     (the monitor reports "warn" when observe-only, so the event never
+//     promises an action that cannot fire), and the enforcing bit.
 //   - rule_of_two_disabled when all three Rule-of-Two flags hold AND the
 //     operator explicitly disabled enforcement via RuleOfTwo.Enforce:false.
 //     This is the audit trail for the override; the validator would
@@ -1067,9 +1183,20 @@ func editStrategyTool(es edit.EditStrategy, exec executor.Executor) *tool.Tool {
 // The event names "untrusted-input", "sensitive-data", and
 // "external-communication" mirror the validator's rejection message so
 // downstream tooling can grep for the same identifiers in both places.
-func emitRuleOfTwoEvents(config *types.RunConfig, sec *security.SecurityLogger) {
+func emitRuleOfTwoEvents(config *types.RunConfig, sec *security.SecurityLogger, arming ruleOfTwoArming) {
 	if sec == nil || config == nil {
 		return
+	}
+	if arming.armed {
+		effectiveAction := arming.action
+		if !arming.enforcing {
+			effectiveAction = "warn"
+		}
+		sec.Emit("info", "rule_of_two_runtime_armed", map[string]any{
+			"classifier": arming.classifier,
+			"onDetect":   effectiveAction,
+			"enforcing":  arming.enforcing,
+		})
 	}
 	u, s, e := types.RuleOfTwoState(config)
 

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -476,7 +476,7 @@ func TestEmitRuleOfTwoEvents_AllThreeWithOverrideEmitsDisabled(t *testing.T) {
 		RuleOfTwo:        &types.RuleOfTwoConfig{Enforce: &enforce},
 	}
 
-	emitRuleOfTwoEvents(cfg, sec)
+	emitRuleOfTwoEvents(cfg, sec, resolveRuleOfTwoArming(cfg))
 
 	out := buf.String()
 	if !strings.Contains(out, `"event":"rule_of_two_disabled"`) {
@@ -498,7 +498,7 @@ func TestEmitRuleOfTwoEvents_AllThreeWithoutOverrideStaysSilent(t *testing.T) {
 		SensitiveData:    &sensitive,
 	}
 
-	emitRuleOfTwoEvents(cfg, sec)
+	emitRuleOfTwoEvents(cfg, sec, resolveRuleOfTwoArming(cfg))
 
 	if strings.Contains(buf.String(), "rule_of_two_disabled") {
 		t.Errorf("ask-upstream all-three path must not emit rule_of_two_disabled, got: %s", buf.String())
@@ -568,7 +568,7 @@ func TestEmitRuleOfTwoEvents_TwoOfThreeEmitsWarning(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			sec, buf := captureSecLogger(t)
-			emitRuleOfTwoEvents(tc.cfg, sec)
+			emitRuleOfTwoEvents(tc.cfg, sec, resolveRuleOfTwoArming(tc.cfg))
 			out := buf.String()
 			if !strings.Contains(out, `"event":"rule_of_two_warning"`) {
 				t.Fatalf("expected rule_of_two_warning event, got: %s", out)
@@ -615,7 +615,7 @@ func TestEmitRuleOfTwoEvents_DisabledPayloadShape(t *testing.T) {
 		SensitiveData:    &sensitive,
 		RuleOfTwo:        &types.RuleOfTwoConfig{Enforce: &enforce},
 	}
-	emitRuleOfTwoEvents(cfg, sec)
+	emitRuleOfTwoEvents(cfg, sec, resolveRuleOfTwoArming(cfg))
 	out := buf.String()
 	if !strings.Contains(out, `"event":"rule_of_two_disabled"`) {
 		t.Fatalf("expected rule_of_two_disabled, got: %s", out)
@@ -633,7 +633,7 @@ func TestEmitRuleOfTwoEvents_NoneOrOneStaysSilent(t *testing.T) {
 		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
 		Tools:            types.ToolsConfig{BuiltIn: []string{"read_file"}},
 	}
-	emitRuleOfTwoEvents(cfg, sec)
+	emitRuleOfTwoEvents(cfg, sec, resolveRuleOfTwoArming(cfg))
 	if buf.Len() > 0 {
 		t.Errorf("zero-or-one flag config should emit nothing, got: %s", buf.String())
 	}

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -152,6 +152,17 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 			}
 		}
 	}
+
+	// Turn-0 Rule-of-Two scan: classify the operator prompt and the
+	// sanitized dynamic-context values before Prompt.Build so a
+	// latch-tier hit is recorded before the first provider call.
+	// Observe-only — redact-mode rewriting of dynamic context lands
+	// with enforcement in wave 4.
+	if config.Prompt != "" {
+		l.observeSensitive(runCtx, config, "prompt", 0, []string{config.Prompt})
+	}
+	l.observeSensitive(runCtx, config, "dynamic_context", 0, sortedContextValues(dynamicContext))
+
 	systemPrompt, err := l.Prompt.Build(runCtx, prompt.PromptContext{
 		Mode:           config.Mode,
 		Workspace:      config.Executor.Workspace,
@@ -469,6 +480,15 @@ func (l *AgenticLoop) runInnerLoop(
 			preTurnDynamic = config.DynamicContext
 		}
 		if chunks := collectUntrustedChunks(messages, turn, preTurnDynamic, config.Prompt); len(chunks) > 0 {
+			// Rule-of-Two scan of the just-arrived tool results,
+			// deterministic-first (before the guard so a later guard-deny
+			// scrub cannot un-trip the latch). Turn-0 chunks are the
+			// prompt and dynamic context, already observed in Run()
+			// under their own source labels — rescanning them here would
+			// double-emit warn-tier detections mislabelled "tool_result".
+			if turn > 0 {
+				l.observeSensitive(ctx, config, "tool_result", turn, chunks)
+			}
 			batched := batchUntrustedChunks(chunks)
 			in := guard.Input{
 				Phase:   guard.PhasePreTurn,
@@ -478,6 +498,7 @@ func (l *AgenticLoop) runInnerLoop(
 				RunID:   config.RunID,
 			}
 			allow, decision, spotlight := l.guardCheck(ctx, in, guardFailOpen(config))
+			l.ratchetRuleOfTwo(ctx, config, decision, turn)
 			switch {
 			case !allow:
 				// On turn 0 the user prompt itself is the untrusted
@@ -898,7 +919,8 @@ func (l *AgenticLoop) runInnerLoop(
 					Mode:    config.Mode,
 					RunID:   config.RunID,
 				}
-				allow, _, spotlight := l.guardCheck(ctx, in, guardFailOpen(config))
+				allow, decision, spotlight := l.guardCheck(ctx, in, guardFailOpen(config))
+				l.ratchetRuleOfTwo(ctx, config, decision, turn)
 				if !allow {
 					return messages, "guardrail_blocked"
 				}
@@ -1312,6 +1334,115 @@ func (l *AgenticLoop) recordSpotlightApplied(ctx context.Context, phase guard.Ph
 	if l.Security != nil {
 		l.Security.GuardSpotlighted(string(phase), decision.GuardID, decision.Reason)
 	}
+}
+
+// observeSensitive runs the Rule-of-Two monitor over freshly-arrived
+// untrusted chunks and emits the observe-only telemetry: the
+// sensitive_scan_ms histogram on every scan, sensitive_data_detected +
+// rule_of_two_detections on any finding, and the once-per-run
+// rule_of_two_triggered + transport warning at the latch transition.
+// Nothing here changes run behaviour — wave 3 ships dark; enforcement
+// consumers arrive in wave 4. A nil monitor (hand-assembled loops)
+// no-ops, mirroring guardCheck's nil-GuardRail branch.
+func (l *AgenticLoop) observeSensitive(ctx context.Context, config *types.RunConfig, source string, turn int, chunks []string) {
+	if l.RuleOfTwo == nil || len(chunks) == 0 {
+		return
+	}
+	start := time.Now()
+	det := l.RuleOfTwo.ObserveChunks(ctx, source, turn, chunks)
+	if l.Metrics != nil {
+		// Fractional milliseconds: scans are routinely sub-millisecond
+		// and this histogram exists to keep regex cost observable —
+		// integer truncation would flatten the series to zero.
+		elapsedMs := float64(time.Since(start)) / float64(time.Millisecond)
+		l.Metrics.SensitiveScan.Record(ctx, elapsedMs, l.metricAttrs(
+			attribute.String("source", source),
+		))
+	}
+	if len(det.Patterns) == 0 {
+		return
+	}
+	action := l.RuleOfTwo.Action()
+	if l.Security != nil {
+		l.Security.SensitiveDataDetected(det.Patterns, det.Tier, source, turn, action, det.Transition)
+	}
+	if l.Metrics != nil {
+		for _, p := range det.Patterns {
+			l.Metrics.RuleOfTwoDetections.Add(ctx, 1, l.metricAttrs(
+				attribute.String("pattern", p),
+				attribute.String("tier", det.Tier),
+				attribute.String("source", source),
+			))
+		}
+	}
+	if det.Transition {
+		l.emitRuleOfTwoTriggered(config, source, action)
+	}
+}
+
+// ratchetRuleOfTwo forwards a guard decision's criterion to the
+// Rule-of-Two monitor's one-way ratchet. Every non-nil decision is
+// forwarded — the monitor filters against its configured guard-criteria
+// set internally, keeping the loop free of criteria logic. Telemetry
+// fires only on the false→true transition: the guard's own deny/allow
+// events already record the decision itself.
+func (l *AgenticLoop) ratchetRuleOfTwo(ctx context.Context, config *types.RunConfig, decision *guard.Decision, turn int) {
+	if l.RuleOfTwo == nil || decision == nil || decision.Criterion == "" {
+		return
+	}
+	if !l.RuleOfTwo.TripFromGuard(decision.GuardID, decision.Criterion) {
+		return
+	}
+	source := "guard:" + decision.GuardID
+	action := l.RuleOfTwo.Action()
+	if l.Security != nil {
+		l.Security.SensitiveDataDetected([]string{decision.Criterion}, security.TierLatch, source, turn, action, true)
+	}
+	if l.Metrics != nil {
+		l.Metrics.RuleOfTwoDetections.Add(ctx, 1, l.metricAttrs(
+			attribute.String("pattern", decision.Criterion),
+			attribute.String("tier", security.TierLatch),
+			attribute.String("source", source),
+		))
+	}
+	l.emitRuleOfTwoTriggered(config, source, action)
+}
+
+// emitRuleOfTwoTriggered records the once-per-run latch transition: the
+// rule_of_two_triggered security event (key names mirror the run-start
+// audit events from emitRuleOfTwoEvents) and a one-time transport
+// warning so operators without a security-event pipeline still see the
+// posture change on the wire.
+func (l *AgenticLoop) emitRuleOfTwoTriggered(config *types.RunConfig, source, action string) {
+	untrusted, _, external := types.RuleOfTwoState(config)
+	if l.Security != nil {
+		l.Security.RuleOfTwoTriggered(untrusted, external, action, source)
+	}
+	_ = l.Transport.Emit(types.HarnessEvent{
+		Type:    "warning",
+		Message: fmt.Sprintf("rule of two: sensitive data detected (source %s); action %q is observe-only this release", source, action),
+	})
+}
+
+// sortedContextValues returns the non-empty dynamic-context values in
+// key order, matching collectUntrustedChunks' deterministic ordering so
+// detection events are stable across runs of the same config.
+func sortedContextValues(dynamicContext map[string]string) []string {
+	if len(dynamicContext) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(dynamicContext))
+	for k := range dynamicContext {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	values := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if v := dynamicContext[k]; v != "" {
+			values = append(values, v)
+		}
+	}
+	return values
 }
 
 // guardIDFromDecision returns the GuardID from a Decision, defaulting to

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -1395,12 +1395,19 @@ func (l *AgenticLoop) ratchetRuleOfTwo(ctx context.Context, config *types.RunCon
 	}
 	source := "guard:" + decision.GuardID
 	action := l.RuleOfTwo.Action()
+	// The criterion is namespaced "guard:<criterion>" in the patterns
+	// field and the pattern metric label so guard-originated trips can
+	// never impersonate deterministic detector names: a coerced guard
+	// returning criterion "secret/aws_access_key_id" must not make
+	// telemetry (or alerting rules keyed on pattern names) read as if
+	// the detector fired.
+	pattern := "guard:" + decision.Criterion
 	if l.Security != nil {
-		l.Security.SensitiveDataDetected([]string{decision.Criterion}, security.TierLatch, source, turn, action, true)
+		l.Security.SensitiveDataDetected([]string{pattern}, security.TierLatch, source, turn, action, true)
 	}
 	if l.Metrics != nil {
 		l.Metrics.RuleOfTwoDetections.Add(ctx, 1, l.metricAttrs(
-			attribute.String("pattern", decision.Criterion),
+			attribute.String("pattern", pattern),
 			attribute.String("tier", security.TierLatch),
 			attribute.String("source", source),
 		))
@@ -1420,7 +1427,7 @@ func (l *AgenticLoop) emitRuleOfTwoTriggered(config *types.RunConfig, source, ac
 	}
 	_ = l.Transport.Emit(types.HarnessEvent{
 		Type:    "warning",
-		Message: fmt.Sprintf("rule of two: sensitive data detected (source %s); action %q is observe-only this release", source, action),
+		Message: fmt.Sprintf("rule of two: sensitive data detected (source %q); action %q is observe-only this release", source, action),
 	})
 }
 
@@ -1471,7 +1478,11 @@ func guardFailOpen(config *types.RunConfig) bool {
 // entries (sorted by key for determinism). On subsequent turns it
 // returns the Content field of every tool_result block in the last
 // message — those entries arrived from external tool execution and
-// have not yet been classified.
+// have not yet been classified — plus the Structured payload (issue
+// #231) when present: the Anthropic adapter forwards it to the model
+// as a second text block and the Gemini adapter embeds it under
+// functionResponse.response.structured, so a credential present only
+// in the structured JSON is model-visible and must be classified too.
 //
 // v1 keeps this conservative: we do not attempt to classify earlier
 // turns' content (already in history), nor model-emitted text (handled
@@ -1510,8 +1521,14 @@ func collectUntrustedChunks(messages []types.Message, turn int, dynamicContext m
 	}
 	chunks := make([]string, 0, len(last.Content))
 	for _, b := range last.Content {
-		if b.Type == "tool_result" && b.Content != "" {
+		if b.Type != "tool_result" {
+			continue
+		}
+		if b.Content != "" {
 			chunks = append(chunks, b.Content)
+		}
+		if len(b.Structured) > 0 {
+			chunks = append(chunks, string(b.Structured))
 		}
 	}
 	return chunks

--- a/harness/internal/core/ruleoftwo_test.go
+++ b/harness/internal/core/ruleoftwo_test.go
@@ -8,7 +8,11 @@ import (
 	"sync"
 	"testing"
 
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/ruleoftwo"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/types"
@@ -332,6 +336,9 @@ func TestLoop_RuleOfTwoDetectsSensitiveToolResult(t *testing.T) {
 	if !strings.Contains(out, `"transition":true`) {
 		t.Errorf("expected transition:true on the latching detection, got: %s", out)
 	}
+	if !strings.Contains(out, `"scanning_suspended":true`) {
+		t.Errorf("expected scanning_suspended:true on the trigger event (soak data ends at the latch), got: %s", out)
+	}
 
 	// Dark-ship pin: an identical run with the Noop monitor must end the
 	// same way — outcome and turn count unchanged by detection.
@@ -355,6 +362,70 @@ func buildTestConfigWithMaxTurns(maxTurns int) *types.RunConfig {
 	cfg := buildTestConfig()
 	cfg.MaxTurns = maxTurns
 	return cfg
+}
+
+// TestLoop_RuleOfTwoDetectsStructuredToolResult closes the structured-
+// result bypass: the Anthropic and Gemini adapters forward
+// ContentBlock.Structured to the model (as a second text block /
+// functionResponse.response.structured respectively), so a credential
+// present only in the structured payload is model-visible and must
+// latch even when the text Content is benign.
+func TestLoop_RuleOfTwoDetectsStructuredToolResult(t *testing.T) {
+	var secBuf bytes.Buffer
+	loop := buildTestLoopWithSecurity(nil, &secBuf)
+	loop.Provider = &scriptedProvider{
+		turns: [][]types.StreamEvent{
+			{
+				{Type: "tool_call", ID: "tc_1", Name: "structured_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "done"},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+	registry, ok := loop.Tools.(*tool.Registry)
+	if !ok {
+		t.Fatalf("test loop Tools is %T, want *tool.Registry", loop.Tools)
+	}
+	registry.Register(&tool.Tool{
+		Name:        "structured_tool",
+		Description: "returns a structured payload carrying a credential",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		StructuredHandler: func(_ context.Context, _ json.RawMessage) (tool.StructuredResult, error) {
+			return tool.StructuredResult{
+				Text:       "command completed",
+				Structured: json.RawMessage(`{"stdout":"` + fakeLiveAWSKey + `"}`),
+				Kind:       "command_result",
+			}, nil
+		},
+	})
+	monitor := defaultRuleOfTwoTestMonitor()
+	loop.RuleOfTwo = monitor
+	config := buildTestConfig()
+	config.MaxTurns = 4
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (observe-only)", runTrace.Outcome)
+	}
+	if !monitor.Tripped() {
+		t.Fatal("monitor must latch on a credential present only in the structured payload")
+	}
+	out := secBuf.String()
+	if !strings.Contains(out, `"event":"sensitive_data_detected"`) {
+		t.Errorf("expected sensitive_data_detected event, got: %s", out)
+	}
+	if !strings.Contains(out, `"source":"tool_result"`) {
+		t.Errorf("expected source tool_result, got: %s", out)
+	}
+	if !strings.Contains(out, `"secret/aws_access_key_id"`) {
+		t.Errorf("expected the pattern name in the event, got: %s", out)
+	}
 }
 
 // trippedAtStreamProvider snapshots the monitor's latch state at the
@@ -451,6 +522,13 @@ func TestLoop_RuleOfTwoGuardCriterionRatchetTrips(t *testing.T) {
 	loop.GuardRail = &criterionGuard{criterion: "sensitive_data"}
 	monitor := defaultRuleOfTwoTestMonitor()
 	loop.RuleOfTwo = monitor
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, err := observability.NewMetricsForTesting(mp)
+	if err != nil {
+		t.Fatalf("NewMetricsForTesting: %v", err)
+	}
+	loop.Metrics = metrics
 	config := buildTestConfig()
 
 	runTrace, err := loop.Run(context.Background(), config)
@@ -467,9 +545,51 @@ func TestLoop_RuleOfTwoGuardCriterionRatchetTrips(t *testing.T) {
 	if !strings.Contains(out, `"source":"guard:stub"`) {
 		t.Errorf("expected source guard:stub, got: %s", out)
 	}
+	// Provenance namespacing: the guard's criterion must land in the
+	// patterns field prefixed "guard:" so it can never impersonate a
+	// deterministic detector name.
+	if !strings.Contains(out, `"patterns":["guard:sensitive_data"]`) {
+		t.Errorf("expected patterns [guard:sensitive_data], got: %s", out)
+	}
 	if !strings.Contains(out, `"event":"rule_of_two_triggered"`) {
 		t.Errorf("expected rule_of_two_triggered event, got: %s", out)
 	}
+	if got := ruleOfTwoDetectionPatternCount(t, reader, "guard:sensitive_data"); got != 1 {
+		t.Errorf("rule-of-two detections with pattern=guard:sensitive_data = %d, want 1", got)
+	}
+	if got := ruleOfTwoDetectionPatternCount(t, reader, "sensitive_data"); got != 0 {
+		t.Errorf("unprefixed criterion leaked into the pattern label: count = %d, want 0", got)
+	}
+}
+
+// ruleOfTwoDetectionPatternCount sums stirrup.ruleoftwo.detections data
+// points whose pattern attribute equals pattern.
+func ruleOfTwoDetectionPatternCount(t *testing.T, reader *sdkmetric.ManualReader, pattern string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "stirrup.ruleoftwo.detections" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				for _, kv := range dp.Attributes.ToSlice() {
+					if string(kv.Key) == "pattern" && kv.Value.AsString() == pattern {
+						total += dp.Value
+					}
+				}
+			}
+		}
+	}
+	return total
 }
 
 func TestLoop_RuleOfTwoGuardNonMatchingCriterionDoesNotTrip(t *testing.T) {

--- a/harness/internal/core/ruleoftwo_test.go
+++ b/harness/internal/core/ruleoftwo_test.go
@@ -1,0 +1,549 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/guard"
+	"github.com/rxbynerd/stirrup/harness/internal/ruleoftwo"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeLiveAWSKey is a live-shaped AKIA key (16 uppercase chars, not
+// EXAMPLE-suffixed) so the detector's doc-example allowlist does not
+// reject it.
+const fakeLiveAWSKey = "AKIAQWERTYUIOPASDFGH"
+
+func defaultRuleOfTwoTestMonitor() *ruleoftwo.PatternMonitor {
+	return ruleoftwo.NewPatternMonitor(true, "block-external", []string{"sensitive_data", "pii"}, false)
+}
+
+// --- arming matrix ---
+
+func TestResolveRuleOfTwoArming_Matrix(t *testing.T) {
+	sensitive := true
+	enforceFalse := false
+
+	// Base config shapes. u = DynamicContext present; e = run_command
+	// enabled; s = SensitiveData declared.
+	uAndE := func() *types.RunConfig {
+		return &types.RunConfig{
+			Mode:             "execution",
+			PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+			Tools:            types.ToolsConfig{BuiltIn: []string{"run_command"}},
+			DynamicContext:   map[string]types.DynamicContextValue{"x": {Value: "y"}},
+		}
+	}
+	eOnly := func() *types.RunConfig {
+		return &types.RunConfig{
+			Mode:             "execution",
+			PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+			Tools:            types.ToolsConfig{BuiltIn: []string{"run_command"}},
+		}
+	}
+	uOnly := func() *types.RunConfig {
+		return &types.RunConfig{
+			Mode:             "execution",
+			PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+			Tools:            types.ToolsConfig{BuiltIn: []string{"read_file"}},
+			DynamicContext:   map[string]types.DynamicContextValue{"x": {Value: "y"}},
+		}
+	}
+
+	cases := []struct {
+		name          string
+		cfg           *types.RunConfig
+		wantArmed     bool
+		wantEnforcing bool
+		wantAction    string
+		wantCriteria  []string
+		wantStatic    bool
+	}{
+		{
+			name: "classifier none disarms even with u&&e",
+			cfg: func() *types.RunConfig {
+				c := uAndE()
+				c.RuleOfTwo = &types.RuleOfTwoConfig{Runtime: &types.RuleOfTwoRuntimeConfig{Classifier: "none"}}
+				return c
+			}(),
+			wantArmed: false,
+		},
+		{
+			name:          "u&&e&&!s default policy arms enforcing with block-external",
+			cfg:           uAndE(),
+			wantArmed:     true,
+			wantEnforcing: true,
+			wantAction:    "block-external",
+			wantCriteria:  []string{"sensitive_data", "pii"},
+		},
+		{
+			name: "u&&e&&!s with onDetect abort arms enforcing abort",
+			cfg: func() *types.RunConfig {
+				c := uAndE()
+				c.RuleOfTwo = &types.RuleOfTwoConfig{Runtime: &types.RuleOfTwoRuntimeConfig{OnDetect: "abort"}}
+				return c
+			}(),
+			wantArmed:     true,
+			wantEnforcing: true,
+			wantAction:    "abort",
+			wantCriteria:  []string{"sensitive_data", "pii"},
+		},
+		{
+			name: "u&&e with ask-upstream arms observe-only",
+			cfg: func() *types.RunConfig {
+				c := uAndE()
+				c.PermissionPolicy = types.PermissionPolicyConfig{Type: "ask-upstream"}
+				return c
+			}(),
+			wantArmed:     true,
+			wantEnforcing: false,
+			wantAction:    "block-external",
+			wantCriteria:  []string{"sensitive_data", "pii"},
+		},
+		{
+			name: "u&&e with enforce:false arms observe-only",
+			cfg: func() *types.RunConfig {
+				c := uAndE()
+				c.RuleOfTwo = &types.RuleOfTwoConfig{Enforce: &enforceFalse}
+				return c
+			}(),
+			wantArmed:     true,
+			wantEnforcing: false,
+			wantAction:    "block-external",
+			wantCriteria:  []string{"sensitive_data", "pii"},
+		},
+		{
+			name: "u&&e&&s arms observe-only with pre-tripped latch",
+			cfg: func() *types.RunConfig {
+				c := uAndE()
+				c.SensitiveData = &sensitive
+				return c
+			}(),
+			wantArmed:     true,
+			wantEnforcing: false,
+			wantAction:    "block-external",
+			wantCriteria:  []string{"sensitive_data", "pii"},
+			wantStatic:    true,
+		},
+		{
+			name:      "e without u stays unarmed",
+			cfg:       eOnly(),
+			wantArmed: false,
+		},
+		{
+			name:      "u without e stays unarmed",
+			cfg:       uOnly(),
+			wantArmed: false,
+		},
+		{
+			name: "explicit patterns classifier arms observe-only without u",
+			cfg: func() *types.RunConfig {
+				c := eOnly()
+				c.RuleOfTwo = &types.RuleOfTwoConfig{Runtime: &types.RuleOfTwoRuntimeConfig{Classifier: "patterns"}}
+				return c
+			}(),
+			wantArmed:     true,
+			wantEnforcing: false,
+			wantAction:    "block-external",
+			wantCriteria:  []string{"sensitive_data", "pii"},
+		},
+		{
+			name: "custom guardCriteria override the default set",
+			cfg: func() *types.RunConfig {
+				c := uAndE()
+				c.RuleOfTwo = &types.RuleOfTwoConfig{Runtime: &types.RuleOfTwoRuntimeConfig{GuardCriteria: []string{"custom_pii"}}}
+				return c
+			}(),
+			wantArmed:     true,
+			wantEnforcing: true,
+			wantAction:    "block-external",
+			wantCriteria:  []string{"custom_pii"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			arming := resolveRuleOfTwoArming(tc.cfg)
+			if arming.armed != tc.wantArmed {
+				t.Fatalf("armed = %v, want %v", arming.armed, tc.wantArmed)
+			}
+			monitor := buildRuleOfTwoMonitor(arming)
+			if !tc.wantArmed {
+				if _, ok := monitor.(ruleoftwo.Noop); !ok {
+					t.Fatalf("expected Noop monitor, got %T", monitor)
+				}
+				return
+			}
+			if _, ok := monitor.(*ruleoftwo.PatternMonitor); !ok {
+				t.Fatalf("expected *PatternMonitor, got %T", monitor)
+			}
+			if arming.enforcing != tc.wantEnforcing {
+				t.Errorf("enforcing = %v, want %v", arming.enforcing, tc.wantEnforcing)
+			}
+			if monitor.Enforcing() != tc.wantEnforcing {
+				t.Errorf("monitor.Enforcing() = %v, want %v", monitor.Enforcing(), tc.wantEnforcing)
+			}
+			if arming.action != tc.wantAction {
+				t.Errorf("action = %q, want %q", arming.action, tc.wantAction)
+			}
+			wantEffective := tc.wantAction
+			if !tc.wantEnforcing {
+				wantEffective = "warn"
+			}
+			if got := monitor.Action(); got != wantEffective {
+				t.Errorf("monitor.Action() = %q, want %q", got, wantEffective)
+			}
+			if len(arming.criteria) != len(tc.wantCriteria) {
+				t.Fatalf("criteria = %v, want %v", arming.criteria, tc.wantCriteria)
+			}
+			for i, c := range tc.wantCriteria {
+				if arming.criteria[i] != c {
+					t.Errorf("criteria[%d] = %q, want %q", i, arming.criteria[i], c)
+				}
+			}
+			if monitor.Tripped() != tc.wantStatic {
+				t.Errorf("monitor.Tripped() = %v, want %v (staticSensitive pre-trip)", monitor.Tripped(), tc.wantStatic)
+			}
+		})
+	}
+}
+
+func TestEmitRuleOfTwoEvents_RuntimeArmedEvent(t *testing.T) {
+	cfg := &types.RunConfig{
+		Mode:             "execution",
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"run_command"}},
+		DynamicContext:   map[string]types.DynamicContextValue{"x": {Value: "y"}},
+	}
+	sec, buf := captureSecLogger(t)
+	emitRuleOfTwoEvents(cfg, sec, resolveRuleOfTwoArming(cfg))
+	out := buf.String()
+	if !strings.Contains(out, `"event":"rule_of_two_runtime_armed"`) {
+		t.Fatalf("expected rule_of_two_runtime_armed event, got: %s", out)
+	}
+	if !strings.Contains(out, `"classifier":"patterns"`) {
+		t.Errorf("expected classifier patterns, got: %s", out)
+	}
+	if !strings.Contains(out, `"onDetect":"block-external"`) {
+		t.Errorf("expected onDetect block-external, got: %s", out)
+	}
+	if !strings.Contains(out, `"enforcing":true`) {
+		t.Errorf("expected enforcing true, got: %s", out)
+	}
+}
+
+func TestEmitRuleOfTwoEvents_UnarmedEmitsNoRuntimeEvent(t *testing.T) {
+	cfg := &types.RunConfig{
+		Mode:             "execution",
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"read_file"}},
+	}
+	sec, buf := captureSecLogger(t)
+	emitRuleOfTwoEvents(cfg, sec, resolveRuleOfTwoArming(cfg))
+	if strings.Contains(buf.String(), "rule_of_two_runtime_armed") {
+		t.Errorf("unarmed run must not emit rule_of_two_runtime_armed, got: %s", buf.String())
+	}
+}
+
+// --- loop wiring ---
+
+// registerLeakyTool adds a tool whose result carries a live-shaped AWS
+// key, simulating an agent reading credentials from a workspace file.
+func registerLeakyTool(t *testing.T, loop *AgenticLoop) {
+	t.Helper()
+	registry, ok := loop.Tools.(*tool.Registry)
+	if !ok {
+		t.Fatalf("test loop Tools is %T, want *tool.Registry", loop.Tools)
+	}
+	registry.Register(&tool.Tool{
+		Name:        "leaky_tool",
+		Description: "returns sensitive content",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "AWS_ACCESS_KEY_ID=" + fakeLiveAWSKey, nil
+		},
+	})
+}
+
+func leakyToolProvider() *scriptedProvider {
+	return &scriptedProvider{
+		turns: [][]types.StreamEvent{
+			{
+				{Type: "tool_call", ID: "tc_1", Name: "leaky_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "done"},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+}
+
+// TestLoop_RuleOfTwoDetectsSensitiveToolResult asserts the dark-ship
+// contract: a tool result carrying a live-shaped key produces
+// sensitive_data_detected + rule_of_two_triggered events while the run
+// completes with the same outcome and turn count as an unmonitored run.
+func TestLoop_RuleOfTwoDetectsSensitiveToolResult(t *testing.T) {
+	var secBuf bytes.Buffer
+	loop := buildTestLoopWithSecurity(nil, &secBuf)
+	loop.Provider = leakyToolProvider()
+	registerLeakyTool(t, loop)
+	monitor := defaultRuleOfTwoTestMonitor()
+	loop.RuleOfTwo = monitor
+	config := buildTestConfig()
+	config.MaxTurns = 4
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if !monitor.Tripped() {
+		t.Fatal("monitor must latch on the key-bearing tool result")
+	}
+
+	out := secBuf.String()
+	if !strings.Contains(out, `"event":"sensitive_data_detected"`) {
+		t.Errorf("expected sensitive_data_detected event, got: %s", out)
+	}
+	if !strings.Contains(out, `"source":"tool_result"`) {
+		t.Errorf("expected source tool_result, got: %s", out)
+	}
+	if !strings.Contains(out, `"secret/aws_access_key_id"`) {
+		t.Errorf("expected the pattern name in the event, got: %s", out)
+	}
+	if strings.Contains(out, fakeLiveAWSKey) {
+		t.Errorf("matched content leaked into the security event stream: %s", out)
+	}
+	if !strings.Contains(out, `"event":"rule_of_two_triggered"`) {
+		t.Errorf("expected rule_of_two_triggered event, got: %s", out)
+	}
+	if !strings.Contains(out, `"sensitiveData":true`) {
+		t.Errorf("expected sensitiveData:true in trigger payload, got: %s", out)
+	}
+	if !strings.Contains(out, `"action":"block-external"`) {
+		t.Errorf("expected action block-external, got: %s", out)
+	}
+	if !strings.Contains(out, `"transition":true`) {
+		t.Errorf("expected transition:true on the latching detection, got: %s", out)
+	}
+
+	// Dark-ship pin: an identical run with the Noop monitor must end the
+	// same way — outcome and turn count unchanged by detection.
+	baseline := buildTestLoop(nil)
+	baseline.Provider = leakyToolProvider()
+	registerLeakyTool(t, baseline)
+	baseline.RuleOfTwo = ruleoftwo.NewNoop()
+	baselineTrace, err := baseline.Run(context.Background(), buildTestConfigWithMaxTurns(4))
+	if err != nil {
+		t.Fatalf("baseline Run() error: %v", err)
+	}
+	if runTrace.Outcome != baselineTrace.Outcome {
+		t.Errorf("outcome diverged: monitored %q vs baseline %q", runTrace.Outcome, baselineTrace.Outcome)
+	}
+	if runTrace.Turns != baselineTrace.Turns {
+		t.Errorf("turns diverged: monitored %d vs baseline %d", runTrace.Turns, baselineTrace.Turns)
+	}
+}
+
+func buildTestConfigWithMaxTurns(maxTurns int) *types.RunConfig {
+	cfg := buildTestConfig()
+	cfg.MaxTurns = maxTurns
+	return cfg
+}
+
+// trippedAtStreamProvider snapshots the monitor's latch state at the
+// moment the provider is first contacted, so tests can assert the
+// turn-0 scan latched before any model call.
+type trippedAtStreamProvider struct {
+	mu            sync.Mutex
+	monitor       ruleoftwo.Monitor
+	trippedAtCall bool
+	called        bool
+	events        []types.StreamEvent
+}
+
+func (p *trippedAtStreamProvider) Stream(_ context.Context, _ types.StreamParams) (<-chan types.StreamEvent, error) {
+	p.mu.Lock()
+	if !p.called {
+		p.called = true
+		p.trippedAtCall = p.monitor.Tripped()
+	}
+	p.mu.Unlock()
+	ch := make(chan types.StreamEvent, len(p.events))
+	for _, e := range p.events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestLoop_RuleOfTwoLatchesOnDynamicContextBeforeFirstProviderCall(t *testing.T) {
+	var secBuf bytes.Buffer
+	loop := buildTestLoopWithSecurity(nil, &secBuf)
+	monitor := defaultRuleOfTwoTestMonitor()
+	loop.RuleOfTwo = monitor
+	prov := &trippedAtStreamProvider{
+		monitor: monitor,
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "ok"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	loop.Provider = prov
+
+	config := buildTestConfig()
+	// Luhn-valid PAN (the canonical Visa test number passes by design).
+	config.DynamicContext = map[string]types.DynamicContextValue{
+		"record": {Value: "customer card 4111111111111111 on file"},
+	}
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (observe-only)", runTrace.Outcome)
+	}
+	if !prov.called {
+		t.Fatal("provider was never contacted")
+	}
+	if !prov.trippedAtCall {
+		t.Fatal("latch must trip before the first provider call (turn-0 scan precedes Prompt.Build)")
+	}
+
+	out := secBuf.String()
+	if !strings.Contains(out, `"source":"dynamic_context"`) {
+		t.Errorf("expected source dynamic_context, got: %s", out)
+	}
+	if !strings.Contains(out, `"pii/credit_card"`) {
+		t.Errorf("expected pii/credit_card pattern, got: %s", out)
+	}
+	if !strings.Contains(out, `"event":"rule_of_two_triggered"`) {
+		t.Errorf("expected rule_of_two_triggered event, got: %s", out)
+	}
+}
+
+// criterionGuard allows everything but tags each decision with a fixed
+// criterion, exercising the ratchet without a deny.
+type criterionGuard struct {
+	criterion string
+}
+
+func (g *criterionGuard) Check(_ context.Context, _ guard.Input) (*guard.Decision, error) {
+	return &guard.Decision{Verdict: guard.VerdictAllow, GuardID: "stub", Criterion: g.criterion}, nil
+}
+
+func TestLoop_RuleOfTwoGuardCriterionRatchetTrips(t *testing.T) {
+	var secBuf bytes.Buffer
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "ok"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	loop := buildTestLoopWithSecurity(prov, &secBuf)
+	loop.GuardRail = &criterionGuard{criterion: "sensitive_data"}
+	monitor := defaultRuleOfTwoTestMonitor()
+	loop.RuleOfTwo = monitor
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success", runTrace.Outcome)
+	}
+	if !monitor.Tripped() {
+		t.Fatal("matching guard criterion must trip the ratchet")
+	}
+	out := secBuf.String()
+	if !strings.Contains(out, `"source":"guard:stub"`) {
+		t.Errorf("expected source guard:stub, got: %s", out)
+	}
+	if !strings.Contains(out, `"event":"rule_of_two_triggered"`) {
+		t.Errorf("expected rule_of_two_triggered event, got: %s", out)
+	}
+}
+
+func TestLoop_RuleOfTwoGuardNonMatchingCriterionDoesNotTrip(t *testing.T) {
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "ok"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	loop := buildTestLoop(prov)
+	loop.GuardRail = &criterionGuard{criterion: "jailbreak"}
+	monitor := defaultRuleOfTwoTestMonitor()
+	loop.RuleOfTwo = monitor
+
+	if _, err := loop.Run(context.Background(), buildTestConfig()); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if monitor.Tripped() {
+		t.Fatal("non-matching criterion must not trip the ratchet")
+	}
+}
+
+func TestLoop_RuleOfTwoNoopEmitsNoEvents(t *testing.T) {
+	var secBuf bytes.Buffer
+	loop := buildTestLoopWithSecurity(nil, &secBuf)
+	loop.Provider = leakyToolProvider()
+	registerLeakyTool(t, loop)
+	loop.RuleOfTwo = ruleoftwo.NewNoop()
+	config := buildTestConfig()
+	config.MaxTurns = 4
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success", runTrace.Outcome)
+	}
+	out := secBuf.String()
+	if strings.Contains(out, "sensitive_data_detected") {
+		t.Errorf("Noop monitor must not emit sensitive_data_detected, got: %s", out)
+	}
+	if strings.Contains(out, "rule_of_two_triggered") {
+		t.Errorf("Noop monitor must not emit rule_of_two_triggered, got: %s", out)
+	}
+}
+
+// --- sub-agent sharing ---
+
+func TestSpawnSubAgent_SharesRuleOfTwoMonitor(t *testing.T) {
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "sub output"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	parentLoop := buildSubAgentTestLoop(prov)
+	monitor := defaultRuleOfTwoTestMonitor()
+	parentLoop.RuleOfTwo = monitor
+	parentConfig := buildTestConfig()
+
+	// The child's turn-0 prompt scan runs against the shared instance:
+	// sensitive content observed inside the sub-agent must latch the
+	// whole run, or spawn_agent becomes a latch escape hatch.
+	result, err := SpawnSubAgent(context.Background(), parentLoop, parentConfig, SubAgentConfig{
+		Prompt: "inspect this credential: " + fakeLiveAWSKey,
+	})
+	if err != nil {
+		t.Fatalf("SpawnSubAgent() error: %v", err)
+	}
+	if result.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (observe-only)", result.Outcome)
+	}
+	if !monitor.Tripped() {
+		t.Fatal("child observation must trip the shared parent monitor")
+	}
+}

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -161,6 +161,11 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 		// Without this, an indirect-injection payload could route
 		// harmful work through spawn_agent and bypass all phases.
 		GuardRail: parent.GuardRail,
+		// Share (not copy) the parent's Rule-of-Two monitor for the
+		// same reason: the latch is run-scoped, so sensitive content
+		// observed by either side must tighten the whole run —
+		// spawn_agent must not be a latch escape hatch.
+		RuleOfTwo: parent.RuleOfTwo,
 		// Tag every metric observation emitted from the child so
 		// dashboards can decompose a run into parent vs sub-agent
 		// contributions. The parent's run id is preserved as

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
 	"github.com/rxbynerd/stirrup/harness/internal/provider"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
+	"github.com/rxbynerd/stirrup/harness/internal/ruleoftwo"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/harness/internal/trace"
@@ -76,13 +77,20 @@ type AgenticLoop struct {
 	// disagrees with the parent's presented names. There is no runtime
 	// guard — compare Tools.(*tool.Presenter).Profile() against ToolProfile
 	// at construction if the wiring is not obviously consistent.
-	ToolProfile  *tool.Profile
-	Executor     executor.Executor
-	Edit         edit.EditStrategy
-	Verifier     verifier.Verifier
-	Permissions  permission.PermissionPolicy
-	Git          git.GitStrategy
-	GuardRail    guard.GuardRail
+	ToolProfile *tool.Profile
+	Executor    executor.Executor
+	Edit        edit.EditStrategy
+	Verifier    verifier.Verifier
+	Permissions permission.PermissionPolicy
+	Git         git.GitStrategy
+	GuardRail   guard.GuardRail
+	// RuleOfTwo is the Rule-of-Two runtime sensitive-data monitor
+	// (observe-only this wave: detections produce events and metrics,
+	// no enforcement consumer exists yet). The factory injects
+	// ruleoftwo.NewNoop() when the run is unarmed so loop call sites
+	// stay unconditional; hand-assembled loops (tests, embedders) may
+	// leave it nil and the observe helpers no-op, mirroring GuardRail.
+	RuleOfTwo    ruleoftwo.Monitor
 	Escalation   EscalationPolicy // tool-choice missed-tool recovery (#230); nil = disabled
 	Transport    transport.Transport
 	Trace        trace.TraceEmitter

--- a/harness/internal/observability/metrics.go
+++ b/harness/internal/observability/metrics.go
@@ -407,9 +407,10 @@ func newMetricsFromMeter(meter metric.Meter, provider *sdkmetric.MeterProvider) 
 		return nil, err
 	}
 
-	m.RuleOfTwoDetections, err = meter.Int64Counter("stirrup.harness.rule_of_two_detections",
+	m.RuleOfTwoDetections, err = meter.Int64Counter("stirrup.ruleoftwo.detections",
 		metric.WithUnit("{detection}"),
-		metric.WithDescription("Sensitive-data detections recorded by the Rule-of-Two runtime monitor, labelled by pattern, tier, and source"),
+		metric.WithDescription("Sensitive-data detections recorded by the Rule-of-Two runtime monitor, labelled by pattern, tier, and source. "+
+			"Guard-ratchet trips carry a \"guard:\"-prefixed pattern label so they are distinguishable from deterministic detector hits."),
 	)
 	if err != nil {
 		return nil, err
@@ -553,7 +554,7 @@ func newMetricsFromMeter(meter metric.Meter, provider *sdkmetric.MeterProvider) 
 		return nil, err
 	}
 
-	m.SensitiveScan, err = meter.Float64Histogram("stirrup.harness.sensitive_scan_ms",
+	m.SensitiveScan, err = meter.Float64Histogram("stirrup.ruleoftwo.scan_duration_ms",
 		metric.WithUnit("ms"),
 		metric.WithDescription("Wall-clock latency of Rule-of-Two sensitive-content scans"),
 	)

--- a/harness/internal/observability/metrics.go
+++ b/harness/internal/observability/metrics.go
@@ -40,6 +40,7 @@ type Metrics struct {
 	GuardErrors           metric.Int64Counter
 	GuardSkips            metric.Int64Counter
 	GuardSpotlights       metric.Int64Counter
+	RuleOfTwoDetections   metric.Int64Counter
 
 	// --- Component-level instruments (issue #97) ---
 	// Counters
@@ -61,6 +62,7 @@ type Metrics struct {
 	ProviderLatency  metric.Float64Histogram
 	ProviderTTFB     metric.Float64Histogram
 	GuardDuration    metric.Float64Histogram
+	SensitiveScan    metric.Float64Histogram
 
 	// --- Component-level histograms (issue #97) ---
 	SubagentDuration metric.Float64Histogram
@@ -405,6 +407,14 @@ func newMetricsFromMeter(meter metric.Meter, provider *sdkmetric.MeterProvider) 
 		return nil, err
 	}
 
+	m.RuleOfTwoDetections, err = meter.Int64Counter("stirrup.harness.rule_of_two_detections",
+		metric.WithUnit("{detection}"),
+		metric.WithDescription("Sensitive-data detections recorded by the Rule-of-Two runtime monitor, labelled by pattern, tier, and source"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	// --- Component-level counters (issue #97) ---
 	//
 	// These instruments expose per-component activity (sub-agent, MCP,
@@ -538,6 +548,14 @@ func newMetricsFromMeter(meter metric.Meter, provider *sdkmetric.MeterProvider) 
 	m.GuardDuration, err = meter.Float64Histogram("stirrup.guard.duration_ms",
 		metric.WithUnit("ms"),
 		metric.WithDescription("Wall-clock latency of guard.Check calls"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.SensitiveScan, err = meter.Float64Histogram("stirrup.harness.sensitive_scan_ms",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Wall-clock latency of Rule-of-Two sensitive-content scans"),
 	)
 	if err != nil {
 		return nil, err

--- a/harness/internal/ruleoftwo/monitor_test.go
+++ b/harness/internal/ruleoftwo/monitor_test.go
@@ -1,0 +1,276 @@
+package ruleoftwo
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+)
+
+// fakeLiveAWSKey is a live-shaped AKIA key (16 uppercase chars, no
+// EXAMPLE suffix) so the detector's doc-example allowlist does not
+// reject it.
+const fakeLiveAWSKey = "AKIAQWERTYUIOPASDFGH"
+
+func defaultCriteria() []string {
+	return []string{"sensitive_data", "pii"}
+}
+
+func TestPatternMonitor_LatchTierFindingTripsOnce(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
+	if m.Tripped() {
+		t.Fatal("fresh monitor must not be tripped")
+	}
+
+	det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{"creds: " + fakeLiveAWSKey})
+	if !det.Transition {
+		t.Error("first latch-tier detection must report Transition")
+	}
+	if det.Tier != security.TierLatch {
+		t.Errorf("Tier = %q, want %q", det.Tier, security.TierLatch)
+	}
+	found := false
+	for _, p := range det.Patterns {
+		if p == "secret/aws_access_key_id" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Patterns = %v, want secret/aws_access_key_id", det.Patterns)
+	}
+	if !m.Tripped() {
+		t.Fatal("monitor must be tripped after a latch-tier finding")
+	}
+
+	// One-way: there is no reset path. Subsequent observations and
+	// guard trips must never report another transition and the latch
+	// must stay set.
+	if again := m.ObserveChunks(context.Background(), "tool_result", 2, []string{fakeLiveAWSKey}); again.Transition {
+		t.Error("second observation must not report Transition")
+	}
+	if m.TripFromGuard("g1", "sensitive_data") {
+		t.Error("TripFromGuard after latch must not report a transition")
+	}
+	if !m.Tripped() {
+		t.Error("latch must remain set")
+	}
+}
+
+func TestPatternMonitor_SkipsRescanAfterTrip(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
+	m.ObserveChunks(context.Background(), "tool_result", 1, []string{fakeLiveAWSKey})
+	if !m.Tripped() {
+		t.Fatal("setup: monitor must be tripped")
+	}
+	det := m.ObserveChunks(context.Background(), "tool_result", 2, []string{fakeLiveAWSKey})
+	if len(det.Patterns) != 0 || det.Tier != "" || det.Transition {
+		t.Errorf("post-trip observation must be empty, got %+v", det)
+	}
+}
+
+func TestPatternMonitor_WarnTierDoesNotLatch(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
+	det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{"see secret://SOME_REF for the key"})
+	if m.Tripped() {
+		t.Error("warn-tier finding must not trip the latch")
+	}
+	if det.Transition {
+		t.Error("warn-tier finding must not report Transition")
+	}
+	if det.Tier != security.TierWarn {
+		t.Errorf("Tier = %q, want %q", det.Tier, security.TierWarn)
+	}
+	if len(det.Patterns) != 1 || det.Patterns[0] != "secret/secret_ref" {
+		t.Errorf("Patterns = %v, want [secret/secret_ref]", det.Patterns)
+	}
+}
+
+func TestPatternMonitor_DeduplicatesPatternNames(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
+	// Two distinct AKIA keys in two chunks: the pattern name appears once.
+	det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{
+		"first " + fakeLiveAWSKey,
+		"second AKIAZXCVBNMASDFGHJKLQ",
+	})
+	count := 0
+	for _, p := range det.Patterns {
+		if p == "secret/aws_access_key_id" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("secret/aws_access_key_id appeared %d times, want 1 (set semantics)", count)
+	}
+}
+
+func TestPatternMonitor_OverlappingFindingsAreASet(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
+	// One sk-ant- key matches both the anthropic and openai patterns:
+	// both names are reported, each exactly once.
+	det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{"key sk-ant-api03-aaaabbbbccccddddeeee"})
+	seen := make(map[string]int)
+	for _, p := range det.Patterns {
+		seen[p]++
+	}
+	if seen["secret/anthropic_api_key"] != 1 || seen["secret/openai_api_key"] != 1 {
+		t.Errorf("Patterns = %v, want both anthropic and openai names exactly once", det.Patterns)
+	}
+	if det.Transition != true {
+		t.Error("overlapping latch findings must still produce exactly one transition")
+	}
+}
+
+func TestPatternMonitor_StaticallySensitiveStartsTripped(t *testing.T) {
+	m := NewPatternMonitor(false, "block-external", defaultCriteria(), true)
+	if !m.Tripped() {
+		t.Fatal("staticallySensitive monitor must start tripped")
+	}
+	det := m.ObserveChunks(context.Background(), "prompt", 0, []string{fakeLiveAWSKey})
+	if det.Transition {
+		t.Error("pre-tripped monitor must never report a transition")
+	}
+	if len(det.Patterns) != 0 {
+		t.Errorf("pre-tripped monitor must skip scanning, got patterns %v", det.Patterns)
+	}
+}
+
+func TestPatternMonitor_GuardCriteriaFiltering(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", []string{"sensitive_data", "pii"}, false)
+	if m.TripFromGuard("g1", "jailbreak") {
+		t.Error("non-matching criterion must not trip")
+	}
+	if m.Tripped() {
+		t.Fatal("monitor tripped on a non-matching criterion")
+	}
+	if !m.TripFromGuard("g1", "sensitive_data") {
+		t.Error("matching criterion must trip and report the transition")
+	}
+	if !m.Tripped() {
+		t.Fatal("monitor must be tripped after a matching criterion")
+	}
+}
+
+func TestPatternMonitor_TransitionReportedExactlyOnceConcurrently(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
+	const n = 32
+	var transitions atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range n {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{"key " + fakeLiveAWSKey})
+			if det.Transition {
+				transitions.Add(1)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			if m.TripFromGuard("g1", "sensitive_data") {
+				transitions.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if got := transitions.Load(); got != 1 {
+		t.Fatalf("transitions = %d, want exactly 1", got)
+	}
+	if !m.Tripped() {
+		t.Fatal("monitor must be tripped after concurrent latch attempts")
+	}
+}
+
+func TestPatternMonitor_ActionAndEnforcing(t *testing.T) {
+	enforcing := NewPatternMonitor(true, "abort", defaultCriteria(), false)
+	if !enforcing.Enforcing() {
+		t.Error("Enforcing() = false, want true")
+	}
+	if got := enforcing.Action(); got != "abort" {
+		t.Errorf("enforcing Action() = %q, want %q", got, "abort")
+	}
+
+	observing := NewPatternMonitor(false, "abort", defaultCriteria(), false)
+	if observing.Enforcing() {
+		t.Error("Enforcing() = true, want false")
+	}
+	if got := observing.Action(); got != "warn" {
+		t.Errorf("observe-only Action() = %q, want %q (forced when not enforcing)", got, "warn")
+	}
+}
+
+func TestPatternMonitor_RedactReplacesLatchSpans(t *testing.T) {
+	m := NewPatternMonitor(true, "redact", defaultCriteria(), false)
+	in := "before " + fakeLiveAWSKey + " after"
+	out, n := m.Redact(in)
+	if n != 1 {
+		t.Errorf("redaction count = %d, want 1", n)
+	}
+	if strings.Contains(out, fakeLiveAWSKey) {
+		t.Errorf("redacted output still contains the key: %q", out)
+	}
+	if !strings.Contains(out, RedactionPlaceholder) {
+		t.Errorf("redacted output missing placeholder: %q", out)
+	}
+	if !strings.HasPrefix(out, "before ") || !strings.HasSuffix(out, " after") {
+		t.Errorf("surrounding text not preserved: %q", out)
+	}
+}
+
+func TestPatternMonitor_RedactMergesOverlappingSpans(t *testing.T) {
+	m := NewPatternMonitor(true, "redact", defaultCriteria(), false)
+	// sk-ant- matches both the anthropic and openai patterns over
+	// overlapping spans; the output must carry a single placeholder.
+	in := "key sk-ant-api03-aaaabbbbccccddddeeee end"
+	out, n := m.Redact(in)
+	if n != 1 {
+		t.Errorf("redaction count = %d, want 1 (overlapping spans merge)", n)
+	}
+	if got := strings.Count(out, RedactionPlaceholder); got != 1 {
+		t.Errorf("placeholder count = %d, want 1: %q", got, out)
+	}
+	if strings.Contains(out, "sk-ant-") {
+		t.Errorf("redacted output still contains key material: %q", out)
+	}
+}
+
+func TestPatternMonitor_RedactLeavesWarnTierIntact(t *testing.T) {
+	m := NewPatternMonitor(true, "redact", defaultCriteria(), false)
+	in := "see secret://SOME_REF for details"
+	out, n := m.Redact(in)
+	if n != 0 {
+		t.Errorf("redaction count = %d, want 0 for warn-tier content", n)
+	}
+	if out != in {
+		t.Errorf("warn-tier content must pass through unchanged, got %q", out)
+	}
+}
+
+func TestNoop_NeverTripsNeverEnforces(t *testing.T) {
+	m := NewNoop()
+	det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{fakeLiveAWSKey})
+	if len(det.Patterns) != 0 || det.Transition {
+		t.Errorf("Noop must not detect, got %+v", det)
+	}
+	if m.TripFromGuard("g1", "sensitive_data") {
+		t.Error("Noop must not trip from a guard")
+	}
+	if m.Tripped() {
+		t.Error("Noop must never be tripped")
+	}
+	if m.Enforcing() {
+		t.Error("Noop must never enforce")
+	}
+	if got := m.Action(); got != "warn" {
+		t.Errorf("Noop Action() = %q, want %q", got, "warn")
+	}
+	if out, n := m.Redact("anything " + fakeLiveAWSKey); out != "anything "+fakeLiveAWSKey || n != 0 {
+		t.Errorf("Noop Redact must pass through unchanged, got (%q, %d)", out, n)
+	}
+}

--- a/harness/internal/ruleoftwo/monitor_test.go
+++ b/harness/internal/ruleoftwo/monitor_test.go
@@ -71,6 +71,23 @@ func TestPatternMonitor_SkipsRescanAfterTrip(t *testing.T) {
 	}
 }
 
+// TestPatternMonitor_WarnTierSuppressedAfterLatch pins the documented
+// contract that post-latch scanning — including warn-tier telemetry —
+// is suspended: after a latch-tier trip, warn-only content produces an
+// empty Detection (no patterns, so the caller emits no events). The
+// rule_of_two_triggered event's scanning_suspended field is what tells
+// operators soak data ends here.
+func TestPatternMonitor_WarnTierSuppressedAfterLatch(t *testing.T) {
+	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
+	if det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{fakeLiveAWSKey}); !det.Transition {
+		t.Fatal("setup: latch-tier content must trip the monitor")
+	}
+	det := m.ObserveChunks(context.Background(), "tool_result", 2, []string{"see secret://SOME_REF for the key"})
+	if len(det.Patterns) != 0 || det.Tier != "" || det.Transition {
+		t.Errorf("post-latch warn-tier observation must be empty Detection, got %+v", det)
+	}
+}
+
 func TestPatternMonitor_WarnTierDoesNotLatch(t *testing.T) {
 	m := NewPatternMonitor(true, "block-external", defaultCriteria(), false)
 	det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{"see secret://SOME_REF for the key"})

--- a/harness/internal/ruleoftwo/noop.go
+++ b/harness/internal/ruleoftwo/noop.go
@@ -1,0 +1,36 @@
+package ruleoftwo
+
+import "context"
+
+// Noop is the default Monitor: it never trips and never enforces. The
+// agentic loop unconditionally calls through the configured monitor, so
+// this type is what the factory wires in when the arming matrix leaves
+// the run unarmed, avoiding a nil-check on every call site.
+type Noop struct{}
+
+var _ Monitor = Noop{}
+
+// NewNoop returns a Monitor that observes nothing and never latches.
+func NewNoop() Monitor {
+	return Noop{}
+}
+
+// ObserveChunks never detects.
+func (Noop) ObserveChunks(_ context.Context, _ string, _ int, _ []string) Detection {
+	return Detection{}
+}
+
+// TripFromGuard never latches.
+func (Noop) TripFromGuard(_, _ string) bool { return false }
+
+// Tripped is always false.
+func (Noop) Tripped() bool { return false }
+
+// Enforcing is always false.
+func (Noop) Enforcing() bool { return false }
+
+// Action mirrors the not-enforcing contract of Monitor.Action.
+func (Noop) Action() string { return "warn" }
+
+// Redact returns the content unchanged.
+func (Noop) Redact(content string) (string, int) { return content, 0 }

--- a/harness/internal/ruleoftwo/patternmonitor.go
+++ b/harness/internal/ruleoftwo/patternmonitor.go
@@ -1,0 +1,158 @@
+package ruleoftwo
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync/atomic"
+
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+)
+
+// RedactionPlaceholder replaces each latch-tier sensitive span rewritten
+// by PatternMonitor.Redact. Fixed (not per-pattern) so the placeholder
+// never echoes anything derived from the matched content.
+const RedactionPlaceholder = "[redacted:sensitive-data]"
+
+// PatternMonitor is the deterministic Monitor backed by
+// security.DetectSensitive. The latch is an atomic.Bool with no reset
+// path; the criteria set is immutable after construction, so the only
+// mutable state shared across goroutines is the latch itself.
+type PatternMonitor struct {
+	enforcing bool
+	action    string
+	criteria  map[string]struct{}
+	tripped   atomic.Bool
+}
+
+var _ Monitor = (*PatternMonitor)(nil)
+
+// NewPatternMonitor constructs the deterministic monitor. action is the
+// configured onDetect (already defaulted by the factory); guardCriteria
+// is the set of guard Decision.Criterion values that ratchet the latch.
+// When staticallySensitive is true — the operator declared sensitivity
+// in the config, so the validator already adjudicated the case — the
+// latch starts tripped and no transition is ever reported.
+func NewPatternMonitor(enforcing bool, action string, guardCriteria []string, staticallySensitive bool) *PatternMonitor {
+	m := &PatternMonitor{
+		enforcing: enforcing,
+		action:    action,
+		criteria:  make(map[string]struct{}, len(guardCriteria)),
+	}
+	for _, c := range guardCriteria {
+		m.criteria[c] = struct{}{}
+	}
+	if staticallySensitive {
+		m.tripped.Store(true)
+	}
+	return m
+}
+
+// ObserveChunks scans each chunk with security.DetectSensitive,
+// aggregates findings as a set of pattern names (a single secret can
+// produce two overlapping findings — sk-ant- keys match both the
+// anthropic and openai patterns, "Bearer eyJ..." matches bearer_token
+// and oidc_jwt), and latches on any latch-tier finding.
+func (m *PatternMonitor) ObserveChunks(_ context.Context, _ string, _ int, chunks []string) Detection {
+	// Once latched, further scans buy nothing: the latch is one-way and
+	// no consumer reads per-chunk findings until redact mode exists
+	// (the detector costs ~80ms/MB, so this skip is the perf budget for
+	// long runs). Wave 4 revisits this for onDetect=redact, which needs
+	// spans on every chunk after the trip.
+	if m.tripped.Load() {
+		return Detection{}
+	}
+	var names []string
+	seen := make(map[string]struct{})
+	latch := false
+	for _, chunk := range chunks {
+		for _, f := range security.DetectSensitive(chunk) {
+			if _, dup := seen[f.Name]; !dup {
+				seen[f.Name] = struct{}{}
+				names = append(names, f.Name)
+			}
+			if f.Tier == security.TierLatch {
+				latch = true
+			}
+		}
+	}
+	if len(names) == 0 {
+		return Detection{}
+	}
+	det := Detection{Patterns: names, Tier: security.TierWarn}
+	if latch {
+		det.Tier = security.TierLatch
+		det.Transition = m.tripped.CompareAndSwap(false, true)
+	}
+	return det
+}
+
+// TripFromGuard latches when criterion is in the configured set.
+// Returns true only for the call that wins the false→true flip.
+func (m *PatternMonitor) TripFromGuard(_, criterion string) bool {
+	if _, ok := m.criteria[criterion]; !ok {
+		return false
+	}
+	return m.tripped.CompareAndSwap(false, true)
+}
+
+// Tripped reports the latch state.
+func (m *PatternMonitor) Tripped() bool {
+	return m.tripped.Load()
+}
+
+// Enforcing reports whether detections may change run behaviour.
+func (m *PatternMonitor) Enforcing() bool {
+	return m.enforcing
+}
+
+// Action returns the configured onDetect when enforcing, "warn"
+// otherwise.
+func (m *PatternMonitor) Action() string {
+	if !m.enforcing {
+		return "warn"
+	}
+	return m.action
+}
+
+// Redact replaces every latch-tier span reported by DetectSensitive
+// with RedactionPlaceholder. Overlapping spans (one secret matched by
+// two patterns) are merged so the output carries a single placeholder
+// per contiguous sensitive region. Warn-tier spans are left intact.
+func (m *PatternMonitor) Redact(content string) (string, int) {
+	findings := security.DetectSensitive(content)
+	spans := make([][2]int, 0, len(findings))
+	for _, f := range findings {
+		if f.Tier == security.TierLatch {
+			spans = append(spans, [2]int{f.Start, f.End})
+		}
+	}
+	if len(spans) == 0 {
+		return content, 0
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i][0] != spans[j][0] {
+			return spans[i][0] < spans[j][0]
+		}
+		return spans[i][1] > spans[j][1]
+	})
+	var b strings.Builder
+	count := 0
+	pos := 0
+	for _, s := range spans {
+		if s[0] < pos {
+			// Overlaps a span already replaced: swallow the tail of the
+			// secret without emitting a second placeholder.
+			if s[1] > pos {
+				pos = s[1]
+			}
+			continue
+		}
+		b.WriteString(content[pos:s[0]])
+		b.WriteString(RedactionPlaceholder)
+		pos = s[1]
+		count++
+	}
+	b.WriteString(content[pos:])
+	return b.String(), count
+}

--- a/harness/internal/ruleoftwo/patternmonitor.go
+++ b/harness/internal/ruleoftwo/patternmonitor.go
@@ -57,8 +57,11 @@ func (m *PatternMonitor) ObserveChunks(_ context.Context, _ string, _ int, chunk
 	// Once latched, further scans buy nothing: the latch is one-way and
 	// no consumer reads per-chunk findings until redact mode exists
 	// (the detector costs ~80ms/MB, so this skip is the perf budget for
-	// long runs). Wave 4 revisits this for onDetect=redact, which needs
-	// spans on every chunk after the trip.
+	// long runs). Warn-tier telemetry is also suppressed post-latch —
+	// a documented contract, not a side-effect: the rule_of_two_triggered
+	// event carries scanning_suspended:true so operators can see where
+	// soak data ends. Wave 4 revisits this for onDetect=redact, which
+	// needs spans on every chunk after the trip.
 	if m.tripped.Load() {
 		return Detection{}
 	}

--- a/harness/internal/ruleoftwo/ruleoftwo.go
+++ b/harness/internal/ruleoftwo/ruleoftwo.go
@@ -1,0 +1,76 @@
+// Package ruleoftwo defines the Monitor interface and supporting types
+// for the harness's Rule-of-Two runtime sensitive-data classifier.
+//
+// A Monitor watches untrusted content as it enters the conversation
+// (the operator prompt, dynamic context, tool results) and owns the
+// run-scoped one-way sensitive-data latch: once sensitive content is
+// observed, the run "holds sensitive data" for the rest of its life.
+// LLM guards participate through TripFromGuard — a guard decision whose
+// criterion matches the configured set tightens the latch but can never
+// loosen it, so a coerced guard stays fail-safe.
+//
+// Like the guard package, this package is deliberately leaf-level: its
+// only harness-internal import is security (for the deterministic
+// detector). The factory decides arming and injects a Monitor into the
+// agentic loop; the loop calls through the interface unconditionally
+// (Noop when unarmed).
+//
+// Interface note: TripFromGuard returns whether the call transitioned
+// the latch false→true. The plan sketched a void return, but the loop
+// needs the transition signal to emit rule_of_two_triggered exactly
+// once under concurrent observation, and only the monitor's atomic
+// latch can adjudicate the winner.
+package ruleoftwo
+
+import "context"
+
+// Monitor classifies freshly-arrived untrusted content and owns the
+// run-scoped sensitive-data latch. Implementations must be safe for
+// concurrent use: sub-agent loops share the parent's monitor.
+type Monitor interface {
+	// ObserveChunks scans content that just entered the conversation.
+	// source and turn identify the provenance for the caller's
+	// telemetry; the returned Detection reports the deduplicated
+	// pattern names, the aggregate tier, and whether this call
+	// transitioned the latch.
+	ObserveChunks(ctx context.Context, source string, turn int, chunks []string) Detection
+
+	// TripFromGuard is the one-way ratchet from an LLM guard. The
+	// monitor filters internally: a criterion outside the configured
+	// guard-criteria set is ignored. Returns true only when this call
+	// transitioned the latch false→true.
+	TripFromGuard(guardID, criterion string) bool
+
+	// Tripped reports whether the latch is set. There is no reset.
+	Tripped() bool
+
+	// Enforcing reports whether detections are allowed to change run
+	// behaviour. False means observe-only: events and metrics fire but
+	// no consumer acts on the latch.
+	Enforcing() bool
+
+	// Action is the effective on-detect action: the configured
+	// onDetect when enforcing, "warn" otherwise.
+	Action() string
+
+	// Redact rewrites latch-tier sensitive spans in content with a
+	// fixed placeholder and returns the rewritten content plus the
+	// number of spans replaced. Not called by the loop in this wave;
+	// the onDetect=redact consumer lands with enforcement.
+	Redact(content string) (string, int)
+}
+
+// Detection is the result of one ObserveChunks call.
+type Detection struct {
+	// Patterns is the deduplicated set of pattern names that matched
+	// across all chunks (e.g. "secret/aws_access_key_id",
+	// "pii/credit_card"). Names only — never matched content.
+	Patterns []string
+	// Tier is the aggregate tier: security.TierLatch when any finding
+	// is latch-tier, security.TierWarn otherwise. Empty when Patterns
+	// is empty.
+	Tier string
+	// Transition is true only when this call flipped the latch
+	// false→true. At most one Detection per run carries it.
+	Transition bool
+}

--- a/harness/internal/security/securityevent.go
+++ b/harness/internal/security/securityevent.go
@@ -275,6 +275,12 @@ func (sl *SecurityLogger) SensitiveDataDetected(patterns []string, tier, source 
 // boolean keys mirror emitRuleOfTwoEvents' run-start audit events so
 // downstream tooling greps one identifier set; sensitiveData is always
 // true here — the transition is the event.
+//
+// scanning_suspended marks where soak telemetry ends: once the latch
+// trips, the monitor stops scanning, so warn-tier detections after
+// this event are deliberately dark. Hardcoded true while the skip is
+// unconditional; the enforcement wave's redact mode (which keeps
+// scanning post-latch) will parameterise it.
 func (sl *SecurityLogger) RuleOfTwoTriggered(untrustedInput, externalCommunication bool, action, source string) {
 	sl.Emit("warn", "rule_of_two_triggered", map[string]any{
 		"untrustedInput":        untrustedInput,
@@ -282,5 +288,6 @@ func (sl *SecurityLogger) RuleOfTwoTriggered(untrustedInput, externalCommunicati
 		"sensitiveData":         true,
 		"action":                action,
 		"source":                source,
+		"scanning_suspended":    true,
 	})
 }

--- a/harness/internal/security/securityevent.go
+++ b/harness/internal/security/securityevent.go
@@ -252,3 +252,35 @@ func (sl *SecurityLogger) GuardError(phase, guardID, errorMessage string) {
 		"error":   errorMessage,
 	})
 }
+
+// SensitiveDataDetected emits when the Rule-of-Two runtime monitor
+// reports sensitive content. patterns carries pattern NAMES only —
+// never matched content (the same no-content contract as GuardDenied).
+// source is the provenance ("prompt", "dynamic_context", "tool_result",
+// or "guard:<id>" for the LLM-guard ratchet); transition is true on the
+// event that flipped the run's sensitive-data latch.
+func (sl *SecurityLogger) SensitiveDataDetected(patterns []string, tier, source string, turn int, action string, transition bool) {
+	sl.Emit("warn", "sensitive_data_detected", map[string]any{
+		"patterns":   patterns,
+		"tier":       tier,
+		"source":     source,
+		"turn":       turn,
+		"action":     action,
+		"transition": transition,
+	})
+}
+
+// RuleOfTwoTriggered emits once per run, at the false→true transition
+// of the sensitive-data latch while the runtime monitor is armed. The
+// boolean keys mirror emitRuleOfTwoEvents' run-start audit events so
+// downstream tooling greps one identifier set; sensitiveData is always
+// true here — the transition is the event.
+func (sl *SecurityLogger) RuleOfTwoTriggered(untrustedInput, externalCommunication bool, action, source string) {
+	sl.Emit("warn", "rule_of_two_triggered", map[string]any{
+		"untrustedInput":        untrustedInput,
+		"externalCommunication": externalCommunication,
+		"sensitiveData":         true,
+		"action":                action,
+		"source":                source,
+	})
+}


### PR DESCRIPTION
## Summary

Wave 3 of 5 making the Rule of Two's sensitive-data leg dynamic (Ring 4). **Stacked on #416** (which stacks on #415). The detector from #416 is now wired into the agentic loop behind a new injected component — and **ships dark**: every detection is events + metrics only; no enforcement consumer exists until Wave 4.

- New package `harness/internal/ruleoftwo`: `Monitor` interface, `PatternMonitor` (one-way atomic latch, CAS-adjudicated transition), `Noop` (installed when unarmed, so loop call sites are unconditional — the `guard` package idiom).
- Loop wiring: turn-0 scan of prompt + sanitized dynamicContext in `Run()` before prompt build; per-turn scan of tool-result chunks (including `ContentBlock.Structured`) at the PreTurn site before `guardCheck`; LLM-guard criterion ratchet at PreTurn + PostTurn (one-way: a guard decision can only tighten).
- Factory arming matrix from `types.RuleOfTwoState`: armed+enforcing when {untrusted input + external comms} hold without declared sensitivity and without ask-upstream/enforce-off gating; armed observe-only otherwise; `Noop` when a leg is missing (unless `classifier: "patterns"` is explicit). Computed in the factory — **the config is never mutated**.
- Sub-agent loops share the parent's monitor (one run boundary, one latch; `spawn_agent` is not an escape hatch — same rationale as the GuardRail inheritance).
- Events: `sensitive_data_detected`, `rule_of_two_triggered` (once per run, with `scanning_suspended: true`), `rule_of_two_runtime_armed`; metrics `stirrup.ruleoftwo.detections` + `stirrup.ruleoftwo.scan_duration_ms`. Pattern names only — never content.

## Why dark-ship

Enforcement defaults flip in Wave 4 (`block-external` revokes egress on detection). This wave exists to soak: operators get real false-positive/tier telemetry from `sensitive_data_detected` events before any run's behaviour changes. A dark-ship pin test asserts run outcome and message flow are byte-identical with and without an armed monitor.

## One-way decisions

- **Event + metric vocabulary freezes here**: event names/payload keys, detector pattern names, the `guard:<criterion>` namespace for guard-originated trips, and `stirrup.ruleoftwo.*` instrument names become operator dashboard surface.
- **Skip-after-trip contract**: once latched, scanning stops (≈80 ms/MB saved per chunk set), which also suppresses warn-tier telemetry; `rule_of_two_triggered` carries `scanning_suspended: true` so dashboards can see where soak data ends. Wave 4's redact mode revisits this.
- **Arming is factory behaviour, not config state** — the `Redact()`-persisted RunConfig stays exactly operator-authored.

## Assumptions

- Turn-0 content is scanned in `Run()` under `prompt`/`dynamic_context` source labels; the loop-site scan is gated `turn > 0` to avoid double-emitting the same content mislabelled `tool_result`.
- Sub-agent child runs share the parent latch rather than getting their own (a child observing sensitive data means the *run* holds it).
- Scanning the stringified JSON of structured tool results is sufficient for the detector's patterns (offsets are not used for redaction until Wave 4).

## Review

One wave of four parallel reviews (code / security / spec-compliance / consistency → synthesized) remediated before opening. Caught and fixed:

- **Structured-result scan bypass** (HIGH): `collectUntrustedChunks` read only `ContentBlock.Content`, but both wired adapters forward `ContentBlock.Structured` to the model — a credential present only in structured JSON was model-visible yet monitor-invisible. Now scanned, with a structured-only regression test.
- **Telemetry forgery seam** (HIGH): a coerced guard returning `criterion = "secret/aws_access_key_id"` could impersonate a deterministic detector hit in events/metrics. Guard trips are now namespaced `guard:<criterion>`.
- Metric namespace moved to `stirrup.ruleoftwo.*` (matches `stirrup.guard.*`) before the names became load-bearing.

## Known gaps inherited by Wave 4 (deliberate)

- `replaceUntrustedChunks`/`spotlightUntrustedChunks` rewrite only `Content` — a PreTurn guard-deny scrub leaves `Structured` intact in history. Wave 4's redact path must rewrite both.
- Dynamic-context entries past the 50 KB sanitizer cap are truncated before scanning (matches what the model sees, but documented).
- The `subagent.go` Permissions type-assertion fix (breaks under any policy wrapper) lands with the wrapper itself in Wave 4, where its regression test can be born green.

## Testing

`just` + `just lint` green; `go test ./harness/internal/ruleoftwo/ ./harness/internal/core/ -race` green. Covers: one-way latch + transition-exactly-once under concurrency, arming-matrix table, scripted-provider loop tests (tool-result latch, structured-only latch, turn-0 PAN latch, guard ratchet, Noop zero-events), sub-agent shared latch, dark-ship outcome pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)