### PR TITLE
types: allow forward slashes in model names for OpenRouter support

### DIFF
--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1368,6 +1368,13 @@ var queryParamKeyPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 // without further escaping.
 var observabilityLabelPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,64}$`)
 
+// modelLabelPattern bounds the character set of model names that ride on
+// the provider.model OTel metric label. Unlike observabilityLabelPattern,
+// it allows forward slashes to support OpenRouter-style "provider/model"
+// naming (e.g. "deepseek/deepseek-v4-flash", "anthropic/claude-sonnet-4.6").
+// The 64-char cap prevents unbounded cardinality expansion on metric labels.
+var modelLabelPattern = regexp.MustCompile(`^[A-Za-z0-9./_-]{1,64}$`)
+
 // traceEmitterHeaderNamePattern restricts trace-emitter header keys to
 // the same minimal set used elsewhere for HTTP header names. Including
 // `_` accommodates underscore-variant headers (e.g. `x_honeycomb_team`)
@@ -3446,9 +3453,8 @@ func validateBedrockModelID(config *RunConfig, errs *[]string) {
 // power (Cloud Run job spec, gRPC submitter) could otherwise set an
 // unbounded or non-printable model string that inflates TSDB cardinality
 // or breaks dashboard label rendering (CWE-400, issue #310). The bound is
-// observabilityLabelPattern — the same ^[A-Za-z0-9._-]{1,64}$ the Gemini
-// precedent (geminiModelNamePattern) and the OTel resource labels already
-// enforce.
+// modelLabelPattern — which allows forward slashes for OpenRouter-style
+// provider/model naming while staying conservative on characters.
 //
 // Scope mirrors validateGeminiModelName: ModelRouter.Model under the
 // resolved default provider, plus each ModeModels override. CheapModel /
@@ -3508,12 +3514,12 @@ func validateProviderModelLabel(config *RunConfig, errs *[]string) {
 			}
 			return
 		}
-		if !observabilityLabelPattern.MatchString(model) {
+		if !modelLabelPattern.MatchString(model) {
 			*errs = append(*errs, fmt.Sprintf(
 				"%s %q must match %s; the model name rides on the provider.model "+
 					"metric label and an unbounded or non-printable value inflates "+
 					"observability cardinality",
-				label, model, observabilityLabelPattern))
+				label, model, modelLabelPattern))
 		}
 	}
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5239,9 +5239,10 @@ func TestValidateRunConfig_BedrockModelIDShape(t *testing.T) {
 // TestValidateRunConfig_ProviderModelLabelBound pins the cardinality
 // guard from #310: the router-resolved model string rides on the
 // provider.model OTel metric label, so for anthropic, openai-compatible,
-// and openai-responses it must match observabilityLabelPattern
-// (^[A-Za-z0-9._-]{1,64}$). #304 hardened the model-controlled tool.name
-// label; this is the operator-controlled sibling.
+// and openai-responses it must match modelLabelPattern
+// (^[A-Za-z0-9./_-]{1,64}$), which allows forward slashes for
+// OpenRouter-style "provider/model" naming. #304 hardened the
+// model-controlled tool.name label; this is the operator-controlled sibling.
 func TestValidateRunConfig_ProviderModelLabelBound(t *testing.T) {
 	// A 65-char model string overruns the 64-char label cap.
 	tooLong := strings.Repeat("a", 65)
@@ -5253,7 +5254,6 @@ func TestValidateRunConfig_ProviderModelLabelBound(t *testing.T) {
 			model    string
 		}{
 			{"anthropic with space", "anthropic", "claude sonnet"},
-			{"anthropic with slash", "anthropic", "anthropic/claude"},
 			{"anthropic too long", "anthropic", tooLong},
 			{"anthropic with newline", "anthropic", "claude\nsonnet"},
 			{"openai-compatible with colon", "openai-compatible", "gpt-4:turbo"},
@@ -5287,7 +5287,9 @@ func TestValidateRunConfig_ProviderModelLabelBound(t *testing.T) {
 			{"anthropic", "claude-opus-4-1"},
 			{"openai-compatible", "gpt-4o"},
 			{"openai-responses", "gpt-4.1"},
-			{"anthropic", strings.Repeat("a", 64)}, // exactly at the cap
+			{"openai-compatible", "deepseek/deepseek-v4-flash"},        // OpenRouter-style model names
+			{"openai-compatible", "anthropic/claude-sonnet-4.6"},       // OpenRouter-style model names
+			{"anthropic", strings.Repeat("a", 64)},                    // exactly at the cap
 		}
 		for _, tc := range cases {
 			t.Run(tc.provider+"/"+tc.model, func(t *testing.T) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5287,9 +5287,11 @@ func TestValidateRunConfig_ProviderModelLabelBound(t *testing.T) {
 			{"anthropic", "claude-opus-4-1"},
 			{"openai-compatible", "gpt-4o"},
 			{"openai-responses", "gpt-4.1"},
-			{"openai-compatible", "deepseek/deepseek-v4-flash"},        // OpenRouter-style model names
-			{"openai-compatible", "anthropic/claude-sonnet-4.6"},       // OpenRouter-style model names
-			{"anthropic", strings.Repeat("a", 64)},                    // exactly at the cap
+			// OpenRouter-style model names with forward slashes
+			{"openai-compatible", "deepseek/deepseek-v4-flash"},
+			{"openai-compatible", "anthropic/claude-sonnet-4.6"},
+			// exactly at the cap
+			{"anthropic", strings.Repeat("a", 64)},
 		}
 		for _, tc := range cases {
 			t.Run(tc.provider+"/"+tc.model, func(t *testing.T) {


### PR DESCRIPTION
Create a separate modelLabelPattern regex that allows forward slashes in model names, enabling valid OpenRouter-style names like "deepseek/deepseek-v4-flash" and "anthropic/claude-sonnet-4.6" to pass validation. The original observabilityLabelPattern remains restrictive for actual OTel resource labels (environment, service.namespace) where slashes are not appropriate.

This change keeps the cardinality guard from #310 while supporting provider namespacing in model identifiers. Bedrock model ARNs with slashes continue to work via their existing exemption.