### PR TITLE
provider, quirks: DeepSeek v4 support via outbound replay-field threading

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -420,8 +420,8 @@ of every `Stream()` call. The layer handles wire-shape and
 behaviour divergences that the canonical `ProviderAdapter`
 interface cannot express: OpenAI reasoning-class sampling-param
 omissions, Z.ai GLM legacy field names, Gemini 3.x
-`thoughtSignature` capture, DeepSeek `reasoning_content` parse-side
-recognition. The `NormalizingAdapter` wraps the concrete adapter
+`thoughtSignature` capture, DeepSeek `reasoning_content` capture
+and replay. The `NormalizingAdapter` wraps the concrete adapter
 from the outside; the quirks resolution sits inside the adapter's
 `Stream()` body. Both layers compose without either knowing about
 the other.

--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -42,9 +42,11 @@ Concrete v1 divergences:
   fix is a registry-driven `ReplayFields` capture.
 - DeepSeek's reasoner and v4 families surface chain-of-thought
   through a `reasoning_content` sibling field on the assistant
-  delta. Parse-side recognition lets the harness expose the field
-  in traces; outbound threading (round-tripping it on the next turn)
-  is a deferred follow-up.
+  delta. DeepSeek v4 thinking mode (default-on) additionally
+  *requires* the field replayed on every request after a tool-call
+  turn — the API returns 400 otherwise — so the `ReplayFields`
+  capture is threaded back outbound on the openai-compatible
+  adapter (see [§3.1](#31-replayfields-rules)).
 
 ### 1.1 Prior art
 
@@ -101,9 +103,13 @@ Fixture trees for the wire-shape contract tests:
 ```
 harness/internal/provider/testdata/quirks/
     openai-compatible/<model>/{request.json, response.sse}
-    openai-compatible/<deepseek-model>/{response.sse, replay.json}
+    openai-compatible/<deepseek-model>/{request.json, response.sse, replay.json}
     gemini/<model>/{request.json, response.sse[, replay.json]}
 ```
+
+A gateway-prefixed model id (e.g. `deepseek/deepseek-v4-flash`) maps
+onto a nested fixture directory; the `<model>` path component is the
+id verbatim.
 
 ### 2.1 ProviderQuirks
 
@@ -118,7 +124,7 @@ type ProviderQuirks struct {
     OmitFields      []string                  // canonical fields the adapter MUST NOT emit
     ValueOverrides  map[string]Value          // forced serialised value, ignoring StreamParams
     EnumCoercions   map[string]map[string]string // caller value → wire value
-    ReplayFields    []string                  // assistant-message paths to preserve (parse-side only in v1)
+    ReplayFields    []string                  // assistant-message paths to preserve across turns
 
     // Cross-provider capabilities (top-level, not per-adapter).
     ToolChoice            ToolChoiceCapability           // native tool_choice support (auto/required/none/named)
@@ -302,8 +308,9 @@ test catch malformed paths at registry-build time.
 | `openai-compatible` | `o[1-9]*`          | OpenAI reasoning-class (o-series): omit sampling params              |
 | `openai-compatible` | `gpt-5*`           | OpenAI gpt-5 family: omit sampling params                            |
 | `openai-compatible` | `gpt-5-chat*`      | OpenAI gpt-5-chat carve-out: chat-class accepts sampling params      |
-| `openai-compatible` | `deepseek-reasoner*` | DeepSeek reasoner: preserve `reasoning_content` (parse-side only)  |
-| `openai-compatible` | `deepseek-v4*`     | DeepSeek v4: preserve `reasoning_content` (parse-side only)          |
+| `openai-compatible` | `deepseek-reasoner*` | DeepSeek reasoner: replay `reasoning_content`, omit sampling params, legacy `max_tokens` (threaded) |
+| `openai-compatible` | `deepseek-v4*`     | DeepSeek v4: replay `reasoning_content`, omit sampling params, legacy `max_tokens` (threaded) |
+| `openai-compatible` | `deepseek/deepseek-v4*` | DeepSeek v4 via gateway prefix (OpenRouter-style ids): same quirk set as `deepseek-v4*` (threaded) |
 | `gemini`            | `*`                | Gemini: off `streamFunctionCallArguments` (post-#191 default)        |
 | `gemini`            | `gemini-3*`        | Gemini 3: preserve `thoughtSignature` as a sibling of `functionCall` on each `parts[]` element (parse-side only) |
 | `openai-responses`  | `*`                | OpenAI Responses: typed input items, `max_output_tokens`, `store:false`; top-level `parallel_tool_calls`; accepts schema examples (#222, #332) |
@@ -319,22 +326,51 @@ The compat profile rule for Z.ai GLM is registered separately via
 `BuiltinRules()` and only loads when `provider.compatProfile =
 "zai-glm"` is set.
 
-### 3.1 ReplayFields rules (parse-side only)
+### 3.1 ReplayFields rules
 
-The three `ReplayFields` rules added in Wave 2 land **parse-side
-recognition only**. Captured values surface in a per-stream debug
-log (and as totals on the active OTel span) so operators can see
-the rule fired, but the values are not yet threaded back into
-outbound message history. Multi-turn runs against affected models
-continue to fail on turn 2 in the same way they did before the
-rule; the observable improvement is the slog DEBUG record and the
-matching span attributes.
+`ReplayFields` rules are no longer uniformly parse-side. Every
+adapter captures the named paths from its decoded stream into a
+per-stream accumulator; what happens next splits into two classes,
+recorded by a mandatory Description suffix:
 
-Outbound threading is design §9 risk 7 and is tracked separately.
-The Description of every ReplayFields rule ends in `(parse-side
-only)` so trace consumers know the captured value is observable but
-not round-tripped. `TestBuiltinRulesParseSideOnlySuffix` enforces
-the convention.
+- **`(threaded)`** — the openai-compatible adapter additionally
+  round-trips the capture. When the stream completes, the
+  accumulator is flattened onto the `message_complete` event's
+  `ReplayFields` (per path: if every captured value is a string,
+  the pieces are concatenated in arrival order and marshalled as
+  one JSON string — the streamed-string case, e.g.
+  `reasoning_content` arriving across many chunks; otherwise the
+  last captured value is marshalled verbatim, snapshot semantics).
+  The agentic loop attaches the map to the assistant `Message` it
+  persists, and on subsequent requests the adapter emits each
+  qualifying entry as a top-level key on the assistant wire
+  message. Qualifying means: the path is named by the quirks
+  resolved for *that* stream (the registry stays the single source
+  of truth — state captured under another model's rules is never
+  replayed), the path is single-segment (no `.`, no `[]`), and it
+  does not collide with a canonical message key (`role`, `content`,
+  `tool_calls`, `tool_call_id`, `name`). Non-qualifying paths are
+  silently skipped at runtime; first-party rules that declare one
+  fail the registry's build-time test instead.
+- **`(parse-side only)`** — the capture surfaces in the length-only
+  observability summaries below but is not round-tripped via this
+  surface. The Gemini 3 `thoughtSignature` rule stays in this
+  class: Gemini's real round-trip is the typed block-level
+  `ContentBlock.ThoughtSignature`, and the ReplayFields capture is
+  corroborating observability.
+
+`TestBuiltinRulesReplayFieldsSuffix` enforces the convention: a
+ReplayFields rule's Description must end in exactly one of the two
+markers, openai-compatible rules must be `(threaded)` with
+threadable paths, and other providers must be `(parse-side only)`.
+
+Known limitation: the gRPC `BatchAdapter` shares the
+openai-compatible request builder, so the outbound half rides along
+for batch submissions — but its result-parse path
+(`fabricateStream`) has no ReplayFields capture, so nothing is
+accumulated to replay. Multi-turn tool-calling against DeepSeek v4
+thinking mode through the batch path therefore still fails with 400
+on the turn after a tool call; see §9 risk 7.
 
 The captured-fields debug log line is `quirks replay fields
 captured` at slog DEBUG level. It records a per-path summary of
@@ -522,14 +558,20 @@ concerns are tracked separately:
    on specificity ordering; `TestRuleCarveOuts` is the load-bearing
    negative test.
 
-7. **ReplayFields threading gap.** Wave 2 lands parse-side
-   recognition only. Operators seeing `provider.quirk.applied:
-   ["Gemini 3: preserve thought_signature on functionCall parts
-   (parse-side only)"]` in their trace must not assume the threading
-   is complete. The `(parse-side only)` suffix on every ReplayFields
-   rule's `Description` is the load-bearing observability signal;
-   `TestBuiltinRulesParseSideOnlySuffix` enforces it. Outbound
-   threading is a follow-up.
+7. **ReplayFields threading scope.** Outbound threading is
+   implemented for the openai-compatible adapter (see
+   [§3.1](#31-replayfields-rules)): captured values ride the
+   `message_complete` event onto the persisted assistant message and
+   are echoed back as top-level wire keys on subsequent requests.
+   Gemini ReplayFields rules remain parse-side observability — the
+   typed block-level `ThoughtSignature` is Gemini's actual
+   round-trip — and no rules target the Anthropic or OpenAI
+   Responses adapters. The Description suffix (`(threaded)` vs
+   `(parse-side only)`) is the load-bearing observability signal;
+   `TestBuiltinRulesReplayFieldsSuffix` enforces it. Remaining gap:
+   the BatchAdapter's result-parse path has no capture, so batch
+   submissions against DeepSeek v4 thinking mode cannot sustain
+   multi-turn tool-calling (§3.1).
 
 8. **`DefaultRegistry()` singleton and test isolation.** The
    singleton is constructed once via `sync.Once` and is read-only
@@ -538,11 +580,32 @@ concerns are tracked separately:
    field. `TestDefaultRegistryConcurrentAccess` stresses the
    singleton under `-race`.
 
-9. **DeepSeek field-path verification gap.** The `reasoning_content`
-   path used by the DeepSeek-reasoner and DeepSeek-v4 rules is
-   sourced from the DeepSeek API documentation, not from a live
-   capture. If a live capture surfaces a different shape (e.g. a
-   structured `thinking` object rather than a flat string), the
-   rule's path and the corresponding `replay.json` fixture need
-   to be adjusted in lockstep. The 180-day staleness window flags
-   the rule for re-verification.
+9. **DeepSeek verification status.** The `reasoning_content` path
+   and the v4 replay requirement are doc-verified as of 2026-06-07
+   against the DeepSeek thinking-mode guide
+   (https://api-docs.deepseek.com/guides/thinking_mode), with broad
+   community corroboration of the 400-on-missing-replay behaviour on
+   both first-party and OpenRouter-served v4 traffic — but no live
+   first-party capture exists yet. Remaining live-capture gaps,
+   each flagged in the rule comments: whether the v4 endpoint also
+   accepts `max_completion_tokens` (the rules pin the doc-consistent
+   legacy `max_tokens`), where `reasoning_effort` sits on the wire
+   (the API reference and the guide disagree on nested-vs-top-level
+   placement, so no rule ships for it), and whether any gateway
+   renames the field to `reasoning`. If a live capture surfaces a
+   different shape (e.g. a structured `thinking` object rather than
+   a flat string), the rule's path and the corresponding
+   `replay.json` fixture need to be adjusted in lockstep. The
+   180-day staleness window flags the rules for re-verification.
+
+   Operators who want v4 *non-thinking* behaviour can inject a rule
+   via `NewRegistry` whose `ExtraBodyFields` carries the documented
+   toggle, `{"thinking": {"type": "disabled"}}`. No builtin rule
+   sets it: thinking default-on is the desired behaviour for a
+   coding agent, and disabling it also forfeits the documented
+   reasoning quality. The legacy `deepseek-chat` /
+   `deepseek-reasoner` ids are first-party aliases for v4-flash
+   non-thinking / thinking modes, fully retired after 2026-07-24
+   15:59 UTC; the reasoner rule carries a matching sunset note and
+   no `deepseek-chat` rule exists (non-thinking, no
+   `reasoning_content`).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -130,9 +130,17 @@ Provider/model pairs sometimes diverge from the adapter's canonical
 wire shape: OpenAI's reasoning-class models reject sampling
 parameters, Z.ai GLM requires the legacy `max_tokens` key, Gemini
 3.x emits a `thoughtSignature` blob that must survive turn
-boundaries. Rather than encoding these as adapter-internal model
-substring checks, the harness routes them through a registry-driven
-quirks layer at `harness/internal/provider/quirks/`.
+boundaries, and DeepSeek v4's default-on thinking mode requires the
+`reasoning_content` it streams replayed back on every request after
+a tool-call turn (the API returns 400 otherwise). Rather than
+encoding these as adapter-internal model substring checks, the
+harness routes them through a registry-driven quirks layer at
+`harness/internal/provider/quirks/`. DeepSeek v4 runs through the
+stock Chat Completions adapter (`provider.type:
+"openai-compatible"` with `provider.baseUrl:
+"https://api.deepseek.com"`); the built-in `deepseek-v4*` and
+`deepseek/deepseek-v4*` rules supply the replay threading, sampling
+suppression, and legacy token key with no operator configuration.
 
 Operators do not author quirk rules. Two surfaces are available:
 

--- a/harness/internal/context/offload.go
+++ b/harness/internal/context/offload.go
@@ -117,10 +117,18 @@ func (o *OffloadToFileStrategy) Prepare(ctx context.Context, messages []types.Me
 		}
 
 		if modified {
+			// ReplayFields must survive the rebuild: it carries the
+			// provider-opaque round-trip state (e.g. DeepSeek v4's
+			// reasoning_content) that the next request replays —
+			// dropping it here silently 400s the following tool-call
+			// turn. The long multi-turn run with large tool outputs
+			// that triggers this offload is exactly the workload the
+			// replay threading exists for.
 			result[i] = types.Message{
-				Role:      msg.Role,
-				Synthetic: msg.Synthetic,
-				Content:   newContent,
+				Role:         msg.Role,
+				Synthetic:    msg.Synthetic,
+				Content:      newContent,
+				ReplayFields: msg.ReplayFields,
 			}
 		}
 	}

--- a/harness/internal/context/offload_test.go
+++ b/harness/internal/context/offload_test.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -106,6 +107,60 @@ func TestOffloadToFile_OverBudget_OffloadsLargeToolResults(t *testing.T) {
 	// Verify the file was written with the original content.
 	if fw.written[expectedPath] != largeContent {
 		t.Errorf("expected file to contain original content")
+	}
+}
+
+func TestOffloadToFile_PreservesReplayFieldsOnModifiedMessages(t *testing.T) {
+	fw := newMockFileWriter()
+	s := NewOffloadToFileStrategy(fw)
+
+	replay := map[string]json.RawMessage{
+		"reasoning_content": json.RawMessage(`"thinking..."`),
+	}
+	largeContent := strings.Repeat("x", 3000)
+	msgs := []types.Message{
+		makeMessage("user", "do something"),
+		// A message that both triggers the offload rebuild (large
+		// tool_result) and carries replay state. The rebuild path
+		// constructs a fresh types.Message; any field not copied
+		// explicitly — ReplayFields here — would be silently dropped,
+		// and the next request against DeepSeek v4 thinking mode would
+		// omit reasoning_content and 400.
+		{
+			Role: "assistant",
+			Content: []types.ContentBlock{
+				{Type: "tool_result", ToolUseID: "t1", Content: largeContent},
+			},
+			ReplayFields: replay,
+		},
+		makeMessage("user", "more context"),
+		makeMessage("assistant", "working on it"),
+		makeMessage("user", "question"),
+		makeMessage("assistant", "answer"),
+		makeMessage("user", "another question"),
+		makeMessage("assistant", "another answer"),
+		// Last 6 messages are indices 2-7, so index 1 is offload-eligible.
+	}
+
+	result, err := s.Prepare(context.Background(), msgs, TokenBudget{
+		MaxTokens:          2000,
+		CurrentTokens:      5000,
+		ReserveForResponse: 500,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error: %v", err)
+	}
+
+	// The rebuild must have fired (the tool_result was offloaded)…
+	if !strings.Contains(result[1].Content[0].Content, "offloaded to") {
+		t.Fatalf("expected the tool_result to be offloaded; got: %s", result[1].Content[0].Content)
+	}
+	// …and the replay state must have survived it intact.
+	if result[1].ReplayFields == nil {
+		t.Fatal("ReplayFields dropped by the offload rebuild")
+	}
+	if got := string(result[1].ReplayFields["reasoning_content"]); got != `"thinking..."` {
+		t.Errorf("ReplayFields[reasoning_content] = %s, want \"thinking...\"", got)
 	}
 }
 

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -863,8 +863,9 @@ func (l *AgenticLoop) runInnerLoop(
 			"tokens.output", sr.OutputTokens,
 			"stopReason", sr.StopReason)
 
-		// Append assistant message.
-		messages = appendAssistantContent(messages, sr.Blocks)
+		// Append assistant message, carrying any provider replay state
+		// from the stream so the next request can round-trip it.
+		messages = appendAssistantContent(messages, sr.Blocks, sr.ReplayFields)
 
 		// Extract tool calls.
 		toolCalls := collectToolCalls(sr.Blocks)

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -1113,6 +1113,51 @@ func TestStreamEventsToResult_ThoughtSignaturePropagatedToBlock(t *testing.T) {
 	})
 }
 
+// TestStreamEventsToResult_ReplayFieldsStashedAndAttached pins the
+// in-loop hop for the message-level replay state (quirks ReplayFields,
+// design §9 risk 7): the message_complete event's ReplayFields must land
+// on the streamResult, and appendAssistantContent must attach it to the
+// persisted assistant Message so the next request can round-trip it.
+// Mirrors the ThoughtSignature test above for the message-level carrier.
+func TestStreamEventsToResult_ReplayFieldsStashedAndAttached(t *testing.T) {
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+
+	replay := map[string]json.RawMessage{
+		"reasoning_content": json.RawMessage(`"step by step"`),
+	}
+	ch := make(chan types.StreamEvent, 2)
+	ch <- types.StreamEvent{Type: "text_delta", Text: "Hello"}
+	ch <- types.StreamEvent{
+		Type:         "message_complete",
+		StopReason:   "end_turn",
+		ReplayFields: replay,
+	}
+	close(ch)
+
+	result, err := streamEventsToResult(context.Background(), ch, tp, slog.Default())
+	if err != nil {
+		t.Fatalf("streamEventsToResult() error: %v", err)
+	}
+	if string(result.ReplayFields["reasoning_content"]) != `"step by step"` {
+		t.Errorf("streamResult.ReplayFields = %v, want reasoning_content stashed", result.ReplayFields)
+	}
+
+	messages := appendAssistantContent(nil, result.Blocks, result.ReplayFields)
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	if string(messages[0].ReplayFields["reasoning_content"]) != `"step by step"` {
+		t.Errorf("assistant Message.ReplayFields = %v, want reasoning_content attached", messages[0].ReplayFields)
+	}
+
+	// The no-replay path must leave the field nil so the persisted
+	// message serialises byte-identically to the prior shape.
+	plain := appendAssistantContent(nil, result.Blocks, nil)
+	if plain[0].ReplayFields != nil {
+		t.Errorf("nil replay state must stay nil on the Message, got %v", plain[0].ReplayFields)
+	}
+}
+
 func TestStreamEventsToResult_MergesMessageCompleteFields(t *testing.T) {
 	ch := make(chan types.StreamEvent, 3)
 	ch <- types.StreamEvent{Type: "text_delta", Text: "Hello"}

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -546,11 +546,17 @@ func buildMessages(userPrompt string) []types.Message {
 }
 
 // appendAssistantContent adds the model's response content blocks to the
-// message history as an assistant message.
-func appendAssistantContent(messages []types.Message, blocks []types.ContentBlock) []types.Message {
+// message history as an assistant message. replayFields is the
+// provider-opaque round-trip state the stream's message_complete event
+// carried (quirks ReplayFields); attaching it to the persisted Message
+// lets the originating provider's adapter echo it back on subsequent
+// turns. nil for providers that emit none — omitempty keeps the
+// serialised message byte-identical in that case.
+func appendAssistantContent(messages []types.Message, blocks []types.ContentBlock, replayFields map[string]json.RawMessage) []types.Message {
 	return append(messages, types.Message{
-		Role:    "assistant",
-		Content: blocks,
+		Role:         "assistant",
+		Content:      blocks,
+		ReplayFields: replayFields,
 	})
 }
 
@@ -589,10 +595,17 @@ func collectToolCalls(blocks []types.ContentBlock) []types.ToolCall {
 }
 
 // streamResult holds the results of consuming a model response stream.
+//
+// ReplayFields is the provider-opaque round-trip state stashed from the
+// stream's message_complete event (quirks ReplayFields, design §9 risk
+// 7). The loop attaches it to the assistant Message it persists; the
+// values are opaque data plumbed through, never inspected or logged
+// here — the loop-purity invariant is untouched.
 type streamResult struct {
 	Blocks       []types.ContentBlock
 	StopReason   string
 	OutputTokens int
+	ReplayFields map[string]json.RawMessage
 }
 
 // streamEventsToResult consumes a stream event channel and returns the
@@ -655,6 +668,9 @@ func streamEventsToResult(ctx context.Context, ch <-chan types.StreamEvent, tp t
 			}
 			if event.OutputTokens > 0 {
 				result.OutputTokens = event.OutputTokens
+			}
+			if len(event.ReplayFields) > 0 {
+				result.ReplayFields = event.ReplayFields
 			}
 
 		case "error":

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -423,7 +423,14 @@ func (g *GeminiAdapter) consumeSSE(
 	if logger == nil {
 		logger = slog.Default()
 	}
+	// replayFieldsTotalBytes / replayFieldsCapped enforce the shared
+	// maxReplayFieldBytes budget (see the constant in openai.go): once
+	// the cap is hit, every later capture is dropped so the
+	// accumulator stays a clean prefix and a hostile upstream cannot
+	// balloon per-stream memory.
 	replayFieldsCapture := map[string][]any{}
+	replayFieldsTotalBytes := 0
+	replayFieldsCapped := false
 	defer func() {
 		if len(replayFieldsCapture) == 0 {
 			return
@@ -561,9 +568,26 @@ func (g *GeminiAdapter) consumeSSE(
 		// (geminiMaxScannerBuffer = 16 MiB, set above). Acceptable
 		// because the path is gated by len(q.ReplayFields) > 0 and
 		// only the gemini-3* rule registers ReplayFields today.
-		if len(q.ReplayFields) > 0 {
+		if !replayFieldsCapped && len(q.ReplayFields) > 0 {
 			if captured := quirks.CaptureFromJSON([]byte(data), q.ReplayFields); len(captured) > 0 {
 				for k, v := range captured {
+					add := 0
+					for _, item := range v {
+						add += replayCaptureByteLen(item)
+					}
+					if replayFieldsTotalBytes+add > maxReplayFieldBytes {
+						replayFieldsCapped = true
+						// One WARN per stream; the captured values
+						// themselves are never logged.
+						logger.WarnContext(ctx, "replay field accumulator cap reached, truncating",
+							slog.String("provider.type", "gemini"),
+							slog.String("provider.model", model),
+							slog.String("path", k),
+							slog.Int("limit_bytes", maxReplayFieldBytes),
+						)
+						break
+					}
+					replayFieldsTotalBytes += add
 					replayFieldsCapture[k] = append(replayFieldsCapture[k], v...)
 				}
 			}

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -444,6 +445,60 @@ func logReplayFieldsCapture(ctx context.Context, logger *slog.Logger, providerTy
 	)
 }
 
+// flattenReplayCapture projects the per-stream ReplayFields accumulator
+// onto the map a "message_complete" StreamEvent carries (the flattening
+// rule documented on types.StreamEvent.ReplayFields):
+//
+//   - when every captured value for a path is a string, the pieces are
+//     concatenated in arrival order and marshalled as one JSON string —
+//     the streamed-string-field case (DeepSeek's reasoning_content
+//     arrives across many chunks);
+//   - otherwise the LAST captured value is marshalled verbatim
+//     (snapshot semantics for object-shaped fields).
+//
+// A value that fails to re-marshal is skipped: every entry in the
+// accumulator was decoded from provider JSON, so the arm is
+// defence-in-depth, and dropping one path must not poison the rest.
+// Returns nil when nothing was captured so the StreamEvent field stays
+// omitted.
+func flattenReplayCapture(capture map[string][]any) map[string]json.RawMessage {
+	if len(capture) == 0 {
+		return nil
+	}
+	out := make(map[string]json.RawMessage, len(capture))
+	for path, values := range capture {
+		if len(values) == 0 {
+			continue
+		}
+		allStrings := true
+		for _, v := range values {
+			if _, ok := v.(string); !ok {
+				allStrings = false
+				break
+			}
+		}
+		var encoded []byte
+		var err error
+		if allStrings {
+			var b strings.Builder
+			for _, v := range values {
+				b.WriteString(v.(string))
+			}
+			encoded, err = json.Marshal(b.String())
+		} else {
+			encoded, err = json.Marshal(values[len(values)-1])
+		}
+		if err != nil {
+			continue
+		}
+		out[path] = encoded
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // canonicalOpenAIFields enumerates the top-level Chat Completions
 // request fields the adapter knows how to emit. ExtraBodyFields rules
 // must not collide with any of these — the registry self-test guards
@@ -476,11 +531,117 @@ func isCanonicalOpenAIField(k string) bool {
 }
 
 // openaiMessage is a single message in OpenAI's Chat Completions format.
+//
+// ReplayFields carries provider-opaque round-trip state (quirks
+// ReplayFields, design D12) to emit as additional top-level keys on an
+// assistant message — e.g. DeepSeek thinking mode's reasoning_content,
+// which the API requires replayed on tool-call turns (400 otherwise).
+// Keyed by the rule's verbatim single-segment path; values are the
+// flattened JSON captured on a prior turn. The `json:"-"` tag keeps
+// the map out of the default (un)marshalling — MarshalJSON merges the
+// entries after the canonical fields, mirroring the openaiRequest
+// ExtraBodyFields pattern. Populated by translateMessages only for
+// paths the resolved quirks name for THIS stream, so stale state from
+// a different model never leaks onto the wire. The decode side
+// deliberately ignores non-canonical message keys: replay state is
+// produced by the harness, never parsed back out of a request body.
 type openaiMessage struct {
-	Role       string           `json:"role"` // "system" | "user" | "assistant" | "tool"
-	Content    any              `json:"content,omitempty"`
-	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string           `json:"tool_call_id,omitempty"`
+	Role         string                     `json:"role"` // "system" | "user" | "assistant" | "tool"
+	Content      any                        `json:"content,omitempty"`
+	ToolCalls    []openaiToolCall           `json:"tool_calls,omitempty"`
+	ToolCallID   string                     `json:"tool_call_id,omitempty"`
+	ReplayFields map[string]json.RawMessage `json:"-"`
+}
+
+// canonicalOpenAIMessageFields enumerates the top-level Chat Completions
+// message keys the adapter owns. A ReplayFields path that collides with
+// any of these is never emitted as an extra key: translateMessages skips
+// it silently at runtime, the quirks registry's build-time test
+// (TestBuiltinRulesReplayFieldsSuffix) rejects first-party rules that
+// declare one, and MarshalJSON errors as defence-in-depth. "name" is in
+// the set even though the struct does not carry it — it is a documented
+// optional key on the OpenAI message schema.
+var canonicalOpenAIMessageFields = map[string]struct{}{
+	"role":         {},
+	"content":      {},
+	"tool_calls":   {},
+	"tool_call_id": {},
+	"name":         {},
+}
+
+// isCanonicalOpenAIMessageField reports whether the given key is owned
+// by the canonical openaiMessage projection.
+func isCanonicalOpenAIMessageField(k string) bool {
+	_, ok := canonicalOpenAIMessageFields[k]
+	return ok
+}
+
+// threadableOpenAIReplayPath reports whether a quirks ReplayFields path
+// can be echoed back as a top-level key on an assistant wire message.
+// Only single-segment paths qualify: a captured value from a nested or
+// array-iterated path (e.g. Gemini's candidates[].content.parts[]
+// shape) has no faithful flat representation on a Chat Completions
+// message, and emitting a guess would be worse than emitting nothing.
+// Canonical message keys are excluded so a rule cannot overwrite
+// role/content/tool_calls via the replay side-channel.
+//
+// Non-qualifying paths are silently skipped here (safe at runtime);
+// the quirks registry's build-time test fails loudly on any first-party
+// openai-compatible rule that declares one.
+func threadableOpenAIReplayPath(path string) bool {
+	segments, err := quirks.ParseReplayPath(path)
+	if err != nil || len(segments) != 1 || segments[0].IsArray {
+		return false
+	}
+	return !isCanonicalOpenAIMessageField(path)
+}
+
+// MarshalJSON emits the canonical message fields in struct order, then
+// appends the ReplayFields entries (sorted by key for determinism).
+// The two-pass shape mirrors openaiRequest.MarshalJSON: canonical
+// fields stay struct-driven so their byte order is stable, and the
+// extras are spliced in after. A ReplayFields key that collides with a
+// canonical message field, or a value that is not valid JSON, is an
+// error — translateMessages filters both cases, so reaching either arm
+// means a non-quirks caller populated the map by hand and should fail
+// loudly before any wire bytes are sent.
+func (m openaiMessage) MarshalJSON() ([]byte, error) {
+	type alias openaiMessage
+	base, err := json.Marshal(alias(m))
+	if err != nil {
+		return nil, err
+	}
+	if len(m.ReplayFields) == 0 {
+		return base, nil
+	}
+	keys := make([]string, 0, len(m.ReplayFields))
+	for k := range m.ReplayFields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	// base is always a non-empty object ("role" has no omitempty), so
+	// stripping the closing brace and splicing ",<key>:<value>" pairs is
+	// safe.
+	buf := bytes.NewBuffer(base[:len(base)-1])
+	for _, k := range keys {
+		if isCanonicalOpenAIMessageField(k) {
+			return nil, fmt.Errorf("openai replay field %q collides with canonical message field", k)
+		}
+		v := m.ReplayFields[k]
+		if !json.Valid(v) {
+			return nil, fmt.Errorf("openai replay field %q carries invalid JSON", k)
+		}
+		keyJSON, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.WriteByte(',')
+		buf.Write(keyJSON)
+		buf.WriteByte(':')
+		buf.Write(v)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
 }
 
 // openaiToolCall represents a tool invocation in an assistant message.
@@ -638,7 +799,17 @@ type openaiToolCallState struct {
 // translateMessages converts stirrup's internal Message/ContentBlock format
 // to OpenAI's chat message format. The system prompt is prepended as a
 // system message.
-func translateMessages(system string, messages []types.Message) []openaiMessage {
+//
+// replayPaths is the resolved quirks ReplayFields for THIS stream. For
+// each assistant message carrying Message.ReplayFields, the entries
+// whose path is (a) named by replayPaths, (b) single-segment, and (c)
+// not a canonical message key are emitted as top-level keys on the
+// assistant wire message — the outbound half of the quirks ReplayFields
+// round-trip (design §9 risk 7). Gating on replayPaths keeps the
+// registry the single source of truth: state captured under a different
+// model's rules (e.g. after a mid-run model switch) is not replayed to
+// a provider whose resolved rules never asked for it.
+func translateMessages(system string, messages []types.Message, replayPaths []string) []openaiMessage {
 	var out []openaiMessage
 
 	if system != "" {
@@ -680,6 +851,20 @@ func translateMessages(system string, messages []types.Message) []openaiMessage 
 			}
 			if len(toolCalls) > 0 {
 				oai.ToolCalls = toolCalls
+			}
+			if len(msg.ReplayFields) > 0 {
+				var extra map[string]json.RawMessage
+				for _, path := range replayPaths {
+					v, ok := msg.ReplayFields[path]
+					if !ok || len(v) == 0 || !threadableOpenAIReplayPath(path) {
+						continue
+					}
+					if extra == nil {
+						extra = make(map[string]json.RawMessage)
+					}
+					extra[path] = v
+				}
+				oai.ReplayFields = extra
 			}
 			out = append(out, oai)
 
@@ -890,7 +1075,7 @@ func buildOpenAIRequest(params types.StreamParams, stream bool, q quirks.Provide
 	}
 	return openaiRequest{
 		Model:              params.Model,
-		Messages:           translateMessages(params.System, params.Messages),
+		Messages:           translateMessages(params.System, params.Messages, q.ReplayFields),
 		Tools:              tools,
 		MaxTokens:          params.MaxTokens,
 		Temperature:        params.Temperature,
@@ -1093,8 +1278,9 @@ func (o *OpenAICompatibleAdapter) recordLatency(ctx context.Context, start time.
 // (design D5). The parser reads q.ReplayFields and captures the named
 // paths from each chunk's delta object — design D12. The captured set
 // surfaces in a per-stream debug log emitted at the end of the stream
-// (Wave 2 lands parse-side recognition only — outbound threading is
-// deferred per §9 risk 7).
+// (length-only) and, flattened, on the message_complete event's
+// ReplayFields so the loop can round-trip it on the next turn (§9
+// risk 7 outbound threading).
 //
 // logger and model are threaded purely so the per-stream replay-fields
 // debug summary names the model and stays on the same logger the
@@ -1186,12 +1372,11 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 		}
 
 		for _, choice := range chunk.Choices {
-			// ReplayFields capture (design D12, Wave 2 parse-side
-			// recognition). Walk the raw delta object once per chunk
-			// and merge any matching paths into the per-stream
-			// accumulator. The path walker is a no-op when
-			// q.ReplayFields is empty so the cost in the zero-rules
-			// case is one slice-length check.
+			// ReplayFields capture (design D12). Walk the raw delta
+			// object once per chunk and merge any matching paths into
+			// the per-stream accumulator. The path walker is a no-op
+			// when q.ReplayFields is empty so the cost in the
+			// zero-rules case is one slice-length check.
 			if len(q.ReplayFields) > 0 && len(choice.RawDelta) > 0 {
 				if captured := quirks.CaptureFromJSON(choice.RawDelta, q.ReplayFields); len(captured) > 0 {
 					for k, v := range captured {
@@ -1237,6 +1422,15 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 				ev := types.StreamEvent{
 					Type:       "message_complete",
 					StopReason: stopReason,
+					// The flattened ReplayFields capture rides on the
+					// message_complete event so the agentic loop can
+					// attach it to the assistant Message it persists —
+					// the outbound half of the round-trip threads it
+					// back via translateMessages on the next turn. The
+					// length-only slog/OTel summary in the deferred
+					// block above is unchanged; the values themselves
+					// are never logged.
+					ReplayFields: flattenReplayCapture(replayFieldsCapture),
 				}
 				if chunk.Usage != nil {
 					ev.OutputTokens = chunk.Usage.CompletionTokens

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -44,6 +44,19 @@ type OpenAIAuthConfig struct {
 const (
 	openaiDefaultBaseURL   = "https://api.openai.com/v1"
 	openaiMaxToolInputSize = 10 * 1024 * 1024 // 10 MB cap on streamed tool argument JSON
+
+	// maxReplayFieldBytes bounds the per-stream ReplayFields capture
+	// accumulator across all paths — 512 kB is generous for any real
+	// chain-of-thought field. Without a cap, a malicious or
+	// misconfigured provider could stream tens of thousands of
+	// captured chunks within the request timeout and balloon the
+	// accumulator (plus the flatten-time copies) to hundreds of MB.
+	// Same precedent as openaiMaxToolInputSize above; shared by the
+	// openai and gemini capture sites. Overflow truncates — the
+	// accumulated prefix is kept, every later capture is dropped so
+	// the flattened value stays a clean prefix — and logs one WARN
+	// per stream. The values themselves are never logged.
+	maxReplayFieldBytes = 512 * 1024
 )
 
 // OpenAICompatibleAdapter implements ProviderAdapter for the OpenAI Chat
@@ -445,6 +458,22 @@ func logReplayFieldsCapture(ctx context.Context, logger *slog.Logger, providerTy
 	)
 }
 
+// replayCaptureByteLen returns the byte-length proxy for one captured
+// replay value: raw length for strings, JSON-encoded length otherwise
+// (zero on a marshal failure). The same proxy summarizeReplayCaptures
+// and logReplayFieldsCapture use, so the maxReplayFieldBytes cap
+// accounting agrees with the observability surfaces.
+func replayCaptureByteLen(v any) int {
+	if s, ok := v.(string); ok {
+		return len(s)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
 // flattenReplayCapture projects the per-stream ReplayFields accumulator
 // onto the map a "message_complete" StreamEvent carries (the flattening
 // rule documented on types.StreamEvent.ReplayFields):
@@ -455,6 +484,12 @@ func logReplayFieldsCapture(ctx context.Context, logger *slog.Logger, providerTy
 //     arrives across many chunks);
 //   - otherwise the LAST captured value is marshalled verbatim
 //     (snapshot semantics for object-shaped fields).
+//
+// JSON nulls (Go nil after decode) are stripped before the
+// all-strings check: a provider that opens the stream with
+// `"reasoning_content": null` before the string chunks must not flip
+// the path onto the last-value snapshot arm and silently drop every
+// intermediate piece.
 //
 // A value that fails to re-marshal is skipped: every entry in the
 // accumulator was decoded from provider JSON, so the arm is
@@ -467,11 +502,17 @@ func flattenReplayCapture(capture map[string][]any) map[string]json.RawMessage {
 	}
 	out := make(map[string]json.RawMessage, len(capture))
 	for path, values := range capture {
-		if len(values) == 0 {
+		nonNil := make([]any, 0, len(values))
+		for _, v := range values {
+			if v != nil {
+				nonNil = append(nonNil, v)
+			}
+		}
+		if len(nonNil) == 0 {
 			continue
 		}
 		allStrings := true
-		for _, v := range values {
+		for _, v := range nonNil {
 			if _, ok := v.(string); !ok {
 				allStrings = false
 				break
@@ -481,12 +522,12 @@ func flattenReplayCapture(capture map[string][]any) map[string]json.RawMessage {
 		var err error
 		if allStrings {
 			var b strings.Builder
-			for _, v := range values {
+			for _, v := range nonNil {
 				b.WriteString(v.(string))
 			}
 			encoded, err = json.Marshal(b.String())
 		} else {
-			encoded, err = json.Marshal(values[len(values)-1])
+			encoded, err = json.Marshal(nonNil[len(nonNil)-1])
 		}
 		if err != nil {
 			continue
@@ -598,9 +639,10 @@ func threadableOpenAIReplayPath(path string) bool {
 
 // MarshalJSON emits the canonical message fields in struct order, then
 // appends the ReplayFields entries (sorted by key for determinism).
-// The two-pass shape mirrors openaiRequest.MarshalJSON: canonical
-// fields stay struct-driven so their byte order is stable, and the
-// extras are spliced in after. A ReplayFields key that collides with a
+// The two-pass shape mirrors openaiChunkChoice.UnmarshalJSON: the alias
+// preserves the canonical typed path and the extras are spliced into
+// the trailing bytes, matching the ExtraBodyFields merge concept in
+// openaiRequest.MarshalJSON. A ReplayFields key that collides with a
 // canonical message field, or a value that is not valid JSON, is an
 // error — translateMessages filters both cases, so reaching either arm
 // means a non-quirks caller populated the map by hand and should fail
@@ -1311,7 +1353,20 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 	// reasoning_content streamed across multiple chunks) records each
 	// piece in arrival order rather than only the last value. The
 	// terminal log line summarises lengths, not values.
+	//
+	// replayFieldsTotalBytes tracks the accumulator's byte budget
+	// (replayCaptureByteLen proxy, across all paths) against
+	// maxReplayFieldBytes. Once the cap is hit, replayFieldsCapped
+	// flips and every later capture is dropped, so the flattened value
+	// stays a clean prefix of the stream rather than gaining holes
+	// from selectively skipped chunks.
 	replayFieldsCapture := map[string][]any{}
+	replayFieldsTotalBytes := 0
+	replayFieldsCapped := false
+	// messageCompleted records whether a finish_reason chunk produced a
+	// message_complete event, so the bare-[DONE] fallback below knows
+	// whether the stream still owes one.
+	messageCompleted := false
 	// Emit the per-stream ReplayFields summary on any exit path
 	// (normal end, early return on error, ctx cancel). Length-only
 	// reporting per design §5: avoid leaking captured content into
@@ -1362,6 +1417,23 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 		if data == "[DONE]" {
 			// Flush any remaining tool calls before ending.
 			o.flushToolCallsVia(toolCalls, emitEvent)
+			// Some gateways terminate with a bare [DONE] and never send
+			// a finish_reason chunk. If replay state accumulated and no
+			// message_complete was emitted, synthesise one so the
+			// captured state still reaches the persisted assistant
+			// message — otherwise the next turn 400s against DeepSeek
+			// v4 thinking mode. Gated on messageCompleted: a stream
+			// that already completed normally must not get a second
+			// event, which would clobber the real stop reason (e.g.
+			// "tool_use") in streamEventsToResult's last-write-wins
+			// merge.
+			if !messageCompleted && len(replayFieldsCapture) > 0 {
+				emitEvent(types.StreamEvent{
+					Type:         "message_complete",
+					StopReason:   mapFinishReason("stop"),
+					ReplayFields: flattenReplayCapture(replayFieldsCapture),
+				})
+			}
 			return
 		}
 
@@ -1374,12 +1446,32 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 		for _, choice := range chunk.Choices {
 			// ReplayFields capture (design D12). Walk the raw delta
 			// object once per chunk and merge any matching paths into
-			// the per-stream accumulator. The path walker is a no-op
+			// the per-stream accumulator, subject to the
+			// maxReplayFieldBytes budget. The path walker is a no-op
 			// when q.ReplayFields is empty so the cost in the
-			// zero-rules case is one slice-length check.
-			if len(q.ReplayFields) > 0 && len(choice.RawDelta) > 0 {
+			// zero-rules case is one slice-length check; once the cap
+			// is hit, the walk is skipped entirely for the rest of the
+			// stream.
+			if !replayFieldsCapped && len(q.ReplayFields) > 0 && len(choice.RawDelta) > 0 {
 				if captured := quirks.CaptureFromJSON(choice.RawDelta, q.ReplayFields); len(captured) > 0 {
 					for k, v := range captured {
+						add := 0
+						for _, item := range v {
+							add += replayCaptureByteLen(item)
+						}
+						if replayFieldsTotalBytes+add > maxReplayFieldBytes {
+							replayFieldsCapped = true
+							// One WARN per stream; the captured values
+							// themselves are never logged.
+							logger.WarnContext(ctx, "replay field accumulator cap reached, truncating",
+								slog.String("provider.type", "openai-compatible"),
+								slog.String("provider.model", model),
+								slog.String("path", k),
+								slog.Int("limit_bytes", maxReplayFieldBytes),
+							)
+							break
+						}
+						replayFieldsTotalBytes += add
 						replayFieldsCapture[k] = append(replayFieldsCapture[k], v...)
 					}
 				}
@@ -1436,6 +1528,7 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 					ev.OutputTokens = chunk.Usage.CompletionTokens
 				}
 				emitEvent(ev)
+				messageCompleted = true
 			}
 		}
 	}

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -192,6 +192,86 @@ func TestOpenAIQuirks_DeepSeekV4Flash_RequestShape(t *testing.T) {
 	}
 }
 
+// TestOpenAIQuirks_DeepSeekReasoner_RequestShape mirrors the v4-flash
+// golden for the retiring deepseek-reasoner alias (a v4-flash thinking
+// alias until 2026-07-24): the rule's behaviour flags must produce the
+// same wire divergences — legacy max_tokens, suppressed temperature,
+// reasoning_content replayed on the assistant message. The fixture pins
+// the current shape for the alias's remaining operation; remove it
+// together with the rule after the sunset.
+func TestOpenAIQuirks_DeepSeekReasoner_RequestShape(t *testing.T) {
+	params := deepseekReplayParams("deepseek-reasoner")
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+		t.Fatalf("deepseek-reasoner: expected OmitSamplingParams=true (rule not firing)")
+	}
+	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
+		t.Fatalf("deepseek-reasoner: expected TokenField=max_tokens, got %v", q.BehaviourFlags.OpenAI.TokenField)
+	}
+	req, err := buildOpenAIRequest(params, true, q, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath(fixtureRoot, "deepseek-reasoner", "request.json"), body)
+
+	s := string(body)
+	if !strings.Contains(s, `"max_tokens"`) || strings.Contains(s, `"max_completion_tokens"`) {
+		t.Errorf("body must use the legacy max_tokens key: %s", s)
+	}
+	if strings.Contains(s, `"temperature"`) {
+		t.Errorf("body contains temperature despite OmitSamplingParams: %s", s)
+	}
+	if !strings.Contains(s, `"reasoning_content"`) {
+		t.Errorf("body missing replayed reasoning_content on the assistant message: %s", s)
+	}
+}
+
+// TestOpenAIQuirks_DeepSeekV4Flash_SSEParse drives the deepseek-v4-flash
+// response fixture through the production Stream path: the SSE parse
+// must capture every reasoning_content delta and the message_complete
+// event must carry the flattened (concatenated) value. Together with
+// the request.json golden this closes the fixture round-trip for the
+// explicit flash id — every other model fixture directory carries both
+// halves.
+func TestOpenAIQuirks_DeepSeekV4Flash_SSEParse(t *testing.T) {
+	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/deepseek-v4-flash/response.sse"))
+	defer srv.Close()
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-v4-flash",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var complete *types.StreamEvent
+	for _, ev := range drainStream(t, ch) {
+		if ev.Type == "message_complete" {
+			evCopy := ev
+			complete = &evCopy
+		}
+	}
+	if complete == nil {
+		t.Fatal("no message_complete event")
+	}
+	if complete.ReplayFields == nil {
+		t.Fatal("message_complete carries no ReplayFields for deepseek-v4-flash")
+	}
+	want := `"Scanning the request. Choosing an answer."`
+	if got := string(complete.ReplayFields["reasoning_content"]); got != want {
+		t.Errorf("ReplayFields[reasoning_content] = %s, want %s", got, want)
+	}
+}
+
 // TestOpenAIQuirks_NoReplayRule_OmitsReplayState pins the negative half
 // of the threading contract: the same message history sent to a model
 // whose resolved quirks register no ReplayFields emits NOTHING extra —

--- a/harness/internal/provider/openai_quirks_test.go
+++ b/harness/internal/provider/openai_quirks_test.go
@@ -127,6 +127,94 @@ func TestOpenAIQuirks_GPT4oNoQuirksApply(t *testing.T) {
 	quirkstest.AssertWireEqual(t, quirkstest.JoinPath(fixtureRoot, "gpt-4o", "request.json"), body)
 }
 
+// deepseekReplayParams returns the canonical multi-turn tool-calling
+// StreamParams for the DeepSeek wire-shape tests: a prior assistant
+// turn that called a tool and carries the captured reasoning_content,
+// followed by the tool result. The shape is the exact scenario the v4
+// thinking-mode guide documents as 400-ing without the replay.
+func deepseekReplayParams(model string) types.StreamParams {
+	return types.StreamParams{
+		Model:       model,
+		MaxTokens:   4096,
+		Temperature: types.Float64Ptr(0.5),
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "list main.go"}}},
+			{
+				Role: "assistant",
+				Content: []types.ContentBlock{
+					{Type: "text", Text: "Reading the file."},
+					{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+				},
+				ReplayFields: map[string]json.RawMessage{
+					"reasoning_content": json.RawMessage(`"The user wants the file contents; read_file is the right tool."`),
+				},
+			},
+			{Role: "user", Content: []types.ContentBlock{{Type: "tool_result", ToolUseID: "call_1", Content: "package main"}}},
+		},
+	}
+}
+
+// TestOpenAIQuirks_DeepSeekV4Flash_RequestShape is the golden contract
+// for the threaded DeepSeek v4 rule: the prior turn's reasoning_content
+// is replayed as a top-level key on the assistant wire message, the
+// token budget uses the legacy max_tokens key, and the caller-supplied
+// temperature is suppressed. The fixture is the source of truth.
+func TestOpenAIQuirks_DeepSeekV4Flash_RequestShape(t *testing.T) {
+	params := deepseekReplayParams("deepseek-v4-flash")
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+		t.Fatalf("deepseek-v4-flash: expected OmitSamplingParams=true (rule not firing)")
+	}
+	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
+		t.Fatalf("deepseek-v4-flash: expected TokenField=max_tokens, got %v", q.BehaviourFlags.OpenAI.TokenField)
+	}
+	req, err := buildOpenAIRequest(params, true, q, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath(fixtureRoot, "deepseek-v4-flash", "request.json"), body)
+
+	// Belt-and-braces string assertions on the load-bearing keys, so a
+	// fixture edit cannot silently weaken the contract.
+	s := string(body)
+	if !strings.Contains(s, `"max_tokens"`) || strings.Contains(s, `"max_completion_tokens"`) {
+		t.Errorf("body must use the legacy max_tokens key: %s", s)
+	}
+	if strings.Contains(s, `"temperature"`) {
+		t.Errorf("body contains temperature despite OmitSamplingParams: %s", s)
+	}
+	if !strings.Contains(s, `"reasoning_content":"The user wants the file contents; read_file is the right tool."`) {
+		t.Errorf("body missing replayed reasoning_content on the assistant message: %s", s)
+	}
+}
+
+// TestOpenAIQuirks_NoReplayRule_OmitsReplayState pins the negative half
+// of the threading contract: the same message history sent to a model
+// whose resolved quirks register no ReplayFields emits NOTHING extra —
+// the registry, not the persisted message, decides what is replayed.
+func TestOpenAIQuirks_NoReplayRule_OmitsReplayState(t *testing.T) {
+	params := deepseekReplayParams("gpt-4o")
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", params.Model)
+	if len(q.ReplayFields) != 0 {
+		t.Fatalf("gpt-4o: expected no ReplayFields, got %v", q.ReplayFields)
+	}
+	req, err := buildOpenAIRequest(params, true, q, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "reasoning_content") {
+		t.Errorf("gpt-4o body leaked reasoning_content with no rule: %s", body)
+	}
+}
+
 // TestNoRegressionMaxCompletionTokensDefault pins design risk 1: the
 // default openai-compatible body MUST emit max_completion_tokens, NOT
 // the legacy max_tokens, regardless of whether a quirk rule fired.

--- a/harness/internal/provider/openai_test.go
+++ b/harness/internal/provider/openai_test.go
@@ -640,7 +640,7 @@ func TestTranslateMessages(t *testing.T) {
 		},
 	}
 
-	result := translateMessages("System prompt", messages)
+	result := translateMessages("System prompt", messages, nil)
 
 	// system + user + assistant + tool = 4 messages.
 	if len(result) != 4 {
@@ -683,7 +683,7 @@ func TestTranslateMessages_ErrorToolResult(t *testing.T) {
 		},
 	}
 
-	result := translateMessages("", messages)
+	result := translateMessages("", messages, nil)
 
 	if len(result) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(result))

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -87,52 +87,145 @@ func BuiltinRules() []Rule {
 		},
 		// --- ReplayFields rules (design §6.5, D12) ---
 		//
-		// Wave 2 lands parse-side recognition only. Each rule's
-		// Description ends in "(parse-side only)" so trace consumers
-		// know the captured value is observable but not yet threaded
-		// back into outbound history. Outbound threading is design
-		// §9 risk 7, deferred to a follow-up.
+		// Each rule's Description ends in exactly one of two markers so
+		// trace consumers know what happens to the captured value:
 		//
-		// The Description suffix is enforced by
-		// TestBuiltinRulesParseSideOnlySuffix in replay_test.go.
+		//   - "(threaded)"        — the value is captured parse-side AND
+		//     echoed back onto subsequent requests (the §9 risk 7
+		//     outbound threading, implemented for openai-compatible).
+		//     Threaded paths must be single-segment and must not collide
+		//     with a canonical wire-message key.
+		//   - "(parse-side only)" — the value surfaces in length-only
+		//     observability (slog/OTel) but is not round-tripped via
+		//     this surface. Gemini's real round-trip is the typed
+		//     block-level ThoughtSignature, so its ReplayFields rule
+		//     stays parse-side.
+		//
+		// The suffix convention and the threadable-path constraint are
+		// enforced by TestBuiltinRulesReplayFieldsSuffix in
+		// replay_test.go.
 		{
 			ProviderType: "openai-compatible",
 			ModelMatch:   "deepseek-reasoner*",
-			Description:  "DeepSeek reasoner: preserve reasoning_content (parse-side only)",
-			LastVerified: Date("2026-05-24"),
+			Description:  "DeepSeek reasoner: replay reasoning_content, omit sampling params, legacy max_tokens (threaded)",
+			LastVerified: Date("2026-06-07"),
 			Apply: func(q *ProviderQuirks) {
-				// DeepSeek's reasoner family surfaces its chain-of-
-				// thought as a `reasoning_content` field on each
-				// assistant delta, alongside the canonical `content`
-				// field. The DeepSeek API docs describe the field as
-				// part of the model's response, and the openai-
-				// compatible streaming layout places it at the same
-				// nesting level as `content` (a direct child of
-				// `delta`). The single-segment path captures it
-				// directly when the adapter walks the choice's raw
-				// delta object.
+				// SUNSET: deepseek-reasoner is now a first-party
+				// compatibility alias for deepseek-v4-flash thinking
+				// mode, fully retired after 2026-07-24 15:59 UTC
+				// (https://api-docs.deepseek.com/updates). Remove this
+				// rule after that date. Note the legacy reasoning-model
+				// guide and the v4 thinking-mode guide give conflicting
+				// input semantics for reasoning_content during the
+				// alias window; the explicit deepseek-v4* ids below are
+				// the supported target.
 				//
-				// Field-path verification status: unverified against a
-				// live DeepSeek-reasoner capture as of LastVerified.
-				// Mark the rule stale if not re-verified within the
-				// 180-day window; the staleness test will surface it.
+				// reasoning_content arrives as a sibling of `content`
+				// on each assistant delta (a direct child of `delta`),
+				// so the single-segment path captures it when the
+				// adapter walks the choice's raw delta object. The
+				// shape is documented in both the legacy reasoning-model
+				// guide and the v4 thinking-mode guide; not yet verified
+				// against a live first-party capture.
 				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+				// The reasoner lineage ignores temperature / top_p /
+				// penalties ("will not trigger an error but will also
+				// have no effect") while logprobs / top_logprobs DO
+				// trigger an API error — see
+				// https://api-docs.deepseek.com/guides/reasoning_model.
+				// OmitSamplingParams covers both sets: hygiene for the
+				// inert params, 400-protection for the log* ones.
+				q.BehaviourFlags.OpenAI.OmitSamplingParams = true
+				// The reasoner guide documents max_tokens (32K default,
+				// 64K max) and never mentions max_completion_tokens.
+				// Doc-derived, pending live-capture verification of
+				// whether the modern key is also accepted.
+				q.BehaviourFlags.OpenAI.TokenField = TokenFieldMaxTokens
 			},
 		},
 		{
 			ProviderType: "openai-compatible",
 			ModelMatch:   "deepseek-v4*",
-			Description:  "DeepSeek v4: preserve reasoning_content (parse-side only)",
-			LastVerified: Date("2026-05-24"),
+			Description:  "DeepSeek v4: replay reasoning_content, omit sampling params, legacy max_tokens (threaded)",
+			LastVerified: Date("2026-06-07"),
 			Apply: func(q *ProviderQuirks) {
-				// DeepSeek's v4 series uses the same reasoning_content
-				// field on the assistant delta as the reasoner family
-				// per the DeepSeek API documentation. If a future v4
-				// release diverges (e.g. adopts a structured
-				// `thinking` field instead) the rule needs a
-				// LastVerified bump and the path adjusted; the
-				// staleness test will surface the prompt.
+				// DeepSeek v4 (deepseek-v4-flash / deepseek-v4-pro) is
+				// dual-mode with thinking DEFAULT-ON, emitting
+				// chain-of-thought as `delta.reasoning_content`. The
+				// thinking-mode guide
+				// (https://api-docs.deepseek.com/guides/thinking_mode)
+				// is explicit that "for turns that do perform tool
+				// calls, the reasoning_content must be fully passed
+				// back to the API in all subsequent requests" and that
+				// the API returns a 400 error otherwise — so this rule
+				// is load-bearing for multi-turn tool-calling, not just
+				// observability. Replaying on all turns is safe: the
+				// field is optional, not forbidden, on non-tool-call
+				// turns. Doc-verified 2026-06-07 with broad community
+				// 400-report corroboration; not yet verified against a
+				// live first-party capture.
 				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+				// Thinking mode IGNORES temperature / top_p / penalties
+				// ("will not trigger an error but will also have no
+				// effect") — omitting them is hygiene, not
+				// 400-protection — while logprobs / top_logprobs
+				// hard-error on the reasoner lineage. See
+				// https://api-docs.deepseek.com/guides/thinking_mode.
+				q.BehaviourFlags.OpenAI.OmitSamplingParams = true
+				// DeepSeek docs use the legacy max_tokens key throughout
+				// and never mention max_completion_tokens. Doc-derived,
+				// pending live-capture verification of whether
+				// max_completion_tokens is also accepted.
+				q.BehaviourFlags.OpenAI.TokenField = TokenFieldMaxTokens
+				// Deliberately NOT set: StrictMode (per-tool strict is
+				// Beta-only on a separate /beta base URL with a known
+				// malformed-JSON bug — deepseek-ai/DeepSeek-V3#1069) and
+				// any ToolChoice/ParallelToolCalls/ToolExamples override
+				// (the openai-compatible base rules already advertise
+				// the documented v4 surface: full tool_choice, 128
+				// tools). parallel_tool_calls is undocumented for
+				// DeepSeek; live-capture TODO alongside required/named
+				// tool-choice honouring in thinking mode.
+			},
+		},
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "deepseek/deepseek-v4*",
+			Description:  "DeepSeek v4 via gateway prefix: replay reasoning_content, omit sampling params, legacy max_tokens (threaded)",
+			LastVerified: Date("2026-06-07"),
+			Apply: func(q *ProviderQuirks) {
+				// OpenRouter (and OpenRouter-style gateways) serve the
+				// same models under prefixed ids
+				// (deepseek/deepseek-v4-flash, deepseek/deepseek-v4-pro)
+				// that the bare deepseek-v4* glob cannot match:
+				// path.Match's `*` does not cross `/`, so this sibling
+				// rule names the prefix literally. The slash also means
+				// the longer glob sorts after deepseek-v4* under
+				// specificity ordering (D10) — moot today because the
+				// two globs are disjoint, but pinned by test so a future
+				// overlap composes predictably.
+				//
+				// Community reports through OpenRouter show the same
+				// 400-on-missing-replay behaviour as the first-party
+				// endpoint, so the full v4 quirk set is mirrored.
+				// Unverified gateway divergences, needing live capture
+				// before any rule change: some gateways rename the
+				// field to `reasoning` (no path for it here until
+				// observed), and gateway thinking-mode defaults may
+				// diverge from first-party default-on.
+				//
+				// Note: the openai-compatible base "*" rules (tool
+				// choice, parallel tool calls, schema examples) do NOT
+				// match slash-prefixed ids for the same path.Match
+				// reason, so those capabilities resolve to their
+				// zero values (unsupported) for gateway ids. That is a
+				// pre-existing property of every slash-prefixed model id
+				// on this provider type, not something this rule
+				// changes; widening the base rules is a separate
+				// decision.
+				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+				q.BehaviourFlags.OpenAI.OmitSamplingParams = true
+				q.BehaviourFlags.OpenAI.TokenField = TokenFieldMaxTokens
 			},
 		},
 		// --- Schema lint / strict-mode rules (#228, Wave 3 Step B) ---

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -39,8 +39,13 @@ type ProviderQuirks struct {
 	EnumCoercions map[string]map[string]string `json:"enumCoercions"`
 
 	// ReplayFields lists assistant-message field paths to preserve verbatim
-	// across turns. Parse-side recognition only in v1; outbound threading is
-	// a follow-up. Paths use dot-separated keys with [] for array-of-objects.
+	// across turns. Paths use dot-separated keys with [] for array-of-objects.
+	// Every adapter captures the named paths parse-side (length-only
+	// observability); the openai-compatible adapter additionally threads
+	// single-segment, non-colliding paths back onto subsequent requests as
+	// top-level assistant-message keys (design §9 risk 7). A rule's
+	// Description suffix — "(threaded)" vs "(parse-side only)" — records
+	// which behaviour applies; see the ReplayFields rules in BuiltinRules.
 	ReplayFields []string `json:"replayFields"`
 
 	// --- Capabilities ---

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -863,6 +863,104 @@ func TestReplayFieldsRules_DeepSeekV4(t *testing.T) {
 	})
 }
 
+// TestDeepSeekV4Resolution pins the full resolved quirk set for the
+// first-party v4 ids. Beyond the ReplayFields path, the rule sets the
+// thinking-mode behaviour flags (sampling params ignored upstream;
+// legacy max_tokens key) and must NOT enable strict mode (Beta-only on
+// a separate /beta base URL with a known malformed-JSON bug) or perturb
+// the base openai-compatible capabilities.
+func TestDeepSeekV4Resolution(t *testing.T) {
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		model := model
+		t.Run(model, func(t *testing.T) {
+			q := DefaultRegistry().Resolve("openai-compatible", model)
+			if len(q.ReplayFields) != 1 || q.ReplayFields[0] != "reasoning_content" {
+				t.Errorf("ReplayFields = %v, want [reasoning_content]", q.ReplayFields)
+			}
+			if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+				t.Errorf("OmitSamplingParams = false, want true (thinking mode ignores sampling params; logprobs hard-errors)")
+			}
+			if q.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxTokens {
+				t.Errorf("TokenField = %v, want TokenFieldMaxTokens (DeepSeek docs use the legacy key)", q.BehaviourFlags.OpenAI.TokenField)
+			}
+			if q.BehaviourFlags.OpenAI.StrictMode {
+				t.Errorf("StrictMode = true, want false (DeepSeek strict tools are Beta-only and unreliable)")
+			}
+			// The openai-compatible base "*" rules still compose: full
+			// tool_choice and parallel/examples capabilities, text-only
+			// structured results.
+			wantTC := ToolChoiceCapability{Supported: true, Auto: true, Required: true, None: true, NamedTool: true}
+			if q.ToolChoice != wantTC {
+				t.Errorf("ToolChoice = %+v, want %+v (base rule must compose)", q.ToolChoice, wantTC)
+			}
+			if q.StructuredToolResults != (StructuredToolResultCapability{}) {
+				t.Errorf("StructuredToolResults = %+v, want zero value (text-only)", q.StructuredToolResults)
+			}
+		})
+	}
+}
+
+// TestDeepSeekV4GatewayPrefixResolution pins the sibling rule for
+// OpenRouter-style prefixed ids. path.Match's `*` does not cross `/`,
+// which cuts both ways: the bare deepseek-v4* glob cannot match the
+// prefixed id (hence the sibling rule), and the openai-compatible base
+// "*" rules cannot either — so the gateway ids resolve the DeepSeek
+// flags but zero-value capabilities. Both directions are pinned so a
+// future glob change is a deliberate edit.
+func TestDeepSeekV4GatewayPrefixResolution(t *testing.T) {
+	for _, model := range []string{"deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"} {
+		model := model
+		t.Run(model, func(t *testing.T) {
+			q, applied := DefaultRegistry().ResolveWithRules("openai-compatible", model)
+			if len(q.ReplayFields) != 1 || q.ReplayFields[0] != "reasoning_content" {
+				t.Errorf("ReplayFields = %v, want [reasoning_content]", q.ReplayFields)
+			}
+			if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+				t.Errorf("OmitSamplingParams = false, want true")
+			}
+			if q.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxTokens {
+				t.Errorf("TokenField = %v, want TokenFieldMaxTokens", q.BehaviourFlags.OpenAI.TokenField)
+			}
+			if q.BehaviourFlags.OpenAI.StrictMode {
+				t.Errorf("StrictMode = true, want false")
+			}
+			// Exactly one rule fires: the slash keeps every other
+			// openai-compatible glob (including the base "*" rules) from
+			// matching. This is the D10 ordering check the rule comment
+			// references — the globs are disjoint, so the longer gateway
+			// glob is the only contributor.
+			if len(applied) != 1 || !strings.Contains(applied[0].Description, "gateway prefix") {
+				descs := make([]string, 0, len(applied))
+				for _, r := range applied {
+					descs = append(descs, r.Description)
+				}
+				t.Errorf("applied rules = %v, want exactly the gateway-prefix rule", descs)
+			}
+			if q.ToolChoice != (ToolChoiceCapability{}) {
+				t.Errorf("ToolChoice = %+v, want zero value (base * rule does not cross the slash)", q.ToolChoice)
+			}
+		})
+	}
+
+	t.Run("bare ids do not fire the gateway rule", func(t *testing.T) {
+		_, applied := DefaultRegistry().ResolveWithRules("openai-compatible", "deepseek-v4-flash")
+		for _, r := range applied {
+			if strings.Contains(r.Description, "gateway prefix") {
+				t.Errorf("gateway-prefix rule fired for a bare id: %v", r.Description)
+			}
+		}
+	})
+
+	t.Run("other prefixed deepseek ids do not fire", func(t *testing.T) {
+		for _, model := range []string{"deepseek/deepseek-chat", "deepseek/deepseek-v3", "openrouter/deepseek-v4-flash"} {
+			q := DefaultRegistry().Resolve("openai-compatible", model)
+			if len(q.ReplayFields) != 0 {
+				t.Errorf("%s: ReplayFields = %v, want none", model, q.ReplayFields)
+			}
+		}
+	})
+}
+
 // TestReplayFieldsRules_Gemini3 pins the gemini-3* ReplayFields rule:
 // fires on gemini-3* model ids, captures the sibling-of-functionCall
 // thoughtSignature path, and does not fire on 2.x or on

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -817,6 +817,21 @@ func TestReplayFieldsRules_DeepSeekReasoner(t *testing.T) {
 		if len(q.ReplayFields) != 1 || q.ReplayFields[0] != "reasoning_content" {
 			t.Errorf("ReplayFields = %v, want [reasoning_content]", q.ReplayFields)
 		}
+		// The reasoner rule carries the same behaviour-flag set as the
+		// v4 rule (it is a v4-flash thinking alias until 2026-07-24):
+		// sampling params suppressed (logprobs hard-errors on the
+		// reasoner lineage), legacy max_tokens key, no strict mode
+		// (Beta-only, unreliable). Without these assertions a
+		// divergence from the v4 rule would pass the suite undetected.
+		if !q.BehaviourFlags.OpenAI.OmitSamplingParams {
+			t.Errorf("OmitSamplingParams = false, want true")
+		}
+		if q.BehaviourFlags.OpenAI.TokenField != TokenFieldMaxTokens {
+			t.Errorf("TokenField = %v, want TokenFieldMaxTokens", q.BehaviourFlags.OpenAI.TokenField)
+		}
+		if q.BehaviourFlags.OpenAI.StrictMode {
+			t.Errorf("StrictMode = true, want false")
+		}
 	})
 	t.Run("fires on deepseek-reasoner-lite (suffix variant)", func(t *testing.T) {
 		q := DefaultRegistry().Resolve("openai-compatible", "deepseek-reasoner-lite")

--- a/harness/internal/provider/quirks/replay.go
+++ b/harness/internal/provider/quirks/replay.go
@@ -9,10 +9,12 @@ import (
 // This file implements the shared ReplayFields path parser and walker.
 // ReplayFields is the design D12 surface: a rule lists assistant-message
 // field paths that should be captured from a provider response so the
-// agentic loop can echo them back on the next turn. Wave 2 lands
-// parse-side recognition only (design §9 risk 7) — the captured values
-// surface in trace attributes so an operator can see the rule fired,
-// but they are not yet threaded back into outbound message history.
+// agentic loop can echo them back on the next turn. Captured values
+// surface in length-only trace attributes on every adapter; the
+// openai-compatible adapter additionally threads single-segment paths
+// back into outbound message history (design §9 risk 7) — see the
+// "(threaded)" / "(parse-side only)" Description convention in
+// builtin.go.
 //
 // The parser is cross-adapter: both openai.go and gemini.go call it
 // against their decoded SSE payloads, so the path syntax is the only

--- a/harness/internal/provider/quirks/replay_test.go
+++ b/harness/internal/provider/quirks/replay_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -309,18 +310,46 @@ func TestBuiltinRulesValidate_ReplayFieldsPathsAreSyntacticallyValid(t *testing.
 	}
 }
 
-// TestBuiltinRulesParseSideOnlySuffix pins design §9 risk 7: a rule
+// canonicalOpenAIMessageFieldNames mirrors the canonical Chat
+// Completions message-key surface enumerated by
+// harness/internal/provider/openai.go's canonicalOpenAIMessageFields.
+// The duplication is intentional, following the existing
+// canonicalOpenAIFieldNames precedent in quirks_test.go: the adapter's
+// set is unexported and the registry must not import the provider
+// package, so the test cross-checks rules against a local copy. When
+// the adapter learns a new canonical message key, add it here too.
+var canonicalOpenAIMessageFieldNames = map[string]bool{
+	"role":         true,
+	"content":      true,
+	"tool_calls":   true,
+	"tool_call_id": true,
+	"name":         true,
+}
+
+// TestBuiltinRulesReplayFieldsSuffix pins design §9 risk 7's
+// observability convention now that outbound threading exists: a rule
 // that registers a ReplayFields path MUST end its Description with
-// "(parse-side only)" so trace consumers know the captured value is
-// observable but not yet threaded back into outbound history. Without
-// this convention an operator reading the trace might assume the
-// preserved field is being round-tripped on the next turn — it is
-// not, by design, in v1.
+// exactly one of two markers so trace consumers know whether the
+// captured value is round-tripped.
+//
+//   - openai-compatible rules must end "(threaded)" — the adapter
+//     threads their captures back onto subsequent requests — and every
+//     path they declare must be threadable: single-segment, no []
+//     iteration, and not a canonical wire-message key. A first-party
+//     rule that declares a non-threadable path fails here at build
+//     time (the adapter would silently skip it at runtime, which is
+//     the wrong failure mode for first-party rules — loud at build,
+//     safe at runtime).
+//   - every other provider's rules must end "(parse-side only)" —
+//     their adapters have no outbound threading path (Gemini's real
+//     round-trip is the typed block-level ThoughtSignature), so
+//     claiming "(threaded)" would be a lie in the trace.
 //
 // The check applies only to rules that write to ReplayFields, so
-// existing wire-shape rules are unaffected.
-func TestBuiltinRulesParseSideOnlySuffix(t *testing.T) {
-	const suffix = "(parse-side only)"
+// wire-shape rules are unaffected.
+func TestBuiltinRulesReplayFieldsSuffix(t *testing.T) {
+	const threadedSuffix = "(threaded)"
+	const parseSideSuffix = "(parse-side only)"
 	for i, rule := range BuiltinRules() {
 		if rule.Apply == nil {
 			continue
@@ -337,46 +366,34 @@ func TestBuiltinRulesParseSideOnlySuffix(t *testing.T) {
 		if len(q.ReplayFields) == 0 {
 			continue
 		}
-		// The convention is a substring (not strict suffix) so a rule
-		// that adds a clarifying parenthetical after the marker stays
-		// valid; the marker presence is the load-bearing signal.
-		if !containsCaseInsensitive(rule.Description, suffix) {
-			t.Errorf("BuiltinRules()[%d] (%q): ReplayFields rule description must contain %q so trace consumers know the value is parse-side only", i, rule.Description, suffix)
-		}
-	}
-}
-
-// containsCaseInsensitive avoids importing strings for a one-shot
-// helper; the test runs once per build and ASCII case-folding is
-// sufficient for the rule descriptions in this repo.
-func containsCaseInsensitive(haystack, needle string) bool {
-	if len(needle) == 0 {
-		return true
-	}
-	if len(haystack) < len(needle) {
-		return false
-	}
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		match := true
-		for j := 0; j < len(needle); j++ {
-			a := haystack[i+j]
-			b := needle[j]
-			if a >= 'A' && a <= 'Z' {
-				a += 'a' - 'A'
+		switch {
+		case rule.ProviderType == "openai-compatible":
+			if !strings.HasSuffix(rule.Description, threadedSuffix) {
+				t.Errorf("BuiltinRules()[%d] (%q): openai-compatible ReplayFields rule description must end with %q (the adapter threads its captures outbound)", i, rule.Description, threadedSuffix)
 			}
-			if b >= 'A' && b <= 'Z' {
-				b += 'a' - 'A'
+			for _, path := range q.ReplayFields {
+				segments, err := ParseReplayPath(path)
+				if err != nil {
+					// TestBuiltinRulesValidate_ReplayFieldsPathsAreSyntacticallyValid
+					// reports the parse failure with a better message.
+					continue
+				}
+				if len(segments) != 1 || segments[0].IsArray {
+					t.Errorf("BuiltinRules()[%d] (%q): ReplayFields path %q is not threadable (must be a single non-array segment for outbound emission)", i, rule.Description, path)
+				}
+				if canonicalOpenAIMessageFieldNames[path] {
+					t.Errorf("BuiltinRules()[%d] (%q): ReplayFields path %q collides with a canonical openai message key", i, rule.Description, path)
+				}
 			}
-			if a != b {
-				match = false
-				break
+		default:
+			if !strings.HasSuffix(rule.Description, parseSideSuffix) {
+				t.Errorf("BuiltinRules()[%d] (%q): ReplayFields rule description must end with %q (no outbound threading exists for provider %q)", i, rule.Description, parseSideSuffix, rule.ProviderType)
+			}
+			if strings.HasSuffix(rule.Description, threadedSuffix) {
+				t.Errorf("BuiltinRules()[%d] (%q): provider %q has no outbound threading; the description must not claim %q", i, rule.Description, rule.ProviderType, threadedSuffix)
 			}
 		}
-		if match {
-			return true
-		}
 	}
-	return false
 }
 
 // TestSortedReplayPathKeys is a small utility test for the trace-attribute

--- a/harness/internal/provider/quirks/replay_test.go
+++ b/harness/internal/provider/quirks/replay_test.go
@@ -366,8 +366,8 @@ func TestBuiltinRulesReplayFieldsSuffix(t *testing.T) {
 		if len(q.ReplayFields) == 0 {
 			continue
 		}
-		switch {
-		case rule.ProviderType == "openai-compatible":
+		switch rule.ProviderType {
+		case "openai-compatible":
 			if !strings.HasSuffix(rule.Description, threadedSuffix) {
 				t.Errorf("BuiltinRules()[%d] (%q): openai-compatible ReplayFields rule description must end with %q (the adapter threads its captures outbound)", i, rule.Description, threadedSuffix)
 			}

--- a/harness/internal/provider/quirks/testdata/model-ids.txt
+++ b/harness/internal/provider/quirks/testdata/model-ids.txt
@@ -2,6 +2,10 @@ claude-3-5-sonnet-20241022
 deepseek-reasoner
 deepseek-v4
 deepseek-v4-chat
+deepseek-v4-flash
+deepseek-v4-pro
+deepseek/deepseek-v4-flash
+deepseek/deepseek-v4-pro
 gemini-2.5-pro
 gemini-3.1-pro-preview
 glm-4-air

--- a/harness/internal/provider/replay.go
+++ b/harness/internal/provider/replay.go
@@ -94,6 +94,17 @@ func (rp *ReplayProvider) Stream(ctx context.Context, _ types.StreamParams) (<-c
 			estimatedTokens = 1
 		}
 
+		// Known gap: ReplayFields is NOT forwarded here. TurnRecord does
+		// not carry the message-level replay state (the trace scrubber
+		// deliberately drops it as provider-opaque), so a
+		// live-continuation run seeded from a recording against
+		// DeepSeek v4 thinking mode will miss reasoning_content on the
+		// replayed turn and 400 on the first real tool-call request.
+		// Closing it needs a TurnRecord schema change (a recording-side
+		// carrier exempt from the scrub drop) — tracked as a follow-up;
+		// live continuation against v4 thinking mode is not a supported
+		// workflow today. Contrast with ThoughtSignature above, which
+		// rides the ContentBlock and is forwarded.
 		ch <- types.StreamEvent{
 			Type:         "message_complete",
 			StopReason:   stopReason,

--- a/harness/internal/provider/replay_quirks_test.go
+++ b/harness/internal/provider/replay_quirks_test.go
@@ -263,6 +263,75 @@ func TestReplayFields_DeepSeekV4_PreservesReasoningContent(t *testing.T) {
 	}
 }
 
+// TestReplayFields_DeepSeekV4Gateway_PreservesReasoningContent drives
+// the OpenRouter-style prefixed id (deepseek/deepseek-v4-flash) through
+// the production Stream path. The gateway sibling rule must fire — the
+// bare deepseek-v4* glob cannot match across the slash — and produce
+// the same capture + flattened message_complete value the first-party
+// rule does.
+func TestReplayFields_DeepSeekV4Gateway_PreservesReasoningContent(t *testing.T) {
+	const ssePath = "testdata/quirks/openai-compatible/deepseek/deepseek-v4-flash/response.sse"
+	const replayPath = "testdata/quirks/openai-compatible/deepseek/deepseek-v4-flash/replay.json"
+
+	srv := sseStubServer(t, streamFixtureSSE(t, ssePath))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek/deepseek-v4-flash",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := drainStream(t, ch)
+
+	// Capture-side: the per-stream summary's piece count matches the
+	// fixture, same as the first-party tests.
+	want := loadReplayFixture(t, replayPath)
+	got := extractReplayFieldsLog(t, buf.String())
+	if got == nil {
+		t.Fatalf("debug log missing 'quirks replay fields captured' record; log:\n%s", buf.String())
+	}
+	for path, wantPieces := range want {
+		if path == "content" {
+			continue
+		}
+		gotCount, ok := got[path]
+		if !ok {
+			t.Errorf("path %q not captured; got summary %v", path, got)
+			continue
+		}
+		if gotCount != len(wantPieces) {
+			t.Errorf("path %q: captured %d pieces, want %d", path, gotCount, len(wantPieces))
+		}
+	}
+
+	// Thread-side: the message_complete event carries the in-order
+	// concatenation of the fixture's reasoning_content pieces.
+	var complete *types.StreamEvent
+	for i := range events {
+		if events[i].Type == "message_complete" {
+			complete = &events[i]
+		}
+	}
+	if complete == nil {
+		t.Fatalf("no message_complete event in %v", events)
+	}
+	wantFlat := `"Weighing the options before answering."`
+	if gotFlat := string(complete.ReplayFields["reasoning_content"]); gotFlat != wantFlat {
+		t.Errorf("message_complete ReplayFields[reasoning_content] = %s, want %s", gotFlat, wantFlat)
+	}
+}
+
 // TestReplayFields_Gemini3_PreservesThoughtSignature drives the
 // gemini-3.1-pro-preview/response.sse fixture through the Gemini
 // adapter and asserts the per-stream summary names the

--- a/harness/internal/provider/replay_threading_test.go
+++ b/harness/internal/provider/replay_threading_test.go
@@ -1,0 +1,404 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// This file covers the outbound half of the quirks ReplayFields
+// round-trip (design §9 risk 7): flattening the per-stream capture onto
+// the message_complete event, attaching it to assistant wire messages,
+// and the cross-provider leakage guards that keep the state from
+// reaching a provider that does not own it.
+
+// TestFlattenReplayCapture pins the flattening rule documented on
+// types.StreamEvent.ReplayFields: all-string captures concatenate in
+// arrival order; anything else snapshots the last value.
+func TestFlattenReplayCapture(t *testing.T) {
+	t.Run("string pieces concatenate in arrival order", func(t *testing.T) {
+		got := flattenReplayCapture(map[string][]any{
+			"reasoning_content": {"", "Let me think. ", "The answer is 4."},
+		})
+		want := `"Let me think. The answer is 4."`
+		if string(got["reasoning_content"]) != want {
+			t.Errorf("reasoning_content = %s, want %s", got["reasoning_content"], want)
+		}
+	})
+	t.Run("non-string values snapshot the last capture", func(t *testing.T) {
+		got := flattenReplayCapture(map[string][]any{
+			"thinking": {
+				map[string]any{"step": float64(1)},
+				map[string]any{"step": float64(2)},
+			},
+		})
+		want := `{"step":2}`
+		if string(got["thinking"]) != want {
+			t.Errorf("thinking = %s, want %s", got["thinking"], want)
+		}
+	})
+	t.Run("mixed types snapshot the last capture", func(t *testing.T) {
+		got := flattenReplayCapture(map[string][]any{
+			"field": {map[string]any{"a": "b"}, "tail"},
+		})
+		want := `"tail"`
+		if string(got["field"]) != want {
+			t.Errorf("field = %s, want %s", got["field"], want)
+		}
+	})
+	t.Run("empty capture returns nil", func(t *testing.T) {
+		if got := flattenReplayCapture(nil); got != nil {
+			t.Errorf("nil capture: got %v, want nil", got)
+		}
+		if got := flattenReplayCapture(map[string][]any{}); got != nil {
+			t.Errorf("empty capture: got %v, want nil", got)
+		}
+		if got := flattenReplayCapture(map[string][]any{"p": {}}); got != nil {
+			t.Errorf("empty value slice: got %v, want nil", got)
+		}
+	})
+}
+
+// TestOpenAIMessage_MarshalJSON_MergesReplayFields pins the wire shape
+// of an assistant message carrying replay state: canonical fields in
+// struct order, replay entries appended in sorted-key order, and the
+// defence-in-depth error arms for collisions and invalid payloads.
+func TestOpenAIMessage_MarshalJSON_MergesReplayFields(t *testing.T) {
+	t.Run("appends replay entries after canonical fields", func(t *testing.T) {
+		m := openaiMessage{
+			Role:    "assistant",
+			Content: "done",
+			ReplayFields: map[string]json.RawMessage{
+				"reasoning_content": json.RawMessage(`"thinking..."`),
+			},
+		}
+		out, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		want := `{"role":"assistant","content":"done","reasoning_content":"thinking..."}`
+		if string(out) != want {
+			t.Errorf("Marshal = %s, want %s", out, want)
+		}
+	})
+	t.Run("multiple entries emit in sorted key order", func(t *testing.T) {
+		m := openaiMessage{
+			Role: "assistant",
+			ReplayFields: map[string]json.RawMessage{
+				"zeta_field":  json.RawMessage(`"z"`),
+				"alpha_field": json.RawMessage(`"a"`),
+			},
+		}
+		out, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		want := `{"role":"assistant","alpha_field":"a","zeta_field":"z"}`
+		if string(out) != want {
+			t.Errorf("Marshal = %s, want %s", out, want)
+		}
+	})
+	t.Run("no replay fields is byte-identical to the plain shape", func(t *testing.T) {
+		m := openaiMessage{Role: "tool", Content: "ok", ToolCallID: "call_1"}
+		out, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		want := `{"role":"tool","content":"ok","tool_call_id":"call_1"}`
+		if string(out) != want {
+			t.Errorf("Marshal = %s, want %s", out, want)
+		}
+	})
+	t.Run("canonical key collision errors", func(t *testing.T) {
+		m := openaiMessage{
+			Role:         "assistant",
+			ReplayFields: map[string]json.RawMessage{"content": json.RawMessage(`"evil"`)},
+		}
+		_, err := json.Marshal(m)
+		if err == nil {
+			t.Fatal("expected collision error, got nil")
+		}
+		if !strings.Contains(err.Error(), "collides with canonical message field") {
+			t.Errorf("error = %q, want collision message", err.Error())
+		}
+	})
+	t.Run("invalid JSON payload errors", func(t *testing.T) {
+		m := openaiMessage{
+			Role:         "assistant",
+			ReplayFields: map[string]json.RawMessage{"reasoning_content": json.RawMessage(`{not json`)},
+		}
+		_, err := json.Marshal(m)
+		if err == nil {
+			t.Fatal("expected invalid-JSON error, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid JSON") {
+			t.Errorf("error = %q, want invalid-JSON message", err.Error())
+		}
+	})
+}
+
+// TestThreadableOpenAIReplayPath pins which path shapes qualify for
+// outbound emission: single-segment, non-array, non-canonical only.
+func TestThreadableOpenAIReplayPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"reasoning_content", true},
+		{"thinking", true},
+		{"delta.reasoning_content", false},                       // multi-segment
+		{"candidates[].content.parts[].thoughtSignature", false}, // array iteration
+		{"role", false},         // canonical message key
+		{"content", false},      // canonical message key
+		{"tool_calls", false},   // canonical message key
+		{"tool_call_id", false}, // canonical message key
+		{"name", false},         // canonical (documented optional key)
+		{"a..b", false},         // malformed
+		{"", false},             // malformed
+	}
+	for _, tc := range cases {
+		if got := threadableOpenAIReplayPath(tc.path); got != tc.want {
+			t.Errorf("threadableOpenAIReplayPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestTranslateMessages_ThreadsQualifyingReplayFields pins the selection
+// rules at the translateMessages seam: only paths named by the resolved
+// quirks for THIS stream are emitted, and non-threadable paths are
+// silently skipped at runtime.
+func TestTranslateMessages_ThreadsQualifyingReplayFields(t *testing.T) {
+	assistant := types.Message{
+		Role:    "assistant",
+		Content: []types.ContentBlock{{Type: "text", Text: "done"}},
+		ReplayFields: map[string]json.RawMessage{
+			"reasoning_content": json.RawMessage(`"thinking"`),
+			"stale_field":       json.RawMessage(`"from another model"`),
+		},
+	}
+
+	t.Run("qualifying path is emitted", func(t *testing.T) {
+		out := translateMessages("", []types.Message{assistant}, []string{"reasoning_content"})
+		if len(out) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(out))
+		}
+		if string(out[0].ReplayFields["reasoning_content"]) != `"thinking"` {
+			t.Errorf("ReplayFields = %v, want reasoning_content threaded", out[0].ReplayFields)
+		}
+		if _, leaked := out[0].ReplayFields["stale_field"]; leaked {
+			t.Errorf("stale_field not in resolved paths must not leak: %v", out[0].ReplayFields)
+		}
+	})
+
+	t.Run("no resolved paths emits nothing (registry is the source of truth)", func(t *testing.T) {
+		out := translateMessages("", []types.Message{assistant}, nil)
+		if out[0].ReplayFields != nil {
+			t.Errorf("expected no replay fields without resolved paths, got %v", out[0].ReplayFields)
+		}
+		body, err := json.Marshal(out[0])
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if strings.Contains(string(body), "reasoning_content") {
+			t.Errorf("wire message leaked reasoning_content with no resolved rule: %s", body)
+		}
+	})
+
+	t.Run("multi-segment and colliding paths are skipped", func(t *testing.T) {
+		msg := types.Message{
+			Role:    "assistant",
+			Content: []types.ContentBlock{{Type: "text", Text: "done"}},
+			ReplayFields: map[string]json.RawMessage{
+				"delta.reasoning_content": json.RawMessage(`"nested"`),
+				"role":                    json.RawMessage(`"evil"`),
+				"reasoning_content":       json.RawMessage(`"ok"`),
+			},
+		}
+		paths := []string{"delta.reasoning_content", "role", "reasoning_content"}
+		out := translateMessages("", []types.Message{msg}, paths)
+		if len(out[0].ReplayFields) != 1 {
+			t.Fatalf("ReplayFields = %v, want only reasoning_content", out[0].ReplayFields)
+		}
+		if string(out[0].ReplayFields["reasoning_content"]) != `"ok"` {
+			t.Errorf("reasoning_content = %s, want \"ok\"", out[0].ReplayFields["reasoning_content"])
+		}
+	})
+
+	t.Run("empty payload is skipped", func(t *testing.T) {
+		msg := types.Message{
+			Role:         "assistant",
+			Content:      []types.ContentBlock{{Type: "text", Text: "done"}},
+			ReplayFields: map[string]json.RawMessage{"reasoning_content": nil},
+		}
+		out := translateMessages("", []types.Message{msg}, []string{"reasoning_content"})
+		if out[0].ReplayFields != nil {
+			t.Errorf("expected empty payload skipped, got %v", out[0].ReplayFields)
+		}
+	})
+
+	t.Run("user and tool messages never carry replay fields", func(t *testing.T) {
+		msgs := []types.Message{
+			{
+				Role:    "user",
+				Content: []types.ContentBlock{{Type: "text", Text: "hi"}},
+				// A user message carrying replay state is malformed input;
+				// the assistant-only emission point must ignore it.
+				ReplayFields: map[string]json.RawMessage{"reasoning_content": json.RawMessage(`"x"`)},
+			},
+		}
+		out := translateMessages("", msgs, []string{"reasoning_content"})
+		for i, m := range out {
+			if m.ReplayFields != nil {
+				t.Errorf("message %d (%s) carries replay fields: %v", i, m.Role, m.ReplayFields)
+			}
+		}
+	})
+}
+
+// TestReplayFields_DeepSeekV4_MessageCompleteCarriesFlattenedValue
+// drives the synthetic deepseek-v4 SSE fixture through the production
+// Stream path and asserts the message_complete event carries the
+// concatenation of every reasoning_content piece — the parse-side half
+// of the round-trip the loop persists onto the assistant Message.
+func TestReplayFields_DeepSeekV4_MessageCompleteCarriesFlattenedValue(t *testing.T) {
+	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/deepseek-v4/response.sse"))
+	defer srv.Close()
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-v4",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := drainStream(t, ch)
+
+	var complete *types.StreamEvent
+	for i := range events {
+		if events[i].Type == "message_complete" {
+			complete = &events[i]
+		}
+	}
+	if complete == nil {
+		t.Fatalf("no message_complete event in %v", events)
+	}
+	// The fixture streams reasoning_content as "" then "Considering the
+	// request carefully." — the flattened value is the in-order
+	// concatenation, marshalled as a JSON string.
+	want := `"Considering the request carefully."`
+	if got := string(complete.ReplayFields["reasoning_content"]); got != want {
+		t.Errorf("message_complete ReplayFields[reasoning_content] = %s, want %s", got, want)
+	}
+}
+
+// TestReplayFields_NoRule_MessageCompleteCarriesNothing pins the
+// negative: a model whose resolved quirks register no ReplayFields
+// produces a message_complete with a nil ReplayFields map, keeping the
+// event byte-identical to the pre-threading shape.
+func TestReplayFields_NoRule_MessageCompleteCarriesNothing(t *testing.T) {
+	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/o1-mini/response.sse"))
+	defer srv.Close()
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gpt-4o",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for _, ev := range drainStream(t, ch) {
+		if ev.Type == "message_complete" && ev.ReplayFields != nil {
+			t.Errorf("message_complete carries ReplayFields with no rule: %v", ev.ReplayFields)
+		}
+	}
+}
+
+// replayLeakageMessages is the shared history for the cross-provider
+// leakage guards: an assistant message carrying ReplayFields state that
+// only an openai-compatible adapter is allowed to serialise.
+func replayLeakageMessages(withReplay bool) []types.Message {
+	msgs := []types.Message{
+		{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "list main.go"}}},
+		{
+			Role: "assistant",
+			Content: []types.ContentBlock{
+				{Type: "text", Text: "Reading."},
+				{Type: "tool_use", ID: "call_1", Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)},
+			},
+		},
+		{Role: "user", Content: []types.ContentBlock{{Type: "tool_result", ToolUseID: "call_1", Content: "package main"}}},
+	}
+	if withReplay {
+		msgs[1].ReplayFields = map[string]json.RawMessage{
+			"reasoning_content": json.RawMessage(`"DeepSeek-private chain of thought"`),
+		}
+	}
+	return msgs
+}
+
+// TestTranslateMessagesAnthropic_IgnoresMessageReplayFields is the
+// cross-provider leakage guard for the message-level replay state: the
+// Anthropic wire body must be byte-identical with and without
+// Message.ReplayFields populated, the same invariant
+// anthropicContentBlock already enforces for the block-level
+// ThoughtSignature (#194).
+func TestTranslateMessagesAnthropic_IgnoresMessageReplayFields(t *testing.T) {
+	without, err := json.Marshal(translateMessagesAnthropic(replayLeakageMessages(false), quirks.StructuredToolResultCapability{}))
+	if err != nil {
+		t.Fatalf("marshal without: %v", err)
+	}
+	with, err := json.Marshal(translateMessagesAnthropic(replayLeakageMessages(true), quirks.StructuredToolResultCapability{}))
+	if err != nil {
+		t.Fatalf("marshal with: %v", err)
+	}
+	if !bytes.Equal(without, with) {
+		t.Errorf("anthropic wire bytes diverge when Message.ReplayFields is set:\nwithout: %s\nwith:    %s", without, with)
+	}
+	if bytes.Contains(with, []byte("reasoning_content")) {
+		t.Errorf("anthropic wire body leaked reasoning_content: %s", with)
+	}
+}
+
+// TestTranslateMessagesGemini_IgnoresMessageReplayFields mirrors the
+// Anthropic guard for the Gemini adapter: Gemini's round-trip state is
+// the typed block-level ThoughtSignature, never the message-level
+// ReplayFields map.
+func TestTranslateMessagesGemini_IgnoresMessageReplayFields(t *testing.T) {
+	contentsWithout, _, err := translateMessagesGemini("sys", replayLeakageMessages(false), quirks.StructuredToolResultCapability{})
+	if err != nil {
+		t.Fatalf("translate without: %v", err)
+	}
+	contentsWith, _, err := translateMessagesGemini("sys", replayLeakageMessages(true), quirks.StructuredToolResultCapability{})
+	if err != nil {
+		t.Fatalf("translate with: %v", err)
+	}
+	without, err := json.Marshal(contentsWithout)
+	if err != nil {
+		t.Fatalf("marshal without: %v", err)
+	}
+	with, err := json.Marshal(contentsWith)
+	if err != nil {
+		t.Fatalf("marshal with: %v", err)
+	}
+	if !bytes.Equal(without, with) {
+		t.Errorf("gemini wire bytes diverge when Message.ReplayFields is set:\nwithout: %s\nwith:    %s", without, with)
+	}
+	if bytes.Contains(with, []byte("reasoning_content")) {
+		t.Errorf("gemini wire body leaked reasoning_content: %s", with)
+	}
+}

--- a/harness/internal/provider/replay_threading_test.go
+++ b/harness/internal/provider/replay_threading_test.go
@@ -486,6 +486,169 @@ func TestReplayFields_CapBoundsAccumulator(t *testing.T) {
 	}
 }
 
+// TestReplayFields_SpanAttributesRecordCaptureSummary pins the OTel
+// half of the per-stream capture observability: when a span is active
+// on the Stream context, the deferred capture summary must set
+// replay_fields_captured.count / .total_len (length-only — values
+// never reach the trace). The stub-server tests never carried a span,
+// leaving summarizeReplayCaptures unexercised.
+func TestReplayFields_SpanAttributesRecordCaptureSummary(t *testing.T) {
+	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/deepseek-v4/response.sse"))
+	defer srv.Close()
+
+	ctx, exporter, span := withRecordingSpan(t)
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+
+	ch, err := adapter.Stream(ctx, types.StreamParams{
+		Model:     "deepseek-v4",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	_ = drainStream(t, ch)
+	span.End()
+
+	var count, totalLen int64
+	found := false
+	for _, stub := range exporter.GetSpans() {
+		for _, attr := range stub.Attributes {
+			switch attr.Key {
+			case "replay_fields_captured.count":
+				count = attr.Value.AsInt64()
+				found = true
+			case "replay_fields_captured.total_len":
+				totalLen = attr.Value.AsInt64()
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("replay_fields_captured.* attributes missing from recorded spans")
+	}
+	// The deepseek-v4 fixture streams two reasoning_content pieces
+	// ("" + "Considering the request carefully.").
+	if count != 2 {
+		t.Errorf("replay_fields_captured.count = %d, want 2", count)
+	}
+	if totalLen != int64(len("Considering the request carefully.")) {
+		t.Errorf("replay_fields_captured.total_len = %d, want %d", totalLen, len("Considering the request carefully."))
+	}
+}
+
+// TestSummarizeReplayCaptures pins both arms of the length proxy
+// directly: raw length for strings, JSON-encoded length for anything
+// else (the arm no streaming fixture reaches, since the current rules
+// only capture string fields).
+func TestSummarizeReplayCaptures(t *testing.T) {
+	t.Run("string values use raw length", func(t *testing.T) {
+		count, totalLen := summarizeReplayCaptures(map[string][]any{
+			"reasoning_content": {"ab", "cde"},
+		})
+		if count != 2 || totalLen != 5 {
+			t.Errorf("got (count=%d, totalLen=%d), want (2, 5)", count, totalLen)
+		}
+	})
+	t.Run("non-string values use JSON-encoded length", func(t *testing.T) {
+		count, totalLen := summarizeReplayCaptures(map[string][]any{
+			"x": {map[string]any{"step": 1}},
+		})
+		// json.Marshal(map[string]any{"step": 1}) = `{"step":1}` (10 bytes).
+		if count != 1 || totalLen != 10 {
+			t.Errorf("got (count=%d, totalLen=%d), want (1, 10)", count, totalLen)
+		}
+	})
+	t.Run("cap accounting helper agrees with the summary proxy", func(t *testing.T) {
+		if got := replayCaptureByteLen("abc"); got != 3 {
+			t.Errorf("string: got %d, want 3", got)
+		}
+		if got := replayCaptureByteLen(map[string]any{"step": 1}); got != 10 {
+			t.Errorf("object: got %d, want 10 (JSON-encoded length)", got)
+		}
+		// Unmarshalable values degrade to zero rather than failing —
+		// the accumulator only ever holds decoded JSON, so this is the
+		// defensive arm.
+		if got := replayCaptureByteLen(func() {}); got != 0 {
+			t.Errorf("unmarshalable: got %d, want 0", got)
+		}
+	})
+}
+
+// TestReplayFields_TwoTurnRoundTrip drives the full failure mode the
+// feature exists to prevent: turn 1 streams a DeepSeek v4 response with
+// reasoning_content, the captured state is attached to the assistant
+// message exactly as the agentic loop does it, and the turn-2 request
+// built from that history must carry reasoning_content as a top-level
+// key on the assistant wire message — the shape whose absence 400s.
+func TestReplayFields_TwoTurnRoundTrip(t *testing.T) {
+	srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/deepseek-v4-flash/response.sse"))
+	defer srv.Close()
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+
+	history := []types.Message{
+		{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+	}
+
+	// Turn 1: stream and assemble the assistant message the way
+	// streamEventsToResult + appendAssistantContent do — text deltas
+	// concatenate into one block, message_complete supplies the
+	// replay state.
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-v4-flash",
+		MaxTokens: 1024,
+		Messages:  history,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var text strings.Builder
+	var replay map[string]json.RawMessage
+	for _, ev := range drainStream(t, ch) {
+		switch ev.Type {
+		case "text_delta":
+			text.WriteString(ev.Text)
+		case "message_complete":
+			replay = ev.ReplayFields
+		}
+	}
+	if replay == nil {
+		t.Fatal("turn 1 produced no ReplayFields")
+	}
+	history = append(history, types.Message{
+		Role:         "assistant",
+		Content:      []types.ContentBlock{{Type: "text", Text: text.String()}},
+		ReplayFields: replay,
+	})
+	history = append(history, types.Message{
+		Role:    "user",
+		Content: []types.ContentBlock{{Type: "text", Text: "and now?"}},
+	})
+
+	// Turn 2: the request built from the updated history must replay
+	// the captured value verbatim on the assistant message.
+	q := quirks.DefaultRegistry().Resolve("openai-compatible", "deepseek-v4-flash")
+	req, err := buildOpenAIRequest(types.StreamParams{
+		Model:     "deepseek-v4-flash",
+		MaxTokens: 1024,
+		Messages:  history,
+	}, true, q, nil)
+	if err != nil {
+		t.Fatalf("build turn-2 request: %v", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal turn-2 request: %v", err)
+	}
+	want := `"reasoning_content":"Scanning the request. Choosing an answer."`
+	if !strings.Contains(string(body), want) {
+		t.Errorf("turn-2 wire body missing replayed reasoning_content:\nwant substring: %s\nbody: %s", want, body)
+	}
+}
+
 // replayLeakageMessages is the shared history for the cross-provider
 // leakage guards: an assistant message carrying ReplayFields state that
 // only an openai-compatible adapter is allowed to serialise.

--- a/harness/internal/provider/replay_threading_test.go
+++ b/harness/internal/provider/replay_threading_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -51,6 +52,18 @@ func TestFlattenReplayCapture(t *testing.T) {
 			t.Errorf("field = %s, want %s", got["field"], want)
 		}
 	})
+	t.Run("nil first chunk then strings concatenates", func(t *testing.T) {
+		// A provider that opens the stream with `"reasoning_content":
+		// null` decodes to a Go nil. The nil must be stripped before
+		// the all-strings check — otherwise the last-value snapshot
+		// arm fires and silently drops every intermediate piece.
+		got := flattenReplayCapture(map[string][]any{
+			"reasoning_content": {nil, "a", "b"},
+		})
+		if string(got["reasoning_content"]) != `"ab"` {
+			t.Errorf("reasoning_content = %s, want \"ab\"", got["reasoning_content"])
+		}
+	})
 	t.Run("empty capture returns nil", func(t *testing.T) {
 		if got := flattenReplayCapture(nil); got != nil {
 			t.Errorf("nil capture: got %v, want nil", got)
@@ -60,6 +73,9 @@ func TestFlattenReplayCapture(t *testing.T) {
 		}
 		if got := flattenReplayCapture(map[string][]any{"p": {}}); got != nil {
 			t.Errorf("empty value slice: got %v, want nil", got)
+		}
+		if got := flattenReplayCapture(map[string][]any{"p": {nil, nil}}); got != nil {
+			t.Errorf("all-nil value slice: got %v, want nil", got)
 		}
 	})
 }
@@ -325,6 +341,148 @@ func TestReplayFields_NoRule_MessageCompleteCarriesNothing(t *testing.T) {
 		if ev.Type == "message_complete" && ev.ReplayFields != nil {
 			t.Errorf("message_complete carries ReplayFields with no rule: %v", ev.ReplayFields)
 		}
+	}
+}
+
+// TestReplayFields_DoneOnlyTermination_EmitsMessageComplete pins the
+// bare-[DONE] fallback: some proxy gateways omit the finish_reason
+// chunk and terminate with [DONE] alone. Accumulated replay state must
+// still reach a message_complete event — silently dropping it would
+// 400 the next DeepSeek turn. The companion sub-test pins the guard's
+// other half: a stream that completed normally must emit exactly one
+// message_complete (a duplicate from the fallback would clobber the
+// real stop reason in streamEventsToResult's last-write-wins merge).
+func TestReplayFields_DoneOnlyTermination_EmitsMessageComplete(t *testing.T) {
+	t.Run("bare DONE emits synthetic message_complete", func(t *testing.T) {
+		sse := "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"reasoning_content\":\"part one \"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"part two\"},\"finish_reason\":null}]}\n\n" +
+			"data: [DONE]\n\n"
+		srv := sseStubServer(t, []byte(sse))
+		defer srv.Close()
+
+		adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+		ch, err := adapter.Stream(context.Background(), types.StreamParams{
+			Model:     "deepseek-v4-flash",
+			MaxTokens: 1024,
+			Messages: []types.Message{
+				{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Stream: %v", err)
+		}
+		var completes []types.StreamEvent
+		for _, ev := range drainStream(t, ch) {
+			if ev.Type == "message_complete" {
+				completes = append(completes, ev)
+			}
+		}
+		if len(completes) != 1 {
+			t.Fatalf("expected exactly 1 message_complete, got %d", len(completes))
+		}
+		if got := string(completes[0].ReplayFields["reasoning_content"]); got != `"part one part two"` {
+			t.Errorf("ReplayFields[reasoning_content] = %s, want \"part one part two\"", got)
+		}
+		if completes[0].StopReason != "end_turn" {
+			t.Errorf("StopReason = %q, want end_turn (canonical mapping of the synthetic stop)", completes[0].StopReason)
+		}
+	})
+
+	t.Run("normal finish_reason stream emits exactly one message_complete", func(t *testing.T) {
+		srv := sseStubServer(t, streamFixtureSSE(t, "testdata/quirks/openai-compatible/deepseek-v4/response.sse"))
+		defer srv.Close()
+
+		adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+		ch, err := adapter.Stream(context.Background(), types.StreamParams{
+			Model:     "deepseek-v4",
+			MaxTokens: 1024,
+			Messages: []types.Message{
+				{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Stream: %v", err)
+		}
+		count := 0
+		var last types.StreamEvent
+		for _, ev := range drainStream(t, ch) {
+			if ev.Type == "message_complete" {
+				count++
+				last = ev
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected exactly 1 message_complete, got %d (the [DONE] fallback must not double-emit)", count)
+		}
+		if last.StopReason != "end_turn" {
+			t.Errorf("StopReason = %q, want end_turn from the finish_reason chunk", last.StopReason)
+		}
+	})
+}
+
+// TestReplayFields_CapBoundsAccumulator pins the maxReplayFieldBytes
+// budget: a provider streaming far more captured content than any real
+// chain-of-thought field must be truncated to a bounded prefix, the
+// stream must complete normally, and one WARN must name the cap. 600
+// chunks of 1 kB exceed the 512 kB budget by ~17%.
+func TestReplayFields_CapBoundsAccumulator(t *testing.T) {
+	piece := strings.Repeat("a", 1024)
+	var sse strings.Builder
+	for i := 0; i < 600; i++ {
+		sse.WriteString(`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"` + piece + `"},"finish_reason":null}]}`)
+		sse.WriteString("\n\n")
+	}
+	sse.WriteString(`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)
+	sse.WriteString("\n\ndata: [DONE]\n\n")
+
+	srv := sseStubServer(t, []byte(sse.String()))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "deepseek-v4-flash",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var complete *types.StreamEvent
+	for _, ev := range drainStream(t, ch) {
+		if ev.Type == "message_complete" {
+			evCopy := ev
+			complete = &evCopy
+		}
+	}
+	if complete == nil {
+		t.Fatal("no message_complete event")
+	}
+	got := complete.ReplayFields["reasoning_content"]
+	if len(got) == 0 {
+		t.Fatal("truncation must keep the accumulated prefix, not drop the field")
+	}
+	// The flattened value is a JSON string: content bytes plus two
+	// quotes (the fixture content needs no escaping).
+	if len(got) > maxReplayFieldBytes+2 {
+		t.Errorf("flattened value is %d bytes, want <= %d (cap not enforced)", len(got), maxReplayFieldBytes+2)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "replay field accumulator cap reached, truncating") {
+		t.Errorf("missing cap WARN log; log:\n%.2000s", logOutput)
+	}
+	if !strings.Contains(logOutput, `"level":"WARN"`) {
+		t.Errorf("cap log entry must be WARN level; log:\n%.2000s", logOutput)
+	}
+	if strings.Contains(logOutput, piece) {
+		t.Errorf("cap WARN leaked captured content into the log")
 	}
 }
 

--- a/harness/internal/provider/replay_threading_test.go
+++ b/harness/internal/provider/replay_threading_test.go
@@ -153,13 +153,13 @@ func TestThreadableOpenAIReplayPath(t *testing.T) {
 		{"thinking", true},
 		{"delta.reasoning_content", false},                       // multi-segment
 		{"candidates[].content.parts[].thoughtSignature", false}, // array iteration
-		{"role", false},         // canonical message key
-		{"content", false},      // canonical message key
-		{"tool_calls", false},   // canonical message key
-		{"tool_call_id", false}, // canonical message key
-		{"name", false},         // canonical (documented optional key)
-		{"a..b", false},         // malformed
-		{"", false},             // malformed
+		{"role", false},                                          // canonical message key
+		{"content", false},                                       // canonical message key
+		{"tool_calls", false},                                    // canonical message key
+		{"tool_call_id", false},                                  // canonical message key
+		{"name", false},                                          // canonical (documented optional key)
+		{"a..b", false},                                          // malformed
+		{"", false},                                              // malformed
 	}
 	for _, tc := range cases {
 		if got := threadableOpenAIReplayPath(tc.path); got != tc.want {

--- a/harness/internal/provider/testdata/quirks/README.md
+++ b/harness/internal/provider/testdata/quirks/README.md
@@ -12,13 +12,14 @@ breaking end-to-end against a live provider.
 testdata/quirks/<provider-type>/<model>/
     request.json     # golden outbound request body (one tool-enabled turn)
     response.sse      # captured streaming response for parser tests
-    replay.json       # captured ReplayFields snapshot (parse-side rules)
+    replay.json       # captured ReplayFields snapshot (ReplayFields rules)
 ```
 
 `<provider-type>` is the `RunConfig` provider type (`anthropic`,
 `openai-compatible`, `openai-responses`, `gemini`); `<model>` is the model the
-fixture was captured for. Not every provider/model carries all three files —
-add only what the test asserts.
+fixture was captured for — a gateway-prefixed id such as
+`deepseek/deepseek-v4-flash` maps onto a nested directory verbatim. Not every
+provider/model carries all three files — add only what the test asserts.
 
 ## `request.json` format
 

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-reasoner/request.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-reasoner/request.json
@@ -1,0 +1,32 @@
+# synthetic: derived from buildOpenAIRequest + DefaultRegistry().Resolve and the DeepSeek reasoning-model guide (https://api-docs.deepseek.com/guides/reasoning_model) because the harness does not yet have a live deepseek-reasoner capture. Pins the retiring alias's wire shape against accidental divergence from the v4 rule during its remaining operation (the alias retires 2026-07-24 15:59 UTC; remove this fixture with the rule): legacy max_tokens key, sampling params omitted despite a caller-supplied temperature, and the prior turn's reasoning_content replayed as a top-level key on the assistant message.
+{
+  "model": "deepseek-reasoner",
+  "messages": [
+    {
+      "role": "user",
+      "content": "list main.go"
+    },
+    {
+      "role": "assistant",
+      "content": "Reading the file.",
+      "tool_calls": [
+        {
+          "id": "call_1",
+          "type": "function",
+          "function": {
+            "name": "read_file",
+            "arguments": "{\"path\":\"main.go\"}"
+          }
+        }
+      ],
+      "reasoning_content": "The user wants the file contents; read_file is the right tool."
+    },
+    {
+      "role": "tool",
+      "content": "package main",
+      "tool_call_id": "call_1"
+    }
+  ],
+  "max_tokens": 4096,
+  "stream": true
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4-flash/request.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4-flash/request.json
@@ -1,0 +1,32 @@
+# synthetic: derived from buildOpenAIRequest + DefaultRegistry().Resolve and the DeepSeek thinking-mode guide (https://api-docs.deepseek.com/guides/thinking_mode) because the harness does not yet have a live deepseek-v4-flash capture. Pins the v4 rule's wire shape: legacy max_tokens key, sampling params omitted despite a caller-supplied temperature, and the prior turn's reasoning_content replayed as a top-level key on the assistant message (the API returns 400 on tool-call turns without it). Replace with a real capture before relying on the rule against live traffic.
+{
+  "model": "deepseek-v4-flash",
+  "messages": [
+    {
+      "role": "user",
+      "content": "list main.go"
+    },
+    {
+      "role": "assistant",
+      "content": "Reading the file.",
+      "tool_calls": [
+        {
+          "id": "call_1",
+          "type": "function",
+          "function": {
+            "name": "read_file",
+            "arguments": "{\"path\":\"main.go\"}"
+          }
+        }
+      ],
+      "reasoning_content": "The user wants the file contents; read_file is the right tool."
+    },
+    {
+      "role": "tool",
+      "content": "package main",
+      "tool_call_id": "call_1"
+    }
+  ],
+  "max_tokens": 4096,
+  "stream": true
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4-flash/response.sse
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek-v4-flash/response.sse
@@ -1,0 +1,12 @@
+# synthetic: derived from the DeepSeek thinking-mode guide (https://api-docs.deepseek.com/guides/thinking_mode) because the harness does not yet have a live deepseek-v4-flash capture. Mirrors the v4 wire shape (reasoning_content streamed as a sibling of content on each assistant delta, thinking default-on) so the SSE-parse contract test walks the capture-and-flatten path end-to-end for the explicit flash id. Replace with a real capture before relying on the rule against live traffic.
+data: {"id":"chatcmpl-ds-v4-flash-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-flash-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"Scanning the request. "},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-flash-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"Choosing an answer."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-flash-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-flash-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":8}}
+
+data: [DONE]

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek/deepseek-v4-flash/replay.json
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek/deepseek-v4-flash/replay.json
@@ -1,0 +1,9 @@
+# synthetic: post-parse capture snapshot matching response.sse in this directory; see that fixture's comment for provenance.
+{
+  "reasoning_content": [
+    "",
+    "Weighing the options ",
+    "before answering."
+  ],
+  "content": "Done."
+}

--- a/harness/internal/provider/testdata/quirks/openai-compatible/deepseek/deepseek-v4-flash/response.sse
+++ b/harness/internal/provider/testdata/quirks/openai-compatible/deepseek/deepseek-v4-flash/response.sse
@@ -1,0 +1,12 @@
+# synthetic: derived from the first-party deepseek-v4 fixture and community reports of OpenRouter-served deepseek/deepseek-v4-* traffic (the gateway preserves the reasoning_content field name and the 400-replay requirement per claude-code-router#1378 and related reports) because the harness does not yet have a live gateway capture. Some gateways are reported to rename the field to "reasoning" — unverified; capture live traffic before adding that path. Replace with a real OpenRouter capture before relying on the rule against live traffic.
+data: {"id":"chatcmpl-ds-v4-gw-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-gw-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"Weighing the options "},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-gw-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"before answering."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-gw-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ds-v4-gw-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":7}}
+
+data: [DONE]

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -300,6 +300,13 @@ func scrubTurnRecord(t types.TurnRecord) types.TurnRecord {
 // Tool definitions and the model string are not scrubbed: tool schemas
 // are constants compiled into the harness, and the model identifier
 // (e.g. "claude-3-5-sonnet-latest") is not a secret.
+//
+// Message.ReplayFields is deliberately absent from the rebuilt Message:
+// like ContentBlock.ThoughtSignature it is provider-opaque round-trip
+// state the harness must never persist verbatim (see the field contract
+// in types/messages.go), and the scrubber cannot inspect an opaque
+// value. The explicit field list below is the drop mechanism — a future
+// edit that copies the source Message wholesale would regress this.
 func scrubModelInput(in types.ModelInput) types.ModelInput {
 	out := types.ModelInput{
 		Model:    in.Model,

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -347,6 +347,49 @@ func TestJSONLTraceEmitter_RecordTurnRecord_DropsThoughtSignature(t *testing.T) 
 	}
 }
 
+// TestJSONLTraceEmitter_RecordTurnRecord_DropsMessageReplayFields mirrors
+// the ThoughtSignature drop test for the message-level
+// Message.ReplayFields carrier (the quirks ReplayFields round-trip
+// state, e.g. DeepSeek's reasoning_content). Same contract, same
+// mechanism: the value is provider-opaque so the scrubber cannot redact
+// within it, and scrubModelInput's explicit field list drops it from
+// the persisted message history outright.
+func TestJSONLTraceEmitter_RecordTurnRecord_DropsMessageReplayFields(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+
+	const replayValue = "opaque-reasoning-content-do-not-persist"
+	emitter.Start("run-replay-fields", nil)
+	emitter.RecordTurnRecord(types.TurnRecord{
+		Turn: 2,
+		ModelInput: types.ModelInput{
+			Model: "deepseek-v4-flash",
+			Messages: []types.Message{
+				{
+					Role: "assistant",
+					Content: []types.ContentBlock{
+						{Type: "text", Text: "prior turn"},
+					},
+					ReplayFields: map[string]json.RawMessage{
+						"reasoning_content": json.RawMessage(`"` + replayValue + `"`),
+					},
+				},
+			},
+		},
+	})
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	onDisk := buf.String()
+	if strings.Contains(onDisk, replayValue) {
+		t.Errorf("Message.ReplayFields value must not survive into the persisted trace:\n%s", onDisk)
+	}
+	if strings.Contains(onDisk, "replay_fields") {
+		t.Errorf("replay_fields key should be absent (omitempty after drop), got:\n%s", onDisk)
+	}
+}
+
 // TestJSONLTraceEmitter_RecordTurnRecord_ScrubsToolResultContent pins
 // the scrub of ContentBlock.Content — the tool_result text rendering
 // that rides the message history into the next turn's ModelInput. The

--- a/types/events.go
+++ b/types/events.go
@@ -80,7 +80,7 @@ type StreamEvent struct {
 	// that do not emit it. ThoughtSignature (above) is the block-level
 	// sibling for per-block provider state; this field carries
 	// message-level state.
-	ReplayFields map[string]json.RawMessage `json:"replayFields,omitempty"`
+	ReplayFields map[string]json.RawMessage `json:"replay_fields,omitempty"`
 }
 
 // ToolChoiceMode is a closed enum selecting how the model is steered

--- a/types/events.go
+++ b/types/events.go
@@ -58,6 +58,29 @@ type StreamEvent struct {
 	// value on a ContentBlock cannot accidentally cross provider
 	// boundaries.
 	ThoughtSignature string `json:"thought_signature,omitempty"`
+
+	// ReplayFields carries the message-level provider-opaque state a
+	// quirks ReplayFields rule captured from this response, keyed by the
+	// rule's verbatim path string. Populated only on "message_complete"
+	// events; the agentic loop copies it onto the persisted assistant
+	// Message so the next request can replay it (e.g. DeepSeek v4
+	// thinking mode returns HTTP 400 on tool-call turns unless
+	// reasoning_content is echoed back).
+	//
+	// Flattening rule: an adapter accumulates captured values per path
+	// across the whole stream. When every captured value for a path is a
+	// string, the pieces are concatenated in arrival order and marshalled
+	// as a single JSON string (the streamed-string-field case, e.g.
+	// reasoning_content arriving across many chunks). Otherwise the LAST
+	// captured value is marshalled verbatim (snapshot semantics).
+	//
+	// The values are provider-opaque: the harness must not introspect,
+	// log verbatim, or mutate them — only round-trip them to the same
+	// provider. `omitempty` keeps the field off the wire for adapters
+	// that do not emit it. ThoughtSignature (above) is the block-level
+	// sibling for per-block provider state; this field carries
+	// message-level state.
+	ReplayFields map[string]json.RawMessage `json:"replayFields,omitempty"`
 }
 
 // ToolChoiceMode is a closed enum selecting how the model is steered

--- a/types/messages.go
+++ b/types/messages.go
@@ -16,6 +16,25 @@ type Message struct {
 	// turns from provenance-sensitive views. The field is omitempty so
 	// non-synthetic messages serialise byte-identically to the pre-#340 shape.
 	Synthetic bool `json:"synthetic,omitempty"`
+
+	// ReplayFields is provider-opaque round-trip state captured from an
+	// assistant response by quirks ReplayFields rules, keyed by the rule's
+	// verbatim path string (e.g. "reasoning_content" for DeepSeek thinking
+	// mode). The agentic loop attaches it to the assistant Message it
+	// persists; the originating provider's adapter echoes qualifying
+	// entries back onto the wire on subsequent turns. Treat the values as
+	// fully opaque — the harness must not introspect, log verbatim, or
+	// mutate them. `omitempty` keeps non-participating messages
+	// byte-identical to the prior shape.
+	//
+	// Adapter-private wire types for other providers (anthropic, gemini)
+	// must NOT serialise this field — the same cross-provider leakage
+	// guard established for ContentBlock.ThoughtSignature (see the
+	// rename-decision note on that field). ThoughtSignature is the
+	// block-level carrier for per-block provider state (Gemini's
+	// per-part signatures); ReplayFields is the message-level sibling
+	// for state that belongs to the assistant turn as a whole.
+	ReplayFields map[string]json.RawMessage `json:"replay_fields,omitempty"`
 }
 
 // ContentBlock is a single block of content within a message.


### PR DESCRIPTION
## Summary

Adds first-class support for DeepSeek v4 Flash and v4 Pro (`deepseek-v4-flash`, `deepseek-v4-pro`) to the openai-compatible adapter, driven by a verified deep-research pass against the DeepSeek API documentation (2026-06-07).

The load-bearing change is **outbound ReplayFields threading** (design §9 risk 7, previously deferred): DeepSeek v4 ships thinking mode default-on, emits chain-of-thought as `delta.reasoning_content`, and **returns 400 on tool-call turns unless `reasoning_content` is replayed back in subsequent requests** ([thinking-mode guide](https://api-docs.deepseek.com/guides/thinking_mode)) — the inverse of the historic `deepseek-reasoner` strip behaviour. Without threading, every multi-turn tool-calling run against v4 fails.

## Changes

**Threading path** (capture already existed parse-side):
- `types.StreamEvent.ReplayFields` / `types.Message.ReplayFields` (`replay_fields`, omitempty) carry provider-opaque replay state; message-level sibling of the block-level `ThoughtSignature`, per its recorded rename-decision note.
- `consumeSSE` flattens the per-stream accumulator onto `message_complete` (string fragments concatenate in arrival order; non-strings keep last-value snapshot), bounded by a 512 KiB cap mirroring the `openaiMaxToolInputSize` precedent; bare-`[DONE]` termination (gateways that omit `finish_reason`) synthesises a gated `message_complete` so accumulated state is not dropped.
- The agentic loop attaches replay state to the persisted assistant message; `OffloadToFileStrategy` preserves it through compaction; the trace scrubber drops it from persisted traces (pinned by test).
- Outbound, `translateMessages` re-emits each path as a top-level assistant-message key via a two-pass `openaiMessage.MarshalJSON` splice — gated on resolved-rule membership, single-segment paths, and non-collision with canonical keys; build-time registry validation fails loudly on non-threadable paths. Anthropic/Gemini/Responses adapters byte-identical with the field present (leakage-guard tests).

**Quirk rules** (`LastVerified` 2026-06-07, doc-verified; live-capture notes per rule format):
- `deepseek-v4*`: `reasoning_content` threading + `OmitSamplingParams` (thinking mode *ignores* sampling params; `logprobs` hard-errors on the reasoner lineage) + `TokenFieldMaxTokens` (docs never mention `max_completion_tokens`).
- `deepseek/deepseek-v4*`: gateway sibling for OpenRouter-prefixed ids (community 400 reports confirm the replay requirement through the gateway).
- `deepseek-reasoner*`: same flags + sunset note — first-party alias of v4-flash thinking mode, retires 2026-07-24 15:59 UTC. No `deepseek-chat` rule (non-thinking alias).
- Deliberately **not** set: `StrictMode` (Beta-only, separate `/beta` base URL, malformed-JSON bug [deepseek-ai/DeepSeek-V3#1069](https://github.com/deepseek-ai/DeepSeek-V3/issues/1069)); no ToolChoice/ParallelToolCalls overrides (v4 documents the full OpenAI surface, 128 tools); no thinking-toggle builtin (default-on is desired; the operator-injectable `{"thinking":{"type":"disabled"}}` shape is documented).

**Docs**: `docs/provider-quirks.md` §3.1 threaded/parse-side suffix convention, §9 risks 7 + 9; `docs/providers.md`.

## Review process

Implemented by a feature-implementer agent, then a five-reviewer wave (code, security, spec-compliance, test-coverage, consistency), synthesized into a remediation brief (5 blocking, 5 cheap, 7 deferred, 8 rejected), and remediated in commits `b1ab38a`–`90a0c46`. Notable remediations: accumulator byte cap (security HIGH), compaction preservation (the most realistic production 400 path), bare-`[DONE]` flush, nil-first-chunk flattening, two-turn round-trip test, `summarizeReplayCaptures` to 100% coverage.

## Known gaps / follow-ups to file

- `ReplayProvider` does not forward `ReplayFields` on `message_complete` — live-continuation from recordings against v4 thinking mode will 400 (gap comment in `replay.go`; needs a `TurnRecord` schema decision).
- Multi-choice (`n>1`) accumulator semantics undocumented — DeepSeek is single-choice; wants a defensive warn-log.
- `deepseek-reasoner*` sunset (2026-07-24) is comment-only, inside the 180-day staleness window — cleanup PR closer to the date.
- `canonicalOpenAIMessageFields` intentional duplication (provider ↔ quirks test) could become a shared exported constant.
- `SummariseStrategy.prependSummary` ReplayFields preservation is alias-safe today but unpinned.
- Live-capture verification still needed for: `max_completion_tokens` acceptance, `reasoning_effort` wire placement (docs conflict), gateway `reasoning` field rename. All fixtures are synthetic pending real captures.

## Sources

Primary: [release note](https://api-docs.deepseek.com/news/news260424), [thinking-mode guide](https://api-docs.deepseek.com/guides/thinking_mode), [API reference](https://api-docs.deepseek.com/api/create-chat-completion), [pricing](https://api-docs.deepseek.com/quick_start/pricing), [tool-calls guide](https://api-docs.deepseek.com/guides/tool_calls), [json-mode guide](https://api-docs.deepseek.com/guides/json_mode). Corroboration: ~10 independent projects hitting the 400-replay error (opencode #24190/#24722, claude-code-router #1378, warp #11592, et al.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
