### PR TITLE
provider: support Claude Sonnet 5 (fix temperature 400 on newest Claude tier)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -635,6 +635,11 @@ Full reference: [`eval.md`](eval.md).
 | `max_tokens` | 64 000 | — |
 | Default model | `claude-sonnet-4-6` | — |
 
+The `temperature` default is resolved unconditionally for every
+provider call; it is not sent on the wire to Claude Opus 4.7+, Claude
+Sonnet 5, or Claude Fable 5 / Mythos 5, which reject a non-default
+value with an HTTP 400. See [`provider-quirks.md`](provider-quirks.md).
+
 ## External dependencies
 
 Provider adapters and the container executor use hand-rolled HTTP

--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -187,6 +187,7 @@ type ProviderBehaviourFlags struct {
     OpenAI          OpenAIBehaviourFlags
     Gemini          GeminiBehaviourFlags
     OpenAIResponses OpenAIResponsesBehaviourFlags
+    Anthropic       AnthropicBehaviourFlags
 }
 ```
 
@@ -212,7 +213,25 @@ type OpenAIResponsesBehaviourFlags struct {
     StoreMode      OpenAIResponsesStoreMode  // store_false (default): always emit explicit store:false
     InputItemShape OpenAIResponsesInputShape // typed_input_items (default): #172 + #199 discriminated union
 }
+
+type AnthropicBehaviourFlags struct {
+    OmitSamplingParams bool // suppress temperature (400 on non-default value for the newest Claude tier)
+}
 ```
+
+`AnthropicBehaviourFlags` mirrors `OpenAIBehaviourFlags.OmitSamplingParams`
+for the one Anthropic wire divergence the harness has needed so far: Claude
+Opus 4.7+, Claude Sonnet 5, and Claude Fable 5 / Mythos 5 return an HTTP 400
+on a non-default `temperature` rather than ignoring it, and the harness
+loop unconditionally resolves a non-nil default temperature
+(`core.defaultTemperature = 0.1`) for every provider call when
+`RunConfig.Temperature` is unset — so without this flag every request to
+one of those models 400s on its first turn. `buildAnthropicRequest` forces
+`anthropicRequest.Temperature` to `nil` when the flag is set, relying on
+the existing `omitempty` tag rather than a custom `MarshalJSON` (unlike
+`openaiRequest`, which needs one for unrelated token-field-selection
+reasons). `StreamParams` carries no `top_p`/`top_k` fields today; the flag
+will cover them too if those are added later.
 
 The typed per-adapter sub-struct is the design choice that replaces
 PR #196's original `StructuralFlags any`: it preserves compile-time
@@ -320,6 +339,18 @@ test catch malformed paths at registry-build time.
 | `gemini`            | `*`                | Gemini: off `streamFunctionCallArguments` (post-#191 default)        |
 | `gemini`            | `gemini-3*`        | Gemini 3: preserve `thoughtSignature` as a sibling of `functionCall` on each `parts[]` element (parse-side only) |
 | `openai-responses`  | `*`                | OpenAI Responses: typed input items, `max_output_tokens`, `store:false`; top-level `parallel_tool_calls`; accepts schema examples (#222, #332) |
+| `anthropic`         | `claude-opus-4-7*` | Anthropic Claude Opus 4.7: omit sampling params (400 on non-default temperature/top_p/top_k) |
+| `anthropic`         | `claude-opus-4-8*` | Anthropic Claude Opus 4.8: omit sampling params (400 on non-default temperature/top_p/top_k) |
+| `anthropic`         | `claude-sonnet-5*` | Anthropic Claude Sonnet 5: omit sampling params (400 on non-default temperature/top_p/top_k) |
+| `anthropic`         | `claude-fable-5*`  | Anthropic Claude Fable 5: omit sampling params (400 on non-default temperature/top_p/top_k) |
+| `anthropic`         | `claude-mythos-5*` | Anthropic Claude Mythos 5: omit sampling params (same API surface as Fable 5; 400 on non-default temperature/top_p/top_k) |
+
+`claude-opus-4-6*`, `claude-sonnet-4-6*`, and `claude-haiku-4-5*` are
+deliberately unmatched — those models still accept a non-default
+temperature. `claude-mythos-preview` (the Mythos 5 predecessor) is also
+unmatched: its sampling-param behaviour is not confirmed against a live
+capture, so a rule is added once verified rather than assumed from the
+Fable 5 family resemblance.
 
 The `openai-responses / *` rule pins the Responses-specific behaviour
 flags (`OpenAIResponsesBehaviourFlags`) to their zero values so the
@@ -415,11 +446,11 @@ The factory composes both without either knowing about the other.
 |---|---|---|
 | `provider.compatProfile` on `ProviderConfig` | `RunConfig` string field | Closed enum. Only legal value in v1: `"zai-glm"`. Unknown values fail at startup via `ValidateRunConfig`. |
 | `stirrup providers quirks --provider X --model Y` | CLI subcommand | Prints resolved `ProviderQuirks` as JSON, plus `Description`, `LastVerified`, staleness flag of every contributing rule. Side-effect-free. |
-| `openai quirks resolved` / `gemini quirks resolved` slog DEBUG line (per-adapter prefix, identical body shape) | structured log | One line per Stream call, listing every contributing rule's Description in apply order. Last entry is the rule whose writes won on overlapping fields. Emitted even when no rule fired (rules:[]) so a missing line unambiguously means "the resolution did not run". Operators writing log filters should match the exact per-adapter prefix; a generic `"quirks resolved"` substring will not find either record. |
+| `openai quirks resolved` / `gemini quirks resolved` / `anthropic quirks resolved` slog DEBUG line (per-adapter prefix, identical body shape) | structured log | One line per Stream call, listing every contributing rule's Description in apply order. Last entry is the rule whose writes won on overlapping fields. Emitted even when no rule fired (rules:[]) so a missing line unambiguously means "the resolution did not run". Operators writing log filters should match the exact per-adapter prefix; a generic `"quirks resolved"` substring will not find every record. |
 | `provider.quirk.applied` OTel span attribute | trace attribute | Set on the active `provider.stream` span at the same point the slog DEBUG line is emitted. Carries the same `[]string` of rule Descriptions. Lets a trace-only consumer (Datadog, Honeycomb, Jaeger) see which rules fired without needing to correlate with a separate log sink. |
 | `quirks replay fields captured` slog DEBUG line | structured log | Per-stream summary of `{count, total_len}` per captured ReplayFields path, emitted on stream exit. Length-only — captured values themselves are not logged. |
 | `replay_fields_captured.count` / `replay_fields_captured.total_len` OTel span attributes | trace attributes | Set on the active `provider.stream` span on stream exit, in parallel with the slog DEBUG record above. Totals across every captured path; length-only invariant matches the slog surface. |
-| `openai quirks suppressed caller temperature` slog WARN line | structured log | Fires when `OmitSamplingParams` suppresses a caller-supplied non-nil `Temperature`. Names the rule that caused the suppression. The suppressed value itself is not logged. |
+| `openai quirks suppressed caller temperature` / `anthropic quirks suppressed caller temperature` slog WARN line | structured log | Fires when `OmitSamplingParams` suppresses a caller-supplied non-nil `Temperature`. Names the rule that caused the suppression. The suppressed value itself is not logged. |
 
 ### 5.1 Read-only registry
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -19,6 +19,18 @@ Federation — see [`docs/anthropic-wif.md`](anthropic-wif.md).
 Default safety thresholds: none — the harness does not configure
 Anthropic safety settings; the API defaults apply.
 
+No model-ID allowlist: `RunConfig.Model` is forwarded to the wire
+verbatim, so a newly released Claude model works with no code change
+as long as its request/response shape matches the Messages API
+contract this adapter already speaks. Claude Opus 4.7 and later, Claude
+Sonnet 5, and Claude Fable 5 / Mythos 5 reject a non-default
+`temperature` outright (HTTP 400) rather than ignoring it; since the
+harness always resolves a non-nil default temperature
+(`core.defaultTemperature = 0.1`) when `RunConfig.Temperature` is
+unset, a per-model quirk rule omits the field for those models before
+it reaches the wire — see [Per-model wire-shape
+quirks](#per-model-wire-shape-quirks) below.
+
 ## AWS Bedrock
 
 **File:** `harness/internal/provider/bedrock.go`
@@ -128,9 +140,11 @@ See `examples/runconfig/vertex-gemini.json` and
 
 Provider/model pairs sometimes diverge from the adapter's canonical
 wire shape: OpenAI's reasoning-class models reject sampling
-parameters, Z.ai GLM requires the legacy `max_tokens` key, Gemini
-3.x emits a `thoughtSignature` blob that must survive turn
-boundaries, and DeepSeek v4's default-on thinking mode requires the
+parameters, the newest Claude tier (Opus 4.7+, Sonnet 5, Fable 5 /
+Mythos 5) rejects a non-default temperature the same way, Z.ai GLM
+requires the legacy `max_tokens` key, Gemini 3.x emits a
+`thoughtSignature` blob that must survive turn boundaries, and
+DeepSeek v4's default-on thinking mode requires the
 `reasoning_content` it streams replayed back on every request after
 a tool-call turn (the API returns 400 otherwise). Rather than
 encoding these as adapter-internal model substring checks, the

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -383,6 +383,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		case *provider.AnthropicAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics
+			pa.Logger = logger
 		case *provider.OpenAICompatibleAdapter:
 			pa.Tracer = tracer
 			pa.Metrics = metrics

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -2933,6 +2933,56 @@ func TestBuildLoopWithTransport_BedrockAdapterHasLogger(t *testing.T) {
 	}
 }
 
+// TestBuildLoopWithTransport_AnthropicAdapterHasLogger asserts that
+// BuildLoopWithTransport injects a non-nil Logger into the
+// AnthropicAdapter, so the "quirks suppressed caller temperature" warn
+// (fired for Claude Opus 4.7+, Sonnet 5, and Fable 5/Mythos 5) runs
+// through the factory's ScrubHandler-backed logger rather than the
+// slog.Default fallback. A future deletion of the `pa.Logger = logger`
+// line in the *provider.AnthropicAdapter factory arm would silently
+// regress the scrub and correlation invariants for that warn; this test
+// surfaces that regression at the assembly seam, mirroring the sibling
+// OpenAI-compatible and Bedrock tests above.
+func TestBuildLoopWithTransport_AnthropicAdapterHasLogger(t *testing.T) {
+	t.Setenv("TEST_ANTHROPIC_KEY", "test-key")
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-test-anthropic-logger",
+		Mode:             "planning",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://TEST_ANTHROPIC_KEY"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-5"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: types.DefaultReadOnlyBuiltInTools()},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	adapter, ok := unwrapNormalizer(loop.Provider).(*provider.AnthropicAdapter)
+	if !ok {
+		t.Fatalf("loop.Provider (after unwrap) type = %T, want *provider.AnthropicAdapter", unwrapNormalizer(loop.Provider))
+	}
+	if adapter.Logger == nil {
+		t.Error("AnthropicAdapter.Logger is nil; factory should inject the ScrubHandler-backed logger so the suppressed-temperature warn keeps run/trace correlation and scrubbing")
+	}
+}
+
 // --- stubSecretStore ---
 
 type stubSecretStore struct {

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -69,6 +69,20 @@ const (
 	// biases for determinism on coding tasks — the historical
 	// hardcoded value, preserved as the harness default so unset
 	// configs see no behaviour change.
+	//
+	// Not every model accepts this value on the wire: Claude Opus 4.7+,
+	// Claude Sonnet 5, and Claude Fable 5 / Mythos 5 return an HTTP 400
+	// on a non-default temperature rather than ignoring it (as do
+	// OpenAI's reasoning-class models, which already had this
+	// constraint). The loop still resolves defaultTemperature
+	// unconditionally for every provider — narrowing it here would
+	// need per-model knowledge this package deliberately does not
+	// have (CLAUDE.md: the loop is a pure function of its interfaces).
+	// The adapters suppress the field for those models via the
+	// per-(provider, model) quirks registry instead
+	// (quirks.AnthropicBehaviourFlags.OmitSamplingParams,
+	// quirks.OpenAIBehaviourFlags.OmitSamplingParams) — see
+	// docs/provider-quirks.md.
 	defaultTemperature = 0.1
 
 	// tokenEstimationDivisor is the approximate character-to-token ratio

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -60,16 +61,18 @@ type AnthropicAdapter struct {
 	baseURL    string                 // overridable for testing
 	Tracer     oteltrace.Tracer       // optional, set by factory for span instrumentation
 	Metrics    *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
+	Logger     *slog.Logger           // optional, set by factory; nil falls back to slog.Default()
 
 	// Registry resolves per-(provider, model) quirks at the top of every
 	// Stream call. The constructor seeds it with quirks.DefaultRegistry()
 	// so callers that ignore the field still get the built-in rule set;
 	// the nil-Registry guard in Stream tolerates direct construction. The
-	// Anthropic adapter only reads the cross-provider ToolChoice
-	// capability today (Anthropic has no wire-shape or sampling-param
-	// divergences StreamParams cannot already express), but resolving
-	// through the registry keeps the tool-choice gating consistent with
-	// the OpenAI and Gemini adapters.
+	// Anthropic adapter reads the cross-provider ToolChoice,
+	// StructuredToolResults, and ParallelToolCalls capabilities plus the
+	// Anthropic-specific OmitSamplingParams behaviour flag (the newest
+	// Claude tier — Opus 4.7+, Sonnet 5, Fable 5 / Mythos 5 — rejects a
+	// non-default temperature outright); resolving through the registry
+	// keeps this consistent with the OpenAI and Gemini adapters.
 	Registry *quirks.Registry
 }
 
@@ -121,7 +124,11 @@ func (a *AnthropicAdapter) AuthMode() AuthMode {
 // wire shape). A non-nil pointer transmits the dereferenced value
 // verbatim, including an explicit 0.0 for greedy decoding. This mirrors
 // the upstream StreamParams.Temperature pointer type so the
-// unset-vs-explicit-zero distinction survives marshalling.
+// unset-vs-explicit-zero distinction survives marshalling. buildAnthropicRequest
+// forces this field back to nil when the resolved quirks set
+// BehaviourFlags.Anthropic.OmitSamplingParams, so the plain omitempty tag
+// is sufficient to suppress the wire key — no custom MarshalJSON needed
+// (contrast openaiRequest, which needs one for other reasons).
 //
 // Messages is typed as []anthropicMessage, not []types.Message, to
 // enforce a cross-provider confidentiality invariant: each adapter owns
@@ -445,6 +452,15 @@ type sseMessageDelta struct {
 // accepts (e.g. thinking_config), change the return type to
 // (json.RawMessage, error) and apply a batch-specific projection here.
 func buildAnthropicRequest(params types.StreamParams, stream bool, q quirks.ProviderQuirks) anthropicRequest {
+	temperature := params.Temperature
+	if q.BehaviourFlags.Anthropic.OmitSamplingParams {
+		// Model families that reject a non-default temperature (Claude
+		// Opus 4.7+, Sonnet 5, Fable 5 / Mythos 5) 400 on the field even
+		// when the loop's default-temperature resolution supplied it.
+		// Forcing the pointer to nil relies on the struct's existing
+		// omitempty tag to drop the wire key.
+		temperature = nil
+	}
 	return anthropicRequest{
 		Model:    params.Model,
 		System:   params.System,
@@ -455,7 +471,7 @@ func buildAnthropicRequest(params types.StreamParams, stream bool, q quirks.Prov
 		// input_schema when the resolved capability supports it.
 		Tools:       translateToolsAnthropic(params.Tools, q.ToolExamples.Supported),
 		MaxTokens:   params.MaxTokens,
-		Temperature: params.Temperature,
+		Temperature: temperature,
 		ToolChoice:  applyAnthropicParallel(anthropicToolChoiceFromParams(params, q.ToolChoice), params, q.ParallelToolCalls),
 		Stream:      stream,
 	}
@@ -479,7 +495,40 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, params types.StreamParams
 	if registry == nil {
 		registry = quirks.DefaultRegistry()
 	}
-	q := registry.Resolve("anthropic", params.Model)
+	q, appliedRules := registry.ResolveWithRules("anthropic", params.Model)
+
+	logger := a.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Debug-level log lists the descriptions of every rule that
+	// contributed to this resolution, mirroring the OpenAI adapter's
+	// equivalent line. Emitted even when the list is empty so an
+	// operator grepping for the line knows the resolution ran.
+	logger.DebugContext(ctx, "anthropic quirks resolved",
+		slog.String("provider.type", "anthropic"),
+		slog.String("provider.model", params.Model),
+		slog.Any("rules", ruleDescriptions(appliedRules)),
+	)
+
+	if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		span.SetAttributes(attribute.StringSlice("provider.quirk.applied", ruleDescriptions(appliedRules)))
+	}
+
+	// Warn-level log when a caller-supplied non-nil Temperature is
+	// suppressed by the OmitSamplingParams quirk (mirrors the OpenAI
+	// adapter's design-risk-2 signal). Without this, an operator who set
+	// RunConfig.Temperature explicitly would silently observe it dropped
+	// on Claude Opus 4.7+/Sonnet 5/Fable 5/Mythos 5. The suppressed value
+	// itself is intentionally NOT logged.
+	if q.BehaviourFlags.Anthropic.OmitSamplingParams && params.Temperature != nil {
+		logger.WarnContext(ctx, "anthropic quirks suppressed caller temperature",
+			slog.String("provider.type", "anthropic"),
+			slog.String("provider.model", params.Model),
+			slog.Any("quirk.rules", ruleDescriptions(appliedRules)),
+		)
+	}
 
 	reqBody := buildAnthropicRequest(params, true, q)
 

--- a/harness/internal/provider/anthropic_test.go
+++ b/harness/internal/provider/anthropic_test.go
@@ -1,10 +1,12 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -349,6 +351,110 @@ func TestAnthropicAdapter_TemperatureWireShape(t *testing.T) {
 				t.Errorf("missing %q in body: %s", tc.wantTempSubstring, body)
 			}
 		})
+	}
+}
+
+// TestAnthropicAdapter_TemperatureSuppressedForNoSamplingParamsModels pins
+// the fix for the model families that reject a non-default temperature
+// outright (Claude Opus 4.7+, Sonnet 5, Fable 5 / Mythos 5 all return a 400
+// rather than ignoring the field). Even though the harness loop always
+// resolves a non-nil default temperature when RunConfig.Temperature is
+// unset (core.defaultTemperature), the wire body must omit "temperature"
+// entirely for these models. claude-sonnet-4-6 is the negative control: it
+// still accepts a non-default temperature, so the key must survive there.
+func TestAnthropicAdapter_TemperatureSuppressedForNoSamplingParamsModels(t *testing.T) {
+	cases := []struct {
+		model       string
+		wantOmitted bool
+	}{
+		{model: "claude-opus-4-7", wantOmitted: true},
+		{model: "claude-opus-4-8", wantOmitted: true},
+		{model: "claude-sonnet-5", wantOmitted: true},
+		{model: "claude-fable-5", wantOmitted: true},
+		{model: "claude-mythos-5", wantOmitted: true},
+		{model: "claude-sonnet-4-6", wantOmitted: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			var rawBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				rawBody, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, makeSSE("message_stop", `{}`))
+			}))
+			defer srv.Close()
+
+			adapter := NewAnthropicAdapter(staticBearer("test-key"), AuthModeAPIKey)
+			adapter.baseURL = srv.URL
+
+			// Deliberately non-nil, non-default: pins that suppression
+			// wins even when a caller (or the loop's own default) set an
+			// explicit temperature.
+			ch, err := adapter.Stream(context.Background(), types.StreamParams{
+				Model:       tc.model,
+				MaxTokens:   1024,
+				Temperature: types.Float64Ptr(0.1),
+			})
+			if err != nil {
+				t.Fatalf("Stream() error: %v", err)
+			}
+			for range ch {
+			}
+
+			hasKey := strings.Contains(string(rawBody), `"temperature"`)
+			if tc.wantOmitted && hasKey {
+				t.Errorf("%s: body contains 'temperature' despite OmitSamplingParams suppression: %s", tc.model, rawBody)
+			}
+			if !tc.wantOmitted && !hasKey {
+				t.Errorf("%s: body missing 'temperature' (over-broad suppression?): %s", tc.model, rawBody)
+			}
+		})
+	}
+}
+
+// TestAnthropicAdapter_OmitSamplingParams_WarnsOnSuppressedTemperature
+// mirrors the OpenAI adapter's design-risk-2 coverage: when the quirk
+// suppresses a caller-supplied non-nil Temperature, the warn log must fire,
+// name the rule that caused the suppression, and never include the
+// suppressed value itself.
+func TestAnthropicAdapter_OmitSamplingParams_WarnsOnSuppressedTemperature(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, makeSSE("message_stop", `{}`))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewAnthropicAdapter(staticBearer("test-key"), AuthModeAPIKey)
+	adapter.baseURL = srv.URL
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:       "claude-sonnet-5",
+		MaxTokens:   4096,
+		Temperature: types.Float64Ptr(0.5),
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "anthropic quirks suppressed caller temperature") {
+		t.Errorf("warn log message absent from output: %s", logOutput)
+	}
+	const wantRule = "Claude Sonnet 5"
+	if !strings.Contains(logOutput, wantRule) {
+		t.Errorf("warn log missing rule description substring %q: %s", wantRule, logOutput)
+	}
+	if strings.Contains(logOutput, "0.5") {
+		t.Errorf("warn log leaks the suppressed temperature value: %s", logOutput)
 	}
 }
 

--- a/harness/internal/provider/anthropic_test.go
+++ b/harness/internal/provider/anthropic_test.go
@@ -458,6 +458,120 @@ func TestAnthropicAdapter_OmitSamplingParams_WarnsOnSuppressedTemperature(t *tes
 	}
 }
 
+// TestAnthropicAdapter_OmitSamplingParams_NoWarnWhenTemperatureUnset covers
+// the "double negative" the suppression logic must handle correctly:
+// a caller who never set Temperature at all, on a model in the omit
+// family. The wire body must still omit "temperature" (the loop's own
+// default-temperature resolution supplies a non-nil pointer in
+// production, but buildAnthropicRequest must not depend on that — a
+// direct nil is the base case), and — unlike
+// TestAnthropicAdapter_OmitSamplingParams_WarnsOnSuppressedTemperature —
+// the WARN log must NOT fire, since there is no caller-supplied value to
+// warn about suppressing (mirrors the `params.Temperature != nil` guard
+// on the log condition).
+func TestAnthropicAdapter_OmitSamplingParams_NoWarnWhenTemperatureUnset(t *testing.T) {
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, makeSSE("message_stop", `{}`))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	adapter := NewAnthropicAdapter(staticBearer("test-key"), AuthModeAPIKey)
+	adapter.baseURL = srv.URL
+	adapter.Logger = logger
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:       "claude-sonnet-5",
+		MaxTokens:   4096,
+		Temperature: nil,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for range ch {
+	}
+
+	if strings.Contains(string(rawBody), `"temperature"`) {
+		t.Errorf("body contains 'temperature' for nil Temperature on an omit-family model: %s", rawBody)
+	}
+	if strings.Contains(buf.String(), "anthropic quirks suppressed caller temperature") {
+		t.Errorf("warn log fired despite no caller-supplied Temperature to suppress: %s", buf.String())
+	}
+}
+
+// TestAnthropicAdapter_DebugLogListsAppliedRules pins the per-Stream debug
+// line, mirroring TestOpenAIAdapter_DebugLogListsAppliedRules: the line
+// fires at the top of every Stream call and lists the descriptions of the
+// rules that contributed to the resolution. An empty rule list is still
+// logged (never happens for "anthropic" in practice, since the base "*"
+// tool-choice/structured-result/parallel-call rules always fire, but the
+// no-omission-rule case for claude-sonnet-4-6 is the useful negative here).
+func TestAnthropicAdapter_DebugLogListsAppliedRules(t *testing.T) {
+	cases := []struct {
+		name               string
+		model              string
+		wantRuleSubstrings []string
+	}{
+		{
+			name:               "sonnet-5 omission rule fires",
+			model:              "claude-sonnet-5",
+			wantRuleSubstrings: []string{"Claude Sonnet 5"},
+		},
+		{
+			name:               "sonnet-4-6 has no omission rule",
+			model:              "claude-sonnet-4-6",
+			wantRuleSubstrings: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, makeSSE("message_stop", `{}`))
+			}))
+			defer srv.Close()
+
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			adapter := NewAnthropicAdapter(staticBearer("test-key"), AuthModeAPIKey)
+			adapter.baseURL = srv.URL
+			adapter.Logger = logger
+
+			ch, err := adapter.Stream(context.Background(), types.StreamParams{
+				Model:     tc.model,
+				MaxTokens: 4096,
+				Messages: []types.Message{
+					{Role: "user", Content: []types.ContentBlock{{Type: "text", Text: "hi"}}},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Stream: %v", err)
+			}
+			for range ch {
+			}
+
+			logOutput := buf.String()
+			if !strings.Contains(logOutput, "anthropic quirks resolved") {
+				t.Errorf("debug log message absent: %s", logOutput)
+			}
+			for _, want := range tc.wantRuleSubstrings {
+				if !strings.Contains(logOutput, want) {
+					t.Errorf("debug log missing rule substring %q: %s", want, logOutput)
+				}
+			}
+		})
+	}
+}
+
 func TestSSE_DeltaForUnknownIndex(t *testing.T) {
 	// Send a content_block_delta for an index that has no content_block_start.
 	// The adapter should skip it silently — no panic, no error event.

--- a/harness/internal/provider/contractfixtures_test.go
+++ b/harness/internal/provider/contractfixtures_test.go
@@ -52,6 +52,31 @@ func TestAnthropicContract_ToolEnabledRequestBody(t *testing.T) {
 	quirkstest.AssertWireEqual(t, quirkstest.JoinPath("testdata", "quirks", "anthropic", "claude-sonnet-4-6", "request.json"), body)
 }
 
+// TestAnthropicContract_ClaudeSonnet5OmitsTemperature pins the outbound
+// Claude Sonnet 5 request shape: identical to the claude-sonnet-4-6 fixture
+// above except "temperature" is absent, even though the same non-nil
+// Temperature is supplied. Claude Sonnet 5 (like Opus 4.7+ and Fable 5 /
+// Mythos 5) returns a 400 on a non-default temperature; the
+// OmitSamplingParams quirk must suppress the field before it reaches the
+// wire.
+func TestAnthropicContract_ClaudeSonnet5OmitsTemperature(t *testing.T) {
+	params := types.StreamParams{
+		Model:       "claude-sonnet-5",
+		System:      "You are helpful.",
+		Messages:    contractFixtureMessages(),
+		Tools:       []types.ToolDefinition{contractFixtureTool()},
+		MaxTokens:   4096,
+		Temperature: types.Float64Ptr(0.5),
+		ToolChoice:  types.ToolChoiceRequired,
+	}
+	q := quirks.DefaultRegistry().Resolve("anthropic", params.Model)
+	body, err := json.Marshal(buildAnthropicRequest(params, true, q))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	quirkstest.AssertWireEqual(t, quirkstest.JoinPath("testdata", "quirks", "anthropic", "claude-sonnet-5", "request.json"), body)
+}
+
 // TestResponsesContract_ToolEnabledRequestBody pins the outbound OpenAI
 // Responses request for a tool-enabled turn, including the typed input-item
 // variants (#199) and the flat function-tool shape.

--- a/harness/internal/provider/quirks/builtin.go
+++ b/harness/internal/provider/quirks/builtin.go
@@ -548,5 +548,58 @@ func BuiltinRules() []Rule {
 				q.BehaviourFlags.OpenAIResponses.InputItemShape = TypedInputItems
 			},
 		},
+		// --- Anthropic sampling-param omission rules ---
+		//
+		// Claude Opus 4.7 removed support for non-default temperature /
+		// top_p / top_k (a 400 error, not a silent ignore); Claude Opus 4.8,
+		// Claude Sonnet 5, and Claude Fable 5 / Mythos 5 inherit the same
+		// constraint. The harness's loop unconditionally resolves a
+		// non-nil default temperature for every provider call
+		// (core.defaultTemperature) when RunConfig.Temperature is unset,
+		// so without this rule every request to one of these models 400s
+		// on its first turn. Mirrors the openai-compatible reasoning-class
+		// rules above: one entry per affected model family, all applying
+		// the same omission.
+		//
+		// Deliberately NOT matched: claude-opus-4-6*, claude-sonnet-4-6*,
+		// claude-haiku-4-5* (still accept a non-default temperature), and
+		// claude-mythos-preview (predecessor to Mythos 5; its sampling-
+		// param behaviour is not confirmed against a live capture — add a
+		// rule once verified rather than guessing).
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "claude-opus-4-7*",
+			Description:  "Anthropic Claude Opus 4.7: omit sampling params (400 on non-default temperature/top_p/top_k)",
+			LastVerified: Date("2026-07-01"),
+			Apply:        applyAnthropicNoSamplingParamsClass,
+		},
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "claude-opus-4-8*",
+			Description:  "Anthropic Claude Opus 4.8: omit sampling params (400 on non-default temperature/top_p/top_k)",
+			LastVerified: Date("2026-07-01"),
+			Apply:        applyAnthropicNoSamplingParamsClass,
+		},
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "claude-sonnet-5*",
+			Description:  "Anthropic Claude Sonnet 5: omit sampling params (400 on non-default temperature/top_p/top_k)",
+			LastVerified: Date("2026-07-01"),
+			Apply:        applyAnthropicNoSamplingParamsClass,
+		},
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "claude-fable-5*",
+			Description:  "Anthropic Claude Fable 5: omit sampling params (400 on non-default temperature/top_p/top_k)",
+			LastVerified: Date("2026-07-01"),
+			Apply:        applyAnthropicNoSamplingParamsClass,
+		},
+		{
+			ProviderType: "anthropic",
+			ModelMatch:   "claude-mythos-5*",
+			Description:  "Anthropic Claude Mythos 5: omit sampling params (same API surface as Fable 5; 400 on non-default temperature/top_p/top_k)",
+			LastVerified: Date("2026-07-01"),
+			Apply:        applyAnthropicNoSamplingParamsClass,
+		},
 	}
 }

--- a/harness/internal/provider/quirks/helpers.go
+++ b/harness/internal/provider/quirks/helpers.go
@@ -17,6 +17,15 @@ func applyOpenAIReasoningClass(q *ProviderQuirks) {
 	q.BehaviourFlags.OpenAI.OmitSamplingParams = true
 }
 
+// applyAnthropicNoSamplingParamsClass sets OmitSamplingParams = true for
+// the Anthropic model families that reject a non-default temperature (and,
+// once StreamParams grows the fields, top_p/top_k) with an HTTP 400 rather
+// than ignoring it. See the "Anthropic sampling-param omission rules"
+// section of BuiltinRules for the affected model list and rationale.
+func applyAnthropicNoSamplingParamsClass(q *ProviderQuirks) {
+	q.BehaviourFlags.Anthropic.OmitSamplingParams = true
+}
+
 // removeFromOmit drops the named field from ProviderQuirks.OmitFields.
 // Used by carve-out rules (e.g. gpt-5-chat*) that need to undo an
 // omission applied by a broader sibling rule. A no-op if the field is

--- a/harness/internal/provider/quirks/quirks.go
+++ b/harness/internal/provider/quirks/quirks.go
@@ -111,8 +111,29 @@ type ProviderBehaviourFlags struct {
 	// it. The zero value reproduces the adapter's pre-quirks hard-coded
 	// behaviour so a Responses request with no rule is byte-identical.
 	OpenAIResponses OpenAIResponsesBehaviourFlags `json:"openaiResponses"`
-	// Future: Anthropic AnthropicBehaviourFlags (reserved; Anthropic v1 has no
-	// structural divergences beyond what StreamParams already encodes).
+	// Anthropic carries the Anthropic Messages API adapter's behaviour
+	// divergences. The zero value reproduces pre-existing behaviour: no
+	// sampling-param suppression.
+	Anthropic AnthropicBehaviourFlags `json:"anthropic"`
+}
+
+// AnthropicBehaviourFlags covers behaviour divergences in the Anthropic
+// Messages API adapter. The zero value reproduces today's behaviour
+// (sampling params forwarded whenever StreamParams.Temperature is non-nil).
+type AnthropicBehaviourFlags struct {
+	// OmitSamplingParams, when true, forces "temperature" out of the
+	// request body even when StreamParams.Temperature is non-nil. Used
+	// for model families that reject a non-default sampling parameter
+	// outright: Claude Opus 4.7+, Claude Sonnet 5, and Claude Fable 5 /
+	// Mythos 5 return a 400 error rather than ignoring the value. Mirrors
+	// quirks.OpenAIBehaviourFlags.OmitSamplingParams — see that field's
+	// doc comment for the design-risk-2 caller-value-suppression warning
+	// this flag also drives in the Anthropic adapter's Stream method.
+	//
+	// StreamParams carries no top_p/top_k fields today, so this flag has
+	// nothing else to suppress; it will cover them too if those fields
+	// are added later.
+	OmitSamplingParams bool `json:"omitSamplingParams"`
 }
 
 // OpenAIBehaviourFlags covers behaviour divergences in openai-compatible

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -652,6 +652,46 @@ func TestStructuredToolResultCapabilityRules(t *testing.T) {
 	})
 }
 
+// TestAnthropicOmitSamplingParamsCapabilityRules pins which Claude model
+// families the harness omits sampling params for. Claude Opus 4.7+, Claude
+// Sonnet 5, and Claude Fable 5 / Mythos 5 return an HTTP 400 on a non-default
+// temperature (see BuiltinRules' "Anthropic sampling-param omission rules"
+// section); Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5 still accept one, so
+// they are the load-bearing negative cases guarding against an over-broad
+// glob silently suppressing temperature on models that support it.
+func TestAnthropicOmitSamplingParamsCapabilityRules(t *testing.T) {
+	omits := []string{
+		"claude-opus-4-7",
+		"claude-opus-4-8",
+		"claude-sonnet-5",
+		"claude-fable-5",
+		"claude-mythos-5",
+	}
+	for _, model := range omits {
+		t.Run(model+" omits sampling params", func(t *testing.T) {
+			q := DefaultRegistry().Resolve("anthropic", model)
+			if !q.BehaviourFlags.Anthropic.OmitSamplingParams {
+				t.Errorf("anthropic/%s: OmitSamplingParams = false, want true (rule not firing)", model)
+			}
+		})
+	}
+
+	accepts := []string{
+		"claude-opus-4-6",
+		"claude-sonnet-4-6",
+		"claude-sonnet-4-5",
+		"claude-haiku-4-5-20251001",
+	}
+	for _, model := range accepts {
+		t.Run(model+" keeps sampling params", func(t *testing.T) {
+			q := DefaultRegistry().Resolve("anthropic", model)
+			if q.BehaviourFlags.Anthropic.OmitSamplingParams {
+				t.Errorf("anthropic/%s: OmitSamplingParams = true, want false (rule misfire)", model)
+			}
+		})
+	}
+}
+
 // TestStructuredToolResultRulesSetSupportedWhenAnyShape pins the structural
 // relationship the adapters depend on: any first-party rule that turns on a
 // structured wire-shape bool must also set Supported. An adapter checks

--- a/harness/internal/provider/quirks/quirks_test.go
+++ b/harness/internal/provider/quirks/quirks_test.go
@@ -681,12 +681,61 @@ func TestAnthropicOmitSamplingParamsCapabilityRules(t *testing.T) {
 		"claude-sonnet-4-6",
 		"claude-sonnet-4-5",
 		"claude-haiku-4-5-20251001",
+		// claude-mythos-preview is deliberately unmatched by any builtin
+		// rule (see BuiltinRules' "Anthropic sampling-param omission
+		// rules" comment) — its sampling-param behaviour is not confirmed
+		// against a live capture, so no rule is added rather than
+		// assumed from the Fable 5 family resemblance. This pin exists
+		// so a future edit that widens "claude-mythos-5*" to
+		// "claude-mythos*" (a plausible-looking cleanup) is a deliberate,
+		// test-visible decision rather than a silent behaviour change.
+		"claude-mythos-preview",
 	}
 	for _, model := range accepts {
 		t.Run(model+" keeps sampling params", func(t *testing.T) {
 			q := DefaultRegistry().Resolve("anthropic", model)
 			if q.BehaviourFlags.Anthropic.OmitSamplingParams {
 				t.Errorf("anthropic/%s: OmitSamplingParams = true, want false (rule misfire)", model)
+			}
+		})
+	}
+}
+
+// TestAnthropicOmitSamplingParamsComposesWithExistingCapabilities pins the
+// specificity-ordering interaction the sampling-param rules introduce:
+// each of the five new claude-*-glob rules (glob length 16-17) resolves
+// strictly after the pre-existing "anthropic / *" capability rules (glob
+// length 1, see registry.go's ascending-length ordering) and must not
+// clobber ToolChoice, StructuredToolResults, or ParallelToolCalls — those
+// rules and the new OmitSamplingParams rules write disjoint struct fields,
+// but this test proves the composition rather than relying on that being
+// self-evident from the code.
+func TestAnthropicOmitSamplingParamsComposesWithExistingCapabilities(t *testing.T) {
+	baseline := DefaultRegistry().Resolve("anthropic", "claude-sonnet-4-5")
+
+	for _, model := range []string{
+		"claude-opus-4-7",
+		"claude-opus-4-8",
+		"claude-sonnet-5",
+		"claude-fable-5",
+		"claude-mythos-5",
+	} {
+		t.Run(model, func(t *testing.T) {
+			q := DefaultRegistry().Resolve("anthropic", model)
+			if !q.BehaviourFlags.Anthropic.OmitSamplingParams {
+				t.Fatalf("anthropic/%s: OmitSamplingParams = false, want true (rule not firing)", model)
+			}
+			if q.ToolChoice != baseline.ToolChoice {
+				t.Errorf("anthropic/%s: ToolChoice = %+v, want unchanged from claude-sonnet-4-5 baseline %+v", model, q.ToolChoice, baseline.ToolChoice)
+			}
+			if q.StructuredToolResults != baseline.StructuredToolResults {
+				t.Errorf("anthropic/%s: StructuredToolResults = %+v, want unchanged from claude-sonnet-4-5 baseline %+v", model, q.StructuredToolResults, baseline.StructuredToolResults)
+			}
+			if q.ParallelToolCalls != baseline.ParallelToolCalls {
+				t.Errorf("anthropic/%s: ParallelToolCalls = %+v, want unchanged from claude-sonnet-4-5 baseline %+v", model, q.ParallelToolCalls, baseline.ParallelToolCalls)
+			}
+			if q.ToolExamples != baseline.ToolExamples {
+				t.Errorf("anthropic/%s: ToolExamples = %+v, want unchanged from claude-sonnet-4-5 baseline %+v", model, q.ToolExamples, baseline.ToolExamples)
 			}
 		})
 	}

--- a/harness/internal/provider/testdata/quirks/anthropic/claude-sonnet-5/request.json
+++ b/harness/internal/provider/testdata/quirks/anthropic/claude-sonnet-5/request.json
@@ -1,0 +1,37 @@
+# synthetic: derived from buildAnthropicRequest + DefaultRegistry().Resolve because the harness does not yet carry a live capture. Identical to the claude-sonnet-4-6 fixture except "temperature" is absent: Claude Sonnet 5 returns a 400 on a non-default temperature, so the OmitSamplingParams quirk (BuiltinRules' "Anthropic sampling-param omission rules") suppresses the field even though the same non-nil Temperature=0.5 was supplied. See testdata/quirks/README.md to refresh.
+{
+  "model": "claude-sonnet-5",
+  "system": "You are helpful.",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "weather in Paris?"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather for a city.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": ["city"],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "max_tokens": 4096,
+  "tool_choice": {
+    "type": "any"
+  },
+  "stream": true
+}


### PR DESCRIPTION
## Summary

Claude Sonnet 5 just shipped. The model ID itself needs no code change — `harness/internal/provider/anthropic.go` has no model allowlist, so `RunConfig.Model: "claude-sonnet-5"` was already forwarded verbatim.

But the harness's agentic loop (`harness/internal/core/loop.go`) unconditionally resolves a non-nil default `temperature` (0.1) for every provider call when `RunConfig.Temperature` is unset. Sonnet 5 — like Opus 4.7/4.8 and Fable 5/Mythos 5 before it — rejects a non-default `temperature` with an HTTP 400 rather than ignoring it. Net effect: **every Stirrup request to `claude-sonnet-5` (and the other affected models) 400ed on turn one**, with no workaround short of hand-authoring a RunConfig JSON that pins `temperature` to Anthropic's own default (1.0) — there's no `--temperature` CLI flag.

### Fix

Mirrors the pattern the project already uses for OpenAI's reasoning-class models: a new `quirks.AnthropicBehaviourFlags.OmitSamplingParams` capability, set by five glob-matched builtin rules (`claude-opus-4-7*`, `claude-opus-4-8*`, `claude-sonnet-5*`, `claude-fable-5*`, `claude-mythos-5*`), forces the wire `temperature` key off in `buildAnthropicRequest` regardless of what the loop resolved. Also backfills DEBUG "quirks resolved" / WARN "quirks suppressed caller temperature" logging on the Anthropic adapter, which — unlike OpenAI/Bedrock/Gemini — had no `Logger` field at all until now.

### On the temperature default itself

Assessed whether `defaultTemperature = 0.1` is still sensible: yes, for every model that still accepts it (Opus 4.6, Sonnet 4.6, Haiku 4.5, and every non-Anthropic provider) — no reason to touch a working default nobody asked to change. The newest Claude tier's outright rejection of custom sampling params is a provider/model-scoped divergence, which is exactly what the quirks registry exists for, not evidence the harness-wide default needs to change. See the updated comment on `defaultTemperature` in `loop.go` and `docs/architecture.md`'s defaults table.

**Deliberately not matched:** `claude-opus-4-6*`, `claude-sonnet-4-6*`, `claude-haiku-4-5*` (still accept a non-default temperature), and `claude-mythos-preview` (Mythos 5's predecessor — its sampling-param behavior isn't confirmed against a live capture, so no rule was added rather than assumed from the Fable 5 family resemblance; pinned as a deliberate negative test).

## Review

Ran a code-reviewer + security-reviewer + test-coverage-auditor pass against this branch before opening:
- **Security:** clean, no findings (no secret/PII leakage in the new logging, no `http.DefaultClient` regression, no weakened timeout config).
- **Code review:** 0 critical/high; 2 medium findings (both test-coverage gaps), 2 low (doc-wording nits, left as-is).
- **Test coverage:** flagged 3 required gaps for a correctness fix of this criticality.

All medium/required findings are remediated in the second commit: a factory-level `Logger`-wiring regression test (matching the existing pattern for every other adapter), a specificity-ordering composition test (proves the new rules don't disturb `ToolChoice`/`StructuredToolResults`/`ParallelToolCalls`/`ToolExamples`), a `claude-mythos-preview` negative pin, the "caller never set Temperature" double-negative case, and a `DebugLogListsAppliedRules` test mirroring OpenAI's.

## Test plan

- [x] `just build test` — full workspace build + test, all green
- [x] `just lint` — 0 issues
- [x] New golden-fixture contract test (`TestAnthropicContract_ClaudeSonnet5OmitsTemperature`) pins the full wire body for a tool-enabled `claude-sonnet-5` request, confirming `temperature` is absent while everything else matches the `claude-sonnet-4-6` fixture
- [x] Mutation-verified by the test-coverage-auditor: disabling the suppression line fails 5/6 subtests + the golden fixture, confirming the tests aren't vacuous
- [x] Negative controls confirm `claude-opus-4-6`/`claude-sonnet-4-6`/`claude-haiku-4-5`/`claude-mythos-preview` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqdPVxfypso2VRWYbRxDqx