### PR TITLE
permission, core: enforce the rule-of-two latch by revoking egress

### DIFF
--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -1102,9 +1102,9 @@ func editStrategyTool(es edit.EditStrategy, exec executor.Executor) *tool.Tool {
 // an LLM guard is expected to name when it spots sensitive content.
 var defaultRuleOfTwoGuardCriteria = []string{"sensitive_data", "pii"}
 
-// defaultRuleOfTwoAction is the documented onDetect default. Inert this
-// wave (no enforcement consumer); it flows into events so the soak
-// shows the action wave 4 will start applying.
+// defaultRuleOfTwoAction is the documented onDetect default, enforced
+// via the permission gate (block-external) when the arming matrix arms
+// the run.
 const defaultRuleOfTwoAction = "block-external"
 
 // ruleOfTwoArming is the factory's arming decision for the Rule-of-Two
@@ -1649,9 +1649,13 @@ func wrapRuleOfTwoGate(pp permission.PermissionPolicy, monitor ruleoftwo.Monitor
 	case "block-external":
 		return permission.NewRuleOfTwoGate(pp, monitor, externalCommToolSet(registry), nil, metrics)
 	case "ask-upstream":
+		// One external-comm set shared by the ask policy and the gate:
+		// both must cover the same tools, and a single allocation keeps
+		// them from silently diverging.
+		extSet := externalCommToolSet(registry)
 		timeout := time.Duration(cfg.PermissionPolicy.Timeout) * time.Second
-		ask := permission.NewAskUpstreamPolicy(tp, externalCommToolSet(registry), timeout)
-		return permission.NewRuleOfTwoGate(pp, monitor, externalCommToolSet(registry), ask, metrics)
+		ask := permission.NewAskUpstreamPolicy(tp, extSet, timeout)
+		return permission.NewRuleOfTwoGate(pp, monitor, extSet, ask, metrics)
 	default:
 		return pp
 	}

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -1172,13 +1172,22 @@ func resolveRuleOfTwoArming(config *types.RunConfig) ruleOfTwoArming {
 			staticSensitive: s,
 		}
 	case classifier == "patterns":
+		// Explicit classifier:"patterns" with !u||!e is observe-only by
+		// construction (no enforcement consumer reads the latch here),
+		// so the monitor must NOT start pre-tripped even when the
+		// operator also declared sensitiveData: pre-tripping would skip
+		// every scan and yield zero detection telemetry — the opposite
+		// of what an operator who explicitly asked for pattern scanning
+		// wants. staticSensitive stays meaningful only on the enforcing
+		// u&&e path above, where a pre-tripped latch is the audited
+		// posture.
 		return ruleOfTwoArming{
 			armed:           true,
 			enforcing:       false,
 			action:          action,
 			criteria:        criteria,
 			classifier:      "patterns",
-			staticSensitive: s,
+			staticSensitive: false,
 		}
 	default:
 		return ruleOfTwoArming{}

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -284,10 +284,11 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 
 	// 10b. Rule-of-Two runtime monitor, from the arming decision
 	// computed alongside the run-start audit events above. Noop when
-	// unarmed so the loop's call sites are unconditional. Observe-only
-	// this wave: enforcing/action flow into events only — no
-	// enforcement consumer exists until wave 4 lands the permission
-	// gate, redact, and abort paths.
+	// unarmed so the loop's call sites are unconditional. Enforcement
+	// is delivered by the permission gate wrapped below (block-external
+	// / ask-upstream) and the loop's redact / abort actions; escape
+	// hatches are ruleOfTwo.runtime.classifier "none" and
+	// ruleOfTwo.enforce: false.
 	rot := buildRuleOfTwoMonitor(ruleOfTwoArmingState)
 
 	// 11. Git strategy.
@@ -346,6 +347,14 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	// (rather than step 7) so the metric-recorder wrapping centralised
 	// in buildVerifier sees a non-nil metrics on the only call site.
 	v = buildVerifier(config.Verifier, prov, metrics)
+
+	// Rule-of-Two enforcement gate, applied BEFORE the metrics wrapper
+	// so gate denials are recorded by stirrup.permission.decisions
+	// under the configured policy label (true attribution rides
+	// stirrup.ruleoftwo.actions, emitted by the gate itself). No-op
+	// unless the monitor is armed and enforcing with a gate-delivered
+	// action.
+	pp = wrapRuleOfTwoGate(pp, rot, ruleOfTwoArmingState, registry, config, tp, metrics)
 
 	// Wrap the previously-built permission policy with metrics so
 	// each Check call records stirrup.permission.decisions tagged
@@ -1595,6 +1604,48 @@ func mutatingToolSet(registry *tool.Registry) map[string]bool {
 		}
 	}
 	return out
+}
+
+// externalCommToolSet returns the names of registered tools that can
+// move data outside the harness sandbox: run_command (shell egress),
+// web_fetch (arbitrary HTTP), and every MCP-imported tool (the remote
+// server receives each call's payload). The Rule-of-Two gate revokes
+// exactly this set once the sensitive-data latch trips. Keys are
+// internal tool IDs — the Presenter never rewrites dispatch names, so
+// toolset-profile aliases cannot bypass the set.
+func externalCommToolSet(registry *tool.Registry) map[string]bool {
+	out := make(map[string]bool)
+	for _, td := range registry.List() {
+		if td.Name == "run_command" || td.Name == "web_fetch" || strings.HasPrefix(td.Name, "mcp_") {
+			out[td.Name] = true
+		}
+	}
+	return out
+}
+
+// wrapRuleOfTwoGate installs the Rule-of-Two enforcement gate around
+// the permission policy when the runtime monitor is armed and
+// enforcing with a gate-delivered action. redact and abort are
+// loop-level actions with no permission-layer component, and
+// observe-only monitors ("warn") never gate — those return pp
+// unchanged. For onDetect=ask-upstream the AskUpstreamPolicy is
+// pre-built eagerly here, idle until the latch trips, so enforcement
+// time never constructs components; the validator already pinned
+// transport=grpc for that action.
+func wrapRuleOfTwoGate(pp permission.PermissionPolicy, monitor ruleoftwo.Monitor, arming ruleOfTwoArming, registry *tool.Registry, cfg *types.RunConfig, tp transport.Transport, metrics *observability.Metrics) permission.PermissionPolicy {
+	if !arming.armed || !arming.enforcing {
+		return pp
+	}
+	switch arming.action {
+	case "block-external":
+		return permission.NewRuleOfTwoGate(pp, monitor, externalCommToolSet(registry), nil, metrics)
+	case "ask-upstream":
+		timeout := time.Duration(cfg.PermissionPolicy.Timeout) * time.Second
+		ask := permission.NewAskUpstreamPolicy(tp, externalCommToolSet(registry), timeout)
+		return permission.NewRuleOfTwoGate(pp, monitor, externalCommToolSet(registry), ask, metrics)
+	default:
+		return pp
+	}
 }
 
 // approvalRequiredToolSet returns the names of registered tools that

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -1853,7 +1853,13 @@ func (l *AgenticLoop) redactSensitiveSpans(messages []types.Message, turn int) i
 				if json.Valid([]byte(redacted)) {
 					last.Content[i].Structured = json.RawMessage(redacted)
 				} else {
-					last.Content[i].Structured = json.RawMessage(`"` + ruleoftwo.RedactionPlaceholder + `"`)
+					// json.Marshal of a Go string always yields a valid
+					// JSON string regardless of the placeholder's
+					// contents; the error is unreachable for a string
+					// argument. This avoids relying on RedactionPlaceholder
+					// never acquiring a quote, backslash, or control char.
+					b, _ := json.Marshal(ruleoftwo.RedactionPlaceholder)
+					last.Content[i].Structured = json.RawMessage(b)
 				}
 				total += n
 			}

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -17,6 +18,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
+	"github.com/rxbynerd/stirrup/harness/internal/ruleoftwo"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/trace"
 	"github.com/rxbynerd/stirrup/harness/internal/verifier"
@@ -170,12 +172,34 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	// Turn-0 Rule-of-Two scan: classify the operator prompt and the
 	// sanitized dynamic-context values before Prompt.Build so a
 	// latch-tier hit is recorded before the first provider call.
-	// Observe-only — redact-mode rewriting of dynamic context lands
-	// with enforcement in wave 4.
+	var turnZeroTransition bool
 	if config.Prompt != "" {
-		l.observeSensitive(runCtx, config, "prompt", 0, []string{config.Prompt})
+		if det := l.observeSensitive(runCtx, config, "prompt", 0, []string{config.Prompt}); det.Transition {
+			turnZeroTransition = true
+		}
 	}
-	l.observeSensitive(runCtx, config, "dynamic_context", 0, sortedContextValues(dynamicContext))
+	if det := l.observeSensitive(runCtx, config, "dynamic_context", 0, sortedContextValues(dynamicContext)); det.Transition {
+		turnZeroTransition = true
+	}
+
+	// Turn-0 enforcement, applied before Prompt.Build: redact rewrites
+	// the dynamic-context values the model will see (the operator's
+	// prompt latches but is never rewritten — changing the task
+	// statement changes run semantics); abort short-circuits the whole
+	// run before the first provider call. block-external / ask-upstream
+	// are enforced later, in the permission gate.
+	turnZeroAbort := false
+	switch l.ruleOfTwoAction() {
+	case "redact":
+		if n := l.redactDynamicContext(dynamicContext); n > 0 {
+			l.recordRuleOfTwoAction(runCtx, "redact")
+		}
+	case "abort":
+		if turnZeroTransition {
+			l.recordRuleOfTwoAction(runCtx, "abort")
+			turnZeroAbort = true
+		}
+	}
 
 	systemPrompt, err := l.Prompt.Build(runCtx, prompt.PromptContext{
 		Mode:           config.Mode,
@@ -282,14 +306,21 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	}
 	defer unregisterCtxTokens()
 
-	// Outer verification loop.
+	// Outer verification loop. A turn-0 Rule-of-Two abort skips it
+	// entirely: the latch tripped on the prompt / dynamic context
+	// before any provider call, so the run terminates with the
+	// rule_of_two_violation outcome through the same finish path as
+	// every other terminal outcome below.
 	outcome := "success"
 	verificationAttempts := 0
 	// finalAssistantText accumulates the last non-empty assistant text across
 	// every runInnerLoop invocation (verification retries re-enter the loop).
 	var finalAssistantText string
+	if turnZeroAbort {
+		outcome = "rule_of_two_violation"
+	}
 
-	for verificationAttempts <= maxVerificationRetries {
+	for !turnZeroAbort && verificationAttempts <= maxVerificationRetries {
 		// Run the inner agentic loop.
 		var innerOutcome, innerFinalText string
 		messages, innerOutcome, innerFinalText = l.runInnerLoop(runCtx, config, systemPrompt, messages, tokenTracker)
@@ -612,8 +643,22 @@ func (l *AgenticLoop) runInnerLoop(
 			// prompt and dynamic context, already observed in Run()
 			// under their own source labels — rescanning them here would
 			// double-emit warn-tier detections mislabelled "tool_result".
+			// The block-external / ask-upstream actions are enforced in
+			// the permission gate; abort and redact are loop-level and
+			// applied here from the Detection.
 			if turn > 0 {
-				l.observeSensitive(ctx, config, "tool_result", turn, chunks)
+				det := l.observeSensitive(ctx, config, "tool_result", turn, chunks)
+				switch l.ruleOfTwoAction() {
+				case "abort":
+					if det.Transition {
+						l.recordRuleOfTwoAction(ctx, "abort")
+						return messages, "rule_of_two_violation", finalAssistantText
+					}
+				case "redact":
+					if n := l.redactSensitiveSpans(messages, turn); n > 0 {
+						l.recordRuleOfTwoAction(ctx, "redact")
+					}
+				}
 			}
 			batched := batchUntrustedChunks(chunks)
 			in := guard.Input{
@@ -1489,16 +1534,18 @@ func (l *AgenticLoop) recordSpotlightApplied(ctx context.Context, phase guard.Ph
 }
 
 // observeSensitive runs the Rule-of-Two monitor over freshly-arrived
-// untrusted chunks and emits the observe-only telemetry: the
-// sensitive_scan_ms histogram on every scan, sensitive_data_detected +
+// untrusted chunks and emits its telemetry: the sensitive_scan_ms
+// histogram on every scan, sensitive_data_detected +
 // rule_of_two_detections on any finding, and the once-per-run
 // rule_of_two_triggered + transport warning at the latch transition.
-// Nothing here changes run behaviour — wave 3 ships dark; enforcement
-// consumers arrive in wave 4. A nil monitor (hand-assembled loops)
-// no-ops, mirroring guardCheck's nil-GuardRail branch.
-func (l *AgenticLoop) observeSensitive(ctx context.Context, config *types.RunConfig, source string, turn int, chunks []string) {
+// It only observes and records — the caller applies any enforcement
+// action (gate is in the permission layer; redact / abort are handled
+// at the call sites from the returned Detection). A nil monitor
+// (hand-assembled loops) no-ops, mirroring guardCheck's nil-GuardRail
+// branch.
+func (l *AgenticLoop) observeSensitive(ctx context.Context, config *types.RunConfig, source string, turn int, chunks []string) ruleoftwo.Detection {
 	if l.RuleOfTwo == nil || len(chunks) == 0 {
-		return
+		return ruleoftwo.Detection{}
 	}
 	start := time.Now()
 	det := l.RuleOfTwo.ObserveChunks(ctx, source, turn, chunks)
@@ -1512,7 +1559,7 @@ func (l *AgenticLoop) observeSensitive(ctx context.Context, config *types.RunCon
 		))
 	}
 	if len(det.Patterns) == 0 {
-		return
+		return det
 	}
 	action := l.RuleOfTwo.Action()
 	if l.Security != nil {
@@ -1530,6 +1577,30 @@ func (l *AgenticLoop) observeSensitive(ctx context.Context, config *types.RunCon
 	if det.Transition {
 		l.emitRuleOfTwoTriggered(config, source, action)
 	}
+	return det
+}
+
+// ruleOfTwoAction returns the monitor's effective on-detect action, or
+// "" when no monitor is wired. "warn" (observe-only) and "block-external"
+// / "ask-upstream" (handled in the permission gate) carry no loop-level
+// behaviour; only "redact" and "abort" are acted on at the scan sites.
+func (l *AgenticLoop) ruleOfTwoAction() string {
+	if l.RuleOfTwo == nil {
+		return ""
+	}
+	return l.RuleOfTwo.Action()
+}
+
+// recordRuleOfTwoAction increments stirrup.ruleoftwo.actions for one
+// applied enforcement action (a redacted chunk set, an abort). Gate
+// denials are recorded by the gate itself in the permission layer.
+func (l *AgenticLoop) recordRuleOfTwoAction(ctx context.Context, action string) {
+	if l.Metrics == nil {
+		return
+	}
+	l.Metrics.RuleOfTwoActions.Add(ctx, 1, l.metricAttrs(
+		attribute.String("action", action),
+	))
 }
 
 // ratchetRuleOfTwo forwards a guard decision's criterion to the
@@ -1571,15 +1642,23 @@ func (l *AgenticLoop) ratchetRuleOfTwo(ctx context.Context, config *types.RunCon
 // rule_of_two_triggered security event (key names mirror the run-start
 // audit events from emitRuleOfTwoEvents) and a one-time transport
 // warning so operators without a security-event pipeline still see the
-// posture change on the wire.
+// posture change on the wire. scanning_suspended is false only for the
+// redact action, which keeps scanning every later tool result.
 func (l *AgenticLoop) emitRuleOfTwoTriggered(config *types.RunConfig, source, action string) {
 	untrusted, _, external := types.RuleOfTwoState(config)
+	scanningSuspended := action != "redact"
 	if l.Security != nil {
-		l.Security.RuleOfTwoTriggered(untrusted, external, action, source)
+		l.Security.RuleOfTwoTriggered(untrusted, external, action, source, scanningSuspended)
+	}
+	var msg string
+	if l.RuleOfTwo != nil && l.RuleOfTwo.Enforcing() {
+		msg = fmt.Sprintf("rule of two: sensitive data detected (source %q); enforcing action %q", source, action)
+	} else {
+		msg = fmt.Sprintf("rule of two: sensitive data detected (source %q); action %q is observe-only", source, action)
 	}
 	_ = l.Transport.Emit(types.HarnessEvent{
 		Type:    "warning",
-		Message: fmt.Sprintf("rule of two: sensitive data detected (source %q); action %q is observe-only this release", source, action),
+		Message: msg,
 	})
 }
 
@@ -1732,6 +1811,76 @@ func replaceUntrustedChunks(messages []types.Message, turn int, placeholder stri
 			last.Content[i].Content = placeholder
 		}
 	}
+}
+
+// redactSensitiveSpans rewrites the latch-tier sensitive spans in every
+// just-arrived tool_result block of the last message, in BOTH the text
+// Content and the Structured payload — the Anthropic and Gemini
+// adapters both forward Structured to the model, so a scrub that
+// ignored it would leave an evasion seam (the wave-3 finding). Returns
+// the total number of spans replaced. Turn 0 is a no-op: its untrusted
+// content is the prompt and dynamic context, which Run() handles before
+// Prompt.Build (the prompt is never rewritten; dynamic context is
+// redacted in place). Modeled on replaceUntrustedChunks.
+func (l *AgenticLoop) redactSensitiveSpans(messages []types.Message, turn int) int {
+	if turn == 0 || len(messages) == 0 || l.RuleOfTwo == nil {
+		return 0
+	}
+	last := &messages[len(messages)-1]
+	if last.Role != "user" {
+		return 0
+	}
+	total := 0
+	for i := range last.Content {
+		if last.Content[i].Type != "tool_result" {
+			continue
+		}
+		if last.Content[i].Content != "" {
+			redacted, n := l.RuleOfTwo.Redact(last.Content[i].Content)
+			if n > 0 {
+				last.Content[i].Content = redacted
+				total += n
+			}
+		}
+		if len(last.Content[i].Structured) > 0 {
+			redacted, n := l.RuleOfTwo.Redact(string(last.Content[i].Structured))
+			if n > 0 {
+				// A placeholder inside a JSON string value keeps the
+				// document valid; a redaction that lands across JSON
+				// structure would not. Fall back to a whole-payload
+				// placeholder rather than emit malformed JSON to the
+				// provider.
+				if json.Valid([]byte(redacted)) {
+					last.Content[i].Structured = json.RawMessage(redacted)
+				} else {
+					last.Content[i].Structured = json.RawMessage(`"` + ruleoftwo.RedactionPlaceholder + `"`)
+				}
+				total += n
+			}
+		}
+	}
+	return total
+}
+
+// redactDynamicContext rewrites latch-tier sensitive spans in every
+// dynamic-context value in place, before Prompt.Build folds them into
+// the system prompt. Returns the number of spans replaced. The
+// operator's config.Prompt is deliberately NOT redacted: rewriting the
+// task statement would change run semantics, so the prompt only latches
+// (for audit and the gate) and is forwarded verbatim.
+func (l *AgenticLoop) redactDynamicContext(dynamicContext map[string]string) int {
+	if l.RuleOfTwo == nil {
+		return 0
+	}
+	total := 0
+	for k, v := range dynamicContext {
+		redacted, n := l.RuleOfTwo.Redact(v)
+		if n > 0 {
+			dynamicContext[k] = redacted
+			total += n
+		}
+	}
+	return total
 }
 
 // spotlightUntrustedChunks rewraps every tool_result block in the last

--- a/harness/internal/core/ruleoftwo_enforcement_test.go
+++ b/harness/internal/core/ruleoftwo_enforcement_test.go
@@ -588,6 +588,39 @@ func TestLoop_RuleOfTwoAbortTurnZeroBeforeProviderCall(t *testing.T) {
 	}
 }
 
+// TestLoop_RuleOfTwoAbortPreTrippedLatchDoesNotAbort documents WHY the
+// validator rejects onDetect:"abort" + sensitiveData:true (Wave-4
+// review item 1): a pre-tripped abort monitor never fires the abort,
+// because the loop keys abort on the false→true Transition and a
+// pre-tripped latch can never transition. The provider IS reached and
+// the run completes normally. This is the regression pin for anyone who
+// later removes the validator check — the loop alone cannot catch this.
+func TestLoop_RuleOfTwoAbortPreTrippedLatchDoesNotAbort(t *testing.T) {
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "ok"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	loop := buildTestLoop(prov)
+	// staticallySensitive=true → latch starts tripped → no transition.
+	loop.RuleOfTwo = ruleoftwo.NewPatternMonitor(true, "abort", []string{"sensitive_data"}, true)
+
+	runTrace, err := loop.Run(context.Background(), buildTestConfig())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome == "rule_of_two_violation" {
+		t.Error("a pre-tripped abort latch must NOT abort (no transition); the validator is what prevents this config")
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (the loop cannot abort a pre-tripped run)", runTrace.Outcome)
+	}
+	if !loop.RuleOfTwo.Tripped() {
+		t.Error("monitor should be pre-tripped")
+	}
+}
+
 // --- default-flip pin (inverse of the wave-3 dark-ship pin) ---
 
 // TestBuildLoop_DefaultArmedEnforcesBlockExternal pins the wave-4

--- a/harness/internal/core/ruleoftwo_enforcement_test.go
+++ b/harness/internal/core/ruleoftwo_enforcement_test.go
@@ -510,6 +510,40 @@ func TestLoop_RuleOfTwoRedactRewritesContentAndStructured(t *testing.T) {
 	}
 }
 
+// TestLoop_RuleOfTwoRedactStructuredInvalidJSONFallback drives the
+// fallback branch of redactSensitiveSpans: when scrubbing a Structured
+// payload breaks its JSON (the generic_hex_secret span consumes the
+// value's closing quote), the field is replaced with a marshalled
+// placeholder rather than emitting malformed JSON. json.Marshal keeps
+// the output valid regardless of the placeholder's contents.
+func TestLoop_RuleOfTwoRedactStructuredInvalidJSONFallback(t *testing.T) {
+	loop := buildTestLoop(nil)
+	loop.RuleOfTwo = ruleoftwo.NewPatternMonitor(true, "redact", []string{"sensitive_data"}, false)
+
+	const hex = "0123456789abcdef0123456789abcdef"
+	messages := []types.Message{
+		{Role: "assistant", Content: []types.ContentBlock{{Type: "text", Text: "x"}}},
+		{Role: "user", Content: []types.ContentBlock{
+			{Type: "tool_result", ToolUseID: "tc_1", Structured: json.RawMessage(`{"note":"password=` + hex + `"}`)},
+		}},
+	}
+	n := loop.redactSensitiveSpans(messages, 1)
+	if n == 0 {
+		t.Fatal("expected the latch-tier secret to be redacted")
+	}
+	got := messages[1].Content[0].Structured
+	if !json.Valid(got) {
+		t.Errorf("fallback must keep Structured valid JSON, got: %q", got)
+	}
+	if strings.Contains(string(got), hex) {
+		t.Errorf("secret survived the fallback: %q", got)
+	}
+	want, _ := json.Marshal(ruleoftwo.RedactionPlaceholder)
+	if string(got) != string(want) {
+		t.Errorf("fallback Structured = %q, want the marshalled placeholder %q", got, want)
+	}
+}
+
 // messageCapturingProvider records the message slice of the LAST Stream
 // call so a test can inspect what the model saw after redaction.
 type messageCapturingProvider struct {

--- a/harness/internal/core/ruleoftwo_enforcement_test.go
+++ b/harness/internal/core/ruleoftwo_enforcement_test.go
@@ -1,0 +1,241 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/permission"
+	"github.com/rxbynerd/stirrup/harness/internal/ruleoftwo"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// --- factory helpers ---
+
+func TestExternalCommToolSet(t *testing.T) {
+	registry := tool.NewRegistry()
+	for _, name := range []string{"run_command", "web_fetch", "read_file", "mcp_github_create_issue"} {
+		registry.Register(&tool.Tool{
+			Name:        name,
+			Description: "t",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+			Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "", nil
+			},
+		})
+	}
+	set := externalCommToolSet(registry)
+	for _, want := range []string{"run_command", "web_fetch", "mcp_github_create_issue"} {
+		if !set[want] {
+			t.Errorf("externalCommToolSet missing %q", want)
+		}
+	}
+	if set["read_file"] {
+		t.Error("read_file is not external-comm")
+	}
+}
+
+func TestWrapRuleOfTwoGate_Matrix(t *testing.T) {
+	registry := tool.NewRegistry()
+	inner := permission.NewAllowAll()
+	cfg := buildTestConfig()
+	metrics := observability.NewNoopMetrics()
+
+	cases := []struct {
+		name     string
+		arming   ruleOfTwoArming
+		wantGate bool
+	}{
+		{name: "unarmed unchanged", arming: ruleOfTwoArming{}, wantGate: false},
+		{name: "armed observe-only unchanged", arming: ruleOfTwoArming{armed: true, enforcing: false, action: "block-external"}, wantGate: false},
+		{name: "enforcing block-external gated", arming: ruleOfTwoArming{armed: true, enforcing: true, action: "block-external"}, wantGate: true},
+		{name: "enforcing ask-upstream gated", arming: ruleOfTwoArming{armed: true, enforcing: true, action: "ask-upstream"}, wantGate: true},
+		{name: "enforcing redact is loop-level", arming: ruleOfTwoArming{armed: true, enforcing: true, action: "redact"}, wantGate: false},
+		{name: "enforcing abort is loop-level", arming: ruleOfTwoArming{armed: true, enforcing: true, action: "abort"}, wantGate: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			monitor := buildRuleOfTwoMonitor(tc.arming)
+			tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+			pp := wrapRuleOfTwoGate(inner, monitor, tc.arming, registry, cfg, tp, metrics)
+			gated := pp != permission.PermissionPolicy(inner)
+			if gated != tc.wantGate {
+				t.Fatalf("gated = %v, want %v (got %T)", gated, tc.wantGate, pp)
+			}
+			if tc.wantGate && permission.Unwrap(pp) != permission.PermissionPolicy(inner) {
+				t.Errorf("Unwrap(gated) must reach the inner policy, got %T", permission.Unwrap(pp))
+			}
+		})
+	}
+}
+
+// --- sub-agent regression: ForChildRun under wrappers ---
+
+// childParentRunIDForbid is a Cedar policy that denies run_command for
+// any principal carrying parentRunId — i.e. exactly sub-agent runs.
+// Mirrors TestPolicyEngine_ForChildRun_PopulatesParentRunID; here it
+// pins that the clone survives the factory's wrapper chain.
+const childParentRunIDForbid = `forbid (
+	principal,
+	action == Action::"tool:run_command",
+	resource == Tool::"run_command"
+) when {
+	principal has parentRunId && principal.parentRunId != ""
+};`
+
+func buildWrappedPolicyEngine(t *testing.T, monitor ruleoftwo.Monitor) permission.PermissionPolicy {
+	t.Helper()
+	policyPath := filepath.Join(t.TempDir(), "policy.cedar")
+	if err := os.WriteFile(policyPath, []byte(childParentRunIDForbid), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	pe, err := permission.New(
+		types.PermissionPolicyConfig{Type: "policy-engine", PolicyFile: policyPath, Fallback: "allow-all"},
+		permission.PolicyEngineEnv{RunID: "run-parent-1", Mode: "execution"},
+		func(string) (permission.PermissionPolicy, error) { return permission.NewAllowAll(), nil },
+	)
+	if err != nil {
+		t.Fatalf("permission.New: %v", err)
+	}
+	gate := permission.NewRuleOfTwoGate(pe, monitor, map[string]bool{"run_command": true, "web_fetch": true}, nil, nil)
+	return permission.NewMetricRecorder(gate, observability.NewNoopMetrics(), "policy-engine")
+}
+
+// registerStubRunCommand registers a run_command stand-in whose handler
+// records execution, so tests can assert a denial happened before
+// dispatch.
+func registerStubRunCommand(t *testing.T, loop *AgenticLoop, ran *atomic.Int32) {
+	t.Helper()
+	registry, ok := loop.Tools.(*tool.Registry)
+	if !ok {
+		t.Fatalf("test loop Tools is %T, want *tool.Registry", loop.Tools)
+	}
+	registry.Register(&tool.Tool{
+		Name:              "run_command",
+		Description:       "stub shell",
+		InputSchema:       json.RawMessage(`{"type":"object","properties":{}}`),
+		WorkspaceMutating: true,
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			ran.Add(1)
+			return "ran", nil
+		},
+	})
+}
+
+// childRunCommandScript scripts a child run: one run_command attempt,
+// then a final answer.
+func childRunCommandScript() *scriptedProvider {
+	return &scriptedProvider{
+		turns: [][]types.StreamEvent{
+			{
+				{Type: "tool_call", ID: "tc_1", Name: "run_command", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "done"},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+}
+
+// TestSpawnSubAgent_ForChildRunSurvivesWrapperChain is the regression
+// for the wave-4 Unwrap fix: with the policy engine wrapped in the
+// rule-of-two gate and the metric recorder, the child must still get a
+// parentRunId-populated Cedar clone — the pre-fix direct type-assert
+// silently skipped the clone under any wrapper, negating the
+// subagent-capability-cap starter policy.
+func TestSpawnSubAgent_ForChildRunSurvivesWrapperChain(t *testing.T) {
+	prov := &mockProvider{}
+	parentLoop := buildSubAgentTestLoop(prov)
+	parentLoop.Provider = childRunCommandScript()
+
+	var secBuf bytes.Buffer
+	parentLoop.Security = security.NewSecurityLogger(&secBuf, "run-parent-1")
+
+	// Untripped monitor: the gate is present but inert, so the denial
+	// observed below can only come from the Cedar parentRunId forbid.
+	monitor := ruleoftwo.NewPatternMonitor(true, "block-external", []string{"sensitive_data"}, false)
+	parentLoop.Permissions = buildWrappedPolicyEngine(t, monitor)
+	parentLoop.RuleOfTwo = monitor
+
+	var ran atomic.Int32
+	registerStubRunCommand(t, parentLoop, &ran)
+
+	parentConfig := buildTestConfig()
+	result, err := SpawnSubAgent(context.Background(), parentLoop, parentConfig, SubAgentConfig{
+		Prompt: "do a subtask with the shell",
+	})
+	if err != nil {
+		t.Fatalf("SpawnSubAgent() error: %v", err)
+	}
+	if result.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (denial is per-call, not terminal)", result.Outcome)
+	}
+	if ran.Load() != 0 {
+		t.Fatalf("run_command handler executed %d times in the child; the Cedar forbid must deny before dispatch", ran.Load())
+	}
+	out := secBuf.String()
+	if !strings.Contains(out, `"event":"permission_denied"`) {
+		t.Fatalf("expected permission_denied event from the child's run_command attempt, got: %s", out)
+	}
+	if strings.Contains(out, "rule_of_two:") {
+		t.Errorf("denial must come from the Cedar clone, not the (untripped) gate: %s", out)
+	}
+}
+
+// TestSpawnSubAgent_ParentLatchBlocksChildEgress pins the shared-latch
+// contract end to end: the parent's tripped monitor, read through the
+// shared gate, denies the child's external-communication tools.
+func TestSpawnSubAgent_ParentLatchBlocksChildEgress(t *testing.T) {
+	prov := &mockProvider{}
+	parentLoop := buildSubAgentTestLoop(prov)
+	parentLoop.Provider = childRunCommandScript()
+
+	var secBuf bytes.Buffer
+	parentLoop.Security = security.NewSecurityLogger(&secBuf, "run-parent-1")
+
+	monitor := ruleoftwo.NewPatternMonitor(true, "block-external", []string{"sensitive_data"}, false)
+	parentLoop.Permissions = permission.NewRuleOfTwoGate(
+		permission.NewAllowAll(), monitor,
+		map[string]bool{"run_command": true, "web_fetch": true}, nil, nil,
+	)
+	parentLoop.RuleOfTwo = monitor
+
+	var ran atomic.Int32
+	registerStubRunCommand(t, parentLoop, &ran)
+
+	if !monitor.TripFromGuard("g1", "sensitive_data") {
+		t.Fatal("setup: monitor must trip")
+	}
+
+	parentConfig := buildTestConfig()
+	result, err := SpawnSubAgent(context.Background(), parentLoop, parentConfig, SubAgentConfig{
+		Prompt: "exfiltrate via the shell",
+	})
+	if err != nil {
+		t.Fatalf("SpawnSubAgent() error: %v", err)
+	}
+	if result.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (block-external keeps the run alive)", result.Outcome)
+	}
+	if ran.Load() != 0 {
+		t.Fatalf("run_command handler executed %d times under a tripped parent latch", ran.Load())
+	}
+	out := secBuf.String()
+	if !strings.Contains(out, `"event":"permission_denied"`) {
+		t.Fatalf("expected permission_denied from the child's egress attempt, got: %s", out)
+	}
+	if !strings.Contains(out, "rule_of_two:") {
+		t.Errorf("denial reason must carry the rule_of_two prefix, got: %s", out)
+	}
+}

--- a/harness/internal/core/ruleoftwo_enforcement_test.go
+++ b/harness/internal/core/ruleoftwo_enforcement_test.go
@@ -78,6 +78,231 @@ func TestWrapRuleOfTwoGate_Matrix(t *testing.T) {
 	}
 }
 
+// TestResolveRuleOfTwoArming_ExplicitPatternsWithSensitiveNotPreTripped
+// is the D5 regression: an operator who explicitly selects
+// classifier:"patterns" AND declares sensitiveData on a run that holds
+// only the external-comm leg gets observe-only arming whose monitor is
+// NOT pre-tripped, so detection telemetry actually flows. Pre-tripping
+// (the pre-fix behaviour) suppressed every scan.
+func TestResolveRuleOfTwoArming_ExplicitPatternsWithSensitiveNotPreTripped(t *testing.T) {
+	sensitive := true
+	cfg := &types.RunConfig{
+		Mode:             "execution",
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"run_command"}}, // e only, not u
+		SensitiveData:    &sensitive,
+		RuleOfTwo:        &types.RuleOfTwoConfig{Runtime: &types.RuleOfTwoRuntimeConfig{Classifier: "patterns"}},
+	}
+	arming := resolveRuleOfTwoArming(cfg)
+	if !arming.armed || arming.enforcing {
+		t.Fatalf("want armed observe-only, got armed=%v enforcing=%v", arming.armed, arming.enforcing)
+	}
+	if arming.staticSensitive {
+		t.Error("explicit-patterns observe-only monitor must not start pre-tripped (telemetry loss)")
+	}
+	monitor := buildRuleOfTwoMonitor(arming)
+	if monitor.Tripped() {
+		t.Error("monitor must not be pre-tripped; the first scan should be live")
+	}
+}
+
+// TestBuildLoop_EnforceFalseObservesOnly is the D2 live-loop pin: with
+// ruleOfTwo.enforce:false the factory arms observe-only — detections
+// still emit, but the gate is absent, so external-comm tools keep
+// working after sensitive data is seen. This is the auditable-override
+// posture (the detection events stay; only enforcement is disarmed).
+func TestBuildLoop_EnforceFalseObservesOnly(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+
+	server := newOpenAIServer(t, nil, []string{
+		openAIChunk(`{"id":"r1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"web_fetch","arguments":"{\"url\":\"https://example.com/\"}"}}]},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`) +
+			"data: [DONE]\n\n",
+		openAIChunk(`{"id":"r2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_2","type":"function","function":{"name":"web_fetch","arguments":"{\"url\":\"https://second.example/\"}"}}]},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`) +
+			"data: [DONE]\n\n",
+		openAIChunk(`{"id":"r3","choices":[{"index":0,"delta":{"content":"done"},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`) +
+			"data: [DONE]\n\n",
+	}, nil)
+	defer server.Close()
+
+	timeout := 30
+	enforce := false
+	config := &types.RunConfig{
+		RunID:            "ruleoftwo-enforce-false",
+		Mode:             "research",
+		Prompt:           "Investigate example.com",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "gpt-4o-mini"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		RuleOfTwo:        &types.RuleOfTwoConfig{Enforce: &enforce},
+		MaxTurns:         5,
+		Timeout:          &timeout,
+	}
+
+	var secBuf bytes.Buffer
+	loop, err := BuildLoopWithTransport(context.Background(), config, transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{}))
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+	loop.Security = security.NewSecurityLogger(&secBuf, config.RunID)
+
+	presenter := loop.Tools.(*tool.Presenter)
+	registry := presenter.Unwrap().(*tool.Registry)
+	original := registry.Resolve("web_fetch")
+	var fetchCalls atomic.Int32
+	registry.Register(&tool.Tool{
+		Name:              original.Name,
+		Description:       original.Description,
+		InputSchema:       original.InputSchema,
+		WorkspaceMutating: original.WorkspaceMutating,
+		RequiresApproval:  original.RequiresApproval,
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			fetchCalls.Add(1)
+			return "fetched AWS_ACCESS_KEY_ID=" + fakeLiveAWSKey, nil
+		},
+	})
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success", runTrace.Outcome)
+	}
+	// Both web_fetch calls run: enforce:false means no gate, so egress
+	// is never revoked despite the key entering the conversation.
+	if got := fetchCalls.Load(); got != 2 {
+		t.Errorf("web_fetch ran %d times; want 2 (egress intact under enforce:false)", got)
+	}
+	for _, call := range runTrace.ToolCalls {
+		if call.Name == "web_fetch" && !call.Success && strings.Contains(call.ErrorReason, "rule_of_two:") {
+			t.Errorf("enforce:false must not deny egress, but web_fetch was gated: %s", call.ErrorReason)
+		}
+	}
+	// Detection telemetry still flows — the override is auditable.
+	out := secBuf.String()
+	if !strings.Contains(out, `"event":"sensitive_data_detected"`) {
+		t.Errorf("observe-only run must still emit sensitive_data_detected, got: %s", out)
+	}
+	if !strings.Contains(out, `"action":"warn"`) {
+		t.Errorf("observe-only detections must carry action=warn, got: %s", out)
+	}
+}
+
+// TestBuildLoop_EnvExfilDeniedEndToEnd is the canonical Rule-of-Two
+// enforcement scenario, driven end-to-end through the factory over a
+// real local executor: the model reads a seeded config file carrying a
+// live-shaped key (sensitive data enters the conversation), then issues
+// an otherwise-innocuous run_command. The factory auto-arms enforcing
+// block-external (a benign dynamic-context entry supplies the
+// untrusted-input leg; run_command supplies external comms), so the
+// run_command call is denied with the rule_of_two reason and the run
+// still finishes cleanly. The seeded file is NOT named .env and the
+// command is a plain `ls`, so neither trips the GuardToolCall tripwire
+// (credential_path / exfiltration_command) — proving the denial comes
+// from the Rule-of-Two gate, which revokes egress regardless of the
+// specific command once sensitive data is on hand.
+func TestBuildLoop_EnvExfilDeniedEndToEnd(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+
+	workspace := t.TempDir()
+	secretFile := filepath.Join(workspace, "deploy-notes.txt")
+	if err := os.WriteFile(secretFile, []byte("the staging key is AWS_ACCESS_KEY_ID="+fakeLiveAWSKey+"\n"), 0o600); err != nil {
+		t.Fatalf("seed secret file: %v", err)
+	}
+
+	server := newOpenAIServer(t, nil, []string{
+		// Turn 1: read the key-bearing notes file.
+		openAIChunk(`{"id":"r1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"deploy-notes.txt\"}"}}]},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`) +
+			"data: [DONE]\n\n",
+		// Turn 2: an innocuous shell command — denied purely because
+		// the latch tripped, not because of the command content.
+		openAIChunk(`{"id":"r2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_2","type":"function","function":{"name":"run_command","arguments":"{\"command\":\"ls -la\"}"}}]},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`) +
+			"data: [DONE]\n\n",
+		// Turn 3: model gives up.
+		openAIChunk(`{"id":"r3","choices":[{"index":0,"delta":{"content":"blocked"},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`) +
+			"data: [DONE]\n\n",
+	}, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "ruleoftwo-env-exfil",
+		Mode:             "execution",
+		Prompt:           "Inspect the workspace",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "gpt-4o-mini"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: workspace},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		// read_file (sensitive-data ingress) + run_command (external
+		// comms). A benign dynamic-context entry supplies the
+		// untrusted-input leg so the factory auto-arms enforcement.
+		Tools:          types.ToolsConfig{BuiltIn: []string{"read_file", "run_command"}},
+		DynamicContext: map[string]types.DynamicContextValue{"task": {Value: "review the repository layout"}},
+		MaxTurns:       5,
+		Timeout:        &timeout,
+	}
+
+	var secBuf bytes.Buffer
+	loop, err := BuildLoopWithTransport(context.Background(), config, transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{}))
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+	loop.Security = security.NewSecurityLogger(&secBuf, config.RunID)
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (block-external is non-fatal)", runTrace.Outcome)
+	}
+	var sawRead, runCommandDenied bool
+	for _, call := range runTrace.ToolCalls {
+		if call.Name == "read_file" && call.Success {
+			sawRead = true
+		}
+		if call.Name == "run_command" {
+			if call.Success {
+				t.Errorf("run_command must be denied after the .env read trips the latch")
+			}
+			if strings.Contains(call.ErrorReason, "rule_of_two:") {
+				runCommandDenied = true
+			}
+		}
+	}
+	if !sawRead {
+		t.Fatal("expected the read_file call to succeed and surface the key")
+	}
+	if !runCommandDenied {
+		t.Errorf("expected run_command denied with the rule_of_two reason; trace: %+v", runTrace.ToolCalls)
+	}
+	if !strings.Contains(secBuf.String(), `"event":"permission_denied"`) {
+		t.Errorf("expected permission_denied security event, got: %s", secBuf.String())
+	}
+}
+
 // --- sub-agent regression: ForChildRun under wrappers ---
 
 // childParentRunIDForbid is a Cedar policy that denies run_command for
@@ -190,6 +415,289 @@ func TestSpawnSubAgent_ForChildRunSurvivesWrapperChain(t *testing.T) {
 	}
 	if strings.Contains(out, "rule_of_two:") {
 		t.Errorf("denial must come from the Cedar clone, not the (untripped) gate: %s", out)
+	}
+}
+
+// --- redact action ---
+
+// structuredLeakProvider scripts a tool call whose result carries a
+// credential in both the text Content and the Structured payload, then
+// a turn that echoes what the model received back as its final text so
+// the test can inspect the post-redaction message history.
+func redactToolProvider() *scriptedProvider {
+	return &scriptedProvider{
+		turns: [][]types.StreamEvent{
+			{
+				{Type: "tool_call", ID: "tc_1", Name: "leaky_struct_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "done"},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+}
+
+func TestLoop_RuleOfTwoRedactRewritesContentAndStructured(t *testing.T) {
+	loop := buildTestLoop(nil)
+	loop.Provider = redactToolProvider()
+	registry, ok := loop.Tools.(*tool.Registry)
+	if !ok {
+		t.Fatalf("test loop Tools is %T, want *tool.Registry", loop.Tools)
+	}
+	registry.Register(&tool.Tool{
+		Name:        "leaky_struct_tool",
+		Description: "leaks a key in text and structured payload",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		StructuredHandler: func(_ context.Context, _ json.RawMessage) (tool.StructuredResult, error) {
+			return tool.StructuredResult{
+				Text:       "key is " + fakeLiveAWSKey + " keep this line",
+				Structured: json.RawMessage(`{"stdout":"` + fakeLiveAWSKey + `","note":"surrounding"}`),
+				Kind:       "command_result",
+			}, nil
+		},
+	})
+	loop.RuleOfTwo = ruleoftwo.NewPatternMonitor(true, "redact", []string{"sensitive_data"}, false)
+
+	config := buildTestConfig()
+	config.MaxTurns = 4
+
+	var capturedMessages []types.Message
+	loop.Provider = &messageCapturingProvider{
+		inner:   redactToolProvider(),
+		capture: &capturedMessages,
+	}
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (redact keeps the run alive)", runTrace.Outcome)
+	}
+
+	// The second provider call must have seen the redacted tool result:
+	// no key in either Content or Structured, surrounding text intact.
+	var toolResult *types.ContentBlock
+	for i := range capturedMessages {
+		for j := range capturedMessages[i].Content {
+			if capturedMessages[i].Content[j].Type == "tool_result" {
+				toolResult = &capturedMessages[i].Content[j]
+			}
+		}
+	}
+	if toolResult == nil {
+		t.Fatal("no tool_result block reached the provider on the second turn")
+	}
+	if strings.Contains(toolResult.Content, fakeLiveAWSKey) {
+		t.Errorf("key survived redaction in Content: %q", toolResult.Content)
+	}
+	if !strings.Contains(toolResult.Content, "keep this line") {
+		t.Errorf("surrounding text lost in Content: %q", toolResult.Content)
+	}
+	if !strings.Contains(toolResult.Content, ruleoftwo.RedactionPlaceholder) {
+		t.Errorf("placeholder missing from Content: %q", toolResult.Content)
+	}
+	if strings.Contains(string(toolResult.Structured), fakeLiveAWSKey) {
+		t.Errorf("key survived redaction in Structured: %q", toolResult.Structured)
+	}
+	if !json.Valid(toolResult.Structured) {
+		t.Errorf("redacted Structured is not valid JSON: %q", toolResult.Structured)
+	}
+	if !strings.Contains(string(toolResult.Structured), "surrounding") {
+		t.Errorf("surrounding structured field lost: %q", toolResult.Structured)
+	}
+}
+
+// messageCapturingProvider records the message slice of the LAST Stream
+// call so a test can inspect what the model saw after redaction.
+type messageCapturingProvider struct {
+	inner   *scriptedProvider
+	capture *[]types.Message
+}
+
+func (p *messageCapturingProvider) Stream(ctx context.Context, params types.StreamParams) (<-chan types.StreamEvent, error) {
+	*p.capture = params.Messages
+	return p.inner.Stream(ctx, params)
+}
+
+// --- abort action ---
+
+func TestLoop_RuleOfTwoAbortTerminatesOnToolResult(t *testing.T) {
+	var secBuf bytes.Buffer
+	loop := buildTestLoopWithSecurity(nil, &secBuf)
+	loop.Provider = childRunCommandScript() // tool call then end_turn
+	registry, ok := loop.Tools.(*tool.Registry)
+	if !ok {
+		t.Fatalf("test loop Tools is %T, want *tool.Registry", loop.Tools)
+	}
+	registry.Register(&tool.Tool{
+		Name:        "run_command",
+		Description: "leaks a key",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "AWS_ACCESS_KEY_ID=" + fakeLiveAWSKey, nil
+		},
+	})
+	loop.RuleOfTwo = ruleoftwo.NewPatternMonitor(true, "abort", []string{"sensitive_data"}, false)
+
+	config := buildTestConfig()
+	config.MaxTurns = 4
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "rule_of_two_violation" {
+		t.Errorf("outcome = %q, want rule_of_two_violation", runTrace.Outcome)
+	}
+	// The abort fires on turn 1's tool_result scan, so exactly one turn
+	// (turn 0) completed before termination.
+	if runTrace.Turns != 1 {
+		t.Errorf("turns = %d, want 1 (abort on the first sensitive tool result)", runTrace.Turns)
+	}
+	if !strings.Contains(secBuf.String(), `"event":"rule_of_two_triggered"`) {
+		t.Errorf("expected rule_of_two_triggered before abort, got: %s", secBuf.String())
+	}
+}
+
+func TestLoop_RuleOfTwoAbortTurnZeroBeforeProviderCall(t *testing.T) {
+	prov := &countingProvider{}
+	loop := buildTestLoop(nil)
+	loop.Provider = prov
+	loop.RuleOfTwo = ruleoftwo.NewPatternMonitor(true, "abort", []string{"sensitive_data"}, false)
+
+	config := buildTestConfig()
+	config.DynamicContext = map[string]types.DynamicContextValue{
+		"record": {Value: "card 4111111111111111 on file"},
+	}
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "rule_of_two_violation" {
+		t.Errorf("outcome = %q, want rule_of_two_violation", runTrace.Outcome)
+	}
+	if prov.calls != 0 {
+		t.Errorf("provider was called %d times; a turn-0 abort must precede the first provider call", prov.calls)
+	}
+	if runTrace.Turns != 0 {
+		t.Errorf("turns = %d, want 0", runTrace.Turns)
+	}
+}
+
+// --- default-flip pin (inverse of the wave-3 dark-ship pin) ---
+
+// TestBuildLoop_DefaultArmedEnforcesBlockExternal pins the wave-4
+// behaviour flip: a factory-built run that holds untrusted input AND
+// external comms (web_fetch) under the default policy now denies egress
+// once sensitive data is observed — the inverse of the wave-3 dark-ship
+// pin, where the identical scenario completed with egress intact.
+func TestBuildLoop_DefaultArmedEnforcesBlockExternal(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+
+	// Turn 1: model calls web_fetch (untrusted + external). Turn 2:
+	// model calls web_fetch again (now denied). Turn 3: final answer.
+	server := newOpenAIServer(t, nil, []string{
+		openAIChunk(`{"id":"r1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"web_fetch","arguments":"{\"url\":\"https://example.com/\"}"}}]},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`) +
+			"data: [DONE]\n\n",
+		openAIChunk(`{"id":"r2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_2","type":"function","function":{"name":"web_fetch","arguments":"{\"url\":\"https://evil.example/\"}"}}]},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`) +
+			"data: [DONE]\n\n",
+		openAIChunk(`{"id":"r3","choices":[{"index":0,"delta":{"content":"stopping"},"finish_reason":null}]}`) +
+			openAIChunk(`{"id":"r3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`) +
+			"data: [DONE]\n\n",
+	}, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "ruleoftwo-default-flip",
+		Mode:             "research",
+		Prompt:           "Investigate example.com",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "gpt-4o-mini"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "whole-file"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		// No RuleOfTwo override: the factory auto-arms enforcing
+		// block-external because web_fetch makes the run hold both
+		// untrusted input and external comms with no static sensitivity.
+		MaxTurns: 5,
+		Timeout:  &timeout,
+	}
+
+	var secBuf bytes.Buffer
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	// Capture security events from the loop's own logger (the factory
+	// wires stderr; reattach to our buffer for assertion).
+	loop.Security = security.NewSecurityLogger(&secBuf, config.RunID)
+
+	// Stub web_fetch so its FIRST call returns a sensitive body, tripping
+	// the latch; the gate then denies the SECOND call.
+	presenter, ok := loop.Tools.(*tool.Presenter)
+	if !ok {
+		t.Fatalf("expected *tool.Presenter, got %T", loop.Tools)
+	}
+	registry, ok := presenter.Unwrap().(*tool.Registry)
+	if !ok {
+		t.Fatalf("expected *tool.Registry under presenter, got %T", presenter.Unwrap())
+	}
+	original := registry.Resolve("web_fetch")
+	if original == nil {
+		t.Fatal("web_fetch must be registered in research mode")
+	}
+	var fetchCalls atomic.Int32
+	registry.Register(&tool.Tool{
+		Name:              original.Name,
+		Description:       original.Description,
+		InputSchema:       original.InputSchema,
+		WorkspaceMutating: original.WorkspaceMutating,
+		RequiresApproval:  original.RequiresApproval,
+		Handler: func(_ context.Context, _ json.RawMessage) (string, error) {
+			fetchCalls.Add(1)
+			return "fetched secret AWS_ACCESS_KEY_ID=" + fakeLiveAWSKey, nil
+		},
+	})
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("outcome = %q, want success (block-external keeps the run alive locally)", runTrace.Outcome)
+	}
+	// Exactly one web_fetch handler execution: the first call runs and
+	// trips the latch; the second is denied by the gate before dispatch.
+	if got := fetchCalls.Load(); got != 1 {
+		t.Errorf("web_fetch handler ran %d times; want 1 (second call gated)", got)
+	}
+	var denied bool
+	for _, call := range runTrace.ToolCalls {
+		if call.Name == "web_fetch" && !call.Success && strings.Contains(call.ErrorReason, "rule_of_two:") {
+			denied = true
+		}
+	}
+	if !denied {
+		t.Errorf("expected a web_fetch call denied with the rule_of_two reason; trace: %+v", runTrace.ToolCalls)
+	}
+	if !strings.Contains(secBuf.String(), `"event":"permission_denied"`) {
+		t.Errorf("expected permission_denied security event, got: %s", secBuf.String())
 	}
 }
 

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -125,15 +125,30 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 	// misleading a trace consumer into thinking it did.
 	childConfig.Hooks = nil
 
-	// Permissions: when the parent is a Cedar policy-engine policy, the
-	// sub-agent gets its own clone with parentRunId populated. This is
-	// the only path that activates the subagent-capability-cap.cedar
-	// starter policy — without it, principal.parentRunId is absent and
-	// `has parentRunId` evaluates to false for every sub-agent run,
-	// silently negating the policy (M3).
+	// Permissions: when the innermost policy is a Cedar policy-engine
+	// policy, the sub-agent gets its own clone with parentRunId
+	// populated. This is the only path that activates the
+	// subagent-capability-cap.cedar starter policy — without it,
+	// principal.parentRunId is absent and `has parentRunId` evaluates
+	// to false for every sub-agent run, silently negating the policy
+	// (M3). The factory wraps the policy (Rule-of-Two gate, metric
+	// recorder), so the assertion goes through permission.Unwrap and
+	// the same wrapper chain is rebuilt around the clone — a direct
+	// type-assert would silently skip the clone under any wrapper, and
+	// substituting the bare clone would shed the gate, turning
+	// spawn_agent into a latch escape hatch.
 	childPermissions := parent.Permissions
-	if parentPolicyEngine, ok := parent.Permissions.(*permission.PolicyEnginePolicy); ok {
-		childPermissions = parentPolicyEngine.ForChildRun(childConfig.RunID)
+	if parentPolicyEngine, ok := permission.Unwrap(parent.Permissions).(*permission.PolicyEnginePolicy); ok {
+		clone := parentPolicyEngine.ForChildRun(childConfig.RunID)
+		if rewrapped, ok := permission.RewrapChain(parent.Permissions, clone); ok {
+			childPermissions = rewrapped
+		} else {
+			// A wrapper without Rewrap support: keep the parent's full
+			// chain (every wrapper intact) at the cost of the per-child
+			// Cedar identity, and surface the divergence — fail toward
+			// more enforcement, not less.
+			parent.Logger.Warn("permission chain not rewrappable; sub-agent keeps parent policy without per-child Cedar identity")
+		}
 	}
 
 	// Forwarding trace emitter: every Turn / ToolCall the child records

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -85,12 +85,13 @@ type AgenticLoop struct {
 	Permissions permission.PermissionPolicy
 	Git         git.GitStrategy
 	GuardRail   guard.GuardRail
-	// RuleOfTwo is the Rule-of-Two runtime sensitive-data monitor
-	// (observe-only this wave: detections produce events and metrics,
-	// no enforcement consumer exists yet). The factory injects
-	// ruleoftwo.NewNoop() when the run is unarmed so loop call sites
-	// stay unconditional; hand-assembled loops (tests, embedders) may
-	// leave it nil and the observe helpers no-op, mirroring GuardRail.
+	// RuleOfTwo is the Rule-of-Two runtime sensitive-data monitor.
+	// Enforcement (block-external / ask-upstream via the permission
+	// gate, and the loop's redact / abort actions) keys on the monitor's
+	// run-scoped latch. The factory injects ruleoftwo.NewNoop() when the
+	// run is unarmed so loop call sites stay unconditional; hand-assembled
+	// loops (tests, embedders) may leave it nil and the observe helpers
+	// no-op, mirroring GuardRail.
 	RuleOfTwo  ruleoftwo.Monitor
 	Escalation EscalationPolicy // tool-choice missed-tool recovery (#230); nil = disabled
 	// Hooks runs the run's configured lifecycle hooks (#461). Optional,

--- a/harness/internal/observability/metrics.go
+++ b/harness/internal/observability/metrics.go
@@ -41,6 +41,7 @@ type Metrics struct {
 	GuardSkips            metric.Int64Counter
 	GuardSpotlights       metric.Int64Counter
 	RuleOfTwoDetections   metric.Int64Counter
+	RuleOfTwoActions      metric.Int64Counter
 
 	// --- Component-level instruments (issue #97) ---
 	// Counters
@@ -411,6 +412,15 @@ func newMetricsFromMeter(meter metric.Meter, provider *sdkmetric.MeterProvider) 
 		metric.WithUnit("{detection}"),
 		metric.WithDescription("Sensitive-data detections recorded by the Rule-of-Two runtime monitor, labelled by pattern, tier, and source. "+
 			"Guard-ratchet trips carry a \"guard:\"-prefixed pattern label so they are distinguishable from deterministic detector hits."),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.RuleOfTwoActions, err = meter.Int64Counter("stirrup.ruleoftwo.actions",
+		metric.WithUnit("{action}"),
+		metric.WithDescription("Rule-of-Two enforcement actions applied after the sensitive-data latch trips: "+
+			"one per gate denial (block-external), per gate-routed upstream ask (ask-upstream), per redacted chunk set (redact), and per terminated run (abort)."),
 	)
 	if err != nil {
 		return nil, err

--- a/harness/internal/permission/askupstream.go
+++ b/harness/internal/permission/askupstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -125,6 +126,15 @@ func (p *AskUpstreamPolicy) Check(ctx context.Context, tool types.ToolDefinition
 	p.mu.Lock()
 	required := p.approvalTools[tool.Name]
 	p.mu.Unlock()
+	// Treat any mcp_-prefixed tool as approval-required even when it is
+	// absent from the construction-time snapshot. This mirrors
+	// ruleOfTwoGate.isExternal, which already applies the prefix: without
+	// it a dynamically-registered MCP tool routed here by the rule-of-two
+	// gate would auto-allow, silently bypassing the upstream approval the
+	// gate intended to enforce.
+	if !required && strings.HasPrefix(tool.Name, "mcp_") {
+		required = true
+	}
 	if !required {
 		return &PermissionResult{Allowed: true}, nil
 	}

--- a/harness/internal/permission/askupstream_test.go
+++ b/harness/internal/permission/askupstream_test.go
@@ -82,6 +82,54 @@ func TestAskUpstream_AutoAllowsReadOnlyTools(t *testing.T) {
 	}
 }
 
+// TestAskUpstream_MCPPrefixRequiresApprovalWhenAbsentFromSnapshot pins
+// the Wave-4 fix: an mcp_-prefixed tool absent from the construction-time
+// approvalTools snapshot must still be forwarded for approval, matching
+// ruleOfTwoGate.isExternal. Without the prefix fallback the call would
+// auto-allow, bypassing the upstream approval the rule-of-two gate routes
+// it here to obtain.
+func TestAskUpstream_MCPPrefixRequiresApprovalWhenAbsentFromSnapshot(t *testing.T) {
+	mt := &mockTransport{}
+	// Snapshot deliberately omits the MCP tool.
+	policy := NewAskUpstreamPolicy(mt, sideEffectingSet(), 0)
+
+	tool := types.ToolDefinition{Name: "mcp_newserver_tool"}
+
+	// Approve asynchronously; if the prefix fallback is missing, Check
+	// returns Allowed immediately without ever emitting a request and the
+	// goroutine's response is dropped (caught by the lastEmitted assertion).
+	go func() {
+		for {
+			time.Sleep(5 * time.Millisecond)
+			e := mt.lastEmitted()
+			if e != nil && e.Type == "permission_request" {
+				allowed := true
+				mt.simulateControlEvent(types.ControlEvent{
+					Type:      "permission_response",
+					RequestID: e.RequestID,
+					Allowed:   &allowed,
+				})
+				return
+			}
+		}
+	}()
+
+	result, err := policy.Check(context.Background(), tool, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected allow after upstream approval")
+	}
+	e := mt.lastEmitted()
+	if e == nil || e.Type != "permission_request" {
+		t.Fatalf("mcp_-prefixed tool must emit a permission_request, not auto-allow; got %+v", e)
+	}
+	if e.ToolName != "mcp_newserver_tool" {
+		t.Errorf("permission_request tool = %q, want mcp_newserver_tool", e.ToolName)
+	}
+}
+
 func TestAskUpstream_EmitsRequestForSideEffectingTool(t *testing.T) {
 	mt := &mockTransport{}
 	policy := NewAskUpstreamPolicy(mt, sideEffectingSet(), 0)

--- a/harness/internal/permission/metrics.go
+++ b/harness/internal/permission/metrics.go
@@ -95,6 +95,14 @@ func (r *metricRecorder) Unwrap() PermissionPolicy {
 	return r.inner
 }
 
+// Rewrap reproduces the metric recorder around a different inner
+// policy, preserving the metrics handle and policy label.
+func (r *metricRecorder) Rewrap(inner PermissionPolicy) PermissionPolicy {
+	clone := *r
+	clone.inner = inner
+	return &clone
+}
+
 // Unwrap returns the underlying PermissionPolicy if pp is wrapped in a
 // metric recorder, or pp itself otherwise. Use this whenever a caller
 // needs to test the concrete policy class rather than dispatch a
@@ -109,4 +117,43 @@ func Unwrap(pp PermissionPolicy) PermissionPolicy {
 		}
 		pp = w.Unwrap()
 	}
+}
+
+// Rewrapper is implemented by policy wrappers that can reproduce
+// themselves around a different inner policy. RewrapChain uses it to
+// rebuild a factory-built wrapper chain around a per-child clone of the
+// innermost policy (see core.SpawnSubAgent): each wrapper's own
+// configuration (metric label, gate state) is shared; only the inner
+// pointer changes.
+type Rewrapper interface {
+	Rewrap(inner PermissionPolicy) PermissionPolicy
+}
+
+// RewrapChain rebuilds pp's wrapper chain around newInner, preserving
+// wrapper order. Returns (pp, false) when any wrapper in the chain does
+// not implement Rewrapper: callers must treat that as "cannot safely
+// re-wrap" and keep the original chain rather than substituting the
+// bare inner — dropping a wrapper here would silently shed its
+// enforcement (a dropped Rule-of-Two gate turns spawn_agent into a
+// latch escape hatch).
+func RewrapChain(pp, newInner PermissionPolicy) (PermissionPolicy, bool) {
+	var wrappers []Rewrapper
+	cur := pp
+	for {
+		u, ok := cur.(interface{ Unwrap() PermissionPolicy })
+		if !ok {
+			break
+		}
+		rw, ok := cur.(Rewrapper)
+		if !ok {
+			return pp, false
+		}
+		wrappers = append(wrappers, rw)
+		cur = u.Unwrap()
+	}
+	out := newInner
+	for i := len(wrappers) - 1; i >= 0; i-- {
+		out = wrappers[i].Rewrap(out)
+	}
+	return out, true
 }

--- a/harness/internal/permission/ruleoftwogate.go
+++ b/harness/internal/permission/ruleoftwogate.go
@@ -1,0 +1,142 @@
+package permission
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// RuleOfTwoDeniedReason is the reason string returned (and surfaced to
+// the model and the permission_denied security event) when the
+// Rule-of-Two gate revokes an external-communication tool. The
+// "rule_of_two:" prefix is the stable grep key for operators and evals.
+const RuleOfTwoDeniedReason = "rule_of_two: sensitive data observed in conversation; external communication revoked for this run"
+
+// RuleOfTwoState is the narrow view of the Rule-of-Two runtime monitor
+// the gate consults on every Check. Declared locally rather than
+// importing harness/internal/ruleoftwo for the same hygiene reason
+// askupstream.go declares its own Transport: permission stays a leaf
+// package, and the gate's tests can substitute a three-method fake.
+// ruleoftwo.Monitor satisfies this interface.
+type RuleOfTwoState interface {
+	// Tripped reports whether the run's sensitive-data latch is set.
+	Tripped() bool
+	// Enforcing reports whether detections may change run behaviour.
+	Enforcing() bool
+	// Action is the effective on-detect action ("warn" when not
+	// enforcing).
+	Action() string
+}
+
+// ruleOfTwoGate wraps a PermissionPolicy and revokes external-
+// communication tools once the Rule-of-Two sensitive-data latch trips.
+// Follows the metricRecorder composition pattern: Check-preserving
+// wrapper with Unwrap for callers that need the concrete policy.
+//
+// Behaviour:
+//
+//   - latch not tripped, monitor not enforcing, or tool not in the
+//     external-communication set → delegate to inner unchanged.
+//   - tripped + action "block-external" → deny with
+//     RuleOfTwoDeniedReason. The inner policy is not consulted: the
+//     gate exists to restore the two-of-three invariant, and no inner
+//     allow may override that.
+//   - tripped + action "ask-upstream" → consult inner FIRST (a Cedar
+//     forbid must still deny), then route the call through the
+//     pre-built AskUpstreamPolicy so the operator adjudicates each
+//     external call individually.
+//
+// redact, abort, and warn are loop-level actions with no permission-
+// layer component; the gate delegates for those.
+type ruleOfTwoGate struct {
+	inner       PermissionPolicy
+	state       RuleOfTwoState
+	externalSet map[string]bool
+	askUpstream *AskUpstreamPolicy
+	metrics     *observability.Metrics
+}
+
+// NewRuleOfTwoGate wraps inner with the Rule-of-Two enforcement gate.
+// externalTools keys are internal tool IDs (the Presenter never
+// rewrites dispatch names, so toolset-profile aliases cannot bypass
+// the set); any "mcp_"-prefixed tool name is treated as external even
+// when absent from the set, covering tools registered after gate
+// construction. askUpstream is consulted only for the "ask-upstream"
+// action and may be nil otherwise; metrics may be nil (no action
+// telemetry).
+func NewRuleOfTwoGate(inner PermissionPolicy, state RuleOfTwoState, externalTools map[string]bool, askUpstream *AskUpstreamPolicy, metrics *observability.Metrics) PermissionPolicy {
+	if inner == nil || state == nil {
+		// Mirror NewMetricRecorder: surface the misuse at the next nil
+		// dereference rather than hiding it behind a silent passthrough.
+		return inner
+	}
+	return &ruleOfTwoGate{
+		inner:       inner,
+		state:       state,
+		externalSet: externalTools,
+		askUpstream: askUpstream,
+		metrics:     metrics,
+	}
+}
+
+// Check implements PermissionPolicy.
+func (g *ruleOfTwoGate) Check(ctx context.Context, tool types.ToolDefinition, input json.RawMessage) (*PermissionResult, error) {
+	if !g.state.Tripped() || !g.state.Enforcing() || !g.isExternal(tool.Name) {
+		return g.inner.Check(ctx, tool, input)
+	}
+	switch g.state.Action() {
+	case "ask-upstream":
+		result, err := g.inner.Check(ctx, tool, input)
+		if err != nil || result == nil || !result.Allowed {
+			return result, err
+		}
+		g.recordAction(ctx, "ask-upstream")
+		if g.askUpstream == nil {
+			// The factory always pre-builds the ask policy for this
+			// action; a nil here means a hand-assembled gate. Fail
+			// closed — silently allowing would defeat the gate.
+			return &PermissionResult{Allowed: false, Reason: RuleOfTwoDeniedReason}, nil
+		}
+		return g.askUpstream.Check(ctx, tool, input)
+	case "block-external":
+		g.recordAction(ctx, "block-external")
+		return &PermissionResult{Allowed: false, Reason: RuleOfTwoDeniedReason}, nil
+	default:
+		return g.inner.Check(ctx, tool, input)
+	}
+}
+
+func (g *ruleOfTwoGate) isExternal(name string) bool {
+	return g.externalSet[name] || strings.HasPrefix(name, "mcp_")
+}
+
+func (g *ruleOfTwoGate) recordAction(ctx context.Context, action string) {
+	if g.metrics == nil {
+		return
+	}
+	g.metrics.RuleOfTwoActions.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("action", action),
+	))
+}
+
+// Unwrap returns the wrapped PermissionPolicy, participating in the
+// permission.Unwrap chain alongside metricRecorder.
+func (g *ruleOfTwoGate) Unwrap() PermissionPolicy {
+	return g.inner
+}
+
+// Rewrap reproduces the gate around a different inner policy. The
+// monitor state, external set, ask policy, and metrics handle are
+// shared — only the inner pointer changes — so a sub-agent's gate
+// reads the same run-scoped latch as the parent's.
+func (g *ruleOfTwoGate) Rewrap(inner PermissionPolicy) PermissionPolicy {
+	clone := *g
+	clone.inner = inner
+	return &clone
+}

--- a/harness/internal/permission/ruleoftwogate_test.go
+++ b/harness/internal/permission/ruleoftwogate_test.go
@@ -1,0 +1,342 @@
+package permission
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeRuleOfTwoState is a hand-set RuleOfTwoState for gate tests.
+type fakeRuleOfTwoState struct {
+	tripped   bool
+	enforcing bool
+	action    string
+}
+
+func (f *fakeRuleOfTwoState) Tripped() bool   { return f.tripped }
+func (f *fakeRuleOfTwoState) Enforcing() bool { return f.enforcing }
+func (f *fakeRuleOfTwoState) Action() string  { return f.action }
+
+// recordingPolicy counts Check calls and returns a configured result.
+type recordingPolicy struct {
+	mu     sync.Mutex
+	calls  []string
+	result *PermissionResult
+}
+
+func (r *recordingPolicy) Check(_ context.Context, tool types.ToolDefinition, _ json.RawMessage) (*PermissionResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, tool.Name)
+	if r.result != nil {
+		return r.result, nil
+	}
+	return &PermissionResult{Allowed: true}, nil
+}
+
+func (r *recordingPolicy) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func externalSet() map[string]bool {
+	return map[string]bool{"run_command": true, "web_fetch": true}
+}
+
+func TestRuleOfTwoGate_DelegatesUntilTripped(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: false, enforcing: true, action: "block-external"}
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), nil, nil)
+
+	result, err := gate.Check(context.Background(), types.ToolDefinition{Name: "run_command"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("untripped gate must delegate to inner (allow-all)")
+	}
+	if inner.callCount() != 1 {
+		t.Errorf("inner.Check calls = %d, want 1 (delegation)", inner.callCount())
+	}
+}
+
+func TestRuleOfTwoGate_NotEnforcingDelegatesEvenWhenTripped(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: false, action: "warn"}
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), nil, nil)
+
+	result, err := gate.Check(context.Background(), types.ToolDefinition{Name: "run_command"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("observe-only gate must never deny")
+	}
+	if inner.callCount() != 1 {
+		t.Errorf("inner.Check calls = %d, want 1", inner.callCount())
+	}
+}
+
+func TestRuleOfTwoGate_BlockExternalDeniesExternalTools(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "block-external"}
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), nil, nil)
+
+	for _, name := range []string{"run_command", "web_fetch"} {
+		result, err := gate.Check(context.Background(), types.ToolDefinition{Name: name}, nil)
+		if err != nil {
+			t.Fatalf("Check(%s): %v", name, err)
+		}
+		if result.Allowed {
+			t.Errorf("%s must be denied after the latch trips", name)
+		}
+		if result.Reason != RuleOfTwoDeniedReason {
+			t.Errorf("%s reason = %q, want RuleOfTwoDeniedReason", name, result.Reason)
+		}
+	}
+	if inner.callCount() != 0 {
+		t.Errorf("inner.Check calls = %d, want 0 (block-external never consults inner)", inner.callCount())
+	}
+}
+
+func TestRuleOfTwoGate_NonExternalToolsDelegateWhileTripped(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "block-external"}
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), nil, nil)
+
+	for _, name := range []string{"read_file", "write_file", "edit_file", "grep_files"} {
+		result, err := gate.Check(context.Background(), types.ToolDefinition{Name: name}, nil)
+		if err != nil {
+			t.Fatalf("Check(%s): %v", name, err)
+		}
+		if !result.Allowed {
+			t.Errorf("%s is not external-comm and must delegate to inner (allow)", name)
+		}
+	}
+	if inner.callCount() != 4 {
+		t.Errorf("inner.Check calls = %d, want 4", inner.callCount())
+	}
+}
+
+func TestRuleOfTwoGate_MCPPrefixDeniedEvenWhenAbsentFromSet(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "block-external"}
+	// External set deliberately omits the MCP tool: the prefix check
+	// must cover tools registered after gate construction.
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), nil, nil)
+
+	result, err := gate.Check(context.Background(), types.ToolDefinition{Name: "mcp_github_create_issue"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.Allowed {
+		t.Error("mcp_-prefixed tool must be denied via the prefix check")
+	}
+	if result.Reason != RuleOfTwoDeniedReason {
+		t.Errorf("reason = %q, want RuleOfTwoDeniedReason", result.Reason)
+	}
+}
+
+func TestRuleOfTwoGate_AskUpstreamConsultsInnerFirst(t *testing.T) {
+	// A Cedar forbid (inner deny) must still deny without ever asking
+	// upstream: ask-upstream loosens nothing the inner policy decided.
+	inner := &recordingPolicy{result: &PermissionResult{Allowed: false, Reason: "cedar forbid"}}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "ask-upstream"}
+	mt := &mockTransport{}
+	ask := NewAskUpstreamPolicy(mt, externalSet(), 0)
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), ask, nil)
+
+	result, err := gate.Check(context.Background(), types.ToolDefinition{Name: "run_command"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.Allowed {
+		t.Error("inner deny must short-circuit the upstream ask")
+	}
+	if result.Reason != "cedar forbid" {
+		t.Errorf("reason = %q, want the inner policy's reason", result.Reason)
+	}
+	if mt.lastEmitted() != nil {
+		t.Error("no permission_request may be emitted when the inner policy already denied")
+	}
+}
+
+func TestRuleOfTwoGate_AskUpstreamRoutesAfterInnerAllow(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "ask-upstream"}
+	mt := &mockTransport{}
+	ask := NewAskUpstreamPolicy(mt, externalSet(), 0)
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), ask, nil)
+
+	// Operator approves asynchronously, mirroring askupstream_test.go.
+	go func() {
+		for {
+			time.Sleep(5 * time.Millisecond)
+			e := mt.lastEmitted()
+			if e != nil && e.Type == "permission_request" {
+				allowed := true
+				mt.simulateControlEvent(types.ControlEvent{
+					Type:      "permission_response",
+					RequestID: e.RequestID,
+					Allowed:   &allowed,
+				})
+				return
+			}
+		}
+	}()
+
+	result, err := gate.Check(context.Background(), types.ToolDefinition{Name: "run_command"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("operator approval must allow the call")
+	}
+	if inner.callCount() != 1 {
+		t.Errorf("inner.Check calls = %d, want 1 (consulted before the ask)", inner.callCount())
+	}
+	e := mt.lastEmitted()
+	if e == nil || e.Type != "permission_request" {
+		t.Fatalf("expected a permission_request on the transport, got %+v", e)
+	}
+	if e.ToolName != "run_command" {
+		t.Errorf("permission_request tool = %q, want run_command", e.ToolName)
+	}
+}
+
+func TestRuleOfTwoGate_AskUpstreamDenialPropagates(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "ask-upstream"}
+	mt := &mockTransport{}
+	ask := NewAskUpstreamPolicy(mt, externalSet(), 0)
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), ask, nil)
+
+	go func() {
+		for {
+			time.Sleep(5 * time.Millisecond)
+			e := mt.lastEmitted()
+			if e != nil && e.Type == "permission_request" {
+				allowed := false
+				mt.simulateControlEvent(types.ControlEvent{
+					Type:      "permission_response",
+					RequestID: e.RequestID,
+					Allowed:   &allowed,
+					Reason:    "operator said no",
+				})
+				return
+			}
+		}
+	}()
+
+	result, err := gate.Check(context.Background(), types.ToolDefinition{Name: "web_fetch"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.Allowed {
+		t.Error("operator denial must deny the call")
+	}
+	if result.Reason != "operator said no" {
+		t.Errorf("reason = %q, want the operator's reason", result.Reason)
+	}
+}
+
+func TestRuleOfTwoGate_AskUpstreamNilFailsClosed(t *testing.T) {
+	inner := &recordingPolicy{}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "ask-upstream"}
+	gate := NewRuleOfTwoGate(inner, state, externalSet(), nil, nil)
+
+	result, err := gate.Check(context.Background(), types.ToolDefinition{Name: "run_command"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.Allowed {
+		t.Error("a gate with no ask policy must fail closed, not allow")
+	}
+	if result.Reason != RuleOfTwoDeniedReason {
+		t.Errorf("reason = %q, want RuleOfTwoDeniedReason", result.Reason)
+	}
+}
+
+func TestRuleOfTwoGate_UnwrapChainThroughGateAndMetrics(t *testing.T) {
+	core := NewAllowAll()
+	state := &fakeRuleOfTwoState{}
+	gate := NewRuleOfTwoGate(core, state, externalSet(), nil, nil)
+	// The metric recorder needs a non-nil metrics handle to wrap; the
+	// chain shape is what matters here, so reuse the gate-only chain
+	// for the single-wrapper case and assert Unwrap reaches the core
+	// through the gate.
+	if got := Unwrap(gate); got != core {
+		t.Errorf("Unwrap(gate) = %T, want the inner *AllowAll", got)
+	}
+}
+
+func TestRewrapChain_RebuildsGateAroundNewInner(t *testing.T) {
+	oldInner := &recordingPolicy{}
+	newInner := &recordingPolicy{result: &PermissionResult{Allowed: false, Reason: "new inner"}}
+	state := &fakeRuleOfTwoState{tripped: true, enforcing: true, action: "block-external"}
+	gate := NewRuleOfTwoGate(oldInner, state, externalSet(), nil, nil)
+
+	rewrapped, ok := RewrapChain(gate, newInner)
+	if !ok {
+		t.Fatal("RewrapChain must succeed for a gate-only chain")
+	}
+	if Unwrap(rewrapped) != PermissionPolicy(newInner) {
+		t.Fatalf("Unwrap(rewrapped) = %T, want the new inner", Unwrap(rewrapped))
+	}
+	// The rebuilt gate shares the tripped state: external tools still
+	// denied with the rule-of-two reason, non-external delegate to the
+	// NEW inner.
+	result, err := rewrapped.Check(context.Background(), types.ToolDefinition{Name: "run_command"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.Allowed || result.Reason != RuleOfTwoDeniedReason {
+		t.Errorf("rebuilt gate must keep denying external tools, got %+v", result)
+	}
+	result, err = rewrapped.Check(context.Background(), types.ToolDefinition{Name: "read_file"}, nil)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.Allowed || result.Reason != "new inner" {
+		t.Errorf("non-external check must reach the new inner, got %+v", result)
+	}
+	if oldInner.callCount() != 0 {
+		t.Errorf("old inner received %d calls after rewrap, want 0", oldInner.callCount())
+	}
+}
+
+func TestRewrapChain_UnrewrappableWrapperRefuses(t *testing.T) {
+	inner := NewAllowAll()
+	wrapped := &unwrapOnlyWrapper{inner: inner}
+	out, ok := RewrapChain(wrapped, NewAllowAll())
+	if ok {
+		t.Fatal("RewrapChain must refuse a chain containing a non-Rewrapper wrapper")
+	}
+	if out != PermissionPolicy(wrapped) {
+		t.Errorf("on refusal RewrapChain must return the original chain, got %T", out)
+	}
+}
+
+// unwrapOnlyWrapper implements Unwrap but not Rewrap, standing in for a
+// hypothetical future wrapper that predates the Rewrapper contract.
+type unwrapOnlyWrapper struct {
+	inner PermissionPolicy
+}
+
+func (w *unwrapOnlyWrapper) Check(ctx context.Context, tool types.ToolDefinition, input json.RawMessage) (*PermissionResult, error) {
+	return w.inner.Check(ctx, tool, input)
+}
+
+func (w *unwrapOnlyWrapper) Unwrap() PermissionPolicy { return w.inner }
+
+func TestRuleOfTwoGate_DeniedReasonNamesRuleOfTwo(t *testing.T) {
+	if !strings.HasPrefix(RuleOfTwoDeniedReason, "rule_of_two:") {
+		t.Errorf("RuleOfTwoDeniedReason must keep the stable rule_of_two: grep prefix, got %q", RuleOfTwoDeniedReason)
+	}
+}

--- a/harness/internal/ruleoftwo/monitor_test.go
+++ b/harness/internal/ruleoftwo/monitor_test.go
@@ -269,6 +269,42 @@ func TestPatternMonitor_RedactLeavesWarnTierIntact(t *testing.T) {
 	}
 }
 
+// TestPatternMonitor_RedactKeepsScanningAfterLatch pins the wave-4
+// exception to skip-after-trip: an enforcing redact monitor must keep
+// returning detections post-latch so the loop can rewrite spans on
+// every later tool result. Every other action (and observe-only)
+// suspends scanning — covered by TestPatternMonitor_SkipsRescanAfterTrip
+// and TestPatternMonitor_WarnTierSuppressedAfterLatch.
+func TestPatternMonitor_RedactKeepsScanningAfterLatch(t *testing.T) {
+	m := NewPatternMonitor(true, "redact", defaultCriteria(), false)
+	if det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{fakeLiveAWSKey}); !det.Transition {
+		t.Fatal("setup: first latch-tier content must transition")
+	}
+	det := m.ObserveChunks(context.Background(), "tool_result", 2, []string{"another " + fakeLiveAWSKey})
+	if det.Transition {
+		t.Error("redact must not report a second transition")
+	}
+	if len(det.Patterns) == 0 {
+		t.Error("redact must keep scanning post-latch (non-empty Detection), got empty")
+	}
+	if det.Tier != security.TierLatch {
+		t.Errorf("Tier = %q, want latch", det.Tier)
+	}
+}
+
+func TestPatternMonitor_NonRedactActionSuspendsScanning(t *testing.T) {
+	for _, action := range []string{"block-external", "ask-upstream", "abort"} {
+		t.Run(action, func(t *testing.T) {
+			m := NewPatternMonitor(true, action, defaultCriteria(), false)
+			m.ObserveChunks(context.Background(), "tool_result", 1, []string{fakeLiveAWSKey})
+			det := m.ObserveChunks(context.Background(), "tool_result", 2, []string{fakeLiveAWSKey})
+			if len(det.Patterns) != 0 {
+				t.Errorf("action %q must suspend scanning post-latch, got %+v", action, det)
+			}
+		})
+	}
+}
+
 func TestNoop_NeverTripsNeverEnforces(t *testing.T) {
 	m := NewNoop()
 	det := m.ObserveChunks(context.Background(), "tool_result", 1, []string{fakeLiveAWSKey})

--- a/harness/internal/ruleoftwo/patternmonitor.go
+++ b/harness/internal/ruleoftwo/patternmonitor.go
@@ -54,15 +54,16 @@ func NewPatternMonitor(enforcing bool, action string, guardCriteria []string, st
 // anthropic and openai patterns, "Bearer eyJ..." matches bearer_token
 // and oidc_jwt), and latches on any latch-tier finding.
 func (m *PatternMonitor) ObserveChunks(_ context.Context, _ string, _ int, chunks []string) Detection {
-	// Once latched, further scans buy nothing: the latch is one-way and
-	// no consumer reads per-chunk findings until redact mode exists
-	// (the detector costs ~80ms/MB, so this skip is the perf budget for
-	// long runs). Warn-tier telemetry is also suppressed post-latch —
-	// a documented contract, not a side-effect: the rule_of_two_triggered
-	// event carries scanning_suspended:true so operators can see where
-	// soak data ends. Wave 4 revisits this for onDetect=redact, which
-	// needs spans on every chunk after the trip.
-	if m.tripped.Load() {
+	// Once latched, further scans buy nothing for every action EXCEPT
+	// redact: the latch is one-way, the gate (block-external /
+	// ask-upstream) keys on Tripped() alone, and abort already
+	// short-circuited the run — so re-scanning only burns the detector's
+	// ~80ms/MB. Redact is the exception: it rewrites matched spans on
+	// every just-arrived tool result for the rest of the run, so it must
+	// keep scanning post-latch. Warn-tier telemetry is therefore also
+	// dark post-latch for non-redact actions (the rule_of_two_triggered
+	// event's scanning_suspended field records where that data ends).
+	if m.tripped.Load() && !m.continuesScanning() {
 		return Detection{}
 	}
 	var names []string
@@ -116,6 +117,14 @@ func (m *PatternMonitor) Action() string {
 		return "warn"
 	}
 	return m.action
+}
+
+// continuesScanning reports whether ObserveChunks keeps scanning after
+// the latch trips. Only the enforcing redact action does — it rewrites
+// matched spans on every subsequent tool result — so the effective
+// action (Action()) being exactly "redact" is the condition.
+func (m *PatternMonitor) continuesScanning() bool {
+	return m.Action() == "redact"
 }
 
 // Redact replaces every latch-tier span reported by DetectSensitive

--- a/harness/internal/security/securityevent.go
+++ b/harness/internal/security/securityevent.go
@@ -276,18 +276,18 @@ func (sl *SecurityLogger) SensitiveDataDetected(patterns []string, tier, source 
 // downstream tooling greps one identifier set; sensitiveData is always
 // true here — the transition is the event.
 //
-// scanning_suspended marks where soak telemetry ends: once the latch
-// trips, the monitor stops scanning, so warn-tier detections after
-// this event are deliberately dark. Hardcoded true while the skip is
-// unconditional; the enforcement wave's redact mode (which keeps
-// scanning post-latch) will parameterise it.
-func (sl *SecurityLogger) RuleOfTwoTriggered(untrustedInput, externalCommunication bool, action, source string) {
+// scanningSuspended marks where soak telemetry ends: for every action
+// except redact the monitor stops scanning once the latch trips, so
+// warn-tier detections after this event are deliberately dark. The
+// redact action keeps scanning (it rewrites spans on every later tool
+// result), so the caller passes false there.
+func (sl *SecurityLogger) RuleOfTwoTriggered(untrustedInput, externalCommunication bool, action, source string, scanningSuspended bool) {
 	sl.Emit("warn", "rule_of_two_triggered", map[string]any{
 		"untrustedInput":        untrustedInput,
 		"externalCommunication": externalCommunication,
 		"sensitiveData":         true,
 		"action":                action,
 		"source":                source,
-		"scanning_suspended":    true,
+		"scanning_suspended":    scanningSuspended,
 	})
 }

--- a/harness/internal/transport/grpc.go
+++ b/harness/internal/transport/grpc.go
@@ -101,6 +101,7 @@ func (g *GRPCTransport) Emit(event types.HarnessEvent) error {
 	event.Text = g.scrubAndReport(event.Text, "transport.grpc.event.text")
 	event.Content = g.scrubAndReport(event.Content, "transport.grpc.event.content")
 	event.Message = g.scrubAndReport(event.Message, "transport.grpc.event.message")
+	event.Input = scrubEventInput(event.Input, g.scrubAndReport, "transport.grpc.event.input")
 
 	pe := harnessEventToProto(event)
 

--- a/harness/internal/transport/grpc_test.go
+++ b/harness/internal/transport/grpc_test.go
@@ -416,6 +416,38 @@ func TestGRPCTransport_EmitScrubsSecrets(t *testing.T) {
 	}
 }
 
+// TestGRPCTransport_EmitScrubsInput mirrors the stdio Input-scrub fix on
+// the gRPC transport: a permission_request forwarding a tool call's raw
+// input must not leak a latch-tripping secret to the control plane.
+func TestGRPCTransport_EmitScrubsInput(t *testing.T) {
+	srv := newTestServer()
+	tr, _, cleanup := setupTestTransport(t, srv)
+	defer cleanup()
+
+	event := types.HarnessEvent{
+		Type:  "permission_request",
+		Name:  "run_command",
+		Input: json.RawMessage(`{"command":"echo AKIAQWERTYUIOPASDFGH"}`),
+	}
+	if err := tr.Emit(event); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	_ = tr.stream.CloseSend()
+	time.Sleep(50 * time.Millisecond)
+
+	received := srv.getReceived()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 received event, got %d", len(received))
+	}
+	if strings.Contains(string(received[0].Input), "AKIAQWERTYUIOPASDFGH") {
+		t.Errorf("live-shaped AWS key was not scrubbed from event Input: %q", received[0].Input)
+	}
+	if !json.Valid(received[0].Input) {
+		t.Errorf("scrubbed Input is not valid JSON: %q", received[0].Input)
+	}
+}
+
 func TestGRPCTransport_EmitFiresSecretRedactedInOutput(t *testing.T) {
 	srv := newTestServer()
 	tr, _, cleanup := setupTestTransport(t, srv)

--- a/harness/internal/transport/stdio.go
+++ b/harness/internal/transport/stdio.go
@@ -45,6 +45,7 @@ func (s *StdioTransport) Emit(event types.HarnessEvent) error {
 	event.Text = s.scrubAndReport(event.Text, "transport.stdio.event.text")
 	event.Content = s.scrubAndReport(event.Content, "transport.stdio.event.content")
 	event.Message = s.scrubAndReport(event.Message, "transport.stdio.event.message")
+	event.Input = scrubEventInput(event.Input, s.scrubAndReport, "transport.stdio.event.input")
 
 	data, err := json.Marshal(event)
 	if err != nil {
@@ -57,6 +58,34 @@ func (s *StdioTransport) Emit(event types.HarnessEvent) error {
 	data = append(data, '\n')
 	_, err = s.writer.Write(data)
 	return err
+}
+
+// scrubInvalidatedJSONPlaceholder replaces an event Input whose JSON is no
+// longer valid after scrubbing. It is deliberately distinct from
+// ruleoftwo.RedactionPlaceholder so an operator can tell at a glance that
+// the redaction came from the transport's scrub-then-revalidate path rather
+// than the rule-of-two redact action.
+const scrubInvalidatedJSONPlaceholder = "[redacted:scrub-invalidated-json]"
+
+// scrubEventInput scrubs secret patterns from a HarnessEvent.Input
+// (json.RawMessage). The ask-upstream rule-of-two gate forwards a tool
+// call's raw input on a permission_request event, and that input can carry
+// the very secret that tripped the sensitive-data latch (an AWS key echoed
+// into a web_fetch URL or run_command argument). Scrubbing the string form
+// can in principle break the JSON (a redaction spanning a structural
+// boundary), so the result is revalidated and falls back to a fixed
+// placeholder rather than emit malformed JSON onto the wire. An empty input
+// is returned unchanged so the omitempty wire field stays absent.
+func scrubEventInput(input json.RawMessage, scrub func(value, location string) string, location string) json.RawMessage {
+	if len(input) == 0 {
+		return input
+	}
+	scrubbed := scrub(string(input), location)
+	if json.Valid([]byte(scrubbed)) {
+		return json.RawMessage(scrubbed)
+	}
+	b, _ := json.Marshal(scrubInvalidatedJSONPlaceholder)
+	return json.RawMessage(b)
 }
 
 // scrubAndReport scrubs s and, if any redaction happened, fires a

--- a/harness/internal/transport/stdio_test.go
+++ b/harness/internal/transport/stdio_test.go
@@ -112,6 +112,73 @@ func TestStdioTransport_EmitScrubsSecrets(t *testing.T) {
 	}
 }
 
+// TestStdioTransport_EmitScrubsInput pins the Wave-4 fix: the
+// ask-upstream rule-of-two gate forwards a tool call's raw Input on a
+// permission_request event after the sensitive-data latch trips, so a
+// secret echoed into the call must not reach the control plane
+// unscrubbed.
+func TestStdioTransport_EmitScrubsInput(t *testing.T) {
+	var buf bytes.Buffer
+	tr := NewStdioTransport(&buf, strings.NewReader(""))
+
+	event := types.HarnessEvent{
+		Type:  "permission_request",
+		Name:  "run_command",
+		Input: json.RawMessage(`{"command":"echo AKIAQWERTYUIOPASDFGH"}`),
+	}
+	if err := tr.Emit(event); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "AKIAQWERTYUIOPASDFGH") {
+		t.Errorf("live-shaped AWS key was not scrubbed from event Input: %s", output)
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] placeholder in scrubbed Input: %s", output)
+	}
+	// The scrubbed Input must remain valid JSON on the wire.
+	var got types.HarnessEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &got); err != nil {
+		t.Fatalf("emitted line is not valid JSON: %v", err)
+	}
+	if !json.Valid(got.Input) {
+		t.Errorf("scrubbed Input is not valid JSON: %q", got.Input)
+	}
+}
+
+// TestStdioTransport_EmitScrubInvalidatedJSONFallback exercises the
+// fallback path: when scrubbing breaks the JSON structure, the Input is
+// replaced with a fixed placeholder rather than emitting malformed JSON.
+// The generic_hex_secret pattern's trailing optional-quote consumes the
+// JSON value's closing quote, so the [REDACTED] replacement leaves an
+// unterminated string — invalidating the document.
+func TestStdioTransport_EmitScrubInvalidatedJSONFallback(t *testing.T) {
+	var buf bytes.Buffer
+	tr := NewStdioTransport(&buf, strings.NewReader(""))
+
+	const hex = "0123456789abcdef0123456789abcdef" // 32 hex chars
+	raw := `{"note":"password=` + hex + `"}`
+	if err := tr.Emit(types.HarnessEvent{Type: "permission_request", Input: json.RawMessage(raw)}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	var got types.HarnessEvent
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("emitted line is not valid JSON: %v", err)
+	}
+	if !json.Valid(got.Input) {
+		t.Errorf("Input must be valid JSON even on the fallback path, got: %q", got.Input)
+	}
+	if strings.Contains(string(got.Input), hex) {
+		t.Errorf("secret survived the fallback: %q", got.Input)
+	}
+	if !strings.Contains(string(got.Input), "scrub-invalidated-json") {
+		t.Errorf("expected the scrub-invalidated-json placeholder, got: %q", got.Input)
+	}
+}
+
 func TestStdioTransport_Close(t *testing.T) {
 	tr := NewStdioTransport(&bytes.Buffer{}, strings.NewReader(""))
 	if err := tr.Close(); err != nil {

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -2406,6 +2406,18 @@ func validateRuleOfTwoRuntime(config *RunConfig, errs *[]string) {
 	} else if rt.OnDetect == "ask-upstream" && config.Transport.Type != "grpc" {
 		*errs = append(*errs, "ruleOfTwo.runtime.onDetect \"ask-upstream\" requires transport=grpc (stdio has no upstream control plane to answer permission requests)")
 	}
+	// Reject dead configuration: "abort" fires only on a runtime latch
+	// transition, but a statically-sensitive run (sensitiveData:true or a
+	// dynamic-context entry marked Sensitive) pre-trips the latch before
+	// the first scan, so the false→true transition never happens and the
+	// abort never fires. An operator declaring the run sensitive up front
+	// wants egress revoked from the start — use block-external (or
+	// ask-upstream) instead.
+	if rt.OnDetect == "abort" && ruleOfTwoSensitiveData(config) {
+		*errs = append(*errs, `ruleOfTwo.runtime.onDetect "abort" has no effect when the run is already statically sensitive `+
+			`(sensitiveData:true or a Sensitive dynamicContext entry): the latch is pre-tripped so no runtime transition can fire; `+
+			`use block-external to revoke egress on a statically-sensitive run`)
+	}
 	for i, criterion := range rt.GuardCriteria {
 		if !guardRailCustomCriterionPattern.MatchString(criterion) {
 			*errs = append(*errs, fmt.Sprintf("ruleOfTwo.runtime.guardCriteria[%d] %q must match %s", i, criterion, guardRailCustomCriterionPattern.String()))

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -3264,6 +3264,61 @@ func TestValidateRunConfig_RuleOfTwoRuntime_NoneClassifierCrossField(t *testing.
 	})
 }
 
+// TestValidateRunConfig_RuleOfTwoRuntime_AbortWithStaticSensitiveCrossField
+// pins the dead-config rejection from the Wave-4 review: onDetect "abort"
+// fires only on a runtime latch transition, but a statically-sensitive run
+// pre-trips the latch before the first scan, so no transition ever fires
+// and the abort silently never happens. The validator rejects the
+// combination and directs the operator to block-external.
+func TestValidateRunConfig_RuleOfTwoRuntime_AbortWithStaticSensitiveCrossField(t *testing.T) {
+	t.Run("abort with sensitiveData rejected", func(t *testing.T) {
+		c := validConfig()
+		// Only the sensitive leg holds (read-only tools, no untrusted
+		// ingress) so the static all-three check stays silent and this
+		// case isolates the abort cross-field rejection.
+		c.Tools = ToolsConfig{BuiltIn: []string{"read_file"}}
+		c.SensitiveData = boolRef(true)
+		c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{OnDetect: "abort"}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected rejection for onDetect=abort with sensitiveData:true, got nil")
+		}
+		if !strings.Contains(err.Error(), "abort") || !strings.Contains(err.Error(), "sensitiveData") {
+			t.Errorf("error should name abort and sensitiveData, got: %v", err)
+		}
+	})
+	t.Run("abort with sensitive dynamicContext entry rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Tools = ToolsConfig{BuiltIn: []string{"read_file"}}
+		c.DynamicContext = map[string]DynamicContextValue{"record": {Value: "x", Sensitive: true}}
+		c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{OnDetect: "abort"}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("expected rejection for onDetect=abort with a Sensitive dynamicContext entry, got nil")
+		}
+		if !strings.Contains(err.Error(), "abort") {
+			t.Errorf("error should name abort, got: %v", err)
+		}
+	})
+	t.Run("block-external with sensitiveData passes", func(t *testing.T) {
+		c := validConfig()
+		c.Tools = ToolsConfig{BuiltIn: []string{"read_file"}}
+		c.SensitiveData = boolRef(true)
+		c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{OnDetect: "block-external"}}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("block-external on a statically-sensitive run should pass, got: %v", err)
+		}
+	})
+	t.Run("abort without static sensitivity passes", func(t *testing.T) {
+		c := validConfig()
+		c.Tools = ToolsConfig{BuiltIn: []string{"read_file"}}
+		c.RuleOfTwo = &RuleOfTwoConfig{Runtime: &RuleOfTwoRuntimeConfig{OnDetect: "abort"}}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("abort on a non-statically-sensitive run should pass, got: %v", err)
+		}
+	})
+}
+
 // TestValidateRunConfig_RuleOfTwoRuntime_AskUpstreamRequiresGRPC pins the
 // cross-field invariant: onDetect "ask-upstream" routes external-comm
 // permission requests upstream, which only exists on the gRPC transport.


### PR DESCRIPTION
## Summary

Wave 4 of 5 making the Rule of Two's sensitive-data leg dynamic (Ring 4). **Stacked on #417.** This is the behaviour-changing wave — the latch that #417 ships dark now *acts*.

- `harness/internal/permission/ruleoftwogate.go`: a latch-aware `PermissionPolicy` wrapper (with `Unwrap()`). While the run's monitor is untripped, or not enforcing, or the tool isn't egress-capable, it delegates to the inner policy unchanged. Once the latch trips under `block-external`, it denies every external-comm tool for the rest of the run.
- External-comm set: `run_command`, `web_fetch`, and any `mcp_`-prefixed tool — keyed on internal dispatch identity, so profile aliases can't dodge it.
- Actions (`ruleOfTwo.runtime.onDetect`): **`block-external`** (default — revoke egress, local work finishes), `ask-upstream` (route external calls through human approval; grpc-pinned by PR1's validator; inner policy consulted first so a Cedar `forbid` still denies), `redact` (rewrite matched latch-tier spans in tool-result `Content` **and** `Structured`, keep scanning post-latch), `abort` (terminal outcome `rule_of_two_violation`), `warn` (observe-only).
- **Default flip**: a run holding untrusted input + external comms with no declared sensitivity now auto-arms *enforcing*. The Wave-3 dark-ship pin test is inverted — the identical scenario now denies egress mid-run.
- Sub-agent latch sharing hardened: `permission.Unwrap` + `RewrapChain` rebuild the wrapper chain around the `ForChildRun` Cedar clone so a spawned child keeps both its `parentRunId` policy clone and the shared gate — `spawn_agent` is not a latch escape hatch.
- Metric `stirrup.ruleoftwo.actions{action}`; gate denials also ride the existing `permission_denied` event and `stirrup.permission.decisions` (no double-emit).

## Operator-visible behaviour change (read before merge)

Runs that previously held two-of-three freely and *also* ingested sensitive content at runtime will now **lose egress on detection** under the default posture. Escape hatches, both reviewable in the RunConfig:
- `ruleOfTwo.runtime.classifier: "none"` — disarm detection entirely.
- `ruleOfTwo.enforce: false` — disarm enforcement, keep auditable detection events.

Known false-positive footgun: Luhn-valid test PANs in fixtures (e.g. `4111111111111111`) trip the latch. FP cost here is availability (the run finishes locally without egress), not a safety failure.

## One-way decisions

- **Denial reason string** `rule_of_two: sensitive data observed in conversation; external communication revoked for this run` is a stable grep/audit key (`permission.RuleOfTwoDeniedReason`).
- **Abort outcome** `rule_of_two_violation` joins the terminal-outcome vocabulary.
- **Layering**: the gate consumes a local `permission.RuleOfTwoState` 3-method interface (`Tripped`/`Enforcing`/`Action`), not an import of `harness/internal/ruleoftwo` — importing the monitor into `permission` would invert leaf-package layering. Mirrors how `askupstream.go` declares its own `Transport` interface.
- **`onDetect: "abort"` + statically-declared sensitivity is rejected at validation** — a pre-tripped latch can never produce the runtime `Transition` that abort fires on, so the combination is dead config; the validator points the operator at `block-external` instead.

## Assumptions

- The gate is reached because every external tool is `WorkspaceMutating` or `RequiresApproval`, so it already routes through `Permissions.Check`. A future external tool that is neither would need adding to the set.
- `redact` operates on `DetectSensitive` span offsets over both the `Content` string and the separate `Structured` JSON string of each tool-result block; the operator `prompt` latches but is never rewritten (rewriting the task statement changes run semantics).

## Honest gap (unchanged, documented in Wave 5)

A single `run_command` that reads and exfiltrates in one shell pipeline — where the data never enters the conversation context — is not caught by this ring (it never reaches a scan boundary). This is Ring 2/3 territory and is the only same-turn exfil path; it predates this work and is unchanged.

## Review

One wave of four parallel reviews (code / security / spec-compliance / consistency → synthesized) + remediation before opening. The security review's lead conclusion: `block-external` is structurally sound — every built-in external tool and every statically-registered MCP tool is denied once the latch trips, and the sub-agent escape hatch is closed by `RewrapChain`. Fixed before opening:

- **Unscrubbed `permission_request.Input`** (security, newly load-bearing): the ask-upstream path forwarded the tool call carrying the latch-tripping secret to the control plane with `Input` unscrubbed. Transport `Emit` now scrubs `HarnessEvent.Input` additively (json-validity fallback), in both stdio and grpc, with existing transport tests confirmed unchanged.
- **`mcp_` prefix gap** in the gate's ask-upstream policy (a latent auto-allow the block-external path didn't have).
- **abort dead-code config** rejected at validation (above).
- Plus: redact JSON fallback via `json.Marshal`, deduplicated tool-set construction, and the now-false Wave-3 "observe-only" comments removed.

## Testing

`just` + `just lint` green; `-race` green on transport / permission / core / ruleoftwo / security. Covers: gate delegate-until-tripped, external-set + `mcp_` prefix, ask-upstream inner-first + fake-transport approval, `Unwrap`/`RewrapChain` chain integrity, redact span-preservation across `Content`+`Structured`, abort outcome incl. turn-0, the inverted default-flip pin, and an end-to-end stdio run where a seeded fake key trips the latch and the subsequent `run_command` is denied while the run completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)