### PR TITLE
trace: complete GenAI semconv coverage on OTel spans

### DIFF
--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -594,6 +594,7 @@ func (l *AgenticLoop) runInnerLoop(
 					StopReason: "error",
 					DurationMs: time.Since(turnStart).Milliseconds(),
 					Mode:       "",
+					Model:      selection.Model,
 				})
 				return messages, "error"
 			}
@@ -606,6 +607,7 @@ func (l *AgenticLoop) runInnerLoop(
 				StopReason: "error",
 				DurationMs: time.Since(turnStart).Milliseconds(),
 				Mode:       "",
+				Model:      selection.Model,
 			})
 			return messages, "error"
 		}
@@ -708,6 +710,7 @@ func (l *AgenticLoop) runInnerLoop(
 				DurationMs: time.Since(turnStart).Milliseconds(),
 				Mode:       turnMode,
 				BatchID:    turnBatchID,
+				Model:      selection.Model,
 			})
 			// If the provider call failed because the run context was
 			// cancelled, surface that so the outer loop can classify the
@@ -768,6 +771,7 @@ func (l *AgenticLoop) runInnerLoop(
 				DurationMs: turnDuration.Milliseconds(),
 				Mode:       turnMode,
 				BatchID:    turnBatchID,
+				Model:      selection.Model,
 			})
 			// Distinguish stream-abort-due-to-ctx from other stream errors
 			// so the outer loop can classify the outcome correctly.
@@ -803,6 +807,7 @@ func (l *AgenticLoop) runInnerLoop(
 			DurationMs: turnDuration.Milliseconds(),
 			Mode:       turnMode,
 			BatchID:    turnBatchID,
+			Model:      selection.Model,
 		})
 
 		// Snapshot the model input the provider just saw and the

--- a/harness/internal/core/subagent_test.go
+++ b/harness/internal/core/subagent_test.go
@@ -472,6 +472,9 @@ func TestSpawnSubAgent_TraceEventsForwardedToParent(t *testing.T) {
 		if turn.RunID == parentConfig.RunID {
 			t.Errorf("forwarded turn RunID must be the child's runID, not the parent's; got %q", turn.RunID)
 		}
+		if turn.Model != "claude-sonnet-4-6" {
+			t.Errorf("forwarded turn Model: got %q, want the router's selected model", turn.Model)
+		}
 	}
 }
 

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -40,6 +41,11 @@ const (
 	genAIUsageOutputTokens = "gen_ai.usage.output_tokens"
 	genAIFinishReasonsKey  = "gen_ai.response.finish_reasons"
 	genAIToolNameKey       = "gen_ai.tool.name"
+
+	// errorTypeKey is the stable (non-Development) semconv error
+	// attribute, emitted on failed tool spans with the bounded
+	// observability.ToolFailureCategory vocabulary as its value.
+	errorTypeKey = "error.type"
 
 	// Message-content attributes, emitted only when CaptureContent is
 	// opted into. As of the pinned semconv (v1.40.0, matching
@@ -485,6 +491,13 @@ func (e *OTelTraceEmitter) emitTurnSpanLocked(turn types.TurnTrace, spanStart, s
 		oteltrace.WithTimestamp(spanStart),
 		oteltrace.WithAttributes(attrs...),
 	)
+	// The loop's error paths (provider resolution, stream open,
+	// mid-stream failure) all record the turn with this sentinel stop
+	// reason and never produce a TurnRecord, so this is the single
+	// choke point that marks failed turns for backend level filtering.
+	if turn.StopReason == "error" {
+		span.SetStatus(codes.Error, "error")
+	}
 	span.End(oteltrace.WithTimestamp(spanEnd))
 }
 
@@ -610,15 +623,30 @@ func (e *OTelTraceEmitter) emitToolSpanLocked(call types.ToolCallTrace, spanStar
 		name = "execute_tool"
 	}
 
+	attrs := []attribute.KeyValue{
+		attribute.String(genAIToolNameKey, call.Name),
+		attribute.String(genAIOperationNameKey, "execute_tool"),
+		attribute.Bool("tool.success", call.Success),
+		attribute.Int64("tool.duration_ms", call.DurationMs),
+	}
+	if !call.Success && call.ErrorCategory != "" {
+		attrs = append(attrs, attribute.String(errorTypeKey, call.ErrorCategory))
+	}
+
 	_, span := e.tracer.Start(e.rootCtx, name,
 		oteltrace.WithTimestamp(spanStart),
-		oteltrace.WithAttributes(
-			attribute.String(genAIToolNameKey, call.Name),
-			attribute.String(genAIOperationNameKey, "execute_tool"),
-			attribute.Bool("tool.success", call.Success),
-			attribute.Int64("tool.duration_ms", call.DurationMs),
-		),
+		oteltrace.WithAttributes(attrs...),
 	)
+	if !call.Success {
+		// ErrorReason is scrubbed at dispatch time; the second pass here
+		// is the same defence-in-depth posture the JSONL emitter applies
+		// — span status strings bypass ScrubHandler.
+		desc := security.Scrub(call.ErrorReason)
+		if desc == "" {
+			desc = "tool call failed"
+		}
+		span.SetStatus(codes.Error, desc)
+	}
 	span.End(oteltrace.WithTimestamp(spanEnd))
 }
 
@@ -657,6 +685,15 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 			attribute.Int("run.turns", len(e.turns)),
 			attribute.Int("run.permission_denials", e.permissionDenials),
 		)
+		// Every non-success outcome — including cancelled — marks the
+		// root Error so backends expose one "didn't finish" predicate;
+		// the run.outcome attribute (and run.cancelled_by, when set by
+		// the loop) disambiguates operator-initiated cancellation from
+		// failure. The outcome vocabulary is a bounded enum, so the
+		// status description needs no scrubbing.
+		if outcome != "success" {
+			e.rootSpan.SetStatus(codes.Error, outcome)
+		}
 		e.rootSpan.End()
 	}
 

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -351,10 +351,15 @@ func (e *OTelTraceEmitter) Start(runID string, config *types.RunConfig) {
 	// defines this as a persistent agent identity (e.g. an OpenAI Assistant ID),
 	// not a per-execution run ID. Stirrup has no first-class named-agent concept;
 	// emit when one exists. See follow-up issue (#127).
+	// The root span is the run-level agent invocation; the semconv
+	// "invoke_agent {gen_ai.agent.name}" span name is not adopted because
+	// stirrup has no named-agent concept (#127) and backends type
+	// observations from the operation-name attribute, not the span name.
 	ctx, span := e.tracer.Start(ctx, "run",
 		oteltrace.WithAttributes(
 			attribute.String("run.id", runID),
 			attribute.String("harness.version", version.Version()),
+			attribute.String(genAIOperationNameKey, "invoke_agent"),
 		),
 	)
 
@@ -455,6 +460,22 @@ func (e *OTelTraceEmitter) emitTurnSpanLocked(turn types.TurnTrace, spanStart, s
 		attribute.Int64("turn.duration_ms", turn.DurationMs),
 		// Per GenAI semconv, a turn is a chat completion.
 		attribute.String(genAIOperationNameKey, "chat"),
+	}
+	// gen_ai.request.model is Required on chat spans per semconv, and
+	// backends price generations from the span-level model — the
+	// root-span copy is not enough. Prefer the router's per-turn
+	// selection; fall back to the run-level configured model for legacy
+	// callers that predate TurnTrace.Model. Skipped when both are empty
+	// (matches the empty-attribute convention in Start).
+	model := turn.Model
+	if model == "" && e.config != nil {
+		model = e.config.ModelRouter.Model
+	}
+	if model != "" {
+		attrs = append(attrs, attribute.String(genAIRequestModelKey, model))
+	}
+	if e.config != nil {
+		attrs = append(attrs, attribute.String(genAIProviderNameKey, genAIProviderName(e.config.Provider.Type)))
 	}
 	if content != nil {
 		attrs = append(attrs, content.attributes(e.systemInstructionsJSON)...)
@@ -570,10 +591,30 @@ func (e *OTelTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	spanEnd := time.Now()
 	spanStart := spanEnd.Add(-time.Duration(call.DurationMs) * time.Millisecond)
 
-	_, span := e.tracer.Start(e.rootCtx, "tool_call",
+	e.emitToolSpanLocked(call, spanStart, spanEnd)
+}
+
+// emitToolSpanLocked creates and ends the execute_tool child span. Must
+// be called with e.mu held.
+//
+// The span name follows the semconv "execute_tool {gen_ai.tool.name}"
+// form so each tool reads distinctly in backend trace trees — except
+// for unknown-tool failures, where the name the model asked for is
+// model-controlled and unbounded; emitting it as a span name would be
+// the cardinality vector #309 bounded on the loop's tool.<name> spans.
+// Those calls use the bare operation name, and the raw requested name
+// still rides the bounded-cardinality-safe gen_ai.tool.name attribute.
+func (e *OTelTraceEmitter) emitToolSpanLocked(call types.ToolCallTrace, spanStart, spanEnd time.Time) {
+	name := "execute_tool " + call.Name
+	if call.ErrorCategory == string(observability.ToolFailureUnknownTool) {
+		name = "execute_tool"
+	}
+
+	_, span := e.tracer.Start(e.rootCtx, name,
 		oteltrace.WithTimestamp(spanStart),
 		oteltrace.WithAttributes(
 			attribute.String(genAIToolNameKey, call.Name),
+			attribute.String(genAIOperationNameKey, "execute_tool"),
 			attribute.Bool("tool.success", call.Success),
 			attribute.Int64("tool.duration_ms", call.DurationMs),
 		),

--- a/harness/internal/trace/otel_test.go
+++ b/harness/internal/trace/otel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
@@ -641,4 +642,109 @@ func findSpanByName(t *testing.T, spans tracetest.SpanStubs, name string) tracet
 	}
 	t.Fatalf("no span named %q exported", name)
 	return tracetest.SpanStub{}
+}
+
+// TestOTelTraceEmitter_ErrorStatus pins the OTel status-code surface:
+// backends derive their error level and message from span status, so a
+// failed run, turn, or tool call must carry codes.Error while the
+// success paths leave status Unset (the spec default; Ok is reserved
+// for explicit operator assertion).
+func TestOTelTraceEmitter_ErrorStatus(t *testing.T) {
+	t.Run("root error for non-success outcomes including cancelled", func(t *testing.T) {
+		for _, outcome := range []string{"max_turns", "cancelled"} {
+			emitter, exporter := newTestOTelEmitter()
+			emitter.Start("run-status", nil)
+			if _, err := emitter.Finish(context.Background(), outcome); err != nil {
+				t.Fatalf("Finish: %v", err)
+			}
+			span := findSpanByName(t, exporter.GetSpans(), "run")
+			if span.Status.Code != codes.Error {
+				t.Errorf("outcome %q: root status = %v, want Error", outcome, span.Status.Code)
+			}
+			if span.Status.Description != outcome {
+				t.Errorf("outcome %q: root status description = %q, want the outcome", outcome, span.Status.Description)
+			}
+		}
+	})
+
+	t.Run("root unset on success", func(t *testing.T) {
+		emitter, exporter := newTestOTelEmitter()
+		emitter.Start("run-status-ok", nil)
+		if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		span := findSpanByName(t, exporter.GetSpans(), "run")
+		if span.Status.Code != codes.Unset {
+			t.Errorf("root status = %v, want Unset", span.Status.Code)
+		}
+	})
+
+	t.Run("turn error on error stop reason", func(t *testing.T) {
+		emitter, exporter := newTestOTelEmitter()
+		emitter.Start("run-status-turn", nil)
+		emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "error", DurationMs: 1})
+		emitter.RecordTurn(types.TurnTrace{Turn: 2, StopReason: "end_turn", DurationMs: 1})
+		if _, err := emitter.Finish(context.Background(), "error"); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		spans := exporter.GetSpans()
+		if got := findSpanByName(t, spans, "turn[1]").Status.Code; got != codes.Error {
+			t.Errorf("error turn status = %v, want Error", got)
+		}
+		if got := findSpanByName(t, spans, "turn[2]").Status.Code; got != codes.Unset {
+			t.Errorf("clean turn status = %v, want Unset", got)
+		}
+	})
+
+	t.Run("tool error with reason and error.type", func(t *testing.T) {
+		emitter, exporter := newTestOTelEmitter()
+		emitter.Start("run-status-tool", nil)
+		emitter.RecordToolCall(types.ToolCallTrace{
+			Name:          "run_command",
+			DurationMs:    3,
+			Success:       false,
+			ErrorReason:   "exit status 1",
+			ErrorCategory: "execution_failed",
+		})
+		emitter.RecordToolCall(types.ToolCallTrace{
+			Name:       "read_file",
+			DurationMs: 1,
+			Success:    true,
+		})
+		if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		spans := exporter.GetSpans()
+		failed := findSpanByName(t, spans, "execute_tool run_command")
+		if failed.Status.Code != codes.Error {
+			t.Errorf("failed tool status = %v, want Error", failed.Status.Code)
+		}
+		if failed.Status.Description != "exit status 1" {
+			t.Errorf("failed tool status description = %q, want the error reason", failed.Status.Description)
+		}
+		assertAttribute(t, failed, errorTypeKey, "execution_failed")
+
+		ok := findSpanByName(t, spans, "execute_tool read_file")
+		if ok.Status.Code != codes.Unset {
+			t.Errorf("successful tool status = %v, want Unset", ok.Status.Code)
+		}
+		for _, attr := range ok.Attributes {
+			if string(attr.Key) == errorTypeKey {
+				t.Errorf("%s should be absent on successful calls, found %q", errorTypeKey, attr.Value.AsString())
+			}
+		}
+	})
+
+	t.Run("failed tool with empty reason gets fallback description", func(t *testing.T) {
+		emitter, exporter := newTestOTelEmitter()
+		emitter.Start("run-status-tool-bare", nil)
+		emitter.RecordToolCall(types.ToolCallTrace{Name: "edit_file", DurationMs: 1, Success: false})
+		if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		span := findSpanByName(t, exporter.GetSpans(), "execute_tool edit_file")
+		if span.Status.Code != codes.Error || span.Status.Description != "tool call failed" {
+			t.Errorf("status = %v %q, want Error with fallback description", span.Status.Code, span.Status.Description)
+		}
+	})
 }

--- a/harness/internal/trace/otel_test.go
+++ b/harness/internal/trace/otel_test.go
@@ -107,7 +107,7 @@ func TestOTelTraceEmitter_FullLifecycle(t *testing.T) {
 		t.Fatal("expected OTel spans to be exported, got none")
 	}
 
-	// We expect: 2 turn spans + 2 tool_call spans + 1 root span = 5.
+	// We expect: 2 turn spans + 2 tool spans + 1 root span = 5.
 	if len(spans) != 5 {
 		t.Errorf("expected 5 spans, got %d", len(spans))
 		for _, s := range spans {
@@ -129,8 +129,11 @@ func TestOTelTraceEmitter_FullLifecycle(t *testing.T) {
 	if spanNames["turn[2]"] != 1 {
 		t.Errorf("expected 1 'turn[2]' span, got %d", spanNames["turn[2]"])
 	}
-	if spanNames["tool_call"] != 2 {
-		t.Errorf("expected 2 'tool_call' spans, got %d", spanNames["tool_call"])
+	if spanNames["execute_tool read_file"] != 1 {
+		t.Errorf("expected 1 'execute_tool read_file' span, got %d", spanNames["execute_tool read_file"])
+	}
+	if spanNames["execute_tool write_file"] != 1 {
+		t.Errorf("expected 1 'execute_tool write_file' span, got %d", spanNames["execute_tool write_file"])
 	}
 
 	// Verify root span has correct attributes.
@@ -217,14 +220,14 @@ func TestOTelTraceEmitter_ToolCallAttributes(t *testing.T) {
 	spans := exporter.GetSpans()
 	var toolSpan tracetest.SpanStub
 	for _, s := range spans {
-		if s.Name == "tool_call" {
+		if s.Name == "execute_tool shell" {
 			toolSpan = s
 			break
 		}
 	}
 
 	if toolSpan.Name == "" {
-		t.Fatal("no tool_call span found")
+		t.Fatal("no 'execute_tool shell' span found")
 	}
 
 	assertAttribute(t, toolSpan, genAIToolNameKey, "shell")
@@ -490,6 +493,7 @@ func TestOTelTraceEmitter_GenAIAttributes(t *testing.T) {
 		ToolCalls:  1,
 		StopReason: "end_turn",
 		DurationMs: 5,
+		Model:      "claude-opus-4-8",
 	})
 	emitter.RecordToolCall(types.ToolCallTrace{
 		Name:       "read_file",
@@ -512,18 +516,19 @@ func TestOTelTraceEmitter_GenAIAttributes(t *testing.T) {
 			root = s
 		case "turn[1]":
 			turn = s
-		case "tool_call":
+		case "execute_tool read_file":
 			tool = s
 		}
 	}
 	if root.Name == "" || turn.Name == "" || tool.Name == "" {
-		t.Fatalf("expected run, turn[1], tool_call spans; got %v", spans)
+		t.Fatalf("expected run, turn[1], execute_tool read_file spans; got %v", spans)
 	}
 
-	// Root span: model, provider, conversation. gen_ai.agent.id is
-	// intentionally NOT emitted; the spec defines it as a persistent
-	// agent identity (e.g. an OpenAI Assistant ID), not a per-execution
-	// run ID.
+	// Root span: operation name, model, provider, conversation.
+	// gen_ai.agent.id is intentionally NOT emitted; the spec defines it
+	// as a persistent agent identity (e.g. an OpenAI Assistant ID), not
+	// a per-execution run ID.
+	assertAttribute(t, root, genAIOperationNameKey, "invoke_agent")
 	assertAttribute(t, root, genAIProviderNameKey, "anthropic")
 	assertAttribute(t, root, genAIRequestModelKey, "claude-sonnet-4-6")
 	assertAttribute(t, root, genAIConversationIDKey, "alignment-test")
@@ -533,12 +538,107 @@ func TestOTelTraceEmitter_GenAIAttributes(t *testing.T) {
 		}
 	}
 
-	// Turn span: usage tokens, finish reasons, operation name.
+	// Turn span: usage tokens, finish reasons, operation name, and the
+	// per-turn model/provider that backends type and price generations
+	// from. The turn-level model (the router's selection) wins over the
+	// run-level configured model.
 	assertIntAttribute(t, turn, genAIUsageInputTokens, 42)
 	assertIntAttribute(t, turn, genAIUsageOutputTokens, 17)
 	assertStringSliceAttribute(t, turn, genAIFinishReasonsKey, []string{"end_turn"})
 	assertAttribute(t, turn, genAIOperationNameKey, "chat")
+	assertAttribute(t, turn, genAIRequestModelKey, "claude-opus-4-8")
+	assertAttribute(t, turn, genAIProviderNameKey, "anthropic")
 
-	// Tool span: tool name.
+	// Tool span: tool name and operation name.
 	assertAttribute(t, tool, genAIToolNameKey, "read_file")
+	assertAttribute(t, tool, genAIOperationNameKey, "execute_tool")
+}
+
+// TestOTelTraceEmitter_TurnModelFallback pins the gen_ai.request.model
+// resolution order on turn spans: the router's per-turn selection
+// (TurnTrace.Model) wins, the run-level configured model fills in for
+// legacy summaries without one, and the attribute is absent when
+// neither is known — empty attributes pollute downstream filtering.
+func TestOTelTraceEmitter_TurnModelFallback(t *testing.T) {
+	timeout := 60
+	config := &types.RunConfig{
+		RunID:       "run-model-fallback",
+		Mode:        "execution",
+		MaxTurns:    5,
+		Timeout:     &timeout,
+		Provider:    types.ProviderConfig{Type: "anthropic"},
+		ModelRouter: types.ModelRouterConfig{Model: "config-model"},
+	}
+
+	t.Run("turn model wins over config", func(t *testing.T) {
+		emitter, exporter := newTestOTelEmitter()
+		emitter.Start("run-model-fallback", config)
+		emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "end_turn", DurationMs: 1, Model: "turn-model"})
+		if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		assertAttribute(t, findSpanByName(t, exporter.GetSpans(), "turn[1]"), genAIRequestModelKey, "turn-model")
+	})
+
+	t.Run("config model fills in", func(t *testing.T) {
+		emitter, exporter := newTestOTelEmitter()
+		emitter.Start("run-model-fallback", config)
+		emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "end_turn", DurationMs: 1})
+		if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		assertAttribute(t, findSpanByName(t, exporter.GetSpans(), "turn[1]"), genAIRequestModelKey, "config-model")
+	})
+
+	t.Run("absent when neither known", func(t *testing.T) {
+		emitter, exporter := newTestOTelEmitter()
+		emitter.Start("run-no-model", nil)
+		emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "end_turn", DurationMs: 1})
+		if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		span := findSpanByName(t, exporter.GetSpans(), "turn[1]")
+		for _, attr := range span.Attributes {
+			if string(attr.Key) == genAIRequestModelKey {
+				t.Errorf("%s should be absent when no model is known, found %q", genAIRequestModelKey, attr.Value.AsString())
+			}
+		}
+	})
+}
+
+// TestOTelTraceEmitter_UnknownToolSpanNameBounded pins the cardinality
+// bound on tool span names: an unknown-tool failure carries a
+// model-controlled tool name, which must not become an unbounded span
+// name (the vector issue #309 bounded on the loop's tool.<name> spans).
+// The raw requested name still rides the gen_ai.tool.name attribute.
+func TestOTelTraceEmitter_UnknownToolSpanNameBounded(t *testing.T) {
+	emitter, exporter := newTestOTelEmitter()
+
+	emitter.Start("run-unknown-tool", nil)
+	emitter.RecordToolCall(types.ToolCallTrace{
+		Name:          "totally_made_up_tool_9000",
+		DurationMs:    1,
+		Success:       false,
+		ErrorReason:   "unknown tool",
+		ErrorCategory: string(observability.ToolFailureUnknownTool),
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	span := findSpanByName(t, exporter.GetSpans(), "execute_tool")
+	assertAttribute(t, span, genAIToolNameKey, "totally_made_up_tool_9000")
+}
+
+// findSpanByName fails the test when no span with the given name was
+// exported.
+func findSpanByName(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+	for _, s := range spans {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("no span named %q exported", name)
+	return tracetest.SpanStub{}
 }

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -94,6 +94,10 @@ type TurnTrace struct {
 	ToolCalls  int        `json:"toolCalls"`
 	StopReason string     `json:"stopReason"`
 	DurationMs int64      `json:"durationMs"`
+	// Model is the router's resolved model for this turn. Empty on traces
+	// that predate the field; consumers fall back to the run-level
+	// configured model when absent.
+	Model string `json:"model,omitempty"`
 	// RunID identifies the run that produced this turn. Populated only
 	// when the turn originated in a sub-agent run forwarded to a parent
 	// emitter; absent (omitempty) on parent-emitted events to preserve


### PR DESCRIPTION
## What

Always-on (capture-independent) completion of the OTel GenAI semconv surface, PR 1 of 2 toward full backend hydration (Langfuse et al.):

- **Per-turn model**: `TurnTrace` gains `Model` (omitempty, wire-invisible today), stamped from the router's per-turn selection at all five `RecordTurn` sites; turn spans emit `gen_ai.request.model` (turn model > config fallback > absent) and `gen_ai.provider.name`. Backends type and price generations from span-level model — the root-span copy was not enough, and `gen_ai.request.model` is Required on chat spans per the pinned semconv (v1.40.0).
- **Operation names**: root span gains `gen_ai.operation.name: invoke_agent` (keeps the `run` name — no agent-name concept, #127); tool spans gain `execute_tool` and are renamed `tool_call` → `execute_tool {gen_ai.tool.name}` per semconv, **bounded** for unknown-tool failures so a model-controlled name cannot become span-name cardinality (the vector #309 bounded on the loop's `tool.<name>` spans).
- **Error status**: root span sets `codes.Error` + outcome for every non-success outcome (including `cancelled`; `run.outcome` / `run.cancelled_by` disambiguate), turn spans mark the loop's `"error"` stop-reason sentinel, failed tool spans carry scrubbed `ErrorReason` as status description plus `error.type` valued with the bounded `ToolFailureCategory` enum. Backends map OTel status to their error level — this is what makes failed runs filterable.

## Operator-visible changes

- Tool span rename `tool_call` → `execute_tool <name>`: dashboards keyed on the old span name need updating (pre-1.0 clean break).
- New attributes on existing spans; no content, nothing capture-gated here.

## Verification

`just test` and `just lint` green. End-to-end against a live Langfuse (with PR 2 stacked on top): generations show `model` + usage, tool observations type as TOOL, a provider-500 run shows `level: ERROR` with status `error` on trace and turn, an unknown-tool call shows a TOOL observation at `level: ERROR` with the failure reason — full matrix in PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)