### PR TITLE
executor: add agents.x-k8s.io v1alpha1 Sandbox CRD accessors (Agent Sandbox prep, 2/5)

### DIFF
--- a/harness/internal/executor/agentsandbox_api.go
+++ b/harness/internal/executor/agentsandbox_api.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// sandboxGVR is the GroupVersionResource for the Agent Sandbox CRD as served
+// by GKE Agent Sandbox. GKE installs v1alpha1; upstream HEAD has moved to
+// v1beta1 with a different field shape, so this is pinned to what the cluster
+// actually serves. Changing this is the single edit needed to track a GKE bump.
+var sandboxGVR = schema.GroupVersionResource{ //nolint:unused // consumed by AgentSandboxExecutor (next PR); declared here to keep all v1alpha1 GVR knowledge in one tested place.
+	Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes",
+}
+
+const (
+	// sandboxNameHashLabel is the label the Sandbox controller puts on every
+	// backing Pod (value = FNV-1a hash of the Sandbox name). It is the
+	// controller-guaranteed selector for the Pod.
+	sandboxNameHashLabel = "agents.x-k8s.io/sandbox-name-hash" //nolint:unused // consumed by AgentSandboxExecutor (next PR); kept here with the other Sandbox CRD keys.
+	// sandboxPodNameAnnotation, when present on the Sandbox, names the backing
+	// Pod. It is set for warm-pool-adopted Sandboxes (random Pod name); for a
+	// cold-created Sandbox it is absent and the Pod name equals the Sandbox name.
+	sandboxPodNameAnnotation = "agents.x-k8s.io/pod-name"
+	// sandboxReadyConditionType is the Sandbox status condition that gates
+	// readiness; the controller sets it True only once the backing Pod is Ready.
+	sandboxReadyConditionType = "Ready"
+)
+
+// sandboxReady reports whether the Sandbox's status carries a "Ready" condition
+// with status "True". It gates purely on that condition and deliberately
+// ignores status.podIPs, which GKE's v1alpha1 controller does not emit. A
+// missing or malformed status yields false rather than a panic, so a partially
+// populated object observed mid-reconcile is simply treated as not-yet-ready.
+func sandboxReady(obj *metav1unstructured.Unstructured) bool {
+	// NestedFieldNoCopy, not NestedSlice: the latter deep-copies the slice and
+	// panics on any element that is not a JSON-native type (e.g. a stray int),
+	// whereas this reader only inspects the conditions and must never panic on a
+	// malformed status. The no-copy accessor returns the raw value untouched.
+	raw, found, err := metav1unstructured.NestedFieldNoCopy(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	conditions, ok := raw.([]any)
+	if !ok {
+		return false
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		condType, ok := cond["type"].(string)
+		if !ok || condType != sandboxReadyConditionType {
+			continue
+		}
+		condStatus, ok := cond["status"].(string)
+		if !ok {
+			return false
+		}
+		return condStatus == "True"
+	}
+	return false
+}
+
+// resolveSandboxPodName returns the name of the Pod backing the Sandbox. It
+// matches the upstream controller's own resolvePodName: the pod-name annotation
+// wins when set (the warm-pool-adopted path, where the Pod has a random name),
+// otherwise the Pod name equals the Sandbox name (the cold-created path).
+func resolveSandboxPodName(obj *metav1unstructured.Unstructured) string {
+	if name := obj.GetAnnotations()[sandboxPodNameAnnotation]; name != "" {
+		return name
+	}
+	return obj.GetName()
+}

--- a/harness/internal/executor/agentsandbox_api_test.go
+++ b/harness/internal/executor/agentsandbox_api_test.go
@@ -1,0 +1,194 @@
+package executor
+
+import (
+	"testing"
+
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// readyCondition models a single status.conditions entry as GKE's v1alpha1
+// Sandbox controller emits it: {type, status, reason, message,
+// lastTransitionTime, observedGeneration}. Only type and status are
+// load-bearing for sandboxReady; the rest are carried so the test documents
+// the real wire shape.
+func readyCondition(condType, status string) map[string]any {
+	return map[string]any{
+		"type":               condType,
+		"status":             status,
+		"reason":             "PodReady",
+		"message":            "backing pod is ready",
+		"lastTransitionTime": "2026-06-15T00:00:00Z",
+		"observedGeneration": int64(1),
+	}
+}
+
+// sandboxWithConditions builds a Sandbox unstructured object carrying the given
+// status.conditions list. Note the deliberate absence of status.podIPs: GKE's
+// v1alpha1 does not emit it, and sandboxReady must not depend on it.
+func sandboxWithConditions(conditions []any) *metav1unstructured.Unstructured {
+	return &metav1unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "agents.x-k8s.io/v1alpha1",
+			"kind":       "Sandbox",
+			"metadata": map[string]any{
+				"name": "demo",
+			},
+			"status": map[string]any{
+				"conditions": conditions,
+			},
+		},
+	}
+}
+
+func TestSandboxReady(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *metav1unstructured.Unstructured
+		want bool
+	}{
+		{
+			name: "ready true",
+			obj:  sandboxWithConditions([]any{readyCondition("Ready", "True")}),
+			want: true,
+		},
+		{
+			name: "ready false",
+			obj:  sandboxWithConditions([]any{readyCondition("Ready", "False")}),
+			want: false,
+		},
+		{
+			name: "ready unknown",
+			obj:  sandboxWithConditions([]any{readyCondition("Ready", "Unknown")}),
+			want: false,
+		},
+		{
+			name: "no conditions field",
+			obj: &metav1unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{},
+			}},
+			want: false,
+		},
+		{
+			name: "no status at all",
+			obj:  &metav1unstructured.Unstructured{Object: map[string]any{}},
+			want: false,
+		},
+		{
+			name: "empty conditions list",
+			obj:  sandboxWithConditions([]any{}),
+			want: false,
+		},
+		{
+			name: "conditions present but no Ready type",
+			obj: sandboxWithConditions([]any{
+				readyCondition("Initialized", "True"),
+				readyCondition("PodScheduled", "True"),
+			}),
+			want: false,
+		},
+		{
+			name: "non-Ready condition True but Ready False",
+			obj: sandboxWithConditions([]any{
+				readyCondition("Initialized", "True"),
+				readyCondition("Ready", "False"),
+			}),
+			want: false,
+		},
+		{
+			name: "malformed entry: not a map",
+			obj:  sandboxWithConditions([]any{"not-a-condition"}),
+			want: false,
+		},
+		{
+			name: "malformed entry: missing type key",
+			obj: sandboxWithConditions([]any{
+				map[string]any{"status": "True"},
+			}),
+			want: false,
+		},
+		{
+			name: "malformed entry: type wrong type",
+			obj: sandboxWithConditions([]any{
+				map[string]any{"type": 42, "status": "True"},
+			}),
+			want: false,
+		},
+		{
+			name: "Ready type but status missing",
+			obj: sandboxWithConditions([]any{
+				map[string]any{"type": "Ready"},
+			}),
+			want: false,
+		},
+		{
+			name: "Ready type but status wrong type",
+			obj: sandboxWithConditions([]any{
+				map[string]any{"type": "Ready", "status": true},
+			}),
+			want: false,
+		},
+		{
+			name: "malformed entry skipped before valid Ready True",
+			obj: sandboxWithConditions([]any{
+				"junk",
+				map[string]any{"type": 7},
+				readyCondition("Ready", "True"),
+			}),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sandboxReady(tt.obj); got != tt.want {
+				t.Errorf("sandboxReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveSandboxPodName(t *testing.T) {
+	sandbox := func(name string, annotations map[string]any) *metav1unstructured.Unstructured {
+		meta := map[string]any{"name": name}
+		if annotations != nil {
+			meta["annotations"] = annotations
+		}
+		return &metav1unstructured.Unstructured{Object: map[string]any{
+			"metadata": meta,
+		}}
+	}
+
+	tests := []struct {
+		name string
+		obj  *metav1unstructured.Unstructured
+		want string
+	}{
+		{
+			name: "annotation present and non-empty wins",
+			obj: sandbox("cold-name", map[string]any{
+				sandboxPodNameAnnotation: "warm-pool-pod-xyz",
+			}),
+			want: "warm-pool-pod-xyz",
+		},
+		{
+			name: "annotation absent falls back to name",
+			obj:  sandbox("cold-name", nil),
+			want: "cold-name",
+		},
+		{
+			name: "annotation present but empty falls back to name",
+			obj: sandbox("cold-name", map[string]any{
+				sandboxPodNameAnnotation: "",
+			}),
+			want: "cold-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveSandboxPodName(tt.obj); got != tt.want {
+				t.Errorf("resolveSandboxPodName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `harness/internal/executor/agentsandbox_api.go`: the small, version-pinned,
unstructured-safe knowledge of the GKE-served `agents.x-k8s.io/v1alpha1` **Sandbox**
CRD that the forthcoming `k8s-sandbox` executor needs.

- `sandboxGVR` — pinned to `agents.x-k8s.io/v1alpha1 sandboxes` (what GKE serves;
  upstream HEAD is v1beta1 with a different field shape). The single edit point to
  track a future GKE bump.
- Label/annotation constants: `agents.x-k8s.io/{sandbox-name-hash, pod-name}` and the
  `Ready` condition type.
- `sandboxReady(obj)` — gates purely on the `Ready` status condition (deliberately
  ignores `status.podIPs`, which GKE v1alpha1 does not emit). Uses `NestedFieldNoCopy`
  (not `NestedSlice`, which deep-copies and **panics** on non-JSON-native elements) so
  a malformed/mid-reconcile status yields `false`, never a panic.
- `resolveSandboxPodName(obj)` — pod-name annotation wins (warm-pool path), else the
  Sandbox name (cold path), matching the upstream controller's own resolver.

## Why

Isolating the v1alpha1/GKE knowledge in one tested place keeps the executor lifecycle
(next PR) clean and makes the version skew a single, obvious edit. Exhaustive
white-box table tests cover Ready True/False/Unknown, absent/empty/malformed
conditions (no panic), and all pod-name resolution branches. These accessors are
consumed by PR 3; `sandboxGVR`/`sandboxNameHashLabel` carry a temporary
`//nolint:unused` until then.

## Verification

`just build`, `just lint` (0 issues), `gofmt` clean; targeted + full package tests
pass. Aligned `any` over `interface{}` to match the codebase convention (174:8).

Part 2 of 5. Stacks on #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)