### PR TITLE
cli: treat an empty auto-detected piped stdin as no config source

### DIFF
--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -5419,6 +5419,104 @@ func TestRunHarness_StdinDashWithoutPipeErrors(t *testing.T) {
 	}
 }
 
+// TestRunHarness_EmptyAutoDetectedStdinFallsThroughToFlags pins the
+// non-interactive-runtime fix: an auto-detected piped stdin that turns
+// out to be empty (a closed anonymous pipe, exactly the fd 0 a GitHub
+// Actions shell step / `docker exec` without -i hands the process) must
+// be treated as "no piped config" and let the flag-only base build
+// proceed — not abort with "input is empty". Without the empty-read
+// downgrade this is the exact failure the OpenAI WIF smoke test hit.
+func TestRunHarness_EmptyAutoDetectedStdinFallsThroughToFlags(t *testing.T) {
+	withPipedStdin(t, "") // empty pipe == an *os.File reporting ModeNamedPipe
+	getOut := captureStdout(t)
+
+	cmd := newTestHarnessCommand()
+	// No --config; a flag-only invocation with just a prompt should
+	// validate as planning off the flag defaults.
+	if err := cmd.Flags().Set("prompt", "prompt from flags"); err != nil {
+		t.Fatalf("set prompt: %v", err)
+	}
+	if err := cmd.Flags().Set("output-runconfig", "-"); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+
+	runErr := runHarness(cmd, nil)
+	out := getOut()
+
+	if runErr != nil {
+		t.Fatalf("empty auto-detected stdin must fall through to flags, got: %v\nstdout: %s", runErr, out)
+	}
+
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("captured output should be parseable JSON: %v\n%s", err, out)
+	}
+	if cfg.Prompt != "prompt from flags" {
+		t.Errorf("Prompt = %q, want it sourced from the flag (not stdin)", cfg.Prompt)
+	}
+}
+
+// TestRunHarness_EmptyStdinWithConfigFileIsNotAmbiguous pins the
+// complement for the --config path: an empty piped stdin is not a
+// competing base, so `--config <path>` alongside it must succeed rather
+// than trip the ambiguous-sources guard. This is what lets a `--config`
+// smoke test run unmodified under a runtime that attaches an empty pipe.
+func TestRunHarness_EmptyStdinWithConfigFileIsNotAmbiguous(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(minimalStdinRunConfig(t)), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	withPipedStdin(t, "") // empty pipe alongside --config
+	getOut := captureStdout(t)
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("config", path); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	if err := cmd.Flags().Set("output-runconfig", "-"); err != nil {
+		t.Fatalf("set output-runconfig: %v", err)
+	}
+
+	runErr := runHarness(cmd, nil)
+	out := getOut()
+
+	if runErr != nil {
+		t.Fatalf("empty stdin must not make --config ambiguous, got: %v\nstdout: %s", runErr, out)
+	}
+
+	var cfg types.RunConfig
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("captured output should be parseable JSON: %v\n%s", err, out)
+	}
+	if cfg.Prompt != "prompt from stdin" {
+		t.Errorf("Prompt = %q, want the --config file's value", cfg.Prompt)
+	}
+}
+
+// TestRunHarness_ExplicitDashWithEmptyPipeStillErrors guards the
+// exemption: the empty-read downgrade applies only to auto-detection.
+// When the operator explicitly names stdin via --config -, an empty pipe
+// is a genuine mistake and must stay a hard "input is empty" error
+// rather than silently falling through to flags.
+func TestRunHarness_ExplicitDashWithEmptyPipeStillErrors(t *testing.T) {
+	withPipedStdin(t, "") // operator pointed --config - at an empty pipe
+
+	cmd := newTestHarnessCommand()
+	if err := cmd.Flags().Set("config", "-"); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	err := runHarness(cmd, nil)
+	if err == nil {
+		t.Fatal("expected --config - against an empty pipe to error")
+	}
+	if !strings.Contains(err.Error(), "input is empty") {
+		t.Errorf("error should report the empty input, got: %v", err)
+	}
+}
+
 // TestRunHarness_OutputRunConfigBadPathErrors pins SF-3: an
 // --output-runconfig path whose parent directory does not exist must
 // surface as a non-nil error mentioning the path. The OpenFile error

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -168,9 +168,12 @@ func BuildRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 // loadBaseRunConfig picks the right base — file, stdin, or
 // flag-derived — and returns a RunConfig pre-population is layered on.
 // The three sources are mutually exclusive: --config <path> with a
-// non-TTY stdin is rejected with both sources cited, because the
-// alternative (silent precedence) would surprise pipeline authors
-// debugging which source landed which field.
+// non-TTY stdin that carries bytes is rejected with both sources cited,
+// because the alternative (silent precedence) would surprise pipeline
+// authors debugging which source landed which field. An auto-detected
+// but empty piped stdin is not a source at all — it is downgraded to
+// "no piped stdin" (see the read below) so non-interactive runtimes
+// that attach an empty pipe to fd 0 do not abort an otherwise-valid run.
 //
 // STIRRUP_CONFIG is a fourth-precedence fallback that fills the same
 // slot as --config when the flag was not passed. It accepts the same
@@ -206,6 +209,34 @@ func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 		}
 	}
 
+	// An auto-detected piped stdin is only a real config source when it
+	// actually carries bytes. Non-interactive runtimes routinely hand the
+	// process a closed, empty anonymous pipe on fd 0 — GitHub Actions
+	// shell steps, `docker exec` without -i, `kubectl exec` — which
+	// os.File.Stat reports as os.ModeNamedPipe, so isStdinPiped treats it
+	// as piped. Reading it once and finding it empty lets the harness tell
+	// "operator piped a config" apart from "the runtime attached an empty
+	// pipe": the latter is downgraded to "no piped stdin" so a flag-only
+	// or --config run proceeds instead of aborting with "input is empty"
+	// or a phantom ambiguity. The explicit --config - / STIRRUP_CONFIG=-
+	// form is exempt — there the operator named stdin as the source, so an
+	// empty read stays a hard error (the explicitStdin case below). The
+	// cost is that a held-open, never-written pipe blocks here rather than
+	// erroring fast; that is already true of the explicit-stdin read and
+	// requires the operator to deliberately attach such a pipe.
+	var pipedConfig []byte
+	if stdinPiped && !explicitStdin {
+		data, err := readCappedStdin(sources.Stdin, "<stdin>")
+		if err != nil {
+			return nil, err
+		}
+		if len(data) == 0 {
+			stdinPiped = false
+		} else {
+			pipedConfig = data
+		}
+	}
+
 	// The base-source preconditions below are configuration mistakes the
 	// operator must resolve before any input is read — ambiguous sources,
 	// or --config -/STIRRUP_CONFIG=- without a usable piped stdin. They
@@ -236,7 +267,10 @@ func loadBaseRunConfig(sources RunConfigSources) (*types.RunConfig, error) {
 		}
 		return readRunConfigFromReader(sources.Stdin, "<stdin>")
 	case stdinPiped && filePath == "":
-		return readRunConfigFromReader(sources.Stdin, "<stdin>")
+		// pipedConfig was buffered above and is guaranteed non-empty: an
+		// empty pipe flips stdinPiped to false, so this case is never
+		// reached for one.
+		return decodeRunConfig(pipedConfig, "<stdin>")
 	case filePath != "":
 		if envConfigSourced {
 			slog.Debug("using STIRRUP_CONFIG as base RunConfig source", "path", filePath)
@@ -306,27 +340,35 @@ func isStdinPiped(r io.Reader) bool {
 	return false
 }
 
-// readRunConfigFromReader mirrors loadRunConfigFile but consumes any
-// io.Reader. Used for both --config - and the auto-detected pipe path
-// in BuildRunConfig. The 1 MiB cap matches the file path (a RunConfig
-// is at most a few KB; megabytes mean a mistake), the
-// DisallowUnknownFields setting matches the file path (typos in piped
-// JSON should fail fast), and the empty-input error is what the spec
-// requires for `stirrup harness < /dev/null`.
-func readRunConfigFromReader(r io.Reader, source string) (*types.RunConfig, error) {
+// readCappedStdin reads up to the config-size cap from r and returns the
+// raw bytes. Emptiness is deliberately NOT an error here: the caller
+// decides whether an empty read is fatal (an explicit --config - / `<
+// config.json` the operator asked for) or benign (an auto-detected pipe
+// that turns out to carry no config — see loadBaseRunConfig). A read
+// failure on the stream itself (broken pipe, flaky redirected file) and
+// an over-cap payload are both I/O errors (exit 3): the bytes never
+// reached the decoder.
+func readCappedStdin(r io.Reader, source string) ([]byte, error) {
 	// +1 lets us distinguish "exactly at the cap" from "larger than the
 	// cap" so the operator-facing error is accurate. Same shape as the
 	// readPromptFile helper above.
 	data, err := io.ReadAll(io.LimitReader(r, maxConfigFileBytes+1))
 	if err != nil {
-		// Read failure on the stream itself (a broken pipe, a flaky
-		// redirected file) is an I/O error (exit 3), not a parse error:
-		// the bytes never reached the decoder.
 		return nil, ioError(fmt.Errorf("reading config from %s: %w", source, err))
 	}
 	if int64(len(data)) > maxConfigFileBytes {
 		return nil, ioError(fmt.Errorf("reading config from %s: exceeds %d byte cap", source, maxConfigFileBytes))
 	}
+	return data, nil
+}
+
+// decodeRunConfig parses already-read config bytes with the same
+// DisallowUnknownFields strictness as the file path (typos in piped JSON
+// should fail fast). Empty input is an I/O error (exit 3) carrying the
+// remediation hint; malformed JSON is a parse error (exit 2). Callers
+// that treat an empty read as benign must gate on len(data) themselves
+// before calling this.
+func decodeRunConfig(data []byte, source string) (*types.RunConfig, error) {
 	if len(data) == 0 {
 		return nil, ioError(fmt.Errorf("reading config from %s: input is empty; pass --config <path> or remove the redirection", source))
 	}
@@ -334,11 +376,21 @@ func readRunConfigFromReader(r io.Reader, source string) (*types.RunConfig, erro
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&cfg); err != nil {
-		// Malformed JSON (syntax error, unknown field, type mismatch) is
-		// a parse error (exit 2): the input was read but did not decode.
 		return nil, parseError(fmt.Errorf("parsing config from %s: %w", source, err))
 	}
 	return &cfg, nil
+}
+
+// readRunConfigFromReader mirrors loadRunConfigFile but consumes any
+// io.Reader. Used for the explicit --config - path, where an empty read
+// is an error. The 1 MiB cap matches the file path (a RunConfig is at
+// most a few KB; megabytes mean a mistake).
+func readRunConfigFromReader(r io.Reader, source string) (*types.RunConfig, error) {
+	data, err := readCappedStdin(r, source)
+	if err != nil {
+		return nil, err
+	}
+	return decodeRunConfig(data, source)
 }
 
 // buildFlagOnlyRunConfig reads the flag values off cmd and constructs


### PR DESCRIPTION
## Problem

The OpenAI WIF smoke test failed with:

```
Error: reading config from <stdin>: input is empty; pass --config <path> or remove the redirection
```
([run 28059846063](https://github.com/rxbynerd/stirrup/actions/runs/28059846063/job/83071191520), exit 3).

Since `7cc8a8e` (2026-05-22, the `run-config | harness` pipeline feature) the CLI builder auto-detects a piped stdin as a base `RunConfig` and reads it **unconditionally**. `isStdinPiped` reports any named-pipe fd 0 as piped — and a GitHub Actions shell step (also `docker exec` without `-i`, `kubectl exec`) hands the process a **closed, empty anonymous pipe** on fd 0, which Go's `os.File.Stat()` reports as `os.ModeNamedPipe`. The harness mistook "the runtime attached an empty pipe" for "the operator piped a config", so the empty read aborted the run.

This was a latent break in **every** shell-step smoke workflow, not just OpenAI WIF:
- flag-only invocations (anthropic, openai-wif) → `input is empty` (exit 3)
- `--config <path>` invocations (azure, bedrock, vertex) → the empty pipe counts as an ambiguous second base

The last green smoke run (anthropic, 2026-05-09) predates `7cc8a8e`; the new OpenAI WIF test is just the first flag-only run since the feature landed. Issue #249 had already exempted *character devices* (`/dev/null`, TTY-less `go test`) but not *anonymous pipes*, which is exactly what CI provides.

## Fix

Treat an **empty piped stdin as "no config source at all."** `loadBaseRunConfig` reads the auto-detected pipe once and, on an empty read, downgrades it to "no piped stdin" so resolution falls through to the intended flag-only / `--config` base. The explicit `--config -` / `STIRRUP_CONFIG=-` form is exempt — there the operator named stdin as the source, so an empty read stays a hard error.

`readRunConfigFromReader` is split into `readCappedStdin` (read, empty-tolerant) and `decodeRunConfig` (empty-fatal) so the auto-detect path can peek emptiness without committing to the error; the explicit-stdin behaviour is unchanged.

The smoke workflows are **left untouched on purpose** — no `< /dev/null` band-aid — so they exercise and regression-guard the real harness behaviour.

## Tests

Three new MF-2 scenarios in `harness_test.go`:
- empty auto-detected stdin falls through to flags
- empty stdin alongside `--config <path>` is not ambiguous
- explicit `--config -` against an empty pipe still errors

Existing MF-2 / exit-code tests unchanged and green; `gofmt` and `golangci-lint v2` clean.

Verified end-to-end against the real condition (empty pipe on stdin, no `/dev/null`): flag-only now passes stdin detection (exit 1 on missing creds, was exit 3), `--config` resolves its file as the sole base, and `--config -` still reports the empty input.

### Known residual

A deliberately held-open, never-written pipe now blocks on the read rather than erroring fast — the same property the explicit-stdin read already had, and pathological in practice (the operator must wire up such a pipe themselves). Noted in a code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)