### PR TITLE
executor: add k8s-sandbox executor backed by the Agent Sandbox CRD (3/5)

### DIFF
--- a/harness/internal/executor/agentsandbox.go
+++ b/harness/internal/executor/agentsandbox.go
@@ -1,0 +1,439 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	// gkeSandboxRuntimeKey / gkeSandboxRuntimeValue are the nodeSelector and
+	// toleration key/value GKE's secure-sandbox-policy ValidatingAdmissionPolicy
+	// requires on every Sandbox: the workload must be pinned to gVisor nodes and
+	// tolerate their NoSchedule taint. Without both, the admission policy rejects
+	// the Sandbox CR before the controller ever materialises a Pod.
+	gkeSandboxRuntimeKey   = "sandbox.gke.io/runtime"
+	gkeSandboxRuntimeValue = "gvisor"
+
+	// agentSandboxMaxTTL is the controller-owned GC backstop written into the
+	// Sandbox's spec.shutdownTime so a crashed orchestrator does not leak a
+	// sandbox: the controller deletes the Sandbox (and cascades to the Pod) once
+	// this absolute time passes. Close() is the normal teardown; this TTL only
+	// fires if Close() never runs. It is deliberately generous so it never cuts a
+	// live run short — a run that legitimately approaches 12h is far rarer than
+	// an orchestrator crash, and the cost of a too-short TTL (killing a working
+	// run) is worse than the cost of a too-long one (a leaked sandbox lingering a
+	// few extra hours).
+	agentSandboxMaxTTL = 12 * time.Hour
+)
+
+// agentSandboxDefaultCPU / agentSandboxDefaultMemory are the per-container
+// limit+request defaults applied when the caller did not pin resources. GKE's
+// secure-sandbox-policy requires explicit CPU and memory limits on every
+// container in the Sandbox CR, so applyAgentSandboxAdmissionDeltas fills any gap
+// with these values rather than letting the Sandbox be rejected for an absent
+// limit. They are package vars (not consts) because resource.Quantity is not a
+// constant-expressible type.
+var (
+	agentSandboxDefaultCPU    = resource.MustParse("500m")
+	agentSandboxDefaultMemory = resource.MustParse("512Mi")
+)
+
+// AgentSandboxExecutor implements Executor by provisioning the sandbox Pod
+// through GKE's Agent Sandbox controller: it creates an
+// agents.x-k8s.io/v1alpha1 Sandbox custom resource and the controller
+// materialises the backing Pod, rather than the executor creating a raw Pod
+// itself (the K8sExecutor path). Once the Sandbox is Ready, command execution
+// and file I/O ride the same pods/exec machinery as K8sExecutor via the
+// embedded podExecCore.
+//
+// The two executors share everything below the provisioning layer: the
+// hardened Pod spec (buildSandboxPodSpec), the per-Pod egress NetworkPolicy
+// (egressPolicyFor / podLabels), and the exec/file-I/O core. They differ only
+// in how the Pod comes into being — direct Pod create vs. the Sandbox CRD.
+type AgentSandboxExecutor struct {
+	podExecCore
+	// dynamicClient drives the agents.x-k8s.io Sandbox CR (create / get / delete);
+	// the clientset embedded in podExecCore handles pods/exec and the
+	// NetworkPolicy.
+	dynamicClient dynamic.Interface
+	// sandboxName is the Sandbox CR's name. On the cold-create path it is also
+	// the backing Pod's name (the controller names the Pod after the Sandbox);
+	// the actual Pod name lives in podExecCore.podName, resolved at construction.
+	sandboxName string
+	// networkPolicyName is the egress NetworkPolicy installed alongside the
+	// Sandbox. Close() deletes it best-effort after the Sandbox.
+	networkPolicyName string
+}
+
+// applyAgentSandboxAdmissionDeltas mutates a base Pod spec (as produced by
+// buildSandboxPodSpec) so the Sandbox CR it is embedded in satisfies GKE's
+// secure-sandbox-policy ValidatingAdmissionPolicy. The base hardened spec
+// already covers drop-ALL, runAsNonRoot, automountServiceAccountToken=false and
+// the no-hostPath/hostNetwork/privileged requirements; this fills the four
+// gvisor-specific gaps the policy additionally mandates:
+//
+//   - spec.runtimeClassName == "gvisor" (forced unconditionally — the Sandbox
+//     path is gVisor-only, so any caller-set runtime is overridden here).
+//   - explicit CPU and memory limits on every container. A container missing
+//     either limit has BOTH that limit and the matching request filled with the
+//     package default; a caller-set value is preserved (only gaps are filled).
+//   - nodeSelector["sandbox.gke.io/runtime"] == "gvisor" (merged into any
+//     existing selector, never clobbering caller entries).
+//   - a toleration for the gVisor NoSchedule taint (appended idempotently).
+func applyAgentSandboxAdmissionDeltas(spec *corev1.PodSpec) {
+	spec.RuntimeClassName = ptr.To(gkeSandboxRuntimeValue)
+
+	for i := range spec.Containers {
+		c := &spec.Containers[i]
+		if c.Resources.Limits == nil {
+			c.Resources.Limits = corev1.ResourceList{}
+		}
+		if c.Resources.Requests == nil {
+			c.Resources.Requests = corev1.ResourceList{}
+		}
+		// DeepCopy the package-default Quantity before storing it: resource.Quantity
+		// carries an internal *big.Int that a plain struct copy would alias, so a
+		// later mutation of a stored limit could corrupt the shared default for the
+		// next sandbox. Limits and Requests share one copy per container, matching
+		// resourcesToPodResources.
+		if _, ok := c.Resources.Limits[corev1.ResourceCPU]; !ok {
+			cpu := agentSandboxDefaultCPU.DeepCopy()
+			c.Resources.Limits[corev1.ResourceCPU] = cpu
+			c.Resources.Requests[corev1.ResourceCPU] = cpu
+		}
+		if _, ok := c.Resources.Limits[corev1.ResourceMemory]; !ok {
+			mem := agentSandboxDefaultMemory.DeepCopy()
+			c.Resources.Limits[corev1.ResourceMemory] = mem
+			c.Resources.Requests[corev1.ResourceMemory] = mem
+		}
+	}
+
+	if spec.NodeSelector == nil {
+		spec.NodeSelector = map[string]string{}
+	}
+	spec.NodeSelector[gkeSandboxRuntimeKey] = gkeSandboxRuntimeValue
+
+	// Append the gVisor toleration only if an equivalent one is not already
+	// present. A flag (rather than an early return) keeps this delta independent
+	// of any future delta added after it.
+	hasToleration := false
+	for _, t := range spec.Tolerations {
+		if t.Key == gkeSandboxRuntimeKey && t.Value == gkeSandboxRuntimeValue &&
+			t.Operator == corev1.TolerationOpEqual && t.Effect == corev1.TaintEffectNoSchedule {
+			hasToleration = true
+			break
+		}
+	}
+	if !hasToleration {
+		spec.Tolerations = append(spec.Tolerations, corev1.Toleration{
+			Key:      gkeSandboxRuntimeKey,
+			Operator: corev1.TolerationOpEqual,
+			Value:    gkeSandboxRuntimeValue,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+}
+
+// buildSandboxObject assembles the agents.x-k8s.io/v1alpha1 Sandbox custom
+// resource that the GKE Agent Sandbox controller reconciles into a Pod. The
+// typed Pod spec is converted to the unstructured map the CR's
+// spec.podTemplate.spec expects; the controller propagates podTemplate labels
+// to the Pod (stripping only agents.x-k8s.io/* keys), so the per-pod
+// stirrup.dev/pod label set by podLabels lands on the controller-created Pod
+// and the egress NetworkPolicy binds to it.
+//
+// shutdownPolicy "Delete" + shutdownTime is the controller's GC backstop: it
+// deletes the Sandbox at shutdownTime if Close() never runs (see
+// agentSandboxMaxTTL).
+func buildSandboxObject(namespace, name string, podSpec corev1.PodSpec, shutdownTime time.Time) (*metav1unstructured.Unstructured, error) {
+	specMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podSpec)
+	if err != nil {
+		return nil, fmt.Errorf("convert pod spec to unstructured: %w", err)
+	}
+
+	// podLabels is the single source of truth for the per-pod label set
+	// (stirrup-sandbox + stirrup.dev/pod). The unstructured tree wants
+	// map[string]any, so widen the map[string]string here rather than rebuild
+	// the labels inline and risk drift from the NetworkPolicy's selector.
+	labels := map[string]any{}
+	for k, v := range podLabels(name) {
+		labels[k] = v
+	}
+
+	return &metav1unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": sandboxGVR.GroupVersion().String(),
+			"kind":       "Sandbox",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]any{
+					k8sSandboxLabel: "true",
+				},
+			},
+			"spec": map[string]any{
+				"shutdownPolicy": "Delete",
+				"shutdownTime":   shutdownTime.Format(time.RFC3339),
+				"podTemplate": map[string]any{
+					"metadata": map[string]any{
+						"labels": labels,
+					},
+					"spec": specMap,
+				},
+			},
+		},
+	}, nil
+}
+
+// NewAgentSandboxExecutor provisions a sandbox via the Agent Sandbox CRD and
+// returns an executor bound to the backing Pod. It mirrors NewK8sExecutor's
+// fail-closed ordering: validate config and compute the proxy env before any
+// cluster op, install the egress NetworkPolicy BEFORE the Sandbox so the Pod
+// never runs with unrestricted egress, then create the Sandbox and wait for the
+// controller to report it Ready. On any failure the partially created objects
+// (NetworkPolicy and/or Sandbox) are deleted best-effort before the error is
+// returned.
+func NewAgentSandboxExecutor(ctx context.Context, cfg K8sExecutorConfig) (*AgentSandboxExecutor, error) {
+	if cfg.Image == "" {
+		return nil, fmt.Errorf("agent sandbox executor requires an image")
+	}
+	if cfg.Namespace == "" {
+		return nil, fmt.Errorf("agent sandbox executor requires a namespace")
+	}
+	// Fail-closed: a nil Network leaves egress posture undefined. Rejecting it
+	// here forces the caller to declare intent, matching NewK8sExecutor and
+	// keeping CanNetwork honest against the installed policy.
+	if cfg.Network == nil {
+		return nil, fmt.Errorf("agent sandbox executor requires a network config (set executor.network.mode to \"none\" or \"allowlist\")")
+	}
+
+	// Compute the proxy env and validate the allowlist→URL requirement BEFORE
+	// creating any cluster objects, so a misconfigured allowlist run fails
+	// without leaving an orphaned Sandbox behind.
+	proxyEnv, err := proxyEnvFor(cfg.Network, cfg.EgressProxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	restCfg, err := buildRESTConfig(cfg.Kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("build kube rest config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build kube clientset: %w", err)
+	}
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build dynamic client: %w", err)
+	}
+
+	logger := slog.Default()
+
+	// gVisor is the only runtime the Agent Sandbox path supports (GKE's
+	// secure-sandbox-policy admits nothing else, and applyAgentSandboxAdmissionDeltas
+	// forces it). Warn if the caller asked for something else so the override is
+	// visible rather than silent.
+	if cfg.RuntimeClassName != "" && cfg.RuntimeClassName != gkeSandboxRuntimeValue {
+		logger.Warn(
+			"agent sandbox executor: overriding executor.runtime with gvisor — the Agent Sandbox path is gVisor-only",
+			"requested", cfg.RuntimeClassName,
+		)
+	}
+
+	// The Sandbox name doubles as the cold-path Pod name: the controller names
+	// the backing Pod after the Sandbox, and the per-pod egress NetworkPolicy /
+	// podLabels select on that name.
+	name, err := generatePodName()
+	if err != nil {
+		return nil, fmt.Errorf("generate sandbox name: %w", err)
+	}
+
+	spec := buildSandboxPodSpec(cfg, proxyEnv)
+	applyAgentSandboxAdmissionDeltas(&spec)
+
+	// Install the egress NetworkPolicy BEFORE creating the Sandbox, for the same
+	// reason NewK8sExecutor does: the Pod name is client-side deterministic
+	// (cold-path Pod name == Sandbox name) and the policy selects on
+	// stirrup.dev/pod=<name>, so the policy can be in place before the
+	// controller materialises the Pod. Installing after readiness would leave a
+	// Running Pod with cluster-default egress in the Ready→policy window. A
+	// failure to install is fatal.
+	policy, err := egressPolicyFor(cfg.Network, cfg.Namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := clientset.NetworkingV1().NetworkPolicies(cfg.Namespace).Create(ctx, policy, metav1.CreateOptions{}); err != nil {
+		return nil, fmt.Errorf("install egress NetworkPolicy for sandbox %s/%s: %w", cfg.Namespace, name, err)
+	}
+
+	obj, err := buildSandboxObject(cfg.Namespace, name, spec, time.Now().Add(agentSandboxMaxTTL))
+	if err != nil {
+		deleteNetworkPolicyBestEffort(clientset, cfg.Namespace, policy.Name, logger)
+		return nil, fmt.Errorf("build sandbox object: %w", err)
+	}
+	if _, err := dyn.Resource(sandboxGVR).Namespace(cfg.Namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		deleteNetworkPolicyBestEffort(clientset, cfg.Namespace, policy.Name, logger)
+		return nil, fmt.Errorf("create sandbox %s/%s: %w", cfg.Namespace, name, err)
+	}
+
+	var ready *metav1unstructured.Unstructured
+	err = wait.PollUntilContextTimeout(ctx, k8sReadyPollPeriod, k8sReadyTimeout, true, func(ctx context.Context) (bool, error) {
+		got, getErr := dyn.Resource(sandboxGVR).Namespace(cfg.Namespace).Get(ctx, name, metav1.GetOptions{})
+		if getErr != nil {
+			// Fail fast only on errors that will not resolve by retrying: an RBAC
+			// denial means the orchestrator cannot read the Sandbox at all. Every
+			// other class — a NotFound from read-after-write lag right after the
+			// create, or a transient 5xx/throttle during the controller's
+			// reconcile flurry (image pull, scheduling) — is retried until the
+			// readiness deadline. The Sandbox path has a wider readiness window
+			// than a raw Pod (controller watch + materialise), so a transient get
+			// error is meaningfully more likely here than in waitForPodReady.
+			if apierrors.IsForbidden(getErr) || apierrors.IsUnauthorized(getErr) {
+				return false, getErr
+			}
+			logger.Debug("transient error polling sandbox readiness, retrying", "namespace", cfg.Namespace, "sandbox", name, "err", getErr)
+			return false, nil
+		}
+		ready = got
+		return sandboxReady(got), nil
+	})
+	if err != nil {
+		deleteSandboxBestEffort(dyn, cfg.Namespace, name, logger)
+		deleteNetworkPolicyBestEffort(clientset, cfg.Namespace, policy.Name, logger)
+		// The duration is intentionally omitted: readiness can end on either
+		// k8sReadyTimeout or a shorter caller-context deadline, and a hardcoded
+		// "after 1m0s" would misreport the latter. The wrapped error carries the
+		// cause.
+		return nil, fmt.Errorf("sandbox %s/%s not ready: %w", cfg.Namespace, name, err)
+	}
+
+	podName := resolveSandboxPodName(ready)
+
+	// v1 supports only the cold-create path, where the backing Pod is named after
+	// the Sandbox and so carries the stirrup.dev/pod=<name> label the egress
+	// NetworkPolicy selects on. A warm-pool-adopted Sandbox backs a Pod with a
+	// different (random) name and without that label, so the policy would bind to
+	// nothing and the Pod would run with unconfined egress — a silent fail-open.
+	// Refuse it until warm-pool support installs the policy against the resolved
+	// Pod name (or the controller-guaranteed sandbox-name-hash label).
+	if podName != name {
+		deleteSandboxBestEffort(dyn, cfg.Namespace, name, logger)
+		deleteNetworkPolicyBestEffort(clientset, cfg.Namespace, policy.Name, logger)
+		return nil, fmt.Errorf(
+			"sandbox %s/%s resolved to backing pod %q: warm-pool adoption is not supported by the agent sandbox executor (its per-pod egress policy would not bind)",
+			cfg.Namespace, name, podName,
+		)
+	}
+
+	return &AgentSandboxExecutor{
+		podExecCore: podExecCore{
+			clientset:  clientset,
+			restConfig: restCfg,
+			namespace:  cfg.Namespace,
+			podName:    podName,
+			network:    cfg.Network,
+			Security:   cfg.Security,
+			logger:     logger,
+		},
+		dynamicClient:     dyn,
+		sandboxName:       name,
+		networkPolicyName: policy.Name,
+	}, nil
+}
+
+// Close tears down the sandbox with its own background context (so cleanup
+// proceeds even if the caller's context is already cancelled).
+//
+// Only the Sandbox is deleted — NOT the Pod or Service. The controller owns them
+// via owner references and cascade-GCs them; deleting the Pod here would race
+// that cascade. The delete uses Foreground propagation, so the Sandbox object
+// lingers (with a deletion finalizer) until its dependent Pod is gone — which
+// makes "Sandbox gone" a reliable signal that the Pod is gone too.
+//
+// The egress NetworkPolicy is removed only AFTER the Sandbox (and, via the
+// foreground cascade, its Pod) is confirmed gone, so egress is never reopened for
+// a still-running Pod — the teardown analogue of the constructor's
+// policy-before-Pod ordering. The posture is fail-closed in three ways:
+//   - If the Sandbox delete fails (the Pod may still run), the policy is LEFT in
+//     place and the error returned; the shutdownTime TTL backstop still GCs the
+//     Sandbox eventually.
+//   - If the Sandbox does not disappear within the close timeout, the policy is
+//     LEFT in place (logged). A leftover policy is inert once the Pod is gone and
+//     still confines it if it somehow lingers.
+//   - A NotFound Sandbox is treated as already-gone (idempotent); the policy is
+//     then safe to remove.
+func (e *AgentSandboxExecutor) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), k8sCloseTimeout)
+	defer cancel()
+
+	foreground := metav1.DeletePropagationForeground
+	sbErr := e.dynamicClient.Resource(sandboxGVR).Namespace(e.namespace).Delete(ctx, e.sandboxName, metav1.DeleteOptions{
+		PropagationPolicy: &foreground,
+	})
+	if sbErr != nil && !apierrors.IsNotFound(sbErr) {
+		// The Sandbox (and its Pod) may still be running; keep the egress policy in
+		// place so the Pod stays confined.
+		return fmt.Errorf("delete sandbox: %w", sbErr)
+	}
+
+	if e.networkPolicyName == "" {
+		return nil
+	}
+
+	// Lift egress confinement only once the Sandbox is actually gone. A NotFound
+	// from the delete means it was already gone; otherwise poll until a Get
+	// reports NotFound (foreground propagation removes the object only after its
+	// dependent Pod is deleted). Transient get errors are ignored — the poll keeps
+	// waiting until the deadline.
+	gone := apierrors.IsNotFound(sbErr)
+	if !gone {
+		waitErr := wait.PollUntilContextTimeout(ctx, k8sReadyPollPeriod, k8sCloseTimeout, true, func(ctx context.Context) (bool, error) {
+			_, getErr := e.dynamicClient.Resource(sandboxGVR).Namespace(e.namespace).Get(ctx, e.sandboxName, metav1.GetOptions{})
+			return apierrors.IsNotFound(getErr), nil
+		})
+		gone = waitErr == nil
+	}
+	if !gone {
+		e.logger.Warn(
+			"agent sandbox executor: sandbox not confirmed deleted within close timeout; leaving egress NetworkPolicy in place (fail closed)",
+			"namespace", e.namespace, "sandbox", e.sandboxName, "networkpolicy", e.networkPolicyName,
+		)
+		return nil
+	}
+
+	npErr := e.clientset.NetworkingV1().NetworkPolicies(e.namespace).Delete(ctx, e.networkPolicyName, metav1.DeleteOptions{})
+	if npErr != nil && !apierrors.IsNotFound(npErr) {
+		e.logger.Warn("agent sandbox executor networkpolicy delete failed", "namespace", e.namespace, "networkpolicy", e.networkPolicyName, "err", npErr)
+	}
+	return nil
+}
+
+// deleteSandboxBestEffort attempts to delete the Sandbox CR, logging (but not
+// returning) any error. Used on constructor error paths to undo a Sandbox whose
+// readiness wait failed, so a failed construction leaves no orphaned Sandbox
+// (and, via the controller cascade, no orphaned Pod) behind.
+func deleteSandboxBestEffort(dyn dynamic.Interface, namespace, name string, logger *slog.Logger) {
+	ctx, cancel := context.WithTimeout(context.Background(), k8sCloseTimeout)
+	defer cancel()
+	err := dyn.Resource(sandboxGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Warn("agent sandbox executor cleanup sandbox delete failed", "namespace", namespace, "sandbox", name, "err", err)
+	}
+}
+
+var _ Executor = (*AgentSandboxExecutor)(nil)

--- a/harness/internal/executor/agentsandbox_api.go
+++ b/harness/internal/executor/agentsandbox_api.go
@@ -9,7 +9,7 @@ import (
 // by GKE Agent Sandbox. GKE installs v1alpha1; upstream HEAD has moved to
 // v1beta1 with a different field shape, so this is pinned to what the cluster
 // actually serves. Changing this is the single edit needed to track a GKE bump.
-var sandboxGVR = schema.GroupVersionResource{ //nolint:unused // consumed by AgentSandboxExecutor (next PR); declared here to keep all v1alpha1 GVR knowledge in one tested place.
+var sandboxGVR = schema.GroupVersionResource{
 	Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes",
 }
 
@@ -17,7 +17,7 @@ const (
 	// sandboxNameHashLabel is the label the Sandbox controller puts on every
 	// backing Pod (value = FNV-1a hash of the Sandbox name). It is the
 	// controller-guaranteed selector for the Pod.
-	sandboxNameHashLabel = "agents.x-k8s.io/sandbox-name-hash" //nolint:unused // consumed by AgentSandboxExecutor (next PR); kept here with the other Sandbox CRD keys.
+	sandboxNameHashLabel = "agents.x-k8s.io/sandbox-name-hash" //nolint:unused // documents the controller-guaranteed Pod label; becomes load-bearing for the warm-pool follow-up, which selects the backing Pod by this hash instead of the cold-path name==Sandbox identity.
 	// sandboxPodNameAnnotation, when present on the Sandbox, names the backing
 	// Pod. It is set for warm-pool-adopted Sandboxes (random Pod name); for a
 	// cold-created Sandbox it is absent and the Pod name equals the Sandbox name.

--- a/harness/internal/executor/agentsandbox_test.go
+++ b/harness/internal/executor/agentsandbox_test.go
@@ -1,0 +1,296 @@
+package executor
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// baseSandboxCfg returns a minimal valid K8sExecutorConfig for the pure-helper
+// tests. Network mode "none" keeps proxyEnv empty so the spec is unencumbered.
+func baseSandboxCfg() K8sExecutorConfig {
+	return K8sExecutorConfig{
+		Image:     "busybox",
+		Namespace: "default",
+		Network:   &types.NetworkConfig{Mode: "none"},
+	}
+}
+
+// TestApplyAgentSandboxAdmissionDeltas covers the four GKE secure-sandbox-policy
+// deltas: forced gvisor runtime, default CPU+mem limits/requests, the gvisor
+// nodeSelector merge, and the gvisor toleration (added once, idempotently).
+func TestApplyAgentSandboxAdmissionDeltas(t *testing.T) {
+	t.Run("forces gvisor even when runtime was empty", func(t *testing.T) {
+		cfg := baseSandboxCfg() // Runtime unset → buildSandboxPodSpec leaves RuntimeClassName nil
+		spec := buildSandboxPodSpec(cfg, nil)
+		if spec.RuntimeClassName != nil {
+			t.Fatalf("precondition: base spec RuntimeClassName = %v, want nil", spec.RuntimeClassName)
+		}
+		applyAgentSandboxAdmissionDeltas(&spec)
+		if spec.RuntimeClassName == nil || *spec.RuntimeClassName != gkeSandboxRuntimeValue {
+			t.Errorf("RuntimeClassName = %v, want %q", spec.RuntimeClassName, gkeSandboxRuntimeValue)
+		}
+	})
+
+	t.Run("fills default cpu+mem limits and requests when resources nil", func(t *testing.T) {
+		cfg := baseSandboxCfg()
+		spec := buildSandboxPodSpec(cfg, nil)
+		// Precondition: no resources pinned (cfg.Resources nil).
+		if len(spec.Containers[0].Resources.Limits) != 0 {
+			t.Fatalf("precondition: base container has limits %v, want none", spec.Containers[0].Resources.Limits)
+		}
+		applyAgentSandboxAdmissionDeltas(&spec)
+
+		res := spec.Containers[0].Resources
+		cpuLim, ok := res.Limits[corev1.ResourceCPU]
+		if !ok || cpuLim.Cmp(agentSandboxDefaultCPU) != 0 {
+			t.Errorf("cpu limit = %v, want %v", cpuLim, agentSandboxDefaultCPU)
+		}
+		memLim, ok := res.Limits[corev1.ResourceMemory]
+		if !ok || memLim.Cmp(agentSandboxDefaultMemory) != 0 {
+			t.Errorf("memory limit = %v, want %v", memLim, agentSandboxDefaultMemory)
+		}
+		cpuReq, ok := res.Requests[corev1.ResourceCPU]
+		if !ok || cpuReq.Cmp(agentSandboxDefaultCPU) != 0 {
+			t.Errorf("cpu request = %v, want %v", cpuReq, agentSandboxDefaultCPU)
+		}
+		memReq, ok := res.Requests[corev1.ResourceMemory]
+		if !ok || memReq.Cmp(agentSandboxDefaultMemory) != 0 {
+			t.Errorf("memory request = %v, want %v", memReq, agentSandboxDefaultMemory)
+		}
+	})
+
+	t.Run("preserves caller-set resources", func(t *testing.T) {
+		cfg := baseSandboxCfg()
+		cfg.Resources = &types.ResourceLimits{CPUs: 2, MemoryMB: 1024}
+		spec := buildSandboxPodSpec(cfg, nil)
+		// Precondition: the caller's values are already on the base spec via
+		// resourcesToPodResources.
+		wantCPU := resource.MustParse("2")
+		wantMem := resource.MustParse("1024Mi")
+		if got := spec.Containers[0].Resources.Limits[corev1.ResourceCPU]; got.Cmp(wantCPU) != 0 {
+			t.Fatalf("precondition: base cpu limit = %v, want %v", got, wantCPU)
+		}
+
+		applyAgentSandboxAdmissionDeltas(&spec)
+
+		res := spec.Containers[0].Resources
+		if got := res.Limits[corev1.ResourceCPU]; got.Cmp(wantCPU) != 0 {
+			t.Errorf("cpu limit = %v, want caller value %v (must not be overwritten with default)", got, wantCPU)
+		}
+		if got := res.Limits[corev1.ResourceMemory]; got.Cmp(wantMem) != 0 {
+			t.Errorf("memory limit = %v, want caller value %v (must not be overwritten with default)", got, wantMem)
+		}
+	})
+
+	t.Run("fills only the missing side when caller pins one resource", func(t *testing.T) {
+		// Caller pins memory but not CPU. The gap-fill must add the CPU default
+		// (limit + request) while leaving the caller's memory untouched — the
+		// admission policy requires BOTH cpu and memory limits.
+		cfg := baseSandboxCfg()
+		cfg.Resources = &types.ResourceLimits{MemoryMB: 1024}
+		spec := buildSandboxPodSpec(cfg, nil)
+		applyAgentSandboxAdmissionDeltas(&spec)
+
+		res := spec.Containers[0].Resources
+		if got := res.Limits[corev1.ResourceCPU]; got.Cmp(agentSandboxDefaultCPU) != 0 {
+			t.Errorf("cpu limit = %v, want filled default %v", got, agentSandboxDefaultCPU)
+		}
+		if got := res.Requests[corev1.ResourceCPU]; got.Cmp(agentSandboxDefaultCPU) != 0 {
+			t.Errorf("cpu request = %v, want filled default %v", got, agentSandboxDefaultCPU)
+		}
+		wantMem := resource.MustParse("1024Mi")
+		if got := res.Limits[corev1.ResourceMemory]; got.Cmp(wantMem) != 0 {
+			t.Errorf("memory limit = %v, want caller value %v (not overwritten by the default)", got, wantMem)
+		}
+	})
+
+	t.Run("merges nodeSelector with a pre-existing entry", func(t *testing.T) {
+		cfg := baseSandboxCfg()
+		cfg.NodeSelector = map[string]string{"disktype": "ssd"}
+		spec := buildSandboxPodSpec(cfg, nil)
+		applyAgentSandboxAdmissionDeltas(&spec)
+
+		if spec.NodeSelector[gkeSandboxRuntimeKey] != gkeSandboxRuntimeValue {
+			t.Errorf("nodeSelector[%q] = %q, want %q", gkeSandboxRuntimeKey, spec.NodeSelector[gkeSandboxRuntimeKey], gkeSandboxRuntimeValue)
+		}
+		if spec.NodeSelector["disktype"] != "ssd" {
+			t.Errorf("pre-existing nodeSelector entry was clobbered: %v", spec.NodeSelector)
+		}
+	})
+
+	t.Run("adds the gvisor toleration and is idempotent", func(t *testing.T) {
+		cfg := baseSandboxCfg()
+		spec := buildSandboxPodSpec(cfg, nil)
+
+		applyAgentSandboxAdmissionDeltas(&spec)
+		applyAgentSandboxAdmissionDeltas(&spec) // second call must not duplicate
+
+		count := 0
+		for _, tol := range spec.Tolerations {
+			if tol.Key == gkeSandboxRuntimeKey && tol.Value == gkeSandboxRuntimeValue &&
+				tol.Operator == corev1.TolerationOpEqual && tol.Effect == corev1.TaintEffectNoSchedule {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("gvisor toleration count = %d, want exactly 1 (idempotent)", count)
+		}
+	})
+}
+
+// TestBuildSandboxObject asserts the assembled Sandbox CR carries the
+// v1alpha1 apiVersion/kind, the Delete shutdown policy, a ~12h shutdownTime,
+// the per-pod labels on the podTemplate, and that the admission deltas
+// (gvisor runtime + resource limits) survived the typed→unstructured
+// conversion into spec.podTemplate.spec.
+func TestBuildSandboxObject(t *testing.T) {
+	const ns, name = "default", "stirrup-abc123"
+
+	cfg := baseSandboxCfg()
+	spec := buildSandboxPodSpec(cfg, nil)
+	applyAgentSandboxAdmissionDeltas(&spec)
+
+	before := time.Now()
+	obj, err := buildSandboxObject(ns, name, spec, before.Add(agentSandboxMaxTTL))
+	if err != nil {
+		t.Fatalf("buildSandboxObject: %v", err)
+	}
+
+	if got := obj.Object["apiVersion"]; got != "agents.x-k8s.io/v1alpha1" {
+		t.Errorf("apiVersion = %v, want agents.x-k8s.io/v1alpha1", got)
+	}
+	if got := obj.Object["kind"]; got != "Sandbox" {
+		t.Errorf("kind = %v, want Sandbox", got)
+	}
+
+	specMap, ok := obj.Object["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec is not a map: %T", obj.Object["spec"])
+	}
+	if got := specMap["shutdownPolicy"]; got != "Delete" {
+		t.Errorf("spec.shutdownPolicy = %v, want Delete", got)
+	}
+
+	shutdownStr, ok := specMap["shutdownTime"].(string)
+	if !ok {
+		t.Fatalf("spec.shutdownTime is not a string: %T", specMap["shutdownTime"])
+	}
+	shutdown, err := time.Parse(time.RFC3339, shutdownStr)
+	if err != nil {
+		t.Fatalf("spec.shutdownTime %q does not parse as RFC3339: %v", shutdownStr, err)
+	}
+	// Should be ~12h ahead of when we built it. Allow a generous slack window so
+	// the assertion is not flaky, while still catching a wildly wrong TTL.
+	delta := shutdown.Sub(before)
+	if delta < agentSandboxMaxTTL-time.Minute || delta > agentSandboxMaxTTL+time.Minute {
+		t.Errorf("shutdownTime delta = %v, want ~%v ahead", delta, agentSandboxMaxTTL)
+	}
+
+	podTemplate, ok := specMap["podTemplate"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec.podTemplate is not a map: %T", specMap["podTemplate"])
+	}
+	ptMeta, ok := podTemplate["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec.podTemplate.metadata is not a map: %T", podTemplate["metadata"])
+	}
+	ptLabels, ok := ptMeta["labels"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec.podTemplate.metadata.labels is not a map: %T", ptMeta["labels"])
+	}
+	if got := ptLabels[k8sPodNameLabel]; got != name {
+		t.Errorf("podTemplate label %q = %v, want %q", k8sPodNameLabel, got, name)
+	}
+	if got := ptLabels[k8sSandboxLabel]; got != "true" {
+		t.Errorf("podTemplate label %q = %v, want \"true\"", k8sSandboxLabel, got)
+	}
+
+	ptSpec, ok := podTemplate["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec.podTemplate.spec is not a map: %T", podTemplate["spec"])
+	}
+	if got := ptSpec["runtimeClassName"]; got != gkeSandboxRuntimeValue {
+		t.Errorf("podTemplate.spec.runtimeClassName = %v, want %q", got, gkeSandboxRuntimeValue)
+	}
+
+	containers, ok := ptSpec["containers"].([]any)
+	if !ok || len(containers) == 0 {
+		t.Fatalf("spec.podTemplate.spec.containers is not a non-empty slice: %T", ptSpec["containers"])
+	}
+	c0, ok := containers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[0] is not a map: %T", containers[0])
+	}
+	resources, ok := c0["resources"].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[0].resources is not a map: %T", c0["resources"])
+	}
+	limits, ok := resources["limits"].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[0].resources.limits is not a map: %T", resources["limits"])
+	}
+	if _, ok := limits["cpu"]; !ok {
+		t.Errorf("containers[0].resources.limits missing cpu: %v", limits)
+	}
+	if _, ok := limits["memory"]; !ok {
+		t.Errorf("containers[0].resources.limits missing memory: %v", limits)
+	}
+
+	// The hardened security fields must survive the typed→unstructured conversion
+	// into the CR. A regression that silently dropped any of these would weaken
+	// the sandbox without failing any other assertion, so guard them explicitly.
+	if got := ptSpec["automountServiceAccountToken"]; got != false {
+		t.Errorf("podTemplate.spec.automountServiceAccountToken = %v, want false", got)
+	}
+	if podSC, ok := ptSpec["securityContext"].(map[string]any); !ok {
+		t.Errorf("podTemplate.spec.securityContext missing/!map: %T", ptSpec["securityContext"])
+	} else if got := podSC["fsGroup"]; got != int64(k8sRunAsUserUID) {
+		t.Errorf("pod securityContext.fsGroup = %v (%T), want %d", got, got, k8sRunAsUserUID)
+	}
+
+	cSC, ok := c0["securityContext"].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[0].securityContext is not a map: %T", c0["securityContext"])
+	}
+	if got := cSC["allowPrivilegeEscalation"]; got != false {
+		t.Errorf("container allowPrivilegeEscalation = %v, want false", got)
+	}
+	if got := cSC["runAsNonRoot"]; got != true {
+		t.Errorf("container runAsNonRoot = %v, want true", got)
+	}
+	if got := cSC["runAsUser"]; got != int64(k8sRunAsUserUID) {
+		t.Errorf("container runAsUser = %v (%T), want %d", got, got, k8sRunAsUserUID)
+	}
+	if seccomp, ok := cSC["seccompProfile"].(map[string]any); !ok {
+		t.Errorf("container seccompProfile missing/!map: %T", cSC["seccompProfile"])
+	} else if got := seccomp["type"]; got != "RuntimeDefault" {
+		t.Errorf("container seccompProfile.type = %v, want RuntimeDefault", got)
+	}
+	if caps, ok := cSC["capabilities"].(map[string]any); !ok {
+		t.Errorf("container capabilities missing/!map: %T", cSC["capabilities"])
+	} else if drop, ok := caps["drop"].([]any); !ok || len(drop) != 1 || drop[0] != "ALL" {
+		t.Errorf("container capabilities.drop = %v, want [ALL]", caps["drop"])
+	}
+
+	// The ephemeral /workspace emptyDir must survive too — without it a non-root
+	// UID cannot write the workspace.
+	vols, ok := ptSpec["volumes"].([]any)
+	if !ok || len(vols) == 0 {
+		t.Fatalf("podTemplate.spec.volumes is not a non-empty slice: %T", ptSpec["volumes"])
+	}
+	v0, ok := vols[0].(map[string]any)
+	if !ok {
+		t.Fatalf("volumes[0] is not a map: %T", vols[0])
+	}
+	if got := v0["name"]; got != k8sWorkspaceVolume {
+		t.Errorf("volumes[0].name = %v, want %q", got, k8sWorkspaceVolume)
+	}
+	if _, ok := v0["emptyDir"]; !ok {
+		t.Errorf("volumes[0] is not an emptyDir: %v", v0)
+	}
+}

--- a/harness/internal/executor/k8s_netpol.go
+++ b/harness/internal/executor/k8s_netpol.go
@@ -12,10 +12,12 @@ import (
 )
 
 const (
-	// k8sSandboxLabel marks every Pod the K8sExecutor creates. It is the
-	// stable selector a cluster operator can target with their own policies
-	// and the key the per-Pod NetworkPolicy selects on (combined with the
-	// unique pod name) so the policy binds to exactly this Pod.
+	// k8sSandboxLabel marks every sandbox Pod the k8s-family executors create —
+	// the K8sExecutor (directly) and the AgentSandboxExecutor (via the Sandbox
+	// CR's propagated podTemplate labels). It is the stable selector a cluster
+	// operator can target with their own policies and the key the per-Pod
+	// NetworkPolicy selects on (combined with the unique pod name) so the policy
+	// binds to exactly this Pod.
 	k8sSandboxLabel = "stirrup-sandbox"
 
 	// k8sPodNameLabel carries the generated Pod name as a label so the


### PR DESCRIPTION
## What

Adds `AgentSandboxExecutor`: a Kubernetes executor that provisions the sandbox by
creating an `agents.x-k8s.io/v1alpha1` **Sandbox** custom resource (the GKE Agent
Sandbox controller materialises the backing Pod), then execs into that Pod via the
shared `podExecCore`. It reuses `K8sExecutorConfig`, `buildSandboxPodSpec`, the
per-pod egress NetworkPolicy (`egressPolicyFor`/`podLabels`), and `proxyEnvFor`
unchanged — it differs from `K8sExecutor` only in how the Pod comes into being.

- **`applyAgentSandboxAdmissionDeltas`** applies the four deltas GKE's
  `secure-sandbox-policy` admission requires on the Sandbox CR (the base hardened
  spec already covers the rest): force `runtimeClassName: gvisor`; ensure CPU+memory
  limits on every container (gap-fill defaults, preserving caller-set values);
  explicit `sandbox.gke.io/runtime=gvisor` nodeSelector (merged); explicit
  `…:NoSchedule` toleration (idempotent).
- **`buildSandboxObject`** assembles the CR via `dynamic` + `unstructured` (pinned to
  v1alpha1, no `controller-runtime` in the build graph) with the typed Pod spec
  converted in. Lifecycle mirrors `NewK8sExecutor`'s fail-closed ordering:
  NetworkPolicy installed *before* the Sandbox; cleanup of both on any error path.
- **TTL GC backstop**: `spec.shutdownTime = now+12h` + `shutdownPolicy: Delete` so a
  crashed orchestrator can't leak a sandbox. `Close()` is the normal teardown.

This entire lifecycle (admission → Pod materialisation → gVisor in force → per-pod
NetworkPolicy enforced by Dataplane V2 → cascade GC) was verified end-to-end on a
live GKE cluster before implementation.

## Review fixes folded in (code-reviewer + security-reviewer + consistency-reviewer)

- **Egress fail-closed `Close()`** (security HIGH): Foreground propagation + remove the
  egress NetworkPolicy *only after* the Sandbox (and its cascaded Pod) is confirmed
  gone; if the Sandbox delete fails or the wait times out, the policy is **left in
  place** (fail closed). Replaces the previous unconditional policy delete that could
  reopen egress for a still-terminating Pod.
- **Transient-error-tolerant readiness poll** (code BLOCKING): retry NotFound /
  5xx / throttle during the controller's reconcile window; fatal only on
  Forbidden/Unauthorized.
- **Warm-pool fail-closed guard**: error if the resolved Pod name ≠ Sandbox name (v1 is
  cold-path only; a warm-pool Pod wouldn't carry the label the egress policy binds to).
- `resource.Quantity` DeepCopy (no aliasing of the package defaults); toleration
  early-`return`→flag; gvisor-override warning; `var _ Executor` at EOF; refreshed
  `k8sSandboxLabel` comment.
- Tests: hardening-field survival through the unstructured conversion
  (automount=false, drop-ALL, runAsNonRoot/65532, seccomp, fsGroup, emptyDir), plus
  asymmetric (memory-only) resource gap-fill.

Not yet reachable end-to-end — PR 4 wires the `k8s-sandbox` executor type into
config/validation/the factory. `just build`, `just lint` (0 issues), full package
tests pass. Part 3 of 5; stacks on #431.

> Follow-up noted for the maintainer: `waitForPodReady` in `k8s.go` (the K8sExecutor
> path) has the same abort-on-transient-Get behaviour; left untouched as out-of-scope
> for this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)