### PR TITLE
ci: fix smoke-test trace outcome assertion (.trace.outcome)

### DIFF
--- a/.github/workflows/smoke-anthropic.yml
+++ b/.github/workflows/smoke-anthropic.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           set -euo pipefail
           [ -s trace.jsonl ] || { echo "trace.jsonl is missing or empty" >&2; exit 1; }
-          jq -e '.outcome == "success"' trace.jsonl
+          jq -e 'select(.kind == "run_finished") | .trace.outcome == "success"' trace.jsonl
 
       - name: Verify workspace output
         run: |

--- a/.github/workflows/smoke-azure-openai.yml
+++ b/.github/workflows/smoke-azure-openai.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           [ -s trace.jsonl ] || { echo "trace.jsonl is missing or empty" >&2; exit 1; }
-          jq -e '.outcome == "success"' trace.jsonl
+          jq -e 'select(.kind == "run_finished") | .trace.outcome == "success"' trace.jsonl
 
       - name: Verify workspace output
         run: |

--- a/.github/workflows/smoke-bedrock.yml
+++ b/.github/workflows/smoke-bedrock.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           [ -s trace.jsonl ] || { echo "trace.jsonl is missing or empty" >&2; exit 1; }
-          jq -e '.outcome == "success"' trace.jsonl
+          jq -e 'select(.kind == "run_finished") | .trace.outcome == "success"' trace.jsonl
 
       - name: Verify workspace output
         run: |

--- a/.github/workflows/smoke-openai-wif.yml
+++ b/.github/workflows/smoke-openai-wif.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           set -euo pipefail
           [ -s trace.jsonl ] || { echo "trace.jsonl is missing or empty" >&2; exit 1; }
-          jq -e '.outcome == "success"' trace.jsonl
+          jq -e 'select(.kind == "run_finished") | .trace.outcome == "success"' trace.jsonl
 
       - name: Verify workspace output
         run: |

--- a/.github/workflows/smoke-vertex-gemini.yml
+++ b/.github/workflows/smoke-vertex-gemini.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           set -euo pipefail
           [ -s trace.jsonl ] || { echo "trace.jsonl is missing or empty" >&2; exit 1; }
-          jq -e '.outcome == "success"' trace.jsonl
+          jq -e 'select(.kind == "run_finished") | .trace.outcome == "success"' trace.jsonl
 
       - name: Verify workspace output
         run: |

--- a/docs/smoke-tests.md
+++ b/docs/smoke-tests.md
@@ -57,16 +57,25 @@ assertions**:
    ```sh
    set -euo pipefail
    [ -s trace.jsonl ] || { echo "trace.jsonl is missing or empty" >&2; exit 1; }
-   jq -e '.outcome == "success"' trace.jsonl
+   jq -e 'select(.kind == "run_finished") | .trace.outcome == "success"' trace.jsonl
    ```
 
+   `trace.jsonl` is a multi-record stream — one `run_started` line, one
+   `turn_record` per turn, then a terminal `run_finished` line that
+   embeds the run summary. The loop's stop reason lives at
+   `.trace.outcome` inside that `run_finished` record, not at the top
+   level, so the assertion selects the record by `kind` first. A
+   harness that exits before finishing writes no `run_finished` line;
+   `jq -e` then produces no output and exits non-zero (status 4), so
+   the missing terminal record is itself a failure signal.
+
    The `[ -s trace.jsonl ]` guard catches the case where the harness
-   exited before writing the trace; `jq -e` exits non-zero when the
-   expression is falsy. Direct read of the single-document JSONL — do
-   **not** rewrite this as `tail -1 | jq`. Under GNU coreutils
-   `tail` silently emits an empty stream for a missing file, which
-   `jq` then passes; the failure becomes invisible. (This was the
-   regression #132 explicitly fixed in review.)
+   exited before writing any trace at all. Do **not** rewrite the
+   `select` as `tail -1 | jq`: it couples the assertion to line
+   ordering, and under GNU coreutils `tail` silently emits an empty
+   stream for a missing file, which `jq` then passes — the failure
+   becomes invisible. (This was the regression #132 explicitly fixed
+   in review.)
 
 2. **Workspace artifact**:
 


### PR DESCRIPTION
## Problem

The **Verify trace outcome** step in every trace-based smoke workflow asserted:

```sh
jq -e '.outcome == "success"' trace.jsonl
```

This fails unconditionally, even on a clean run. `trace.jsonl` is a *multi-record* JSONL stream — one `run_started` line, one `turn_record` per turn, then a terminal `run_finished` line that embeds the `RunTrace` summary. The loop's stop reason lives at **`.trace.outcome`** inside that `run_finished` record, never at the top level (`harness/internal/trace/events.go` → `Trace *types.RunTrace json:"trace"`; `types/runtrace.go:32` → `Outcome string json:"outcome"`). Every line evaluated falsy, so `jq -e` exited 1 regardless of the real outcome.

Confirmed against a real trace artifact downloaded from the OpenAI WIF smoke run ([run 28092010245](https://github.com/rxbynerd/stirrup/actions/runs/28092010245/job/83172076016)): `outcome` sits under the top-level `trace` object.

## Fix

Select the terminal record by `kind`, then read the nested outcome:

```sh
jq -e 'select(.kind == "run_finished") | .trace.outcome == "success"' trace.jsonl
```

- **success** → `true`, exit 0
- **non-success outcome** → `false`, exit non-zero (fails)
- **no `run_finished` line** (crash / SIGKILL) → `select` yields no output, `jq -e` exits 4 (fails) — the missing terminal record is itself a failure signal, preserving the intent of the existing `[ -s trace.jsonl ]` guard.

This is the **same pattern the repo's own `Justfile` integration-test targets already use** (lines 67–118), including a comment block documenting the identical rationale. The CI smoke workflows had simply diverged from that canonical form.

## Scope

Fixed in all five trace-based smoke workflows:

- `smoke-anthropic.yml`
- `smoke-azure-openai.yml`
- `smoke-bedrock.yml`
- `smoke-openai-wif.yml`
- `smoke-vertex-gemini.yml`

`docs/smoke-tests.md` documented the same broken assertion and called `trace.jsonl` a "single-document JSONL"; both are corrected.

### Deliberately left unchanged

- **`smoke-cloud-run-job.yml` (Shape A)** — `jq -e '.outcome == "success" and .schemaVersion == 1'` operates on the `STIRRUP_RESULT` `RunResult` payload (`types/result.go`), where `outcome` and `schemaVersion` are genuinely top-level. A different surface from the trace stream; correct as-is.
- **`docs/trace-inspection.md`** — `stirrup trace grep --jq '.outcome == ...'` is the `trace grep` mini-grammar, a separate code path, not raw jq over the JSONL stream.

## Verification

- Ran both assertions against the real trace artifact: old → exit 1; new → exit 0.
- Validated the crash (exit 4) and error-outcome (exit 1) cases.
- `actionlint` passes on all five workflows.
- Independent code-reviewer subagent pass: no findings; confirmed completeness and that the cloud-run-job assertion was correctly preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxAiQCoe7dvbYnXNoup2mZ