### PR TITLE
trace, docs: capture-gated content hydration (root I/O, tool I/O) + Langfuse recipe

### DIFF
--- a/docs/observability-cloud.md
+++ b/docs/observability-cloud.md
@@ -3,8 +3,8 @@
 Stirrup's OTel exporters speak both **OTLP/gRPC** (the default) and
 **OTLP/HTTP with binary protobuf** (issue #100). The HTTP path is what
 unlocks first-class native support for Grafana Cloud, Honeycomb, GCP
-Cloud Trace, Datadog's OTLP intake, and the long tail of managed APMs
-that reject gRPC at the edge.
+Cloud Trace, Datadog's OTLP intake, Langfuse, and the long tail of
+managed APMs that reject gRPC at the edge.
 
 This document is the operator walkthrough. For the underlying signal
 model — what spans, metrics, and resource attributes Stirrup emits —
@@ -117,9 +117,78 @@ Prefer `--otel-header` where both are available.
 | Honeycomb | `https://api.honeycomb.io` | `x-honeycomb-team: secret://HC_API_KEY` |
 | GCP Cloud Trace (via gateway) | gateway URL | `Authorization: secret://GCP_BEARER` |
 | Datadog OTLP intake | `https://trace.agent.datadoghq.com` | `dd-api-key: secret://DD_API_KEY` |
+| Langfuse (cloud or self-hosted) | `https://cloud.langfuse.com/api/public/otel` | `Authorization: secret://LANGFUSE_AUTH` |
 
 Stirrup does not vendor-detect — `protocol`, `endpoint`, and `headers`
 are sufficient for any OTLP/HTTP-protobuf gateway.
+
+## Langfuse
+
+Langfuse is an LLM-observability backend that ingests OTLP natively
+and reads the GenAI semantic-convention attributes Stirrup emits — no
+vendor-specific configuration exists or is needed. Self-hosted
+requires v3.22.0+.
+
+```json
+{
+  "traceEmitter": {
+    "type": "otel",
+    "protocol": "http/protobuf",
+    "endpoint": "http://localhost:3000/api/public/otel",
+    "metricsEndpoint": "http://localhost:3000/api/public/otel",
+    "headers": {
+      "Authorization": "secret://LANGFUSE_AUTH"
+    }
+  }
+}
+```
+
+where the secret resolves to Basic auth over the project's API key
+pair:
+
+```sh
+export LANGFUSE_AUTH="Basic $(printf '%s' 'pk-lf-...:sk-lf-...' | base64)"
+```
+
+**`protocol: "http/protobuf"` is required.** Langfuse's OTLP ingest is
+HTTP-only; on the default gRPC path the spans are silently dropped.
+The per-signal URL appending (below) lands exactly on Langfuse's
+`/api/public/otel/v1/traces` and `/v1/metrics` routes.
+
+How Stirrup's signal model surfaces in Langfuse:
+
+- **Observation typing.** The root `run` span
+  (`gen_ai.operation.name: invoke_agent`) renders as an agent
+  observation, `turn[N]` spans (`chat`) as generations, and
+  `execute_tool <name>` spans as tool observations.
+- **Input/output panels** populate only with
+  [`captureContent`](#span-content-capture-opt-in): the root span's
+  run-level I/O feeds the trace-level input/output views, turn spans
+  feed per-generation I/O, and tool spans feed per-tool
+  arguments/results. Without the toggle, traces show structure,
+  usage, model, and timing with empty content panels.
+- **Cost.** Generations carry `gen_ai.request.model` per turn;
+  Langfuse prices models it recognises by name and needs a custom
+  model definition for others.
+- **Error filtering.** Failed runs, turns, and tool calls carry OTel
+  error status, which Langfuse maps to `level: ERROR` with the status
+  message — filter traces and observations by level to triage
+  failures.
+- **Sessions.** `--session-name` is emitted as
+  `gen_ai.conversation.id`, which Langfuse maps to its session
+  grouping natively.
+- **Environments.** `observability.environment` reaches Langfuse via
+  the `deployment.environment` resource attribute.
+
+One rendering caveat: Stirrup serialises message content in the
+semconv parts schema (`{role, parts: [...]}`), which Langfuse ingests
+and displays but does not yet pretty-render as chat bubbles — the
+content panels show structured JSON. Backend-native concepts beyond
+these (Langfuse users, tags) live in the `langfuse.*` attribute
+namespace, which Stirrup deliberately does not emit; operators who
+need them can rewrite attributes in a collector
+(`transformprocessor`), keeping the vendor mapping in operator
+config.
 
 ## Span content capture (opt-in)
 
@@ -130,15 +199,16 @@ Datadog LLM Observability, Phoenix) shows correct structure, token
 usage, model, and timing, with an empty prompt/IO view.
 
 `traceEmitter.captureContent: true` (CLI: `--otel-capture-content`)
-opts the run into recording content on each `turn[N]` span using the
-standard GenAI semantic-convention attributes those backends read
-natively:
+opts the run into recording content using the standard GenAI
+semantic-convention attributes those backends read natively:
 
-| Attribute | Carries |
-|---|---|
-| `gen_ai.input.messages` | The message history the model saw on the turn (JSON, semconv message schema). |
-| `gen_ai.output.messages` | The model's response blocks, including tool calls, with `finish_reason`. |
-| `gen_ai.system_instructions` | The run's built system prompt. |
+| Attribute | On | Carries |
+|---|---|---|
+| `gen_ai.input.messages` | `turn[N]` | The message history the model saw on the turn (JSON, semconv message schema). |
+| `gen_ai.output.messages` | `turn[N]` | The model's response blocks, including tool calls, with `finish_reason`. |
+| `gen_ai.system_instructions` | `turn[N]` | The run's built system prompt. |
+| `gen_ai.input.messages` / `gen_ai.output.messages` | `run` (root) | Run-level I/O — the seed prompt and the final assistant message — feeding backends' trace-level input/output views. |
+| `gen_ai.tool.call.id` / `.arguments` / `.result` | `execute_tool <name>` | Each tool call's identifier, input arguments, and result text. |
 
 The toggle is vendor-neutral: no backend detection, no vendor
 attribute namespace — any OTLP consumer that understands the GenAI
@@ -146,10 +216,11 @@ conventions gets the same view.
 
 Safety properties:
 
-- **Off by default.** The OTel GenAI spec marks message content
-  Opt-In precisely because it is likely to contain PII. With the
-  toggle off, span output is byte-identical to the no-capture
-  emitter.
+- **Off by default.** The OTel GenAI spec marks message and tool-call
+  content Opt-In precisely because it is likely to contain PII. With
+  the toggle off, span output is identical to the capture-on output
+  minus the content attributes — counters, typing, model, and error
+  status are capture-independent.
 - **Scrubbed before export.** Content passes through the same
   `security.Scrub` defence-in-depth layer the JSONL emitter applies
   to its `turn_record` lines, so secret-shaped substrings are

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -329,6 +329,7 @@ func (l *AgenticLoop) planAndDispatch(
 			internalForTrace = p.internalName
 		}
 		l.Trace.RecordToolCall(types.ToolCallTrace{
+			ID:            p.call.ID,
 			Name:          p.call.Name,
 			InternalName:  internalForTrace,
 			DurationMs:    callDuration.Milliseconds(),

--- a/harness/internal/core/subagent_test.go
+++ b/harness/internal/core/subagent_test.go
@@ -533,6 +533,9 @@ func TestSpawnSubAgent_TraceToolCallsForwardedToParent(t *testing.T) {
 		if c.Name != "test_tool" {
 			t.Errorf("forwarded ToolCallTrace.Name: got %q, want %q", c.Name, "test_tool")
 		}
+		if c.ID != "tc_1" {
+			t.Errorf("forwarded ToolCallTrace.ID: got %q, want the provider's tool_use ID %q", c.ID, "tc_1")
+		}
 	}
 }
 

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -159,6 +159,7 @@ func (e *JSONLTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	// tool_call_record here so live consumers see per-call events
 	// before the turn finishes.
 	tc := types.ToolCallRecord{
+		ID:      call.ID,
 		Name:    call.Name,
 		Success: call.Success,
 		// DurationMs and other counters live on call; for the

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -122,6 +122,18 @@ type OTelTraceEmitter struct {
 	// forwarded a prompt.
 	systemInstructionsJSON string
 
+	// rootInputMessagesJSON / rootOutputMessagesJSON are the run-level
+	// content stamped on the root span at Finish, making the root span a
+	// complete invoke_agent observation (the agent's input and final
+	// output) for backends that derive trace-level views from it. Both
+	// are retained from the parent run's own turn records (RunID == "");
+	// forwarded sub-agent records never contribute. Input is set-once —
+	// turn 0's input messages are exactly the seed prompt — and output
+	// is overwrite-always so the final assistant message wins. Empty
+	// when capture is off.
+	rootInputMessagesJSON  string
+	rootOutputMessagesJSON string
+
 	// pendingTurns buffers turn summaries (and the span timestamps
 	// derived at RecordTurn time) between RecordTurn and the matching
 	// RecordTurnRecord while capture is on, so a single turn[N] span
@@ -350,6 +362,8 @@ func (e *OTelTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.toolCalls = nil
 	e.permissionDenials = 0
 	e.systemInstructionsJSON = ""
+	e.rootInputMessagesJSON = ""
+	e.rootOutputMessagesJSON = ""
 	e.pendingTurns = nil
 
 	ctx := context.Background()
@@ -549,11 +563,13 @@ func (e *OTelTraceEmitter) RecordTurnRecord(turn types.TurnRecord) {
 		// the same span (raw provider vocabulary, not the semconv enum,
 		// for consistency between the two surfaces).
 		content.outputMessages = genAIOutputMessagesJSON(scrubbed.ModelOutput, pending.trace.StopReason)
+		e.retainRootContentLocked(scrubbed.RunID, content)
 		e.emitTurnSpanLocked(pending.trace, pending.spanStart, pending.spanEnd, content)
 		return
 	}
 
 	content.outputMessages = genAIOutputMessagesJSON(scrubbed.ModelOutput, "")
+	e.retainRootContentLocked(scrubbed.RunID, content)
 	attrs := append([]attribute.KeyValue{
 		attribute.Int("turn.number", scrubbed.Turn),
 		attribute.String(genAIOperationNameKey, "chat"),
@@ -569,6 +585,28 @@ func (e *OTelTraceEmitter) RecordTurnRecord(turn types.TurnRecord) {
 		oteltrace.WithAttributes(attrs...),
 	)
 	span.End(oteltrace.WithTimestamp(now))
+}
+
+// retainRootContentLocked feeds a captured turn's content into the
+// run-level slots stamped on the root span at Finish. Only the parent
+// run's own records contribute (runID is empty exactly there; forwarded
+// sub-agent records carry the child's run ID) — a sub-agent's transcript
+// is its spawn_agent tool call's business, not the run's I/O. Input is
+// set-once: turn 0's input messages are the seed prompt verbatim, and if
+// that record never arrives, a later turn's history still embeds the
+// seed. Output overwrites so the final assistant message wins; an empty
+// serialisation (e.g. an aborted turn with no output blocks) never
+// clobbers earlier content. Must be called with e.mu held.
+func (e *OTelTraceEmitter) retainRootContentLocked(runID string, content *turnContent) {
+	if runID != "" {
+		return
+	}
+	if e.rootInputMessagesJSON == "" {
+		e.rootInputMessagesJSON = content.inputMessages
+	}
+	if content.outputMessages != "" {
+		e.rootOutputMessagesJSON = content.outputMessages
+	}
 }
 
 // RecordSystemInstructions stores the run's built system prompt for
@@ -685,6 +723,19 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 			attribute.Int("run.turns", len(e.turns)),
 			attribute.Int("run.permission_denials", e.permissionDenials),
 		)
+		// Stamp the run-level content retained from the parent run's
+		// turn records (see retainRootContentLocked), completing the
+		// root span as an invoke_agent observation. Must happen before
+		// End below — the SDK silently drops attributes set afterwards.
+		if e.captureContent {
+			rootContent := turnContent{
+				inputMessages:  e.rootInputMessagesJSON,
+				outputMessages: e.rootOutputMessagesJSON,
+			}
+			if attrs := rootContent.attributes(e.systemInstructionsJSON); len(attrs) > 0 {
+				e.rootSpan.SetAttributes(attrs...)
+			}
+		}
 		// Every non-success outcome — including cancelled — marks the
 		// root Error so backends expose one "didn't finish" predicate;
 		// the run.outcome attribute (and run.cancelled_by, when set by

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -60,6 +60,15 @@ const (
 	genAIInputMessagesKey      = "gen_ai.input.messages"
 	genAIOutputMessagesKey     = "gen_ai.output.messages"
 	genAISystemInstructionsKey = "gen_ai.system_instructions"
+
+	// Tool-call content attributes, likewise capture-gated: the spec
+	// marks gen_ai.tool.call.arguments / .result Opt-In for the same
+	// PII reasons as message content. The call ID rides along so a tool
+	// span correlates with the tool_call / tool_call_response parts
+	// inside the surrounding turn's message attributes.
+	genAIToolCallIDKey        = "gen_ai.tool.call.id"
+	genAIToolCallArgumentsKey = "gen_ai.tool.call.arguments"
+	genAIToolCallResultKey    = "gen_ai.tool.call.result"
 )
 
 // genAIProviderName maps stirrup provider type strings to the OTel GenAI
@@ -145,6 +154,16 @@ type OTelTraceEmitter struct {
 	// return) are flushed as plain counter spans at Finish. Nil when
 	// capture is off.
 	pendingTurns map[pendingTurnKey]pendingTurn
+
+	// pendingToolCalls is the tool-call analogue of pendingTurns: while
+	// capture is on, RecordToolCall buffers the summary (timestamps
+	// frozen) until the enclosing turn's RecordTurnRecord delivers the
+	// call's arguments and result, so one execute_tool span carries the
+	// counters and the content together. Keyed by (RunID, tool_use ID);
+	// calls without an ID are un-keyable and emit immediately as plain
+	// spans instead of buffering. Entries whose record never arrives are
+	// flushed as plain spans at Finish. Nil when capture is off.
+	pendingToolCalls map[pendingToolKey]pendingToolCall
 }
 
 // Compile-time interface satisfaction guards: the loop discovers the
@@ -168,6 +187,21 @@ type pendingTurnKey struct {
 // the same timestamps an unmerged span would have.
 type pendingTurn struct {
 	trace     types.TurnTrace
+	spanStart time.Time
+	spanEnd   time.Time
+}
+
+// pendingToolKey pairs a buffered tool call summary with its later
+// transcript entry. See OTelTraceEmitter.pendingToolCalls.
+type pendingToolKey struct {
+	runID string
+	id    string
+}
+
+// pendingToolCall is a tool call summary awaiting its transcript entry,
+// with the span timing frozen at RecordToolCall time.
+type pendingToolCall struct {
+	call      types.ToolCallTrace
 	spanStart time.Time
 	spanEnd   time.Time
 }
@@ -365,6 +399,7 @@ func (e *OTelTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.rootInputMessagesJSON = ""
 	e.rootOutputMessagesJSON = ""
 	e.pendingTurns = nil
+	e.pendingToolCalls = nil
 
 	ctx := context.Background()
 	// NOTE: gen_ai.agent.id is intentionally NOT emitted. The OTel GenAI spec
@@ -565,26 +600,73 @@ func (e *OTelTraceEmitter) RecordTurnRecord(turn types.TurnRecord) {
 		content.outputMessages = genAIOutputMessagesJSON(scrubbed.ModelOutput, pending.trace.StopReason)
 		e.retainRootContentLocked(scrubbed.RunID, content)
 		e.emitTurnSpanLocked(pending.trace, pending.spanStart, pending.spanEnd, content)
-		return
+	} else {
+		content.outputMessages = genAIOutputMessagesJSON(scrubbed.ModelOutput, "")
+		e.retainRootContentLocked(scrubbed.RunID, content)
+		attrs := append([]attribute.KeyValue{
+			attribute.Int("turn.number", scrubbed.Turn),
+			attribute.String(genAIOperationNameKey, "chat"),
+		}, content.attributes(e.systemInstructionsJSON)...)
+		// No summary means no duration to derive timing from: the span is
+		// pinned to the wall clock at delivery time (start == end). That is
+		// a deliberate degraded shape for a path the loop never takes — the
+		// content is preserved, the timing is honest about knowing only
+		// when the record arrived.
+		now := time.Now()
+		_, span := e.tracer.Start(e.rootCtx, fmt.Sprintf("turn[%d]", scrubbed.Turn),
+			oteltrace.WithTimestamp(now),
+			oteltrace.WithAttributes(attrs...),
+		)
+		span.End(oteltrace.WithTimestamp(now))
 	}
 
-	content.outputMessages = genAIOutputMessagesJSON(scrubbed.ModelOutput, "")
-	e.retainRootContentLocked(scrubbed.RunID, content)
-	attrs := append([]attribute.KeyValue{
-		attribute.Int("turn.number", scrubbed.Turn),
-		attribute.String(genAIOperationNameKey, "chat"),
-	}, content.attributes(e.systemInstructionsJSON)...)
-	// No summary means no duration to derive timing from: the span is
-	// pinned to the wall clock at delivery time (start == end). That is
-	// a deliberate degraded shape for a path the loop never takes — the
-	// content is preserved, the timing is honest about knowing only
-	// when the record arrived.
-	now := time.Now()
-	_, span := e.tracer.Start(e.rootCtx, fmt.Sprintf("turn[%d]", scrubbed.Turn),
-		oteltrace.WithTimestamp(now),
-		oteltrace.WithAttributes(attrs...),
-	)
-	span.End(oteltrace.WithTimestamp(now))
+	// The record also carries the turn's tool transcript: pair each
+	// entry with its buffered summary and emit the execute_tool spans.
+	// Runs after the turn-span branch on both arms — a record that
+	// missed its turn summary can still complete its tool spans.
+	e.emitCapturedToolSpansLocked(scrubbed)
+}
+
+// emitCapturedToolSpansLocked emits execute_tool spans for a captured
+// turn record's tool calls, merging each with the summary RecordToolCall
+// buffered under (RunID, tool_use ID). The inputs are already scrubbed —
+// the caller passes the scrubTurnRecord output, which covers tool Input
+// and Output. Must be called with e.mu held.
+//
+// Entries without an ID are skipped: their plain span was already
+// emitted on RecordToolCall's immediate path, and a content span here
+// would double-count the call. Entries with no buffered summary (a
+// forwarded sub-agent record arriving unpaired) synthesise counters from
+// the record itself — unlike the unpaired-turn fallback, the record
+// carries a real duration, so span timing derives from it.
+func (e *OTelTraceEmitter) emitCapturedToolSpansLocked(scrubbed types.TurnRecord) {
+	for _, tc := range scrubbed.ToolCalls {
+		if tc.ID == "" {
+			continue
+		}
+		content := &toolContent{
+			id:        tc.ID,
+			arguments: validRawJSON(tc.Input),
+			result:    tc.Output,
+		}
+		key := pendingToolKey{runID: scrubbed.RunID, id: tc.ID}
+		if pending, ok := e.pendingToolCalls[key]; ok {
+			delete(e.pendingToolCalls, key)
+			e.emitToolSpanLocked(pending.call, pending.spanStart, pending.spanEnd, content)
+			continue
+		}
+		spanEnd := time.Now()
+		spanStart := spanEnd.Add(-time.Duration(tc.DurationMs) * time.Millisecond)
+		e.emitToolSpanLocked(types.ToolCallTrace{
+			ID:           tc.ID,
+			Name:         tc.Name,
+			InternalName: tc.InternalName,
+			DurationMs:   tc.DurationMs,
+			Success:      tc.Success,
+			RunID:        scrubbed.RunID,
+			ParentRunID:  scrubbed.ParentRunID,
+		}, spanStart, spanEnd, content)
+	}
 }
 
 // retainRootContentLocked feeds a captured turn's content into the
@@ -629,6 +711,14 @@ func (e *OTelTraceEmitter) RecordSystemInstructions(system string) {
 }
 
 // RecordToolCall creates a child span for a tool invocation.
+//
+// When content capture is on and the call carries a tool_use ID, the
+// span is not emitted here: the summary is buffered (timestamps frozen)
+// until the enclosing turn's RecordTurnRecord delivers the call's
+// arguments and result, so one execute_tool span carries counters and
+// content together. Calls without an ID are un-keyable for pairing and
+// emit immediately; unmatched entries are flushed as plain spans at
+// Finish.
 func (e *OTelTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -642,11 +732,32 @@ func (e *OTelTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 	spanEnd := time.Now()
 	spanStart := spanEnd.Add(-time.Duration(call.DurationMs) * time.Millisecond)
 
-	e.emitToolSpanLocked(call, spanStart, spanEnd)
+	if e.captureContent && call.ID != "" {
+		key := pendingToolKey{runID: call.RunID, id: call.ID}
+		if prev, ok := e.pendingToolCalls[key]; ok {
+			// A second summary under the same key without an intervening
+			// record. Provider IDs are unique within a stream, so this is
+			// defensive (mirroring the duplicate-summary handling in
+			// RecordTurn): flush the stale entry as a plain span rather
+			// than silently dropping it.
+			e.emitToolSpanLocked(prev.call, prev.spanStart, prev.spanEnd, nil)
+		}
+		if e.pendingToolCalls == nil {
+			e.pendingToolCalls = map[pendingToolKey]pendingToolCall{}
+		}
+		e.pendingToolCalls[key] = pendingToolCall{call: call, spanStart: spanStart, spanEnd: spanEnd}
+		return
+	}
+
+	e.emitToolSpanLocked(call, spanStart, spanEnd, nil)
 }
 
-// emitToolSpanLocked creates and ends the execute_tool child span. Must
-// be called with e.mu held.
+// emitToolSpanLocked creates and ends the execute_tool child span.
+// content is nil on the no-capture path (and for flushed unmatched
+// summaries), keeping the attribute set identical to the
+// capture-off emitter; non-nil content appends the gen_ai.tool.call.*
+// attributes after the counter attributes, mirroring
+// emitTurnSpanLocked's contract. Must be called with e.mu held.
 //
 // The span name follows the semconv "execute_tool {gen_ai.tool.name}"
 // form so each tool reads distinctly in backend trace trees — except
@@ -655,7 +766,7 @@ func (e *OTelTraceEmitter) RecordToolCall(call types.ToolCallTrace) {
 // the cardinality vector #309 bounded on the loop's tool.<name> spans.
 // Those calls use the bare operation name, and the raw requested name
 // still rides the bounded-cardinality-safe gen_ai.tool.name attribute.
-func (e *OTelTraceEmitter) emitToolSpanLocked(call types.ToolCallTrace, spanStart, spanEnd time.Time) {
+func (e *OTelTraceEmitter) emitToolSpanLocked(call types.ToolCallTrace, spanStart, spanEnd time.Time, content *toolContent) {
 	name := "execute_tool " + call.Name
 	if call.ErrorCategory == string(observability.ToolFailureUnknownTool) {
 		name = "execute_tool"
@@ -669,6 +780,9 @@ func (e *OTelTraceEmitter) emitToolSpanLocked(call types.ToolCallTrace, spanStar
 	}
 	if !call.Success && call.ErrorCategory != "" {
 		attrs = append(attrs, attribute.String(errorTypeKey, call.ErrorCategory))
+	}
+	if content != nil {
+		attrs = append(attrs, content.attributes()...)
 	}
 
 	_, span := e.tracer.Start(e.rootCtx, name,
@@ -715,6 +829,14 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 		e.emitTurnSpanLocked(pending.trace, pending.spanStart, pending.spanEnd, nil)
 	}
 	e.pendingTurns = nil
+
+	// Same flush for tool call summaries whose transcript entry never
+	// arrived: a missing record costs the content attributes, never the
+	// tool span itself.
+	for _, pending := range e.pendingToolCalls {
+		e.emitToolSpanLocked(pending.call, pending.spanStart, pending.spanEnd, nil)
+	}
+	e.pendingToolCalls = nil
 
 	// Set outcome on root span and end it.
 	if e.rootSpan != nil && e.rootSpan.SpanContext().IsValid() {

--- a/harness/internal/trace/otel_content.go
+++ b/harness/internal/trace/otel_content.go
@@ -53,6 +53,33 @@ func (c *turnContent) attributes(systemInstructionsJSON string) []attribute.KeyV
 	return attrs
 }
 
+// toolContent carries the content attributes for one captured
+// execute_tool span: the tool_use ID and the call's arguments/result.
+// Arguments and result are the semconv gen_ai.tool.call.{arguments,
+// result} attributes ("Any" typed in the spec; the JSON-string /
+// plain-string fallback applies, same as the message attributes).
+type toolContent struct {
+	id        string
+	arguments json.RawMessage
+	result    string
+}
+
+// attributes renders the non-empty fields as span attributes, mirroring
+// turnContent.attributes' skip-empty contract.
+func (c *toolContent) attributes() []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 3)
+	if c.id != "" {
+		attrs = append(attrs, attribute.String(genAIToolCallIDKey, c.id))
+	}
+	if len(c.arguments) > 0 {
+		attrs = append(attrs, attribute.String(genAIToolCallArgumentsKey, string(c.arguments)))
+	}
+	if c.result != "" {
+		attrs = append(attrs, attribute.String(genAIToolCallResultKey, c.result))
+	}
+	return attrs
+}
+
 // genAIMessage mirrors the ChatMessage / OutputMessage shape shared by
 // the input- and output-messages schemas. FinishReason is only set on
 // output messages (omitempty keeps it off input messages).

--- a/harness/internal/trace/otel_content_test.go
+++ b/harness/internal/trace/otel_content_test.go
@@ -417,3 +417,111 @@ func TestOTelTraceEmitter_CaptureContent_PairsByRunID(t *testing.T) {
 	assertIntAttribute(t, *childSpan, genAIUsageInputTokens, 77)
 	assertIntAttribute(t, *parentSpan, genAIUsageInputTokens, 1000)
 }
+
+// TestOTelTraceEmitter_CaptureContent_RootSpanIO pins the run-level
+// content surface: the root span carries the first parent turn's input
+// (the seed prompt), the last parent turn's output (the final assistant
+// message), and the system instructions — and forwarded sub-agent
+// records contribute to none of them. Backends derive their trace-level
+// input/output views from the root span, so a regression here empties
+// those panels while leaving every turn span intact.
+func TestOTelTraceEmitter_CaptureContent_RootSpanIO(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-root-io", nil)
+	emitter.RecordSystemInstructions("You are a coding agent.")
+
+	// Parent turn 0: the seed prompt and an intermediate answer.
+	emitter.RecordTurn(types.TurnTrace{Turn: 0, StopReason: "tool_use", DurationMs: 10})
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 0,
+		ModelInput: types.ModelInput{Messages: []types.Message{{
+			Role:    "user",
+			Content: []types.ContentBlock{{Type: "text", Text: "the seed prompt"}},
+		}}},
+		ModelOutput: []types.ContentBlock{{Type: "text", Text: "intermediate answer"}},
+	})
+
+	// A forwarded sub-agent record between the parent's turns: must not
+	// leak into the run-level slots.
+	emitter.RecordTurn(types.TurnTrace{Turn: 0, RunID: "child-run", ParentRunID: "run-root-io", StopReason: "end_turn", DurationMs: 5})
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 0, RunID: "child-run", ParentRunID: "run-root-io",
+		ModelInput: types.ModelInput{Messages: []types.Message{{
+			Role:    "user",
+			Content: []types.ContentBlock{{Type: "text", Text: "child sub-task"}},
+		}}},
+		ModelOutput: []types.ContentBlock{{Type: "text", Text: "child answer"}},
+	})
+
+	// Parent turn 1: history embeds the seed; output is the final answer.
+	emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "end_turn", DurationMs: 10})
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 1,
+		ModelInput: types.ModelInput{Messages: []types.Message{{
+			Role:    "user",
+			Content: []types.ContentBlock{{Type: "text", Text: "the seed prompt"}},
+		}, {
+			Role:    "assistant",
+			Content: []types.ContentBlock{{Type: "text", Text: "intermediate answer"}},
+		}}},
+		ModelOutput: []types.ContentBlock{{Type: "text", Text: "the final answer"}},
+	})
+
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	root := findSpan(t, exporter, "run")
+
+	input, ok := spanAttrString(root, genAIInputMessagesKey)
+	if !ok {
+		t.Fatal("root span missing gen_ai.input.messages")
+	}
+	if !strings.Contains(input, "the seed prompt") {
+		t.Errorf("root input should carry the seed prompt, got %q", input)
+	}
+	if strings.Contains(input, "intermediate answer") {
+		t.Errorf("root input must be turn 0's input (set-once), not a later turn's history: %q", input)
+	}
+
+	output, ok := spanAttrString(root, genAIOutputMessagesKey)
+	if !ok {
+		t.Fatal("root span missing gen_ai.output.messages")
+	}
+	if !strings.Contains(output, "the final answer") {
+		t.Errorf("root output should carry the last parent turn's output, got %q", output)
+	}
+
+	for _, val := range []string{input, output} {
+		if strings.Contains(val, "child") {
+			t.Errorf("forwarded sub-agent content leaked into root span: %q", val)
+		}
+	}
+
+	system, ok := spanAttrString(root, genAISystemInstructionsKey)
+	if !ok || !strings.Contains(system, "You are a coding agent.") {
+		t.Errorf("root span system instructions: got %q (present=%v)", system, ok)
+	}
+}
+
+// TestOTelTraceEmitter_CaptureContent_RootSpanIOAbsentWithoutRecords
+// pins the degraded shape: a run that produced no transcript records
+// (every loop error path) finishes with a bare root span — no content
+// keys, never empty-string attributes.
+func TestOTelTraceEmitter_CaptureContent_RootSpanIOAbsentWithoutRecords(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-root-bare", nil)
+	emitter.RecordTurn(types.TurnTrace{Turn: 0, StopReason: "", DurationMs: 5})
+	if _, err := emitter.Finish(context.Background(), "error"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	root := findSpan(t, exporter, "run")
+	for _, key := range []string{genAIInputMessagesKey, genAIOutputMessagesKey, genAISystemInstructionsKey} {
+		if val, ok := spanAttrString(root, key); ok {
+			t.Errorf("root span carries %q (%q) with no records", key, val)
+		}
+	}
+}

--- a/harness/internal/trace/otel_content_test.go
+++ b/harness/internal/trace/otel_content_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -99,17 +100,27 @@ func TestOTelTraceEmitter_RecordTurnRecord_NoOpWithoutCapture(t *testing.T) {
 		StopReason: "end_turn",
 		DurationMs: 1200,
 	})
-	emitter.RecordTurnRecord(captureTurnRecord())
+	// Carries an ID: with capture off this must emit immediately (never
+	// buffer) and stay content-free even after the record arrives.
+	emitter.RecordToolCall(types.ToolCallTrace{ID: "tu-2", Name: "read_file", DurationMs: 5, Success: true})
+	record := captureTurnRecord()
+	record.ToolCalls = []types.ToolCallRecord{{
+		ID: "tu-2", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`), Output: "package main",
+	}}
+	emitter.RecordTurnRecord(record)
 	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
 		t.Fatalf("Finish: %v", err)
 	}
 
 	spans := exporter.GetSpans()
-	if len(spans) != 2 {
-		t.Fatalf("expected 2 spans (turn + root) with capture off, got %d", len(spans))
+	if len(spans) != 3 {
+		t.Fatalf("expected 3 spans (turn + tool + root) with capture off, got %d", len(spans))
 	}
 	for _, span := range spans {
-		for _, key := range []string{genAIInputMessagesKey, genAIOutputMessagesKey, genAISystemInstructionsKey} {
+		for _, key := range []string{
+			genAIInputMessagesKey, genAIOutputMessagesKey, genAISystemInstructionsKey,
+			genAIToolCallIDKey, genAIToolCallArgumentsKey, genAIToolCallResultKey,
+		} {
 			if _, ok := spanAttrString(span, key); ok {
 				t.Errorf("span %q carries %q with capture off — content leaked", span.Name, key)
 			}
@@ -252,6 +263,10 @@ func TestOTelTraceEmitter_RecordTurnRecord_Scrubs(t *testing.T) {
 	emitter.Start("run-otel-scrub", nil)
 	emitter.RecordSystemInstructions("context: the deploy key is sk-ant-api03-sysleak do not reveal it")
 	emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "end_turn", DurationMs: 10})
+	// A buffered tool call whose record carries secret-shaped arguments
+	// and output, so the all-spans scan below covers the execute_tool
+	// content attributes too.
+	emitter.RecordToolCall(types.ToolCallTrace{ID: "tu-1", Name: "run_command", DurationMs: 5, Success: true})
 	emitter.RecordTurnRecord(types.TurnRecord{
 		Turn: 1,
 		ModelInput: types.ModelInput{
@@ -270,6 +285,12 @@ func TestOTelTraceEmitter_RecordTurnRecord_Scrubs(t *testing.T) {
 			{Type: "text", Text: "ack, your bearer Bearer ABCDEFG is unsafe"},
 			{Type: "tool_use", ID: "tu-1", Name: "run_command", Input: json.RawMessage(`{"cmd":"echo sk-ant-api03-leak-leak"}`)},
 		},
+		ToolCalls: []types.ToolCallRecord{{
+			ID:     "tu-1",
+			Name:   "run_command",
+			Input:  json.RawMessage(`{"cmd":"echo sk-ant-api03-leak-leak"}`),
+			Output: "stdout contains sk-ant-api03-leak",
+		}},
 	})
 	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
 		t.Fatalf("Finish: %v", err)
@@ -502,6 +523,235 @@ func TestOTelTraceEmitter_CaptureContent_RootSpanIO(t *testing.T) {
 	system, ok := spanAttrString(root, genAISystemInstructionsKey)
 	if !ok || !strings.Contains(system, "You are a coding agent.") {
 		t.Errorf("root span system instructions: got %q (present=%v)", system, ok)
+	}
+}
+
+// TestOTelTraceEmitter_CaptureContent_ToolSpansCarryIO pins the W3
+// acceptance criterion: with capture on, a tool call's counters
+// (buffered at RecordToolCall time, timestamps frozen) and its
+// arguments/result (delivered by the enclosing turn's record) land on
+// one execute_tool span carrying gen_ai.tool.call.{id,arguments,result}.
+func TestOTelTraceEmitter_CaptureContent_ToolSpansCarryIO(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-tool-io", nil)
+	emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "tool_use", DurationMs: 40})
+	emitter.RecordToolCall(types.ToolCallTrace{ID: "tu-9", Name: "read_file", DurationMs: 12, Success: true})
+
+	// Nothing exports until the record arrives: the summary is buffered.
+	for _, s := range exporter.GetSpans() {
+		if strings.HasPrefix(s.Name, "execute_tool") {
+			t.Fatalf("tool span %q exported before its record arrived — buffering broken", s.Name)
+		}
+	}
+
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 1,
+		ModelOutput: []types.ContentBlock{
+			{Type: "tool_use", ID: "tu-9", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+		},
+		ToolCalls: []types.ToolCallRecord{{
+			ID:         "tu-9",
+			Name:       "read_file",
+			Input:      json.RawMessage(`{"path":"main.go"}`),
+			Output:     "package main",
+			DurationMs: 12,
+			Success:    true,
+		}},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	span := findSpan(t, exporter, "execute_tool read_file")
+
+	// Counters from the buffered summary.
+	assertAttribute(t, span, genAIToolNameKey, "read_file")
+	assertAttribute(t, span, genAIOperationNameKey, "execute_tool")
+
+	// Content from the record.
+	assertAttribute(t, span, genAIToolCallIDKey, "tu-9")
+	args, _ := spanAttrString(span, genAIToolCallArgumentsKey)
+	if args != `{"path":"main.go"}` {
+		t.Errorf("gen_ai.tool.call.arguments = %q, want the call input", args)
+	}
+	result, _ := spanAttrString(span, genAIToolCallResultKey)
+	if result != "package main" {
+		t.Errorf("gen_ai.tool.call.result = %q, want the call output", result)
+	}
+
+	// Timing frozen at RecordToolCall time: a real 12ms duration, not
+	// the zero-duration record-delivery fallback.
+	if got := span.EndTime.Sub(span.StartTime); got != 12*time.Millisecond {
+		t.Errorf("span duration = %v, want the frozen 12ms from the buffered summary", got)
+	}
+
+	// Exactly one execute_tool span: pairing must not double-emit.
+	var toolSpans int
+	for _, s := range exporter.GetSpans() {
+		if strings.HasPrefix(s.Name, "execute_tool") {
+			toolSpans++
+		}
+	}
+	if toolSpans != 1 {
+		t.Errorf("expected exactly 1 execute_tool span, got %d", toolSpans)
+	}
+}
+
+// TestOTelTraceEmitter_CaptureContent_EmptyIDToolEmitsImmediately pins
+// the un-keyable path: a call without a tool_use ID cannot pair, so it
+// emits a plain span at RecordToolCall time, and the record walk skips
+// ID-less entries rather than emitting a duplicate content span.
+func TestOTelTraceEmitter_CaptureContent_EmptyIDToolEmitsImmediately(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-tool-noid", nil)
+	emitter.RecordToolCall(types.ToolCallTrace{Name: "shell", DurationMs: 3, Success: true})
+
+	span := findSpan(t, exporter, "execute_tool shell")
+	if _, ok := spanAttrString(span, genAIToolCallArgumentsKey); ok {
+		t.Error("immediate-path span must not carry content attributes")
+	}
+
+	emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "end_turn", DurationMs: 10})
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn:      1,
+		ToolCalls: []types.ToolCallRecord{{Name: "shell", Input: json.RawMessage(`{}`), Output: "ok"}},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	var toolSpans int
+	for _, s := range exporter.GetSpans() {
+		if strings.HasPrefix(s.Name, "execute_tool") {
+			toolSpans++
+		}
+	}
+	if toolSpans != 1 {
+		t.Errorf("ID-less call must produce exactly 1 span, got %d", toolSpans)
+	}
+}
+
+// TestOTelTraceEmitter_CaptureContent_DuplicateToolIDFlushesPrior pins
+// the defensive duplicate handling: a second summary under the same
+// (RunID, ID) before any record flushes the first as a plain span
+// (last-wins, mirroring RecordTurn's duplicate-summary handling), and
+// the record then pairs with the survivor.
+func TestOTelTraceEmitter_CaptureContent_DuplicateToolIDFlushesPrior(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-tool-dup", nil)
+	emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "tool_use", DurationMs: 5})
+	emitter.RecordToolCall(types.ToolCallTrace{ID: "tu-dup", Name: "first_call", DurationMs: 1, Success: true})
+	emitter.RecordToolCall(types.ToolCallTrace{ID: "tu-dup", Name: "second_call", DurationMs: 2, Success: true})
+
+	// The stale first summary flushed plain.
+	flushed := findSpan(t, exporter, "execute_tool first_call")
+	if _, ok := spanAttrString(flushed, genAIToolCallResultKey); ok {
+		t.Error("flushed duplicate must not carry content")
+	}
+
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn:      1,
+		ToolCalls: []types.ToolCallRecord{{ID: "tu-dup", Name: "second_call", Output: "paired"}},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	paired := findSpan(t, exporter, "execute_tool second_call")
+	result, _ := spanAttrString(paired, genAIToolCallResultKey)
+	if result != "paired" {
+		t.Errorf("surviving summary should pair with the record, result = %q", result)
+	}
+}
+
+// TestOTelTraceEmitter_CaptureContent_FlushesUnmatchedToolAtFinish pins
+// the Finish-time flush: a buffered tool call whose turn record never
+// arrives (the loop's error returns skip RecordTurnRecord) still
+// produces its counter span — buffering must never lose a call.
+func TestOTelTraceEmitter_CaptureContent_FlushesUnmatchedToolAtFinish(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-tool-flush", nil)
+	emitter.RecordToolCall(types.ToolCallTrace{
+		ID: "tu-orphan", Name: "run_command", DurationMs: 7, Success: false,
+		ErrorReason: "exit status 1", ErrorCategory: "handler_error",
+	})
+	if _, err := emitter.Finish(context.Background(), "error"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	span := findSpan(t, exporter, "execute_tool run_command")
+	assertAttribute(t, span, errorTypeKey, "handler_error")
+	if _, ok := spanAttrString(span, genAIToolCallResultKey); ok {
+		t.Error("flushed unmatched tool call must not carry content attributes")
+	}
+}
+
+// TestOTelTraceEmitter_CaptureContent_UnpairedToolRecordSynthesisesSpan
+// pins the inverse fallback: a record entry with no buffered summary (a
+// forwarded sub-agent record arriving unpaired) emits a content span
+// with counters synthesised from the record — which, unlike the
+// unpaired-turn fallback, carries a real duration to derive timing from.
+func TestOTelTraceEmitter_CaptureContent_UnpairedToolRecordSynthesisesSpan(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-tool-unpaired", nil)
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 2, RunID: "child-run", ParentRunID: "run-tool-unpaired",
+		ToolCalls: []types.ToolCallRecord{{
+			ID: "tu-x", Name: "write_file", Input: json.RawMessage(`{"path":"a"}`),
+			Output: "written", DurationMs: 30, Success: true,
+		}},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	span := findSpan(t, exporter, "execute_tool write_file")
+	result, _ := spanAttrString(span, genAIToolCallResultKey)
+	if result != "written" {
+		t.Errorf("synthesised span result = %q, want the record output", result)
+	}
+	if got := span.EndTime.Sub(span.StartTime); got != 30*time.Millisecond {
+		t.Errorf("span duration = %v, want the record's 30ms", got)
+	}
+}
+
+// TestOTelTraceEmitter_CaptureContent_ToolPairsByRunID pins the
+// sub-agent disambiguation on the tool path: a parent call and a
+// forwarded child call sharing a tool_use ID value pair independently —
+// only the (RunID, ID) composite key keeps them apart.
+func TestOTelTraceEmitter_CaptureContent_ToolPairsByRunID(t *testing.T) {
+	emitter, exporter := newTestOTelEmitterWithCapture()
+
+	emitter.Start("run-tool-runs", nil)
+	emitter.RecordTurn(types.TurnTrace{Turn: 1, StopReason: "tool_use", DurationMs: 5})
+	emitter.RecordToolCall(types.ToolCallTrace{ID: "tu-1", Name: "parent_tool", DurationMs: 1, Success: true})
+	emitter.RecordToolCall(types.ToolCallTrace{ID: "tu-1", RunID: "child-run", Name: "child_tool", DurationMs: 2, Success: true})
+
+	// Child record first: must pair with the child's buffered call only.
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 1, RunID: "child-run", ParentRunID: "run-tool-runs",
+		ToolCalls: []types.ToolCallRecord{{ID: "tu-1", Name: "child_tool", Output: "child result"}},
+	})
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn:      1,
+		ToolCalls: []types.ToolCallRecord{{ID: "tu-1", Name: "parent_tool", Output: "parent result"}},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	child := findSpan(t, exporter, "execute_tool child_tool")
+	if result, _ := spanAttrString(child, genAIToolCallResultKey); result != "child result" {
+		t.Errorf("child span result = %q, want %q", result, "child result")
+	}
+	parent := findSpan(t, exporter, "execute_tool parent_tool")
+	if result, _ := spanAttrString(parent, genAIToolCallResultKey); result != "parent result" {
+		t.Errorf("parent span result = %q, want %q", result, "parent result")
 	}
 }
 

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -48,6 +48,10 @@ type RunTrace struct {
 // profile is recorded in the run's RunConfig (tools.profile); read it
 // alongside the record to disambiguate.
 type ToolCallSummary struct {
+	// ID is the provider-assigned tool_use identifier the call arrived
+	// under. Empty on traces that predate the field and for providers
+	// without call identifiers; mirrors ToolCallRecord.ID.
+	ID           string `json:"id,omitempty"`
 	Name         string `json:"name"`
 	InternalName string `json:"internalName,omitempty"`
 	DurationMs   int64  `json:"durationMs"`
@@ -134,6 +138,12 @@ func (t TurnTrace) IsBatch() bool {
 // ambiguity (default profile vs unresolved name under a non-default
 // profile).
 type ToolCallTrace struct {
+	// ID is the provider-assigned tool_use identifier the call arrived
+	// under. Empty on traces that predate the field and for providers
+	// without call identifiers. The OTel emitter's content-capture path
+	// keys its tool-call pairing on (RunID, ID); an empty ID opts the
+	// call out of pairing, never out of its span.
+	ID           string `json:"id,omitempty"`
 	Name         string `json:"name"`
 	InternalName string `json:"internalName,omitempty"`
 	DurationMs   int64  `json:"durationMs"`

--- a/types/runtrace_test.go
+++ b/types/runtrace_test.go
@@ -246,6 +246,63 @@ func TestTurnTrace_LegacyJSON_DeserialisesToEmptyMode(t *testing.T) {
 	}
 }
 
+// TestToolCallTrace_IDOmittedWhenEmpty pins the omitempty contract on
+// the tool_use ID mirrored onto ToolCallTrace/ToolCallSummary: legacy
+// traces and providers without call identifiers keep the pre-ID wire
+// shape, and a populated ID round-trips. The OTel content-capture path
+// keys tool-span pairing on this field, so silent loss here downgrades
+// captured tool spans to plain counter spans.
+func TestToolCallTrace_IDOmittedWhenEmpty(t *testing.T) {
+	bare, err := json.Marshal(ToolCallTrace{Name: "read_file", DurationMs: 1, Success: true})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(bare), `"id"`) {
+		t.Errorf("empty ID must be omitted; JSON = %s", bare)
+	}
+
+	populated, err := json.Marshal(ToolCallSummary{ID: "tu-1", Name: "read_file", DurationMs: 1, Success: true})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(populated), `"id":"tu-1"`) {
+		t.Errorf("populated ID must be emitted; JSON = %s", populated)
+	}
+
+	var round ToolCallTrace
+	if err := json.Unmarshal(populated, &round); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if round.ID != "tu-1" {
+		t.Errorf("round-trip ID = %q, want %q", round.ID, "tu-1")
+	}
+}
+
+// TestTurnTrace_ModelOmittedWhenEmpty pins the omitempty contract on
+// the per-turn model added for gen_ai.request.model stamping: legacy
+// traces keep their wire shape, and the router's selection round-trips.
+func TestTurnTrace_ModelOmittedWhenEmpty(t *testing.T) {
+	bare, err := json.Marshal(TurnTrace{Turn: 1, StopReason: "end_turn"})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(bare), `"model"`) {
+		t.Errorf("empty Model must be omitted; JSON = %s", bare)
+	}
+
+	data, err := json.Marshal(TurnTrace{Turn: 1, Model: "claude-sonnet-4-6"})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var round TurnTrace
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if round.Model != "claude-sonnet-4-6" {
+		t.Errorf("round-trip Model = %q, want %q", round.Model, "claude-sonnet-4-6")
+	}
+}
+
 func TestRunTracePermissionDenialsJSONCompatibility(t *testing.T) {
 	var oldTrace RunTrace
 	if err := json.Unmarshal([]byte(`{"id":"run-1","turns":2}`), &oldTrace); err != nil {


### PR DESCRIPTION
## What

PR 2 of 2 (stacked on #421): the capture-gated content that fully hydrates LLM-observability backends, plus the Langfuse operator recipe. Everything stays vendor-neutral GenAI semconv behind the existing `traceEmitter.captureContent` gate and scrub layer — no `langfuse.*` string anywhere in the binary.

- **Run-level I/O on the root span** (`trace: stamp run-level I/O…`): the emitter retains the parent run's seed prompt (turn 0 input, set-once) and final assistant message (overwrite-always) from the records it already receives, and stamps `gen_ai.input.messages` / `gen_ai.output.messages` / `gen_ai.system_instructions` on the root span at Finish. Backends derive their trace-level input/output views from the root observation — this fills the panels that stayed empty after #414. Sub-agent records are excluded; emitter-internal, zero loop/interface changes.
- **Tool I/O on execute_tool spans** (`types:`, `core, trace:`, `trace: emit tool I/O…`): `ToolCallTrace`/`ToolCallSummary` gain the provider `tool_use` ID (mirrored fields, parity-test enforced; dispatch stamps it; the JSONL inline `tool_call_record` id finally populates). Under capture, `RecordToolCall` buffers summaries keyed `(RunID, ID)` and the enclosing turn's record pairs them, emitting one span carrying counters plus `gen_ai.tool.call.{id,arguments,result}` — mirroring the existing turn pairing, including the degraded shapes (ID-less calls emit immediately, unmatched buffers flush plain at Finish, unpaired record entries synthesise counters with real timing).
- **Docs** (`docs:`): Langfuse row + dedicated recipe in `observability-cloud.md` (HTTP-only gotcha, Basic-auth via `secret://`, hydration map, sessions via `gen_ai.conversation.id`, environments via `deployment.environment`, model-pricing and parts-rendering caveats), and the content-capture table gains the root-span and tool rows.

## End-to-end verification (live Langfuse, podman, langfuse/langfuse:3)

Real `stirrup` binary, local executor, scripted openai-compatible provider, OTLP/http-protobuf to `/api/public/otel`, asserted via the Langfuse public API:

| Scenario | Trace input/output | turn[N] | tool observations | Error filtering |
|---|---|---|---|---|
| capture **on**, write+read task | populated (seed prompt w/ system prepended; final answer) | GENERATION, `model: fake-sonnet-1`, usage 2506/18, full message I/O | `write_file`/`read_file` TOOL with `{'path': 'hello.txt', …}` → `Successfully edited hello.txt` | — |
| capture **on**, unknown tool | populated | GENERATION w/ I/O | TOOL `level: ERROR`, status `Unknown tool: definitely_not_a_tool`, args + error output | tool-level ✓ |
| capture **on**, provider 500 | absent (no records — degraded shape by design) | GENERATION `level: ERROR` status `error` | — | root AGENT `level: ERROR` status `error` ✓ |
| capture **off** (control) | null | GENERATION typed w/ model, **no content keys** | TOOL typed, **no content keys** | — |

Sessions (`--name` → `gen_ai.conversation.id` → Langfuse session) and environments (`deployment.environment` resource attr → `local`) confirmed populating with zero new code, as researched. `just test` + `just lint` green.

## Notes

- Buffered tool spans are lost to SIGKILL on the same terms as `pendingTurns` and the exporter batch tail.
- Pre-existing bug found during review, not fixed here: `scrubTurnRecord` drops `InternalName`/`Kind` when rebuilding `ToolCallRecord` (`jsonl.go`) — follow-up issue to come.
- Langfuse renders the semconv parts format as raw JSON (no parts adapter in its ChatML normaliser yet) — documented as a caveat; an upstream Langfuse contribution would fix presentation for every semconv emitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)