### PR TITLE
provider, compat: support Z.ai GLM 4.7 thinking family (reasoning_content replay + thinking param)

### DIFF
--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -35,7 +35,13 @@ Concrete v1 divergences:
   `max_tokens`.
 - Z.ai's GLM endpoint speaks the OpenAI Chat Completions wire format
   but requires `max_tokens` (the legacy key) and accepts a
-  proprietary `tool_stream: true` extension.
+  proprietary `tool_stream: true` extension. The GLM-4.5-and-above
+  thinking family (`glm-4.5`/`4.6`/`4.7` and the `glm-5` line)
+  additionally emits `reasoning_content` on the assistant delta and
+  accepts a top-level `thinking: {"type":"enabled"}` object; the
+  reasoning is replayed back outbound (same `ReplayFields` threading
+  as DeepSeek). The legacy hyphenated line (`glm-4-plus` etc.) has no
+  thinking mode and receives only the base quirks.
 - Vertex AI's Gemini 3.x stream emits a `thoughtSignature` blob on
   every `parts[]` entry that the harness must preserve verbatim for
   multi-turn reasoning continuity. Issue #194 traced the symptom; the
@@ -94,7 +100,7 @@ Compatibility profiles (operator-selected via
 ```
 harness/internal/provider/compat/
     zai/
-        zai.go      — CompatRule() returning the Z.ai GLM rule
+        zai.go      — CompatRules() returning the Z.ai GLM rule set
         zai_test.go — httptest contract test
 ```
 
@@ -321,10 +327,10 @@ resolved struct, not the adapter, is the source of truth for the
 Responses send path; the pinned values reproduce the adapter's prior
 hard-coded shape byte-for-byte. See [§2.1](#21-providerquirks).
 
-The compat profile rule for Z.ai GLM is registered separately via
-`harness/internal/provider/compat/zai/CompatRule()`; it is not in
-`BuiltinRules()` and only loads when `provider.compatProfile =
-"zai-glm"` is set.
+The compat profile rules for Z.ai GLM are registered separately via
+`harness/internal/provider/compat/zai/CompatRules()`; they are not in
+`BuiltinRules()` and only load when `provider.compatProfile =
+"zai-glm"` is set. See [§6](#6-zai-compat-placement) for the rule set.
 
 ### 3.1 ReplayFields rules
 
@@ -432,10 +438,33 @@ applied override must fire a `SecurityLogger` event.
 
 ## 6. Z.ai compat placement
 
-Z.ai/GLM is a compatibility-only target. The rule lives at
-`harness/internal/provider/compat/zai/zai.go` and exports a single
-`CompatRule()` function. The factory injects it into the registry
-when `provider.compatProfile = "zai-glm"` is set.
+Z.ai/GLM is a compatibility-only target. The rules live at
+`harness/internal/provider/compat/zai/zai.go` and are exported by
+`CompatRules()`, which returns a composing set rather than a single
+rule. The factory injects the set into the registry when
+`provider.compatProfile = "zai-glm"` is set; `resolveCompatProfile`
+returns the whole slice and the injection site spreads it after
+`BuiltinRules()`.
+
+The set composes — `quirks.Registry.Resolve` runs every matching
+rule's `Apply` in specificity-then-declaration order, so the more
+specific thinking-family rules ADD to the base rule without re-setting
+its fields:
+
+| ModelMatch       | Quirks                                                       | Notes |
+|------------------|--------------------------------------------------------------|-------|
+| `glm-*`          | legacy `max_tokens`; `tool_stream: true`                     | all GLM, incl. the legacy hyphenated line (`glm-4-plus`) |
+| `glm-4.[5-9]*`   | + replay `reasoning_content`; + `thinking: {"type":"enabled"}` | GLM-4.5/4.6/4.7 thinking family; the dot excludes the hyphenated legacy line |
+| `glm-5*`         | same as `glm-4.[5-9]*`                                        | GLM-5/5.1 thinking family |
+| `z-ai/glm-*`     | legacy `max_tokens`; + replay `reasoning_content`            | OpenRouter gateway-prefixed ids (`*` does not cross `/`); no `tool_stream`/`thinking` — vendor extras unverified through gateways |
+
+`reasoning_content` threading (the `(threaded)` ReplayFields suffix in
+[§3.1](#31-replayfields-rules)) now applies to the GLM-4.5+ thinking
+family: the captured reasoning is round-tripped onto subsequent
+openai-compatible requests, with zero adapter code — the rule only
+appends the path to `ReplayFields`. Sampling params are NOT suppressed
+for GLM (it accepts and recommends `temperature`/`top_p`), unlike the
+DeepSeek and OpenAI reasoning-class rules.
 
 `CompatProfile` does not violate the "no wire-shape on `RunConfig`"
 invariant: it is a named profile selector from a closed enum (only

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -703,18 +703,18 @@ func buildProvider(ctx context.Context, cfg types.ProviderConfig, secrets securi
 		// validator.
 		retry := provider.RetryPolicyFromConfig(cfg.Retry)
 		adapter := provider.NewOpenAICompatibleAdapter(cred.BearerToken, cfg.BaseURL, auth, retry)
-		// Inject a compat rule into the adapter's registry when the
+		// Inject the compat rules into the adapter's registry when the
 		// operator selected a compatProfile. The default registry is
 		// already attached by the constructor; we replace it with a
-		// new registry containing the compat rule appended after
-		// BuiltinRules so the compat rule's specificity ordering wins
-		// against any first-party glob it overlaps.
+		// new registry containing the compat rules appended after
+		// BuiltinRules so their specificity ordering wins against any
+		// first-party glob they overlap.
 		if cfg.CompatProfile != "" {
 			extra, err := resolveCompatProfile(cfg.CompatProfile)
 			if err != nil {
 				return nil, fmt.Errorf("resolve compat profile: %w", err)
 			}
-			rules := append(quirks.BuiltinRules(), extra)
+			rules := append(quirks.BuiltinRules(), extra...)
 			adapter.Registry = quirks.NewRegistry(rules)
 		}
 		return adapter, nil
@@ -1719,7 +1719,7 @@ func buildGCSTraceCredentialSource(cfg *types.CredentialConfig) (credential.Sour
 }
 
 // resolveCompatProfile maps the closed enum of supported
-// compatProfile names to the rule the corresponding compat package
+// compatProfile names to the rules the corresponding compat package
 // exports. The set must stay aligned with validCompatProfiles in
 // types/runconfig.go — ValidateRunConfig rejects unknown values at
 // startup, so an unknown value reaching this switch is a defence-in-
@@ -1729,13 +1729,13 @@ func buildGCSTraceCredentialSource(cfg *types.CredentialConfig) (credential.Sour
 // New entries here require a corresponding compat package under
 // harness/internal/provider/compat/<name>/ and an addition to
 // validCompatProfiles. Adding a name to the validator without a rule
-// would silently no-op for runs that selected the new profile.
-func resolveCompatProfile(profile string) (quirks.Rule, error) {
+// set would silently no-op for runs that selected the new profile.
+func resolveCompatProfile(profile string) ([]quirks.Rule, error) {
 	switch profile {
 	case "zai-glm":
-		return zai.CompatRule(), nil
+		return zai.CompatRules(), nil
 	default:
-		return quirks.Rule{}, fmt.Errorf("unknown compat profile %q (supported: zai-glm)", profile)
+		return nil, fmt.Errorf("unknown compat profile %q (supported: zai-glm)", profile)
 	}
 }
 

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -714,6 +714,9 @@ func buildProvider(ctx context.Context, cfg types.ProviderConfig, secrets securi
 			if err != nil {
 				return nil, fmt.Errorf("resolve compat profile: %w", err)
 			}
+			// BuiltinRules() returns a fresh slice on every call, so
+			// appending the compat rules here cannot mutate the shared
+			// builtin catalogue used by every other adapter.
 			rules := append(quirks.BuiltinRules(), extra...)
 			adapter.Registry = quirks.NewRegistry(rules)
 		}

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -2071,8 +2071,10 @@ func TestBuildProvider_OpenAICompatibleWithRetryConfig(t *testing.T) {
 //
 // The assertion uses the adapter's exported Registry field to
 // resolve the GLM model end-to-end: the registry returned by the
-// factory must include zai.CompatRule, so a glm-4-plus resolution
-// produces TokenFieldMaxTokens and the tool_stream extra body field.
+// factory must include zai.CompatRules(), so a glm-4-plus resolution
+// produces TokenFieldMaxTokens and the tool_stream extra body field,
+// and a glm-4.7 resolution additionally produces the thinking-family
+// quirks (reasoning_content replay + the thinking extra body).
 func TestBuildProvider_OpenAICompatibleWithCompatProfile_ZAI(t *testing.T) {
 	secrets := &stubSecretStore{secrets: map[string]string{"secret://OPENAI_KEY": "sk-test"}}
 	prov, err := buildProvider(context.Background(), types.ProviderConfig{

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -2101,6 +2101,30 @@ func TestBuildProvider_OpenAICompatibleWithCompatProfile_ZAI(t *testing.T) {
 	} else if b, isBool := v.(bool); !isBool || !b {
 		t.Errorf("glm-4-plus resolution: ExtraBodyFields[tool_stream] = %v (type %T), want true", v, v)
 	}
+
+	// A thinking-family model (glm-4.7) must additionally resolve the
+	// reasoning_content replay field and the thinking extra body through
+	// the same factory-built registry — proving resolveCompatProfile
+	// returns the full CompatRules() slice, not just the base rule.
+	qt := adapter.Registry.Resolve("openai-compatible", "glm-4.7")
+	hasReasoning := false
+	for _, p := range qt.ReplayFields {
+		if p == "reasoning_content" {
+			hasReasoning = true
+			break
+		}
+	}
+	if !hasReasoning {
+		t.Errorf("glm-4.7 resolution: reasoning_content not in ReplayFields %v (thinking-family rule did not fire via factory)", qt.ReplayFields)
+	}
+	thinking, ok := qt.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"]
+	if !ok {
+		t.Fatalf("glm-4.7 resolution: ExtraBodyFields[thinking] missing; thinking-family rule should set it")
+	}
+	tm, ok := thinking.(map[string]any)
+	if !ok || len(tm) != 1 || tm["type"] != "enabled" {
+		t.Errorf("glm-4.7 resolution: thinking = %#v, want map[string]any{\"type\":\"enabled\"}", thinking)
+	}
 }
 
 // TestBuildProvider_OpenAICompatibleWithUnknownCompatProfile_Errors

--- a/harness/internal/provider/compat/zai/zai.go
+++ b/harness/internal/provider/compat/zai/zai.go
@@ -84,45 +84,37 @@ func CompatRules() []quirks.Rule {
 		// thinking quirks to the legacy line would be wrong. The
 		// [5-9] char class bounds the family at glm-4.9 (precedent:
 		// the o[1-9]* builtin rule); glm-4.10+ would need a revisit.
+		//
+		// Provenance: doc-derived from the Z.ai thinking-mode and
+		// core-parameters guides plus the GLM-4.7 model card (sources
+		// in tmp/glm-4.7-quirks-plan.md §1). Not yet verified against a
+		// live first-party capture — same discipline as the DeepSeek v4
+		// builtin rules.
 		{
 			ProviderType: "openai-compatible",
 			ModelMatch:   "glm-4.[5-9]*",
 			Description:  "Z.ai GLM-4.5+ thinking: replay reasoning_content, enable thinking (threaded)",
 			LastVerified: quirks.Date("2026-06-08"),
-			Apply: func(q *quirks.ProviderQuirks) {
-				// reasoning_content arrives as a sibling of `content`
-				// on each assistant delta (a direct child of `delta`),
-				// so the single-segment path captures it when the
-				// adapter walks the decoded delta object. The Z.ai
-				// thinking-mode docs require it be replayed across
-				// multi-turn tool calls to keep the reasoning coherent;
-				// the openai-compatible adapter threads it back
-				// outbound. Replaying on every turn is safe — the field
-				// is optional, not forbidden, on non-thinking turns.
-				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
-				// The top-level "thinking" object turns thinking mode
-				// deterministically on for agentic tool use (matches the
-				// documented default). On the openai-compatible endpoint
-				// it is a top-level body key (OpenAI SDK extra_body →
-				// top-level). clear_thinking is deliberately NOT pinned:
-				// its server-side semantics are unverified by live
-				// capture and Preserved-Thinking behaviour is already
-				// carried client-side by replaying reasoning_content.
-				q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"] = map[string]any{"type": "enabled"}
-			},
+			Apply:        applyThinkingFamily,
 		},
-		// Rule C — GLM-5/5.1 thinking family (same Apply as Rule B).
-		// glm-5* covers glm-5, glm-5.1, and future minor versions on
-		// the GLM-5 line, all of which inherit the thinking surface.
+		// Rule C — GLM-5/5.1 thinking family. Shares applyThinkingFamily
+		// with Rule B. glm-5* covers glm-5, glm-5.1, and future minor
+		// versions on the GLM-5 line, all of which inherit the thinking
+		// surface.
+		//
+		// Breadth caveat: glm-5* is deliberately broader than the
+		// verified id set — it forward-matches an as-yet-unreleased
+		// line. If Z.ai later ships a non-thinking GLM-5 variant (a
+		// hypothetical glm-5-flash), it would need a longer-glob
+		// carve-out that clears these flags, exactly as gpt-5-chat*
+		// carves out of gpt-5* in the builtin rules. Provenance: same
+		// doc-derived, pending-live-capture status as Rule B.
 		{
 			ProviderType: "openai-compatible",
 			ModelMatch:   "glm-5*",
 			Description:  "Z.ai GLM-5 thinking: replay reasoning_content, enable thinking (threaded)",
 			LastVerified: quirks.Date("2026-06-08"),
-			Apply: func(q *quirks.ProviderQuirks) {
-				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
-				q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"] = map[string]any{"type": "enabled"}
-			},
+			Apply:        applyThinkingFamily,
 		},
 		// Rule D — OpenRouter (and OpenRouter-style gateway) ids,
 		// which serve GLM under a vendor prefix (z-ai/glm-4.7). The
@@ -137,6 +129,10 @@ func CompatRules() []quirks.Rule {
 		// vendor extras whose behaviour through gateways is unverified
 		// (a gateway may reject or silently drop them). When live
 		// gateway capture confirms them, widen this rule.
+		//
+		// Provenance: the OpenRouter GLM-4.7 listing
+		// (https://openrouter.ai/z-ai/glm-4.7) plus the first-party
+		// docs above; not yet verified against a live gateway capture.
 		{
 			ProviderType: "openai-compatible",
 			ModelMatch:   "z-ai/glm-*",
@@ -157,4 +153,29 @@ func CompatRules() []quirks.Rule {
 		//     left at their base-rule values; no GLM-specific override.
 		//   - clear_thinking: not pinned (see Rule B comment).
 	}
+}
+
+// applyThinkingFamily is the shared Apply for the GLM-4.5+ thinking
+// rules (Rules B and C). Both lines expose the identical thinking
+// surface, so the body lives in one place — a field added here reaches
+// both rules — mirroring the applyOpenAIReasoningClass precedent in
+// quirks/helpers.go.
+func applyThinkingFamily(q *quirks.ProviderQuirks) {
+	// reasoning_content arrives as a sibling of `content` on each
+	// assistant delta (a direct child of `delta`), so the
+	// single-segment path captures it when the adapter walks the
+	// decoded delta object. The Z.ai thinking-mode docs require it be
+	// replayed across multi-turn tool calls to keep the reasoning
+	// coherent; the openai-compatible adapter threads it back outbound.
+	// Replaying on every turn is safe — the field is optional, not
+	// forbidden, on non-thinking turns.
+	q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+	// The top-level "thinking" object turns thinking mode
+	// deterministically on for agentic tool use (matches the documented
+	// default). On the openai-compatible endpoint it is a top-level body
+	// key (OpenAI SDK extra_body → top-level). clear_thinking is
+	// deliberately NOT pinned: its server-side semantics are unverified
+	// by live capture and Preserved-Thinking behaviour is already
+	// carried client-side by replaying reasoning_content.
+	q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"] = map[string]any{"type": "enabled"}
 }

--- a/harness/internal/provider/compat/zai/zai.go
+++ b/harness/internal/provider/compat/zai/zai.go
@@ -1,21 +1,36 @@
-// Package zai provides the Z.ai GLM compatibility rule for the
+// Package zai provides the Z.ai GLM compatibility rules for the
 // openai-compatible adapter. Z.ai exposes an OpenAI-compatible Chat
-// Completions endpoint but with two divergences from the canonical
+// Completions endpoint but with several divergences from the canonical
 // upstream:
 //
 //   - It requires the legacy "max_tokens" key, not
 //     "max_completion_tokens" (which OpenAI's reasoning models now
-//     mandate).
+//     mandate). This applies to every GLM model.
 //   - It accepts an extension flag "tool_stream: true" that enables
 //     streaming of tool-call results.
+//   - The GLM-4.5-and-above "thinking" family (glm-4.5, glm-4.6,
+//     glm-4.7, and the forthcoming glm-5 line) emits a
+//     chain-of-thought as `delta.reasoning_content` alongside the
+//     assistant content, and accepts a top-level "thinking" request
+//     object ({"type":"enabled"}). For multi-turn tool calling the
+//     captured reasoning_content must be replayed onto subsequent
+//     requests to keep the reasoning coherent — wired here via
+//     ReplayFields, which the openai-compatible adapter threads back
+//     outbound with no adapter-side code.
+//
+// The thinking divergences are scoped to GLM-4.5 and above: the
+// older hyphenated line (glm-4-plus, glm-4-flash, glm-4-air) has no
+// thinking mode and must not receive the thinking quirks. The glob
+// boundary is the dot after "4." — see CompatRules for the exact
+// matching rationale.
 //
 // Z.ai is a compatibility-only target (design D3): there is no
 // peer "zai" ProviderType. Operators using Z.ai configure
 // provider.type = "openai-compatible" and set
 // provider.compatProfile = "zai-glm" in their RunConfig; the
-// factory injects CompatRule() into the adapter's registry.
+// factory injects CompatRules() into the adapter's registry.
 //
-// The rule is intentionally not part of BuiltinRules() — its
+// The rules are intentionally not part of BuiltinRules() — their
 // activation is operator-gated through the CompatProfile field.
 package zai
 
@@ -23,11 +38,20 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 )
 
-// CompatRule returns the Z.ai-specific quirks rule for injection
-// into an openai-compatible adapter's registry. The rule targets
-// every GLM model under "glm-*" (the only family Z.ai serves today);
-// operators using a custom alias must register a tailored rule
-// themselves.
+// CompatRules returns the Z.ai-specific quirks rules for injection
+// into an openai-compatible adapter's registry. Quirks compose:
+// quirks.Registry.Resolve runs every matching rule's Apply in
+// specificity-then-declaration order, all mutating the same
+// ProviderQuirks. The base "glm-*" rule therefore supplies the
+// shared wire shape (legacy token field, tool_stream) and the more
+// specific thinking-family rules ADD to it without re-setting those
+// fields.
+//
+// LastVerified dates are doc-derived (Z.ai docs + model card +
+// OpenRouter listing); live first-party capture is still pending for
+// the thinking-family rules (token-key acceptance, thinking wire
+// placement, reasoning_content replay strictness, parallel tool
+// calls) — same provenance discipline as the DeepSeek v4 rules.
 //
 // Design risk 5 notes that the precise inbound-side semantics of
 // tool_stream:true are not fully documented; the conservative
@@ -36,17 +60,101 @@ import (
 // later observed to emit a different event shape when tool_stream
 // is true, an additional parse-side flag will be needed on
 // OpenAIBehaviourFlags.
-func CompatRule() quirks.Rule {
-	return quirks.Rule{
-		ProviderType: "openai-compatible",
-		ModelMatch:   "glm-*",
-		Description:  "Z.ai GLM: legacy max_tokens field and tool_stream extension",
-		LastVerified: quirks.Date("2026-05-24"),
-		Apply: func(q *quirks.ProviderQuirks) {
-			q.BehaviourFlags.OpenAI.TokenField = quirks.TokenFieldMaxTokens
-			// ExtraBodyFields is pre-initialised by Resolve to an
-			// empty non-nil map, so direct assignment is safe.
-			q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"] = true
+func CompatRules() []quirks.Rule {
+	return []quirks.Rule{
+		// Rule A — base: every GLM model, including the legacy
+		// hyphenated line (glm-4-plus, glm-4-flash, glm-4-air).
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "glm-*",
+			Description:  "Z.ai GLM: legacy max_tokens field and tool_stream extension",
+			LastVerified: quirks.Date("2026-05-24"),
+			Apply: func(q *quirks.ProviderQuirks) {
+				q.BehaviourFlags.OpenAI.TokenField = quirks.TokenFieldMaxTokens
+				// ExtraBodyFields is pre-initialised by Resolve to an
+				// empty non-nil map, so direct assignment is safe.
+				q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"] = true
+			},
 		},
+		// Rule B — GLM-4.5/4.6/4.7 thinking family. The glob uses a
+		// dot ("4.") so it matches glm-4.5, glm-4.6, glm-4.7, and
+		// glm-4.5-air but NOT the hyphenated legacy line
+		// (glm-4-plus, glm-4-flash, glm-4-air), which has no thinking
+		// mode. Thinking is "GLM-4.5 and above" only — applying the
+		// thinking quirks to the legacy line would be wrong. The
+		// [5-9] char class bounds the family at glm-4.9 (precedent:
+		// the o[1-9]* builtin rule); glm-4.10+ would need a revisit.
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "glm-4.[5-9]*",
+			Description:  "Z.ai GLM-4.5+ thinking: replay reasoning_content, enable thinking (threaded)",
+			LastVerified: quirks.Date("2026-06-08"),
+			Apply: func(q *quirks.ProviderQuirks) {
+				// reasoning_content arrives as a sibling of `content`
+				// on each assistant delta (a direct child of `delta`),
+				// so the single-segment path captures it when the
+				// adapter walks the decoded delta object. The Z.ai
+				// thinking-mode docs require it be replayed across
+				// multi-turn tool calls to keep the reasoning coherent;
+				// the openai-compatible adapter threads it back
+				// outbound. Replaying on every turn is safe — the field
+				// is optional, not forbidden, on non-thinking turns.
+				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+				// The top-level "thinking" object turns thinking mode
+				// deterministically on for agentic tool use (matches the
+				// documented default). On the openai-compatible endpoint
+				// it is a top-level body key (OpenAI SDK extra_body →
+				// top-level). clear_thinking is deliberately NOT pinned:
+				// its server-side semantics are unverified by live
+				// capture and Preserved-Thinking behaviour is already
+				// carried client-side by replaying reasoning_content.
+				q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"] = map[string]any{"type": "enabled"}
+			},
+		},
+		// Rule C — GLM-5/5.1 thinking family (same Apply as Rule B).
+		// glm-5* covers glm-5, glm-5.1, and future minor versions on
+		// the GLM-5 line, all of which inherit the thinking surface.
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "glm-5*",
+			Description:  "Z.ai GLM-5 thinking: replay reasoning_content, enable thinking (threaded)",
+			LastVerified: quirks.Date("2026-06-08"),
+			Apply: func(q *quirks.ProviderQuirks) {
+				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+				q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"] = map[string]any{"type": "enabled"}
+			},
+		},
+		// Rule D — OpenRouter (and OpenRouter-style gateway) ids,
+		// which serve GLM under a vendor prefix (z-ai/glm-4.7). The
+		// bare "glm-*" glob cannot match these: path.Match's `*` does
+		// not cross `/`, so this sibling rule names the prefix
+		// literally — the same construction as the deepseek/deepseek-v4*
+		// gateway rule.
+		//
+		// Only the portable quirks are mirrored: the legacy max_tokens
+		// field and reasoning_content replay. tool_stream and the
+		// thinking object are NOT set here — those are first-party
+		// vendor extras whose behaviour through gateways is unverified
+		// (a gateway may reject or silently drop them). When live
+		// gateway capture confirms them, widen this rule.
+		{
+			ProviderType: "openai-compatible",
+			ModelMatch:   "z-ai/glm-*",
+			Description:  "Z.ai GLM via gateway prefix: legacy max_tokens, replay reasoning_content (threaded)",
+			LastVerified: quirks.Date("2026-06-08"),
+			Apply: func(q *quirks.ProviderQuirks) {
+				q.BehaviourFlags.OpenAI.TokenField = quirks.TokenFieldMaxTokens
+				q.ReplayFields = append(q.ReplayFields, "reasoning_content")
+			},
+		},
+		// Explicit non-goals across all rules above (no Apply sets
+		// these, by design):
+		//   - OmitSamplingParams: GLM accepts and recommends
+		//     temperature=1.0, top_p=0.95 (verified) — unlike DeepSeek
+		//     v4 / the OpenAI reasoning class, sampling params are NOT
+		//     suppressed.
+		//   - StrictMode / ToolChoice / ParallelToolCalls overrides:
+		//     left at their base-rule values; no GLM-specific override.
+		//   - clear_thinking: not pinned (see Rule B comment).
 	}
 }

--- a/harness/internal/provider/compat/zai/zai_test.go
+++ b/harness/internal/provider/compat/zai/zai_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -26,11 +27,22 @@ func staticBearer(s string) func(context.Context) (string, error) {
 	}
 }
 
+// hasReplayField reports whether path appears in the resolved
+// ReplayFields slice.
+func hasReplayField(q quirks.ProviderQuirks, path string) bool {
+	for _, p := range q.ReplayFields {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
 // TestZAICompatRule_AppliesTokenFieldAndExtraBody pins the two
-// divergences the Z.ai compat profile enforces: TokenFieldMaxTokens
+// divergences the base Z.ai compat rule enforces: TokenFieldMaxTokens
 // (so the wire body uses "max_tokens" rather than the modern
 // "max_completion_tokens") and the "tool_stream": true extra body
-// field. The test injects the rule into a registry, attaches it to
+// field. The test injects the rules into a registry, attaches them to
 // an OpenAICompatibleAdapter, fires a request against an httptest
 // server, and inspects the captured body — the same end-to-end
 // path a real Z.ai run takes.
@@ -55,9 +67,9 @@ func TestZAICompatRule_AppliesTokenFieldAndExtraBody(t *testing.T) {
 		provider.OpenAIAuthConfig{},
 		provider.RetryPolicy{},
 	)
-	// Inject the Z.ai compat rule on top of BuiltinRules so this
+	// Inject the Z.ai compat rules on top of BuiltinRules so this
 	// test mirrors what core/factory.go does for compatProfile=zai-glm.
-	rules := append(quirks.BuiltinRules(), zai.CompatRule())
+	rules := append(quirks.BuiltinRules(), zai.CompatRules()...)
 	adapter.Registry = quirks.NewRegistry(rules)
 
 	ch, err := adapter.Stream(context.Background(), types.StreamParams{
@@ -96,13 +108,178 @@ func TestZAICompatRule_AppliesTokenFieldAndExtraBody(t *testing.T) {
 	}
 }
 
+// TestZAICompatRule_GLM47AppliesThinkingFamilyBody is the end-to-end
+// twin of the base-rule test for a thinking-family model. It drives a
+// glm-4.7 request through the adapter and asserts the wire body carries
+// the base quirks (max_tokens, tool_stream) AND the thinking-family
+// extra: a top-level "thinking" object == {"type":"enabled"}. The
+// reasoning_content half of the round-trip (outbound threading) is
+// exercised by the resolution tests below plus the provider package's
+// replay_threading_test.go; here we pin the request-shape contribution.
+func TestZAICompatRule_GLM47AppliesThinkingFamilyBody(t *testing.T) {
+	captured := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			return
+		}
+		captured <- b
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	adapter := provider.NewOpenAICompatibleAdapter(
+		staticBearer("test-key"),
+		srv.URL,
+		provider.OpenAIAuthConfig{},
+		provider.RetryPolicy{},
+	)
+	rules := append(quirks.BuiltinRules(), zai.CompatRules()...)
+	adapter.Registry = quirks.NewRegistry(rules)
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "glm-4.7",
+		MaxTokens: 4096,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+	body := <-captured
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, body)
+	}
+
+	// Base rule still contributes (glm-* matches glm-4.7 too).
+	if _, ok := got["max_tokens"]; !ok {
+		t.Errorf("glm-4.7 body missing 'max_tokens' (base rule must still fire): %s", body)
+	}
+	if v, ok := got["tool_stream"]; !ok {
+		t.Errorf("glm-4.7 body missing 'tool_stream': %s", body)
+	} else if b, isBool := v.(bool); !isBool || !b {
+		t.Errorf("glm-4.7 'tool_stream' = %v (type %T), want true", v, v)
+	}
+	// Thinking-family rule contribution: top-level thinking object.
+	thinking, ok := got["thinking"]
+	if !ok {
+		t.Fatalf("glm-4.7 body missing 'thinking' object: %s", body)
+	}
+	tm, ok := thinking.(map[string]any)
+	if !ok {
+		t.Fatalf("glm-4.7 'thinking' = %v (type %T), want object", thinking, thinking)
+	}
+	if tm["type"] != "enabled" {
+		t.Errorf("glm-4.7 thinking.type = %v, want \"enabled\": %s", tm["type"], body)
+	}
+}
+
+// TestZAICompatRules_ThinkingFamilyResolution pins the resolved quirks
+// for the thinking-family models against a registry assembled exactly
+// as the factory does. These are unit-level resolution assertions that
+// complement the end-to-end body test above: they confirm the
+// reasoning_content ReplayFields entry and the thinking extra body land
+// for glm-4.7 and glm-4.5-air.
+func TestZAICompatRules_ThinkingFamilyResolution(t *testing.T) {
+	reg := quirks.NewRegistry(append(quirks.BuiltinRules(), zai.CompatRules()...))
+
+	for _, model := range []string{"glm-4.7", "glm-4.5-air"} {
+		t.Run(model, func(t *testing.T) {
+			q := reg.Resolve("openai-compatible", model)
+
+			// Base quirks still resolve.
+			if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
+				t.Errorf("%s: TokenField = %v, want max_tokens", model, q.BehaviourFlags.OpenAI.TokenField)
+			}
+			if v, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"]; !ok {
+				t.Errorf("%s: tool_stream missing from ExtraBodyFields", model)
+			} else if b, isBool := v.(bool); !isBool || !b {
+				t.Errorf("%s: tool_stream = %v (type %T), want true", model, v, v)
+			}
+
+			// Thinking-family quirks: reasoning_content replay + thinking object.
+			if !hasReplayField(q, "reasoning_content") {
+				t.Errorf("%s: reasoning_content not in ReplayFields %v", model, q.ReplayFields)
+			}
+			thinking, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"]
+			if !ok {
+				t.Fatalf("%s: thinking missing from ExtraBodyFields", model)
+			}
+			if !reflect.DeepEqual(thinking, map[string]any{"type": "enabled"}) {
+				t.Errorf("%s: thinking = %#v, want map[string]any{\"type\":\"enabled\"}", model, thinking)
+			}
+		})
+	}
+}
+
+// TestZAICompatRules_LegacyLineHasNoThinking is the negative pin: the
+// hyphenated legacy GLM line (glm-4-plus) must receive ONLY the base
+// quirks. The glm-4.[5-9]* glob deliberately uses a dot so it does not
+// match the hyphenated id — if the scoping ever leaked (e.g. a glob
+// widened to glm-4*), this test fails. A non-thinking model receiving
+// a "thinking" body or replaying reasoning_content would be a wire
+// regression.
+func TestZAICompatRules_LegacyLineHasNoThinking(t *testing.T) {
+	reg := quirks.NewRegistry(append(quirks.BuiltinRules(), zai.CompatRules()...))
+	q := reg.Resolve("openai-compatible", "glm-4-plus")
+
+	// Base quirks present.
+	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
+		t.Errorf("glm-4-plus: TokenField = %v, want max_tokens", q.BehaviourFlags.OpenAI.TokenField)
+	}
+	if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"]; !ok {
+		t.Errorf("glm-4-plus: tool_stream missing; base rule should fire")
+	}
+
+	// Thinking quirks ABSENT — the 4.5+ scoping must not leak down.
+	if hasReplayField(q, "reasoning_content") {
+		t.Errorf("glm-4-plus: reasoning_content leaked into ReplayFields %v (legacy line has no thinking mode)", q.ReplayFields)
+	}
+	if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"]; ok {
+		t.Errorf("glm-4-plus: thinking leaked into ExtraBodyFields (legacy line has no thinking mode)")
+	}
+}
+
+// TestZAICompatRules_GatewayPrefixResolution pins the OpenRouter
+// gateway rule (z-ai/glm-*). The bare glm-* glob cannot match a
+// slash-prefixed id (path.Match's `*` does not cross `/`), so the
+// gateway rule supplies the portable quirks itself: legacy max_tokens
+// and reasoning_content replay. tool_stream and thinking are
+// deliberately ABSENT — vendor extras unverified through gateways.
+func TestZAICompatRules_GatewayPrefixResolution(t *testing.T) {
+	reg := quirks.NewRegistry(append(quirks.BuiltinRules(), zai.CompatRules()...))
+	q := reg.Resolve("openai-compatible", "z-ai/glm-4.7")
+
+	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
+		t.Errorf("z-ai/glm-4.7: TokenField = %v, want max_tokens", q.BehaviourFlags.OpenAI.TokenField)
+	}
+	if !hasReplayField(q, "reasoning_content") {
+		t.Errorf("z-ai/glm-4.7: reasoning_content not in ReplayFields %v", q.ReplayFields)
+	}
+	// tool_stream and thinking must NOT be present for gateway ids.
+	if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"]; ok {
+		t.Errorf("z-ai/glm-4.7: tool_stream leaked (vendor extra unverified through gateways)")
+	}
+	if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"]; ok {
+		t.Errorf("z-ai/glm-4.7: thinking leaked (vendor extra unverified through gateways)")
+	}
+}
+
 // TestZAICompatRule_DoesNotAffectNonGLMModels guards against the
-// rule's ModelMatch leaking to non-GLM models served from the same
+// rules' ModelMatch leaking to non-GLM models served from the same
 // adapter. If an operator multiplexes openai-compatible against
 // multiple base URLs with the same registry, a non-GLM model
 // resolution must keep the modern token field.
 func TestZAICompatRule_DoesNotAffectNonGLMModels(t *testing.T) {
-	rules := append(quirks.BuiltinRules(), zai.CompatRule())
+	rules := append(quirks.BuiltinRules(), zai.CompatRules()...)
 	reg := quirks.NewRegistry(rules)
 
 	// gpt-4o is not a glm-* model; the rule should not fire.
@@ -121,32 +298,87 @@ func TestZAICompatRule_DoesNotAffectNonGLMModels(t *testing.T) {
 	}
 }
 
+// TestCompatRulesReplayFieldsSuffix is the compat-package mirror of
+// quirks.TestBuiltinRulesReplayFieldsSuffix: every rule in CompatRules()
+// whose Apply registers a ReplayFields path must end its Description
+// with "(threaded)", because the openai-compatible adapter threads
+// those captures back onto subsequent requests. A rule author who adds
+// a ReplayFields entry without the suffix (or declares a non-threadable
+// multi-segment path) fails here at build time rather than silently
+// regressing trace observability. Compat rules are not part of
+// BuiltinRules(), so the quirks_test.go version cannot reach them.
+func TestCompatRulesReplayFieldsSuffix(t *testing.T) {
+	const threadedSuffix = "(threaded)"
+	for i, rule := range zai.CompatRules() {
+		if rule.Apply == nil {
+			continue
+		}
+		q := quirks.ProviderQuirks{
+			FieldRenames:   map[string]string{},
+			OmitFields:     []string{},
+			ValueOverrides: map[string]quirks.Value{},
+			EnumCoercions:  map[string]map[string]string{},
+			ReplayFields:   []string{},
+			BehaviourFlags: quirks.ProviderBehaviourFlags{OpenAI: quirks.OpenAIBehaviourFlags{ExtraBodyFields: map[string]any{}}},
+		}
+		rule.Apply(&q)
+		if len(q.ReplayFields) == 0 {
+			continue
+		}
+		if rule.ProviderType != "openai-compatible" {
+			t.Errorf("CompatRules()[%d] (%q): unexpected ProviderType %q for a ReplayFields rule", i, rule.Description, rule.ProviderType)
+			continue
+		}
+		if !strings.HasSuffix(rule.Description, threadedSuffix) {
+			t.Errorf("CompatRules()[%d] (%q): openai-compatible ReplayFields rule description must end with %q", i, rule.Description, threadedSuffix)
+		}
+		for _, path := range q.ReplayFields {
+			segments, err := quirks.ParseReplayPath(path)
+			if err != nil {
+				t.Errorf("CompatRules()[%d] (%q): ReplayFields path %q is invalid: %v", i, rule.Description, path, err)
+				continue
+			}
+			if len(segments) != 1 || segments[0].IsArray {
+				t.Errorf("CompatRules()[%d] (%q): ReplayFields path %q is not threadable (must be a single non-array segment)", i, rule.Description, path)
+			}
+		}
+	}
+}
+
 // TestCompatRuleExtraBodyFieldsNoSecrets is the per-compat-package
 // mirror of quirks.TestBuiltinRulesExtraBodyFieldsNoSecrets: it
-// materialises the Z.ai rule into a fresh ProviderQuirks and walks
+// materialises each Z.ai rule into a fresh ProviderQuirks and walks
 // every ExtraBodyFields value for the secret:// prefix. The map is
 // serialised verbatim into the request body, and RunConfig.Redact()
 // never reaches inside a quirks rule, so a secret reference embedded
 // here would propagate to every wire request without redaction.
 //
-// The current rule stores a bool (tool_stream: true) so the check
-// is trivially satisfied today. The test is structural insurance
-// for the next time the rule grows — and the pattern is intended
-// for every future compat package to copy: each compat package
-// must contribute its own version of this test against its own
-// CompatRule, because the quirks_test.go version only walks
-// BuiltinRules() and cannot reach compat rules that are not part
-// of the registry default.
+// The check walks EVERY rule in CompatRules() (resolving each against a
+// representative model id) so a future rule that grows a string-valued
+// extra body field — not just the original base rule — is covered. The
+// pattern is intended for every compat package to copy: each must
+// contribute its own version against its own CompatRules, because the
+// quirks_test.go version only walks BuiltinRules() and cannot reach
+// compat rules that are not part of the registry default.
 func TestCompatRuleExtraBodyFieldsNoSecrets(t *testing.T) {
-	q := quirks.NewRegistry([]quirks.Rule{zai.CompatRule()}).Resolve("openai-compatible", "glm-4-plus")
-	for k, v := range q.BehaviourFlags.OpenAI.ExtraBodyFields {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if strings.Contains(s, "secret://") {
-			t.Errorf("Z.ai CompatRule ExtraBodyFields[%q] = %q contains a secret:// reference; "+
-				"compat rule values are serialised verbatim and bypass RunConfig.Redact()", k, s)
+	// Representative model id per rule, in declaration order: the id
+	// must match that rule's glob so Resolve materialises its Apply.
+	models := []string{"glm-4-plus", "glm-4.7", "glm-5", "z-ai/glm-4.7"}
+	rules := zai.CompatRules()
+	if len(models) != len(rules) {
+		t.Fatalf("models slice (%d) out of sync with CompatRules() (%d); add a representative model for the new rule", len(models), len(rules))
+	}
+	for i, rule := range rules {
+		q := quirks.NewRegistry([]quirks.Rule{rule}).Resolve("openai-compatible", models[i])
+		for k, v := range q.BehaviourFlags.OpenAI.ExtraBodyFields {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			if strings.Contains(s, "secret://") {
+				t.Errorf("Z.ai CompatRules()[%d] (%q) ExtraBodyFields[%q] = %q contains a secret:// reference; "+
+					"compat rule values are serialised verbatim and bypass RunConfig.Redact()", i, rule.Description, k, s)
+			}
 		}
 	}
 }

--- a/harness/internal/provider/compat/zai/zai_test.go
+++ b/harness/internal/provider/compat/zai/zai_test.go
@@ -46,7 +46,7 @@ func hasReplayField(q quirks.ProviderQuirks, path string) bool {
 // an OpenAICompatibleAdapter, fires a request against an httptest
 // server, and inspects the captured body — the same end-to-end
 // path a real Z.ai run takes.
-func TestZAICompatRule_AppliesTokenFieldAndExtraBody(t *testing.T) {
+func TestZAICompatRules_AppliesTokenFieldAndExtraBody(t *testing.T) {
 	captured := make(chan []byte, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
@@ -91,9 +91,11 @@ func TestZAICompatRule_AppliesTokenFieldAndExtraBody(t *testing.T) {
 		t.Fatalf("unmarshal: %v\nbody: %s", err, body)
 	}
 
-	// Legacy token field present, modern key absent.
-	if _, ok := got["max_tokens"]; !ok {
+	// Legacy token field present (with the caller's value), modern key absent.
+	if v, ok := got["max_tokens"]; !ok {
 		t.Errorf("Z.ai body missing 'max_tokens' (legacy field required): %s", body)
+	} else if n, isNum := v.(float64); !isNum || n != 4096 {
+		t.Errorf("Z.ai 'max_tokens' = %v (type %T), want 4096", v, v)
 	}
 	if _, ok := got["max_completion_tokens"]; ok {
 		t.Errorf("Z.ai body contains 'max_completion_tokens' (rule failed to switch field): %s", body)
@@ -116,7 +118,7 @@ func TestZAICompatRule_AppliesTokenFieldAndExtraBody(t *testing.T) {
 // reasoning_content half of the round-trip (outbound threading) is
 // exercised by the resolution tests below plus the provider package's
 // replay_threading_test.go; here we pin the request-shape contribution.
-func TestZAICompatRule_GLM47AppliesThinkingFamilyBody(t *testing.T) {
+func TestZAICompatRules_GLM47AppliesThinkingFamilyBody(t *testing.T) {
 	captured := make(chan []byte, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
@@ -160,8 +162,10 @@ func TestZAICompatRule_GLM47AppliesThinkingFamilyBody(t *testing.T) {
 	}
 
 	// Base rule still contributes (glm-* matches glm-4.7 too).
-	if _, ok := got["max_tokens"]; !ok {
+	if v, ok := got["max_tokens"]; !ok {
 		t.Errorf("glm-4.7 body missing 'max_tokens' (base rule must still fire): %s", body)
+	} else if n, isNum := v.(float64); !isNum || n != 4096 {
+		t.Errorf("glm-4.7 'max_tokens' = %v (type %T), want 4096", v, v)
 	}
 	if v, ok := got["tool_stream"]; !ok {
 		t.Errorf("glm-4.7 body missing 'tool_stream': %s", body)
@@ -182,16 +186,182 @@ func TestZAICompatRule_GLM47AppliesThinkingFamilyBody(t *testing.T) {
 	}
 }
 
+// glm47ReasoningSSE is a synthetic GLM-4.7 streaming response that
+// mirrors the deepseek-v4-flash fixture's wire shape exactly:
+// reasoning_content is streamed as a sibling of content on each
+// assistant delta, the docs assert GLM uses the identical
+// delta.reasoning_content shape. The two reasoning pieces concatenate
+// to "Scanning the request. Choosing an answer." — the value the
+// capture-and-flatten path must surface on message_complete.
+const glm47ReasoningSSE = "data: {\"id\":\"glm-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"reasoning_content\":\"\"},\"finish_reason\":null}]}\n\n" +
+	"data: {\"id\":\"glm-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"Scanning the request. \"},\"finish_reason\":null}]}\n\n" +
+	"data: {\"id\":\"glm-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"Choosing an answer.\"},\"finish_reason\":null}]}\n\n" +
+	"data: {\"id\":\"glm-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Done.\"},\"finish_reason\":null}]}\n\n" +
+	"data: {\"id\":\"glm-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":8}}\n\n" +
+	"data: [DONE]\n\n"
+
+// zaiTestAdapter builds an OpenAICompatibleAdapter pointed at srvURL
+// with a registry assembled exactly as core/factory.go does for
+// compatProfile=zai-glm (BuiltinRules + zai.CompatRules()).
+func zaiTestAdapter(srvURL string) *provider.OpenAICompatibleAdapter {
+	adapter := provider.NewOpenAICompatibleAdapter(
+		staticBearer("test-key"),
+		srvURL,
+		provider.OpenAIAuthConfig{},
+		provider.RetryPolicy{},
+	)
+	adapter.Registry = quirks.NewRegistry(append(quirks.BuiltinRules(), zai.CompatRules()...))
+	return adapter
+}
+
+// TestZAICompatRules_GLM47CapturesReasoningContent is the GLM-scoped
+// parse-side capture test. It drives adapter.Stream() with Model:
+// "glm-4.7" against a server emitting the GLM reasoning SSE shape and
+// asserts message_complete.ReplayFields["reasoning_content"] accumulates
+// to the concatenated pieces. The generic deepseek capture test proves
+// the walker; this proves the zai compat rule actually registers the
+// reasoning_content path so the walker runs for a GLM model.
+func TestZAICompatRules_GLM47CapturesReasoningContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, glm47ReasoningSSE)
+	}))
+	defer srv.Close()
+
+	adapter := zaiTestAdapter(srv.URL)
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "glm-4.7",
+		MaxTokens: 1024,
+		Messages: []types.Message{
+			{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var complete *types.StreamEvent
+	for ev := range ch {
+		if ev.Type == "message_complete" {
+			e := ev
+			complete = &e
+		}
+	}
+	if complete == nil {
+		t.Fatal("no message_complete event; GLM stream did not complete")
+	}
+	want := `"Scanning the request. Choosing an answer."`
+	if got := string(complete.ReplayFields["reasoning_content"]); got != want {
+		t.Errorf("message_complete ReplayFields[reasoning_content] = %s, want %s "+
+			"(zai compat rule must register the reasoning_content path for glm-4.7)", got, want)
+	}
+}
+
+// TestZAICompatRules_GLM47TwoTurnRoundTrip is the GLM-scoped end-to-end
+// round-trip — the test the spec deviation in review wave 1 flagged as
+// missing. The existing replay_threading_test.go TwoTurnRoundTrip
+// resolves from DefaultRegistry() (BuiltinRules), so it proves
+// DeepSeek's BUILTIN reasoning_content path, not the zai COMPAT-INJECTED
+// path. Here the registry is assembled the way the factory does for
+// compatProfile=zai-glm, so the assertion is that the compat injection
+// closes the loop: turn 1 streams a glm-4.7 response carrying
+// reasoning_content, the captured state is attached to the assistant
+// message exactly as the agentic loop does, and the turn-2 request body
+// must carry reasoning_content as a top-level assistant-message key.
+func TestZAICompatRules_GLM47TwoTurnRoundTrip(t *testing.T) {
+	bodies := make(chan []byte, 2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			return
+		}
+		bodies <- b
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, glm47ReasoningSSE)
+	}))
+	defer srv.Close()
+
+	adapter := zaiTestAdapter(srv.URL)
+
+	history := []types.Message{
+		{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+	}
+
+	// Turn 1: stream and assemble the assistant message the way
+	// streamEventsToResult + appendAssistantContent do — text deltas
+	// concatenate into one block; message_complete supplies the replay
+	// state.
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "glm-4.7",
+		MaxTokens: 1024,
+		Messages:  history,
+	})
+	if err != nil {
+		t.Fatalf("turn-1 Stream: %v", err)
+	}
+	var text strings.Builder
+	var replay map[string]json.RawMessage
+	for ev := range ch {
+		switch ev.Type {
+		case "text_delta":
+			text.WriteString(ev.Text)
+		case "message_complete":
+			replay = ev.ReplayFields
+		}
+	}
+	if replay == nil {
+		t.Fatal("turn 1 produced no ReplayFields; capture path did not run for glm-4.7")
+	}
+	<-bodies // discard the turn-1 request body
+
+	history = append(history,
+		types.Message{
+			Role:         "assistant",
+			Content:      []types.ContentBlock{{Type: "text", Text: text.String()}},
+			ReplayFields: replay,
+		},
+		types.Message{
+			Role:    "user",
+			Content: []types.ContentBlock{{Type: "text", Text: "and now?"}},
+		},
+	)
+
+	// Turn 2: the request built from the updated history must thread the
+	// captured value back onto the assistant wire message.
+	ch2, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "glm-4.7",
+		MaxTokens: 1024,
+		Messages:  history,
+	})
+	if err != nil {
+		t.Fatalf("turn-2 Stream: %v", err)
+	}
+	for range ch2 {
+	}
+	turn2Body := <-bodies
+
+	want := `"reasoning_content":"Scanning the request. Choosing an answer."`
+	if !strings.Contains(string(turn2Body), want) {
+		t.Errorf("turn-2 wire body missing threaded reasoning_content:\nwant substring: %s\nbody: %s", want, turn2Body)
+	}
+}
+
 // TestZAICompatRules_ThinkingFamilyResolution pins the resolved quirks
 // for the thinking-family models against a registry assembled exactly
 // as the factory does. These are unit-level resolution assertions that
 // complement the end-to-end body test above: they confirm the
 // reasoning_content ReplayFields entry and the thinking extra body land
-// for glm-4.7 and glm-4.5-air.
+// for both glob families — Rule B (glm-4.[5-9]*: glm-4.7, glm-4.5-air)
+// and Rule C (glm-5*: glm-5, glm-5.1). Rule C shares applyThinkingFamily
+// with Rule B, so covering it here catches a future divergence in the
+// glm-5 line that the shared helper alone would not surface.
 func TestZAICompatRules_ThinkingFamilyResolution(t *testing.T) {
 	reg := quirks.NewRegistry(append(quirks.BuiltinRules(), zai.CompatRules()...))
 
-	for _, model := range []string{"glm-4.7", "glm-4.5-air"} {
+	for _, model := range []string{"glm-4.7", "glm-4.5-air", "glm-5", "glm-5.1"} {
 		t.Run(model, func(t *testing.T) {
 			q := reg.Resolve("openai-compatible", model)
 
@@ -220,31 +390,62 @@ func TestZAICompatRules_ThinkingFamilyResolution(t *testing.T) {
 	}
 }
 
-// TestZAICompatRules_LegacyLineHasNoThinking is the negative pin: the
-// hyphenated legacy GLM line (glm-4-plus) must receive ONLY the base
-// quirks. The glm-4.[5-9]* glob deliberately uses a dot so it does not
-// match the hyphenated id — if the scoping ever leaked (e.g. a glob
-// widened to glm-4*), this test fails. A non-thinking model receiving
-// a "thinking" body or replaying reasoning_content would be a wire
-// regression.
+// TestZAICompatRules_LegacyLineHasNoThinking is the negative pin: every
+// hyphenated legacy GLM id (glm-4-plus, glm-4-flash, glm-4-air) must
+// receive ONLY the base quirks. The glm-4.[5-9]* glob deliberately uses
+// a dot so it does not match the hyphenated ids — if the scoping ever
+// leaked (e.g. a glob widened to glm-4*), this test fails for whichever
+// id regressed. A non-thinking model receiving a "thinking" body or
+// replaying reasoning_content would be a wire regression.
 func TestZAICompatRules_LegacyLineHasNoThinking(t *testing.T) {
 	reg := quirks.NewRegistry(append(quirks.BuiltinRules(), zai.CompatRules()...))
-	q := reg.Resolve("openai-compatible", "glm-4-plus")
 
-	// Base quirks present.
+	for _, model := range []string{"glm-4-plus", "glm-4-flash", "glm-4-air"} {
+		t.Run(model, func(t *testing.T) {
+			q := reg.Resolve("openai-compatible", model)
+
+			// Base quirks present.
+			if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
+				t.Errorf("%s: TokenField = %v, want max_tokens", model, q.BehaviourFlags.OpenAI.TokenField)
+			}
+			if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"]; !ok {
+				t.Errorf("%s: tool_stream missing; base rule should fire", model)
+			}
+
+			// Thinking quirks ABSENT — the 4.5+ scoping must not leak down.
+			if hasReplayField(q, "reasoning_content") {
+				t.Errorf("%s: reasoning_content leaked into ReplayFields %v (legacy line has no thinking mode)", model, q.ReplayFields)
+			}
+			if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"]; ok {
+				t.Errorf("%s: thinking leaked into ExtraBodyFields (legacy line has no thinking mode)", model)
+			}
+		})
+	}
+}
+
+// TestZAICompatRules_GLM410IsAKnownGap pins a documented limitation
+// rather than a desired behaviour: the glm-4.[5-9]* char class stops at
+// 9, so a future glm-4.10 (if Z.ai ever ships double-digit minors)
+// would NOT match Rule B and would receive only the base quirks — no
+// thinking, no reasoning_content replay. This is the conservative
+// default (do not speculatively widen the glob), and the test makes the
+// gap visible: when glm-4.10 becomes real, this test starts failing the
+// day the rule is fixed, signalling the comment in zai.go must be
+// updated alongside it.
+func TestZAICompatRules_GLM410IsAKnownGap(t *testing.T) {
+	reg := quirks.NewRegistry(append(quirks.BuiltinRules(), zai.CompatRules()...))
+	q := reg.Resolve("openai-compatible", "glm-4.10")
+
+	// Base rule still fires (glm-* matches glm-4.10).
 	if q.BehaviourFlags.OpenAI.TokenField != quirks.TokenFieldMaxTokens {
-		t.Errorf("glm-4-plus: TokenField = %v, want max_tokens", q.BehaviourFlags.OpenAI.TokenField)
+		t.Errorf("glm-4.10: TokenField = %v, want max_tokens (base rule)", q.BehaviourFlags.OpenAI.TokenField)
 	}
-	if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["tool_stream"]; !ok {
-		t.Errorf("glm-4-plus: tool_stream missing; base rule should fire")
-	}
-
-	// Thinking quirks ABSENT — the 4.5+ scoping must not leak down.
+	// Thinking quirks ABSENT — the [5-9] class does not reach 10.
 	if hasReplayField(q, "reasoning_content") {
-		t.Errorf("glm-4-plus: reasoning_content leaked into ReplayFields %v (legacy line has no thinking mode)", q.ReplayFields)
+		t.Errorf("glm-4.10: reasoning_content present in %v — the [5-9] glob now matches double-digit minors; update the zai.go Rule B comment and this test", q.ReplayFields)
 	}
 	if _, ok := q.BehaviourFlags.OpenAI.ExtraBodyFields["thinking"]; ok {
-		t.Errorf("glm-4-plus: thinking leaked into ExtraBodyFields (legacy line has no thinking mode)")
+		t.Errorf("glm-4.10: thinking present — the [5-9] glob now matches double-digit minors; update the zai.go Rule B comment and this test")
 	}
 }
 
@@ -278,7 +479,7 @@ func TestZAICompatRules_GatewayPrefixResolution(t *testing.T) {
 // adapter. If an operator multiplexes openai-compatible against
 // multiple base URLs with the same registry, a non-GLM model
 // resolution must keep the modern token field.
-func TestZAICompatRule_DoesNotAffectNonGLMModels(t *testing.T) {
+func TestZAICompatRules_DoesNotAffectNonGLMModels(t *testing.T) {
 	rules := append(quirks.BuiltinRules(), zai.CompatRules()...)
 	reg := quirks.NewRegistry(rules)
 
@@ -345,6 +546,59 @@ func TestCompatRulesReplayFieldsSuffix(t *testing.T) {
 	}
 }
 
+// TestCompatRulesValidate is the per-compat-package mirror of
+// quirks.TestBuiltinRulesValidate: every rule in CompatRules() must
+// carry a non-empty Description (operators read it in the introspection
+// subcommand), a non-zero LastVerified (the staleness signal), and a
+// non-nil Apply (a rule that does nothing is a registration bug). The
+// quirks_test.go version walks only BuiltinRules() and cannot reach the
+// operator-gated compat rules, so each compat package owns this check.
+func TestCompatRulesValidate(t *testing.T) {
+	for i, rule := range zai.CompatRules() {
+		if rule.Description == "" {
+			t.Errorf("CompatRules()[%d]: Description is required", i)
+		}
+		if rule.LastVerified.IsZero() {
+			t.Errorf("CompatRules()[%d] (%q): LastVerified is required", i, rule.Description)
+		}
+		if rule.Apply == nil {
+			t.Errorf("CompatRules()[%d] (%q): Apply is required", i, rule.Description)
+		}
+		if rule.ProviderType != "openai-compatible" {
+			t.Errorf("CompatRules()[%d] (%q): ProviderType = %q, want openai-compatible (Z.ai is a compat profile on that adapter)", i, rule.Description, rule.ProviderType)
+		}
+	}
+}
+
+// scanForSecretRefs walks v recursively (maps and slices) and reports
+// the first string value containing a secret:// reference, or "" if
+// none. ExtraBodyFields is serialised verbatim into the request body
+// and RunConfig.Redact() never reaches inside a quirks rule, so any
+// nested string carrying a secret reference would leak unredacted — the
+// thinking object's {"type":"enabled"} map is the first nested value, so
+// the walk must descend, not just check top-level strings.
+func scanForSecretRefs(v any) string {
+	switch x := v.(type) {
+	case string:
+		if strings.Contains(x, "secret://") {
+			return x
+		}
+	case map[string]any:
+		for _, nv := range x {
+			if hit := scanForSecretRefs(nv); hit != "" {
+				return hit
+			}
+		}
+	case []any:
+		for _, nv := range x {
+			if hit := scanForSecretRefs(nv); hit != "" {
+				return hit
+			}
+		}
+	}
+	return ""
+}
+
 // TestCompatRuleExtraBodyFieldsNoSecrets is the per-compat-package
 // mirror of quirks.TestBuiltinRulesExtraBodyFieldsNoSecrets: it
 // materialises each Z.ai rule into a fresh ProviderQuirks and walks
@@ -354,9 +608,9 @@ func TestCompatRulesReplayFieldsSuffix(t *testing.T) {
 // here would propagate to every wire request without redaction.
 //
 // The check walks EVERY rule in CompatRules() (resolving each against a
-// representative model id) so a future rule that grows a string-valued
-// extra body field — not just the original base rule — is covered. The
-// pattern is intended for every compat package to copy: each must
+// representative model id) and recurses into nested maps/slices so the
+// thinking object's contents are covered, not just top-level strings.
+// The pattern is intended for every compat package to copy: each must
 // contribute its own version against its own CompatRules, because the
 // quirks_test.go version only walks BuiltinRules() and cannot reach
 // compat rules that are not part of the registry default.
@@ -371,13 +625,9 @@ func TestCompatRuleExtraBodyFieldsNoSecrets(t *testing.T) {
 	for i, rule := range rules {
 		q := quirks.NewRegistry([]quirks.Rule{rule}).Resolve("openai-compatible", models[i])
 		for k, v := range q.BehaviourFlags.OpenAI.ExtraBodyFields {
-			s, ok := v.(string)
-			if !ok {
-				continue
-			}
-			if strings.Contains(s, "secret://") {
-				t.Errorf("Z.ai CompatRules()[%d] (%q) ExtraBodyFields[%q] = %q contains a secret:// reference; "+
-					"compat rule values are serialised verbatim and bypass RunConfig.Redact()", i, rule.Description, k, s)
+			if hit := scanForSecretRefs(v); hit != "" {
+				t.Errorf("Z.ai CompatRules()[%d] (%q) ExtraBodyFields[%q] contains a secret:// reference (%q); "+
+					"compat rule values are serialised verbatim and bypass RunConfig.Redact()", i, rule.Description, k, hit)
 			}
 		}
 	}

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -692,8 +692,12 @@ type ProviderConfig struct {
 	//
 	//   ""          — no compat profile (default).
 	//   "zai-glm"   — Z.ai GLM tool_stream extension and legacy
-	//                 max_tokens field. Applied on top of provider.type
-	//                 = "openai-compatible".
+	//                 max_tokens field for all GLM models, plus
+	//                 reasoning_content replay and the thinking object
+	//                 ({"type":"enabled"}) for the GLM-4.5+ thinking
+	//                 family (glm-4.5/4.6/4.7 and the glm-5 line).
+	//                 Applied on top of provider.type =
+	//                 "openai-compatible".
 	//
 	// Unknown values are rejected by ValidateRunConfig. Adding a new
 	// value requires both an entry in validCompatProfiles and a matching


### PR DESCRIPTION
## What

Adds first-class quirks support for Z.ai's **GLM 4.7** (and the wider GLM-4.5+
"thinking" family) under the existing `zai-glm` compat profile. GLM 4.7's
thinking mode is default-on and emits chain-of-thought as
`delta.reasoning_content`, which — like DeepSeek v4 (#424) — must be replayed
across turns to keep multi-turn tool calling coherent. It also accepts a
top-level `thinking` request object.

The Z.ai rule changes from a single `CompatRule()` to `CompatRules() []Rule`
so multiple model globs can be expressed; quirks compose, so the specific
thinking rules *add* to the base `glm-*` rule rather than replacing it.

## Rules (all `openai-compatible`, operator-gated via `provider.compatProfile = "zai-glm"`)

| Glob | Quirks | Notes |
|---|---|---|
| `glm-*` (unchanged) | legacy `max_tokens`; `tool_stream:true` | all GLM, incl. legacy `glm-4-plus` |
| `glm-4.[5-9]*` (new) | + replay `reasoning_content`; + `thinking:{"type":"enabled"}` | GLM-4.5/4.6/4.7 thinking family |
| `glm-5*` (new) | same as above | GLM-5/5.1 line |
| `z-ai/glm-*` (new) | legacy `max_tokens`; + replay `reasoning_content` | OpenRouter gateway prefix; no vendor extras |

The `glm-4.[5-9]*` glob uses a literal dot so it matches `glm-4.5`/`glm-4.7`/
`glm-4.5-air` but **not** the hyphenated legacy line (`glm-4-plus`,
`glm-4-flash`, `glm-4-air`), which has no thinking mode.

`reasoning_content` round-trips with **zero adapter changes** — the
openai-compatible adapter already threads single-segment, non-colliding
`ReplayFields` paths back outbound (the same mechanism DeepSeek v4 uses).

## Verified GLM 4.7 facts (web research)

- Token field is legacy `max_tokens` (200K context, up to 128K output).
- `thinking` is a top-level object, `{"type":"enabled"}` (default) /
  `{"type":"disabled"}`; **GLM-4.5 and above only**.
- `reasoning_content` must be replayed across multi-turn tool calls to keep
  reasoning coherent ("consecutive reasoning_content blocks must exactly
  match the original sequence").
- Sampling params are **accepted and recommended** (temp 1.0, top_p 0.95) —
  so, unlike DeepSeek v4 / OpenAI reasoning-class, `OmitSamplingParams` is
  deliberately **not** set.

Sources: Z.ai docs (thinking-mode, core-parameters), the GLM-4.7 Hugging Face
model card, apidog GLM-4.7 guide, OpenRouter listing.

### Explicit non-goals (commented in code)
No `OmitSamplingParams`; no `StrictMode`/`ToolChoice`/`ParallelToolCalls`
override; `clear_thinking` not pinned (server-side semantics unverified;
Preserved-Thinking is carried client-side by the `reasoning_content` replay).

## Tests

- Resolution: `glm-4.7`, `glm-4.5-air`, `glm-5`/`glm-5.1` get the thinking
  quirks; negative pins for `glm-4-plus`/`glm-4-flash`/`glm-4-air` (no leak to
  the legacy line); `z-ai/glm-4.7` gateway scoping.
- End-to-end httptest: GLM-4.7 request body carries `max_tokens:4096`,
  `tool_stream:true`, `thinking:{"type":"enabled"}`.
- **Two-turn round-trip** through a factory-equivalent registry
  (`BuiltinRules + CompatRules`) proving the compat-injected `reasoning_content`
  threads back onto the turn-2 wire body.
- Parse-side capture test: a GLM SSE stream accumulates `reasoning_content`
  into `message_complete.ReplayFields`.
- Structural: `CompatRulesValidate`, `(threaded)` suffix convention, recursive
  no-secrets walk over `ExtraBodyFields`, and a documented-limitation pin for
  the `glm-4.10` glob boundary.
- Factory injection path asserts GLM-4.7 thinking quirks resolve through
  `buildProvider`.

## Process

Researched (web) → planned → feature-implementer → one wave of synthesised
review (code / consistency / spec-compliance / test-coverage, 4 parallel
reviewers) → remediation. The review wave found no Critical/High correctness
defects; remediation closed test-coverage gaps and one confirmed spec
deviation (the prior two-turn test exercised the DeepSeek *builtin* registry,
not the zai *compat-injected* path).

`just build`, `go test ./harness/... ./types/... ./eval/...` (40 packages),
and `just lint` (0 issues) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)