### PR TITLE
core, cmd: populate RunResult.finalAssistantText end-to-end

### DIFF
--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -136,12 +136,6 @@ func hookSummaryCounts(results []types.HookExecution) (ran, failed int) {
 // completed RunTrace. The mapping is straightforward; see
 // types/result.go for the schema's stability rules.
 //
-// FinalAssistantText is left empty for v1: the loop computes it (see
-// loop.go::lastAssistantText) but does not thread it onto RunTrace, and
-// the brief is explicit about keeping schema additions to Chunk A.
-// TODO(#164): expose the loop's last assistant text so the resultSink
-// can carry the run's *answer* as well as its bookkeeping.
-//
 // VerifierVerdict is populated from the most recent VerificationResult
 // when one exists. Treating an empty Feedback string as "no verifier
 // ran" would conflate "verifier passed silently" with "verifier was
@@ -160,12 +154,13 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 		return types.RunResult{SchemaVersion: 1, Outcome: "internal-error"}
 	}
 	res := types.RunResult{
-		SchemaVersion: 1,
-		RunID:         rt.ID,
-		Outcome:       rt.Outcome,
-		Turns:         rt.Turns,
-		TokenUsage:    rt.TokenUsage,
-		DurationMs:    rt.CompletedAt.Sub(rt.StartedAt).Milliseconds(),
+		SchemaVersion:      1,
+		RunID:              rt.ID,
+		Outcome:            rt.Outcome,
+		Turns:              rt.Turns,
+		TokenUsage:         rt.TokenUsage,
+		DurationMs:         rt.CompletedAt.Sub(rt.StartedAt).Milliseconds(),
+		FinalAssistantText: rt.FinalAssistantText,
 	}
 	if n := len(rt.VerificationResults); n > 0 {
 		last := rt.VerificationResults[n-1]

--- a/harness/cmd/stirrup/cmd/root_test.go
+++ b/harness/cmd/stirrup/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -182,6 +183,46 @@ func TestBuildRunResult_NoVerificationResultsLeavesVerdictNil(t *testing.T) {
 	}
 	if got := buildRunResult(rt); got.VerifierVerdict != nil {
 		t.Errorf("VerifierVerdict = %+v, want nil", got.VerifierVerdict)
+	}
+}
+
+// TestBuildRunResult_FinalAssistantText pins the RunTrace →
+// RunResult mapping of the run's last assistant text: a populated
+// RunTrace.FinalAssistantText carries through verbatim, and an empty
+// one leaves RunResult.FinalAssistantText empty so the omitempty tag
+// drops it from the wire.
+func TestBuildRunResult_FinalAssistantText(t *testing.T) {
+	cases := []struct {
+		name     string
+		traceIn  string
+		wantText string
+	}{
+		{"populated", "the answer is 42", "the answer is 42"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &types.RunTrace{
+				ID:                 "run-fat",
+				Outcome:            "success",
+				FinalAssistantText: tc.traceIn,
+			}
+			got := buildRunResult(rt)
+			if got.FinalAssistantText != tc.wantText {
+				t.Errorf("FinalAssistantText = %q, want %q", got.FinalAssistantText, tc.wantText)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			hasField := strings.Contains(string(encoded), "finalAssistantText")
+			if tc.wantText == "" && hasField {
+				t.Errorf("empty FinalAssistantText should be omitted from JSON, got %s", encoded)
+			}
+			if tc.wantText != "" && !hasField {
+				t.Errorf("populated FinalAssistantText should be present in JSON, got %s", encoded)
+			}
+		})
 	}
 }
 

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -454,6 +454,25 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	// Stop heartbeat before finishing the trace.
 	stopHeartbeat()
 
+	// Scrub the run's last non-empty assistant text before it reaches any
+	// external surface. The PhasePostTurn guard that cleared this text is a
+	// sensitivity classifier, not a deterministic secret redactor: content
+	// that clears the guard can still carry a secret-shaped substring (e.g. a
+	// credential echoed back from a tool result). This is the single scrub
+	// site for the field — downstream of the guard gate — so both the
+	// returned RunResult and the persisted trace carry the scrubbed form.
+	// Mirrors the scrubbedErr treatment at the provider/guard call sites.
+	finalAssistantText = security.Scrub(finalAssistantText)
+
+	// Hand the scrubbed, guard-approved text to the emitter BEFORE Finish so
+	// the persisted trace (JSONL run_finished line, GCS trace object) carries
+	// it: the concrete emitters build and serialise the RunTrace inside
+	// Finish, so a post-Finish assignment on the returned struct would never
+	// reach disk. Same optional-capability pattern as RecordSystemInstructions.
+	if recorder, ok := l.Trace.(trace.FinalAssistantTextRecorder); ok {
+		recorder.RecordFinalAssistantText(finalAssistantText)
+	}
+
 	// Finish trace using the parent ctx — the trace exporter's ForceFlush
 	// should still have a usable deadline even if the run-scoped ctx is
 	// already cancelled.
@@ -461,10 +480,6 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	if traceErr != nil {
 		return nil, fmt.Errorf("finish trace: %w", traceErr)
 	}
-	// Carry the run's last non-empty assistant text onto the trace so the
-	// resultSink can surface the run's answer. Left empty (and omitted from
-	// JSON) when no turn produced any text.
-	runTrace.FinalAssistantText = finalAssistantText
 
 	return runTrace, nil
 }
@@ -981,7 +996,18 @@ func (l *AgenticLoop) runInnerLoop(
 		// Capture the assistant's text for this turn. The last non-empty
 		// value across all turns becomes RunTrace.FinalAssistantText; the
 		// end_turn path below reuses finalText for its PhasePostTurn guard.
+		//
+		// priorFinalText snapshots the accumulator BEFORE this turn's
+		// commit. The PhasePostTurn guard on the end_turn path below runs
+		// AFTER the commit, so on a guard deny the run must return this
+		// prior value — never the just-committed, denied text. Returning
+		// the denied text would forward it through RunTrace/RunResult and
+		// out the resultSink, bypassing the guard's explicit "do not
+		// forward this content" decision. This is the one new forwarding
+		// channel the FinalAssistantText field adds, so the guard contract
+		// must hold on it.
 		finalText := lastAssistantText(sr.Blocks)
+		priorFinalText := finalAssistantText
 		if finalText != "" {
 			finalAssistantText = finalText
 		}
@@ -1046,7 +1072,9 @@ func (l *AgenticLoop) runInnerLoop(
 				allow, decision, spotlight := l.guardCheck(ctx, in, guardFailOpen(config))
 				l.ratchetRuleOfTwo(ctx, config, decision, turn)
 				if !allow {
-					return messages, "guardrail_blocked", finalAssistantText
+					// Return the prior (non-denied) accumulated text, not
+					// this turn's just-committed text — see priorFinalText.
+					return messages, "guardrail_blocked", priorFinalText
 				}
 				if spotlight {
 					// PostTurn spotlight is intentionally a log-only

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -285,11 +285,17 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	// Outer verification loop.
 	outcome := "success"
 	verificationAttempts := 0
+	// finalAssistantText accumulates the last non-empty assistant text across
+	// every runInnerLoop invocation (verification retries re-enter the loop).
+	var finalAssistantText string
 
 	for verificationAttempts <= maxVerificationRetries {
 		// Run the inner agentic loop.
-		var innerOutcome string
-		messages, innerOutcome = l.runInnerLoop(runCtx, config, systemPrompt, messages, tokenTracker)
+		var innerOutcome, innerFinalText string
+		messages, innerOutcome, innerFinalText = l.runInnerLoop(runCtx, config, systemPrompt, messages, tokenTracker)
+		if innerFinalText != "" {
+			finalAssistantText = innerFinalText
+		}
 
 		if innerOutcome != "success" {
 			outcome = innerOutcome
@@ -455,6 +461,10 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	if traceErr != nil {
 		return nil, fmt.Errorf("finish trace: %w", traceErr)
 	}
+	// Carry the run's last non-empty assistant text onto the trace so the
+	// resultSink can surface the run's answer. Left empty (and omitted from
+	// JSON) when no turn produced any text.
+	runTrace.FinalAssistantText = finalAssistantText
 
 	return runTrace, nil
 }
@@ -524,15 +534,20 @@ func (l *AgenticLoop) setRootCancelAttribute(cause error) {
 
 // runInnerLoop runs the agentic loop turns until the model says "done",
 // max turns is reached, budget is exceeded, or an error occurs.
-// Returns the updated messages and the outcome.
+// Returns the updated messages, the outcome, and the last non-empty
+// assistant text observed across the turns (empty when no turn produced
+// any text).
 func (l *AgenticLoop) runInnerLoop(
 	ctx context.Context,
 	config *types.RunConfig,
 	systemPrompt string,
 	messages []types.Message,
 	tokenTracker *TokenTracker,
-) ([]types.Message, string) {
+) ([]types.Message, string, string) {
 	var lastStopReason string
+	// finalAssistantText holds the last non-empty assistant text seen across
+	// all turns. Threaded onto RunTrace.FinalAssistantText at loop completion.
+	var finalAssistantText string
 	stall := &stallDetector{}
 
 	// Tool-choice escalation state (#230). priorToolCalls tracks whether
@@ -552,7 +567,7 @@ func (l *AgenticLoop) runInnerLoop(
 		// Check budget before each turn.
 		budgetCheck := tokenTracker.CheckBudget(config.MaxTokenBudget)
 		if !budgetCheck.WithinBudget {
-			return messages, "budget_exceeded"
+			return messages, "budget_exceeded", finalAssistantText
 		}
 
 		// Check context cancellation. Return a sentinel outcome so the
@@ -561,7 +576,7 @@ func (l *AgenticLoop) runInnerLoop(
 		// context.Cause().
 		select {
 		case <-ctx.Done():
-			return messages, outcomeCtxDone
+			return messages, outcomeCtxDone, finalAssistantText
 		default:
 		}
 
@@ -604,7 +619,7 @@ func (l *AgenticLoop) runInnerLoop(
 				// action is to abort the run before the model sees
 				// the offending input.
 				if turn == 0 {
-					return messages, "guardrail_blocked"
+					return messages, "guardrail_blocked", finalAssistantText
 				}
 				// On later turns PreTurn deny scrubs the untrusted
 				// content rather than aborting: the just-arrived
@@ -663,9 +678,9 @@ func (l *AgenticLoop) runInnerLoop(
 			contextSpan.SetStatus(codes.Error, err.Error())
 			contextSpan.End()
 			if ctx.Err() != nil {
-				return messages, outcomeCtxDone
+				return messages, outcomeCtxDone, finalAssistantText
 			}
-			return messages, "error"
+			return messages, "error", finalAssistantText
 		}
 		// Publish the post-Prepare absolute token estimate so the
 		// ContextTokens observable gauge callback (registered in Run)
@@ -713,7 +728,7 @@ func (l *AgenticLoop) runInnerLoop(
 					Mode:       "",
 					Model:      selection.Model,
 				})
-				return messages, "error"
+				return messages, "error", finalAssistantText
 			}
 			selectedProvider = prov
 		}
@@ -726,7 +741,7 @@ func (l *AgenticLoop) runInnerLoop(
 				Mode:       "",
 				Model:      selection.Model,
 			})
-			return messages, "error"
+			return messages, "error", finalAssistantText
 		}
 		providerAttrs := l.metricAttrs(
 			attribute.String("provider.type", selection.Provider),
@@ -833,9 +848,9 @@ func (l *AgenticLoop) runInnerLoop(
 			// cancelled, surface that so the outer loop can classify the
 			// outcome as cancelled/timeout rather than a generic error.
 			if ctx.Err() != nil {
-				return messages, outcomeCtxDone
+				return messages, outcomeCtxDone, finalAssistantText
 			}
-			return messages, "error"
+			return messages, "error", finalAssistantText
 		}
 
 		// Consume stream events.
@@ -893,9 +908,9 @@ func (l *AgenticLoop) runInnerLoop(
 			// Distinguish stream-abort-due-to-ctx from other stream errors
 			// so the outer loop can classify the outcome correctly.
 			if ctx.Err() != nil {
-				return messages, outcomeCtxDone
+				return messages, outcomeCtxDone, finalAssistantText
 			}
-			return messages, "error"
+			return messages, "error", finalAssistantText
 		}
 		providerSpan.SetAttributes(
 			attribute.Int("tokens.output", sr.OutputTokens),
@@ -963,6 +978,14 @@ func (l *AgenticLoop) runInnerLoop(
 		// from the stream so the next request can round-trip it.
 		messages = appendAssistantContent(messages, sr.Blocks, sr.ReplayFields)
 
+		// Capture the assistant's text for this turn. The last non-empty
+		// value across all turns becomes RunTrace.FinalAssistantText; the
+		// end_turn path below reuses finalText for its PhasePostTurn guard.
+		finalText := lastAssistantText(sr.Blocks)
+		if finalText != "" {
+			finalAssistantText = finalText
+		}
+
 		// Extract tool calls.
 		toolCalls := collectToolCalls(sr.Blocks)
 
@@ -1012,7 +1035,6 @@ func (l *AgenticLoop) runInnerLoop(
 			// rewrap the child's output; for v1 we log the request and
 			// forward the response unchanged because rewriting the
 			// user-visible text would break tool-protocol expectations.
-			finalText := lastAssistantText(sr.Blocks)
 			if finalText != "" {
 				in := guard.Input{
 					Phase:   guard.PhasePostTurn,
@@ -1024,7 +1046,7 @@ func (l *AgenticLoop) runInnerLoop(
 				allow, decision, spotlight := l.guardCheck(ctx, in, guardFailOpen(config))
 				l.ratchetRuleOfTwo(ctx, config, decision, turn)
 				if !allow {
-					return messages, "guardrail_blocked"
+					return messages, "guardrail_blocked", finalAssistantText
 				}
 				if spotlight {
 					// PostTurn spotlight is intentionally a log-only
@@ -1036,23 +1058,23 @@ func (l *AgenticLoop) runInnerLoop(
 					l.Logger.Info("postTurn guard requested spotlight; not rewriting in v1")
 				}
 			}
-			return messages, "success"
+			return messages, "success", finalAssistantText
 		}
 		if sr.StopReason != "tool_use" {
 			if sr.StopReason == "" {
 				l.Logger.Warn("provider returned empty stop reason", "turn", turn)
-				return messages, "error"
+				return messages, "error", finalAssistantText
 			}
 			// Non-tool-use, non-end-turn stop reasons still represent
 			// a completed exchange that replay/mining cares about.
 			l.Trace.RecordTurnRecord(turnRecord)
-			return messages, sr.StopReason
+			return messages, sr.StopReason, finalAssistantText
 		}
 		if len(toolCalls) == 0 {
 			// Provider declared tool_use but produced no tool blocks —
 			// degenerate but observable.
 			l.Trace.RecordTurnRecord(turnRecord)
-			return messages, "error"
+			return messages, "error", finalAssistantText
 		}
 
 		// Dispatch tool calls. Sync calls run inline in assistant-message
@@ -1074,14 +1096,14 @@ func (l *AgenticLoop) runInnerLoop(
 		// no-tool answer is a legitimate judgement and is left alone.
 		priorToolCalls += len(toolCalls)
 		if stallOutcome != "" {
-			return messages, stallOutcome
+			return messages, stallOutcome, finalAssistantText
 		}
 
 		// Re-check budget after tool results are appended. This prevents the
 		// next turn from sending an over-budget context to the provider.
 		budgetCheck = tokenTracker.CheckBudget(config.MaxTokenBudget)
 		if !budgetCheck.WithinBudget {
-			return messages, "budget_exceeded"
+			return messages, "budget_exceeded", finalAssistantText
 		}
 
 		// Git checkpoint after tool use.
@@ -1098,7 +1120,7 @@ func (l *AgenticLoop) runInnerLoop(
 	}
 
 	// Reached max turns.
-	return messages, "max_turns"
+	return messages, "max_turns", finalAssistantText
 }
 
 // applyEscalation performs the recovery the EscalationPolicy chose for a

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -20,6 +20,7 @@ import (
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/guard"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
@@ -371,6 +372,199 @@ func TestLoop_FinalAssistantText_EmptyWhenNoText(t *testing.T) {
 	}
 	if runTrace.FinalAssistantText != "" {
 		t.Errorf("FinalAssistantText = %q, want empty", runTrace.FinalAssistantText)
+	}
+}
+
+// TestLoop_FinalAssistantText_GuardrailBlockedDoesNotLeakDeniedText pins
+// the guard-ordering invariant: when the PhasePostTurn guard denies a
+// turn's final text, that denied text must not appear on
+// RunTrace.FinalAssistantText. With no prior approved turn the field is
+// empty — never the just-denied content, which would otherwise flow out
+// the resultSink and bypass the guard's "do not forward" decision.
+func TestLoop_FinalAssistantText_GuardrailBlockedDoesNotLeakDeniedText(t *testing.T) {
+	const deniedText = "The secret is ghp_shouldnotleak and here it is."
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: deniedText},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	loop := buildTestLoop(prov)
+	loop.GuardRail = &phaseAwareFakeGuard{
+		verdicts: map[guard.Phase]guard.Verdict{
+			guard.PhasePreTurn:  guard.VerdictAllow,
+			guard.PhasePostTurn: guard.VerdictDeny,
+		},
+	}
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "guardrail_blocked" {
+		t.Fatalf("outcome = %q, want guardrail_blocked", runTrace.Outcome)
+	}
+	if runTrace.FinalAssistantText != "" {
+		t.Errorf("FinalAssistantText = %q, want empty (denied turn's text must not leak)", runTrace.FinalAssistantText)
+	}
+}
+
+// TestLoop_FinalAssistantText_GuardrailBlockedReturnsPriorApprovedText is
+// the two-turn variant of the guard-ordering invariant: turn 0 produces
+// text alongside a tool call (no PostTurn guard on a tool_use turn), turn
+// 1 produces a final answer the PostTurn guard denies. The run must
+// surface turn 0's prior, non-denied text — not turn 1's denied answer.
+func TestLoop_FinalAssistantText_GuardrailBlockedReturnsPriorApprovedText(t *testing.T) {
+	const priorText = "Prior non-denied answer."
+	const deniedText = "Denied final answer."
+	prov := &multiCallProvider{
+		calls: [][]types.StreamEvent{
+			{
+				{Type: "text_delta", Text: priorText},
+				{Type: "tool_call", ID: "tc_1", Name: "test_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: deniedText},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+	loop := buildTestLoop(nil)
+	loop.Provider = prov
+	loop.GuardRail = &phaseAwareFakeGuard{
+		verdicts: map[guard.Phase]guard.Verdict{
+			guard.PhasePreTurn:  guard.VerdictAllow,
+			guard.PhasePreTool:  guard.VerdictAllow,
+			guard.PhasePostTurn: guard.VerdictDeny,
+		},
+	}
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "guardrail_blocked" {
+		t.Fatalf("outcome = %q, want guardrail_blocked", runTrace.Outcome)
+	}
+	if runTrace.FinalAssistantText != priorText {
+		t.Errorf("FinalAssistantText = %q, want %q (prior non-denied turn's text)", runTrace.FinalAssistantText, priorText)
+	}
+	if strings.Contains(runTrace.FinalAssistantText, deniedText) {
+		t.Errorf("FinalAssistantText leaked denied turn's text: %q", runTrace.FinalAssistantText)
+	}
+}
+
+// TestLoop_FinalAssistantText_NotClobberedByEmptyLaterTurn pins the
+// `if finalText != ""` protective path: a text-bearing tool_use turn
+// followed by a terminal turn carrying no text blocks must not blank out
+// the earlier turn's text. Distinct from LastNonEmptyAcrossTurns, which
+// covers a later non-empty turn overwriting an earlier one.
+func TestLoop_FinalAssistantText_NotClobberedByEmptyLaterTurn(t *testing.T) {
+	const text0 = "Here is the result."
+	prov := &multiCallProvider{
+		calls: [][]types.StreamEvent{
+			{
+				{Type: "text_delta", Text: text0},
+				{Type: "tool_call", ID: "tc_1", Name: "test_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				// Terminal turn with no text blocks.
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+	loop := buildTestLoop(nil)
+	loop.Provider = prov
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Fatalf("outcome = %q, want success", runTrace.Outcome)
+	}
+	if runTrace.FinalAssistantText != text0 {
+		t.Errorf("FinalAssistantText = %q, want %q (earlier text retained across empty end_turn)", runTrace.FinalAssistantText, text0)
+	}
+}
+
+// TestLoop_FinalAssistantText_ReachesPersistedJSONLTrace proves the field
+// reaches the persisted trace, not merely the returned struct: it re-parses
+// the JSONL emitter's buffer and asserts the serialized run_finished event's
+// embedded RunTrace carries finalAssistantText.
+func TestLoop_FinalAssistantText_ReachesPersistedJSONLTrace(t *testing.T) {
+	const answer = "The persisted answer."
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: answer},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	var buf bytes.Buffer
+	loop := buildTestLoop(prov)
+	loop.Trace = trace.NewJSONLTraceEmitter(&buf)
+	config := buildTestConfig()
+
+	if _, err := loop.Run(context.Background(), config); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	var found bool
+	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var ev trace.Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("unmarshal trace line: %v", err)
+		}
+		if ev.Kind != trace.EventKindRunFinished {
+			continue
+		}
+		found = true
+		if ev.Trace == nil {
+			t.Fatal("run_finished event carries nil Trace")
+		}
+		if ev.Trace.FinalAssistantText != answer {
+			t.Errorf("persisted FinalAssistantText = %q, want %q", ev.Trace.FinalAssistantText, answer)
+		}
+	}
+	if !found {
+		t.Fatal("no run_finished event found in JSONL output")
+	}
+}
+
+// TestLoop_FinalAssistantText_ScrubbedBeforePersist pins that the final
+// assistant text is passed through security.Scrub before it reaches the
+// trace/resultSink: a secret-shaped substring the PhasePostTurn guard
+// (a sensitivity classifier, not a deterministic redactor) let through
+// must be redacted.
+func TestLoop_FinalAssistantText_ScrubbedBeforePersist(t *testing.T) {
+	// ghp_ GitHub PAT shape is a known deterministic scrub pattern.
+	const secret = "ghp_0123456789abcdefghijABCDEFGHIJ0123"
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "Your token is " + secret + " keep it safe."},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	loop := buildTestLoop(prov)
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if strings.Contains(runTrace.FinalAssistantText, secret) || strings.Contains(runTrace.FinalAssistantText, "ghp_") {
+		t.Errorf("FinalAssistantText leaked raw secret: %q", runTrace.FinalAssistantText)
+	}
+	if !strings.Contains(runTrace.FinalAssistantText, "[REDACTED]") {
+		t.Errorf("FinalAssistantText = %q, want scrubbed [REDACTED] marker", runTrace.FinalAssistantText)
 	}
 }
 

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -287,6 +287,93 @@ func TestLoop_MaxTurns(t *testing.T) {
 	}
 }
 
+// TestLoop_FinalAssistantText_Populated pins the happy path: a run whose
+// final assistant turn carries text lands that text on
+// RunTrace.FinalAssistantText, from where buildRunResult maps it onto the
+// RunResult the resultSink emits.
+func TestLoop_FinalAssistantText_Populated(t *testing.T) {
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "The answer "},
+			{Type: "text_delta", Text: "is 42."},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+
+	loop := buildTestLoop(prov)
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Fatalf("expected outcome 'success', got %q", runTrace.Outcome)
+	}
+	if runTrace.FinalAssistantText != "The answer is 42." {
+		t.Errorf("FinalAssistantText = %q, want %q", runTrace.FinalAssistantText, "The answer is 42.")
+	}
+}
+
+// TestLoop_FinalAssistantText_LastNonEmptyAcrossTurns pins that the loop
+// captures the last non-empty assistant text across every turn: a
+// tool-use turn (text, then a tool call) followed by a final text turn
+// leaves the final turn's text on the trace.
+func TestLoop_FinalAssistantText_LastNonEmptyAcrossTurns(t *testing.T) {
+	prov := &multiCallProvider{
+		calls: [][]types.StreamEvent{
+			{
+				{Type: "text_delta", Text: "Let me check."},
+				{Type: "tool_call", ID: "tc_1", Name: "test_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "All done."},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+
+	loop := buildTestLoop(nil)
+	loop.Provider = prov
+	config := buildTestConfig()
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Fatalf("expected outcome 'success', got %q", runTrace.Outcome)
+	}
+	if runTrace.FinalAssistantText != "All done." {
+		t.Errorf("FinalAssistantText = %q, want %q", runTrace.FinalAssistantText, "All done.")
+	}
+}
+
+// TestLoop_FinalAssistantText_EmptyWhenNoText pins the omit path: a run
+// that never produces an assistant text block (here, hitting max_turns
+// with tool-only turns) leaves FinalAssistantText empty so the omitempty
+// tag drops it from the emitted RunResult.
+func TestLoop_FinalAssistantText_EmptyWhenNoText(t *testing.T) {
+	prov := &infiniteToolCallProvider{}
+
+	loop := buildTestLoop(nil)
+	loop.Provider = prov
+	config := buildTestConfig()
+	config.MaxTurns = 3
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "max_turns" {
+		t.Fatalf("expected outcome 'max_turns', got %q", runTrace.Outcome)
+	}
+	if runTrace.FinalAssistantText != "" {
+		t.Errorf("FinalAssistantText = %q, want empty", runTrace.FinalAssistantText)
+	}
+}
+
 func TestLoop_BudgetExceeded(t *testing.T) {
 	prov := &mockProvider{
 		events: []types.StreamEvent{

--- a/harness/internal/resultsink/resultsink_test.go
+++ b/harness/internal/resultsink/resultsink_test.go
@@ -57,6 +57,49 @@ func TestStdoutJSONSink_EmitsSentinelAndJSON(t *testing.T) {
 	}
 }
 
+// TestStdoutJSONSink_FinalAssistantText pins the wire behaviour of the
+// run's last assistant text through the sink: a populated value both
+// appears in the emitted JSON and round-trips on decode, while an empty
+// value is dropped entirely by the omitempty tag so a run with no
+// assistant text emits no finalAssistantText key.
+func TestStdoutJSONSink_FinalAssistantText(t *testing.T) {
+	cases := []struct {
+		name    string
+		text    string
+		wantKey bool
+	}{
+		{"populated", "the answer is 42", true},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			sink := NewStdoutJSONSinkTo(&buf)
+			res := types.RunResult{
+				SchemaVersion:      1,
+				RunID:              "run-fat",
+				Outcome:            "success",
+				FinalAssistantText: tc.text,
+			}
+			if err := sink.Emit(context.Background(), res); err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(buf.String(), StdoutResultSentinel))
+			hasKey := strings.Contains(payload, "finalAssistantText")
+			if hasKey != tc.wantKey {
+				t.Errorf("finalAssistantText key present = %v, want %v\npayload=%q", hasKey, tc.wantKey, payload)
+			}
+			var decoded types.RunResult
+			if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+				t.Fatalf("unmarshal payload: %v\npayload=%q", err, payload)
+			}
+			if decoded.FinalAssistantText != tc.text {
+				t.Errorf("decoded FinalAssistantText = %q, want %q", decoded.FinalAssistantText, tc.text)
+			}
+		})
+	}
+}
+
 func TestNoneSink_NoOp(t *testing.T) {
 	sink := NoneSink{}
 	if err := sink.Emit(context.Background(), types.RunResult{}); err != nil {

--- a/harness/internal/trace/gcs.go
+++ b/harness/internal/trace/gcs.go
@@ -62,14 +62,17 @@ type GCSTraceEmitter struct {
 	httpClient      *http.Client
 	endpointBaseURL string // override for tests
 
-	mu                sync.Mutex
-	runID             string
-	config            *types.RunConfig
-	startedAt         time.Time
-	turns             []types.TurnTrace
-	toolCalls         []types.ToolCallTrace
-	permissionDenials int
+	mu                 sync.Mutex
+	runID              string
+	config             *types.RunConfig
+	startedAt          time.Time
+	turns              []types.TurnTrace
+	toolCalls          []types.ToolCallTrace
+	permissionDenials  int
+	finalAssistantText string
 }
+
+var _ FinalAssistantTextRecorder = (*GCSTraceEmitter)(nil)
 
 // GCSTraceEmitterOptions configures a GCSTraceEmitter. Bucket is
 // required; ObjectPrefix is optional. CredentialSource is the resolved
@@ -145,6 +148,7 @@ func (e *GCSTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.turns = nil
 	e.toolCalls = nil
 	e.permissionDenials = 0
+	e.finalAssistantText = ""
 }
 
 // RecordTurn appends a turn trace.
@@ -175,6 +179,15 @@ func (e *GCSTraceEmitter) RecordPermissionDenial() {
 	e.permissionDenials++
 }
 
+// RecordFinalAssistantText stores the run's final assistant text so the
+// uploaded trace object carries it. The loop forwards a value already
+// scrubbed and gated by the PhasePostTurn guard.
+func (e *GCSTraceEmitter) RecordFinalAssistantText(text string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.finalAssistantText = text
+}
+
 // Finish builds the final RunTrace, marshals it as a single JSONL
 // line, and PUTs the bytes to gs://{bucket}/{objectPrefix}/{runID}.jsonl.
 // A run with zero turns still produces a single valid JSON line —
@@ -196,6 +209,7 @@ func (e *GCSTraceEmitter) Finish(ctx context.Context, outcome string) (*types.Ru
 	turns := append([]types.TurnTrace(nil), e.turns...)
 	toolCalls := append([]types.ToolCallTrace(nil), e.toolCalls...)
 	permissionDenials := e.permissionDenials
+	finalAssistantText := e.finalAssistantText
 	e.mu.Unlock()
 
 	now := time.Now()
@@ -217,15 +231,16 @@ func (e *GCSTraceEmitter) Finish(ctx context.Context, outcome string) (*types.Ru
 	}
 
 	trace := &types.RunTrace{
-		ID:                runID,
-		Config:            redactedConfig,
-		StartedAt:         startedAt,
-		CompletedAt:       now,
-		Turns:             len(turns),
-		TokenUsage:        totalTokens,
-		ToolCalls:         summaries,
-		PermissionDenials: permissionDenials,
-		Outcome:           outcome,
+		ID:                 runID,
+		Config:             redactedConfig,
+		StartedAt:          startedAt,
+		CompletedAt:        now,
+		Turns:              len(turns),
+		TokenUsage:         totalTokens,
+		ToolCalls:          summaries,
+		PermissionDenials:  permissionDenials,
+		Outcome:            outcome,
+		FinalAssistantText: finalAssistantText,
 	}
 
 	data, err := json.Marshal(trace)

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -42,11 +42,14 @@ type JSONLTraceEmitter struct {
 	// canonical RunTrace (token totals, tool call summaries, outcome)
 	// for the in-process caller (harness factory, eval runner) that
 	// reads it directly without re-parsing the file.
-	turns             []types.TurnTrace
-	toolCalls         []types.ToolCallTrace
-	permissionDenials int
-	hookResults       []types.HookExecution
+	turns              []types.TurnTrace
+	toolCalls          []types.ToolCallTrace
+	permissionDenials  int
+	hookResults        []types.HookExecution
+	finalAssistantText string
 }
+
+var _ FinalAssistantTextRecorder = (*JSONLTraceEmitter)(nil)
 
 // NewJSONLTraceEmitter creates a streaming trace emitter that writes to w.
 // If w implements io.Closer, Close on the emitter closes it.
@@ -93,6 +96,7 @@ func (e *JSONLTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.toolCalls = nil
 	e.permissionDenials = 0
 	e.hookResults = nil
+	e.finalAssistantText = ""
 
 	startedAt := e.startedAt
 	var redacted types.RunConfig
@@ -213,6 +217,15 @@ func (e *JSONLTraceEmitter) RecordHookExecution(exec types.HookExecution) {
 	_ = e.writeLineLocked(ev)
 }
 
+// RecordFinalAssistantText stores the run's final assistant text so the
+// run_finished event's embedded RunTrace carries it. The loop forwards a
+// value already scrubbed and gated by the PhasePostTurn guard.
+func (e *JSONLTraceEmitter) RecordFinalAssistantText(text string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.finalAssistantText = text
+}
+
 // Finish builds the canonical RunTrace summary, writes the
 // run_finished event, and returns the summary. A run with zero turns
 // still produces a valid run_finished line.
@@ -239,16 +252,17 @@ func (e *JSONLTraceEmitter) Finish(_ context.Context, outcome string) (*types.Ru
 	}
 
 	trace := &types.RunTrace{
-		ID:                e.runID,
-		Config:            redactedConfig,
-		StartedAt:         e.startedAt,
-		CompletedAt:       now,
-		Turns:             len(e.turns),
-		TokenUsage:        totalTokens,
-		ToolCalls:         summaries,
-		PermissionDenials: e.permissionDenials,
-		Outcome:           outcome,
-		HookResults:       e.hookResults,
+		ID:                 e.runID,
+		Config:             redactedConfig,
+		StartedAt:          e.startedAt,
+		CompletedAt:        now,
+		Turns:              len(e.turns),
+		TokenUsage:         totalTokens,
+		ToolCalls:          summaries,
+		PermissionDenials:  e.permissionDenials,
+		Outcome:            outcome,
+		FinalAssistantText: e.finalAssistantText,
+		HookResults:        e.hookResults,
 	}
 
 	ev := Event{

--- a/harness/internal/trace/nested_jsonl.go
+++ b/harness/internal/trace/nested_jsonl.go
@@ -38,14 +38,17 @@ type NestedJSONLEmitter struct {
 	parent      TraceEmitter
 	parentRunID string
 
-	mu                sync.Mutex
-	runID             string
-	config            *types.RunConfig
-	startedAt         time.Time
-	turns             []types.TurnTrace
-	toolCalls         []types.ToolCallTrace
-	permissionDenials int
+	mu                 sync.Mutex
+	runID              string
+	config             *types.RunConfig
+	startedAt          time.Time
+	turns              []types.TurnTrace
+	toolCalls          []types.ToolCallTrace
+	permissionDenials  int
+	finalAssistantText string
 }
+
+var _ FinalAssistantTextRecorder = (*NestedJSONLEmitter)(nil)
 
 // NewNestedJSONLEmitter returns an emitter that forwards Turn/ToolCall
 // events to parent, tagged with parentRunID and the child's runID set
@@ -72,6 +75,7 @@ func (e *NestedJSONLEmitter) Start(runID string, config *types.RunConfig) {
 	e.turns = nil
 	e.toolCalls = nil
 	e.permissionDenials = 0
+	e.finalAssistantText = ""
 }
 
 // RecordTurn appends to the child's local trace and forwards a tagged
@@ -143,6 +147,18 @@ func (e *NestedJSONLEmitter) RecordPermissionDenial() {
 	e.parent.RecordPermissionDenial()
 }
 
+// RecordFinalAssistantText stores the child run's final assistant text
+// on the local accumulator so the child's own Finish returns it. It is
+// deliberately NOT forwarded to the parent: the parent stamps its own
+// final text at its own Finish, and forwarding would clobber that single
+// stored value — the same reason sub-agent system instructions are not
+// forwarded (see SystemInstructionsRecorder).
+func (e *NestedJSONLEmitter) RecordFinalAssistantText(text string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.finalAssistantText = text
+}
+
 // Finish builds and returns the child's RunTrace. It does NOT call
 // parent.Finish: the parent's own Run finishes its emitter exactly
 // once when the outer run completes; calling it from a child would
@@ -170,14 +186,15 @@ func (e *NestedJSONLEmitter) Finish(_ context.Context, outcome string) (*types.R
 	}
 
 	return &types.RunTrace{
-		ID:                e.runID,
-		Config:            redactedConfig,
-		StartedAt:         e.startedAt,
-		CompletedAt:       now,
-		Turns:             len(e.turns),
-		TokenUsage:        totalTokens,
-		ToolCalls:         summaries,
-		PermissionDenials: e.permissionDenials,
-		Outcome:           outcome,
+		ID:                 e.runID,
+		Config:             redactedConfig,
+		StartedAt:          e.startedAt,
+		CompletedAt:        now,
+		Turns:              len(e.turns),
+		TokenUsage:         totalTokens,
+		ToolCalls:          summaries,
+		PermissionDenials:  e.permissionDenials,
+		Outcome:            outcome,
+		FinalAssistantText: e.finalAssistantText,
 	}, nil
 }

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -113,15 +113,16 @@ type OTelTraceEmitter struct {
 	// behaviour.
 	captureContent bool
 
-	mu                sync.Mutex
-	runID             string
-	config            *types.RunConfig
-	startedAt         time.Time
-	rootSpan          oteltrace.Span
-	rootCtx           context.Context
-	turns             []types.TurnTrace
-	toolCalls         []types.ToolCallTrace
-	permissionDenials int
+	mu                 sync.Mutex
+	runID              string
+	config             *types.RunConfig
+	startedAt          time.Time
+	rootSpan           oteltrace.Span
+	rootCtx            context.Context
+	turns              []types.TurnTrace
+	toolCalls          []types.ToolCallTrace
+	permissionDenials  int
+	finalAssistantText string
 
 	// systemInstructionsJSON is the run's system prompt, scrubbed and
 	// pre-serialised to the gen_ai.system_instructions attribute encoding
@@ -173,6 +174,7 @@ type OTelTraceEmitter struct {
 var (
 	_ TraceEmitter               = (*OTelTraceEmitter)(nil)
 	_ SystemInstructionsRecorder = (*OTelTraceEmitter)(nil)
+	_ FinalAssistantTextRecorder = (*OTelTraceEmitter)(nil)
 )
 
 // pendingTurnKey pairs a buffered turn summary with its later
@@ -395,6 +397,7 @@ func (e *OTelTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.turns = nil
 	e.toolCalls = nil
 	e.permissionDenials = 0
+	e.finalAssistantText = ""
 	e.systemInstructionsJSON = ""
 	e.rootInputMessagesJSON = ""
 	e.rootOutputMessagesJSON = ""
@@ -710,6 +713,19 @@ func (e *OTelTraceEmitter) RecordSystemInstructions(system string) {
 	e.systemInstructionsJSON = genAISystemInstructionsJSON(security.Scrub(system))
 }
 
+// RecordFinalAssistantText stores the run's final assistant text so the
+// RunTrace aggregate returned by Finish carries it for the in-process
+// caller (harness factory → RunResult). Unlike RecordSystemInstructions,
+// this is not gated on captureContent: the value feeds the RunResult, not
+// a span attribute, so it is retained regardless of content capture. The
+// loop forwards a value already scrubbed and gated by the PhasePostTurn
+// guard.
+func (e *OTelTraceEmitter) RecordFinalAssistantText(text string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.finalAssistantText = text
+}
+
 // RecordToolCall creates a child span for a tool invocation.
 //
 // When content capture is on and the call carries a tool_use ID, the
@@ -904,15 +920,16 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 	}
 
 	trace := &types.RunTrace{
-		ID:                e.runID,
-		Config:            redactedConfig,
-		StartedAt:         e.startedAt,
-		CompletedAt:       now,
-		Turns:             len(e.turns),
-		TokenUsage:        totalTokens,
-		ToolCalls:         summaries,
-		PermissionDenials: e.permissionDenials,
-		Outcome:           outcome,
+		ID:                 e.runID,
+		Config:             redactedConfig,
+		StartedAt:          e.startedAt,
+		CompletedAt:        now,
+		Turns:              len(e.turns),
+		TokenUsage:         totalTokens,
+		ToolCalls:          summaries,
+		PermissionDenials:  e.permissionDenials,
+		Outcome:            outcome,
+		FinalAssistantText: e.finalAssistantText,
 	}
 
 	return trace, nil

--- a/harness/internal/trace/trace.go
+++ b/harness/internal/trace/trace.go
@@ -70,3 +70,16 @@ type SystemInstructionsRecorder interface {
 type HookRecorder interface {
 	RecordHookExecution(exec types.HookExecution)
 }
+
+// FinalAssistantTextRecorder is an optional capability a TraceEmitter
+// can implement to receive the run's final assistant text just before
+// Finish. The agentic loop forwards the guard-approved, scrubbed text
+// via a type assertion — the same optional-capability pattern as
+// SystemInstructionsRecorder — so the emitter can stamp it onto the
+// RunTrace it builds and serialises inside Finish. A post-Finish
+// assignment on the returned struct would never reach the persisted
+// trace, because the concrete emitters marshal/write the RunTrace
+// before Finish returns.
+type FinalAssistantTextRecorder interface {
+	RecordFinalAssistantText(text string)
+}

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -38,6 +38,11 @@ type RunTrace struct {
 	// an otherwise-successful run (it never overrides a non-success outcome —
 	// the primary failure cause stays authoritative).
 	Outcome string `json:"outcome"`
+	// FinalAssistantText is the loop's last non-empty assistant text,
+	// concatenated across the text blocks of the final response and carried
+	// through to RunResult.FinalAssistantText. Omitted when the run produced
+	// no assistant turn (e.g. an early validation failure before any turn).
+	FinalAssistantText string `json:"finalAssistantText,omitempty"`
 	// HookResults carries every lifecycle hook execution recorded during
 	// the run (issue #461), across both phases, in dispatch order. Empty
 	// when no hooks were configured. Populated by trace emitters that


### PR DESCRIPTION
## Summary

Populates `RunResult.FinalAssistantText`, which was declared on the RunResult wire type but never filled in. Resolves CONTROL_PLANE.md §7 item 3. After every run the stdout-json result sink now carries the model's last non-empty assistant answer alongside the bookkeeping (turns/tokens/outcome), and the same value is persisted on the trace surfaces used by serverless/Cloud Run collection.

The loop already computed `lastAssistantText(sr.Blocks)` on the `end_turn` path but discarded it; this threads that value through to the trace and the RunResult.

## What changed

- `types/runtrace.go` — new `FinalAssistantText` field on `RunTrace` (omitempty).
- `harness/internal/core/loop.go` — captures the last non-empty assistant text across every turn (computed once, reused by the `end_turn` PhasePostTurn guard), and stamps it onto the finished trace at the single shared finalisation point. The value is:
  - **gated behind the post-turn guard**: a turn whose text the PhasePostTurn guard denies (`guardrail_blocked`) never appears in the field — the prior guard-approved value (or empty) is returned instead, so the new forwarding channel honours the guard's do-not-forward contract.
  - **scrubbed** via `security.Scrub` at a single site, consistent with every other externally-forwarded string in the loop.
- `harness/internal/trace/*` — new optional `FinalAssistantTextRecorder` capability interface (mirroring the existing `SystemInstructionsRecorder` pattern), implemented by all four emitters (jsonl, gcs, otel, nested_jsonl) so the persisted `run_finished` trace / GCS object carries the field, not just the in-memory RunResult. On the OTel emitter the value feeds only the returned in-process `RunTrace` aggregate (→ RunResult), not an exported span attribute, so it is intentionally independent of `captureContent` and does not affect OTel content export.
- `harness/cmd/stirrup/cmd/root.go` — `buildRunResult` maps the field onto `RunResult`; removed a stale stub comment.

Scope is contained to types + loop + trace + root + tests. No proto / gRPC `done` event changes; `buf generate` was not run.

## Tests

- `harness/internal/core/loop_test.go` — populated case (incl. JSONL-buffer re-parse proving the persisted trace carries it), last-non-empty-across-turns, not-clobbered-by-a-later-empty-turn, single-turn and two-turn guardrail-blocked no-leak, and a scrub assertion.
- `harness/cmd/stirrup/cmd/root_test.go`, `harness/internal/resultsink/resultsink_test.go` — mapping + sink round-trip, including omitempty (key absent when empty).

## Review

Implemented, then run through a reviewer wave (code, spec-compliance, test-coverage) and remediated before this PR: fixed a guardrail-denied-text leak through the new channel, closed a gap where the field never reached the persisted JSONL/GCS trace, added a secret-scrub pass matching the surrounding code, and added the regression tests above. `just build`, `just test`, and `just lint` all pass.

## Follow-up (not in this PR)

- No size bound / truncation on the field yet — a very long answer could truncate the `STIRRUP_RESULT` JSON line in Cloud Logging. Worth a documented byte cap in a follow-up.
- `docs/CONTROL_PLANE.md` §2.5 still says the field is "currently never populated — issue #164". That doc does not exist on `main` (it lives on the in-flight `control-plane` branch), so the row edit + stale-#164 removal must be applied there. `docs/configuration.md` / `README.md` have no such claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)