### PR TITLE
core, types, executor: lifecycle hooks — pre/post-run sandbox exec (#461)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ stirrup/
       verifier/              # Verifier: none, test-runner, composite, llm-judge
       permission/            # PermissionPolicy: allow-all, deny-side-effects, ask-upstream, policy-engine (Cedar)
       git/                   # GitStrategy: none, deterministic
+      hook/                  # Lifecycle hooks: Runner, Noop, ExecRunner (pre/post-run exec, #461)
       transport/             # Transport: stdio, gRPC bidi streaming, null (sub-agents)
       guard/                 # GuardRail: none, granite-guardian, cloud-judge, composite, phase-gated
       trace/                 # TraceEmitter: JSONL, OpenTelemetry (OTLP/gRPC or OTLP/HTTP)
@@ -190,10 +191,14 @@ The `guard` package (`guard/`) provides an LLM-based safety classifier called at
 - `max_tokens: 64000`, `temperature: 0.1`
 - File size limit: 10MB (read/write)
 - Command output cap: 1MB
-- Command timeout: 30s default, 5min max
+- Command timeout: 30s default, 5min max (`run_command` tool clamp;
+  the shared `Executor.Exec` hard cap is 30min, raised for lifecycle
+  hooks — #461)
 - Follow-up grace cap: 3600s
 - Token budget cap: 50M
 - Cost budget cap: $100
+- Lifecycle hook timeout: 300s default, 1800s (30min) max per hook;
+  32 hooks max per phase
 
 ## Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ Quick map for "I need to change X" lookups:
 | Provider behaviour or wire format | `harness/internal/provider/<name>.go` |
 | Tool definition or schema | `harness/internal/tool/builtins/<name>.go` |
 | Edit fallback logic | `harness/internal/edit/multi.go` |
+| Lifecycle hooks (pre/post-run exec, #461) | `harness/internal/hook/` (Runner/Noop/ExecRunner), loop wiring in `harness/internal/core/loop.go` (operator doc: `docs/configuration.md#lifecycle-hooks`) |
 | Permission gating logic | `harness/internal/permission/<type>.go` |
 | Cedar policy semantics | `harness/internal/permission/policyengine.go` |
 | Container runtime / network mode wiring | `harness/internal/executor/container*.go` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,6 +127,24 @@ the `Verifier` validates output. The `Transport` carries events to
 and from the control plane; the `TraceEmitter` records spans and
 metrics throughout.
 
+Lifecycle hooks (issue #461) run around this loop, not inside it. A
+configured `hook.Runner` (`hook.Noop` when the run has none) executes
+`preRun` hooks after `PromptBuilder` builds the system prompt and
+before `GitStrategy.Setup` — the deterministic git strategy assumes an
+existing checkout, so a clone hook has to create it first — under the
+run's own wall-clock context. `postRun` hooks execute after outcome
+classification and `GitStrategy.Finalise`, before the run reports
+`done`, on a context detached from the run's own cancellation and
+deadline (`context.WithoutCancel`) and bounded by the sum of the
+configured `postRun` timeouts plus a 30 s margin, so an artifact
+upload can still finish after the run's wall-clock timeout has
+expired. Hook output never enters the model's context; it is
+trace-only, recorded via the optional `trace.HookRecorder` capability
+the same way `trace.SystemInstructionsRecorder` is. Sub-agent loops
+always get `hook.Noop` — hooks are parent-run-only. Full schema,
+defaults, and failure-semantics reference: [`configuration.md`
+"Lifecycle hooks"](configuration.md#lifecycle-hooks).
+
 ## Modes
 
 Five run modes ship as partial `RunConfig` presets that select
@@ -226,10 +244,25 @@ are accessed. Three tiers ship, selected per-task:
   `/var/run/podman/podman.sock`.
 
 Filesystem executors enforce a 10 MB file size cap, a 1 MB command
-output cap, a 30 s default command timeout (5 min hard cap), and
-symlink-aware workspace containment. The container executor is
-hardened with `CapDrop: ALL`, `no-new-privileges`, and
-`NetworkMode: none` by default; API keys never enter the container.
+output cap, a 30 s default command timeout, and symlink-aware
+workspace containment. The container executor is hardened with
+`CapDrop: ALL`, `no-new-privileges`, and `NetworkMode: none` by
+default; API keys never enter the container.
+
+Two independent timeout ceilings apply to command execution, and they
+are deliberately decoupled. The shared `Executor.Exec` hard cap the
+`local`, `container`, `k8s`, and `k8s-sandbox` executors clamp
+against — 30 minutes as of issue #461, raised from 5 minutes so a
+`preRun` lifecycle hook can run a cold `bundle install` — bounds
+every real command execution uniformly. The agent-reachable
+`run_command` tool clamps independently at 300 s (5 minutes) inside
+`builtins/shell.go`, not derived from the executor constant, so
+raising the executor's ceiling for hooks does not hand the model a
+longer exec budget. The eval-only `ReplayExecutor` ignores its
+timeout argument entirely (it replays a recorded output instantly)
+and reports its own fixed 5-minute `Capabilities().MaxTimeout`,
+unaffected by the raised cap — see [Eval framework](#eval-framework)
+below for the resulting hooks-under-replay gap.
 
 The Engine API path was chosen deliberately: the official Docker Go
 SDK pulls in moby, containerd, and OCI specs, which conflicts with
@@ -610,6 +643,13 @@ deterministically:
   indexed by `(toolName, canonicalInput)`. Tracks writes for
   assertion via `Writes()`.
 
+Lifecycle hooks (issue #461) dispatch through `Executor.Exec` directly
+— outside the `(toolName, canonicalInput)` indexing `ReplayExecutor`
+looks up against — so a recorded-replay eval of a run that used hooks
+is undefined behaviour in v1: there is no recorded hook execution for
+`ReplayExecutor` to match against. Suites that need lifecycle hooks
+should use live evaluation until replay support lands as a follow-up.
+
 Suites are authored in HCLv2. The runner clones repos, invokes the
 harness binary, parses JSONL traces, and applies judges
 (`test-command`, `file-exists`, `file-contains`, `composite`). The
@@ -629,11 +669,14 @@ Full reference: [`eval.md`](eval.md).
 | `MaxCostBudget` | unset | $100 |
 | File read/write size | 10 MB | — |
 | Command output | 1 MB | — |
-| Command timeout | 30 s | 5 min |
+| Command timeout (`run_command` tool) | 30 s | 5 min |
+| `Executor.Exec` hard cap (`local`/`container`/`k8s`/`k8s-sandbox`) | 30 s | 30 min |
 | Web fetch response | 100 KB | — |
 | `temperature` | 0.1 | — |
 | `max_tokens` | 64 000 | — |
 | Default model | `claude-sonnet-4-6` | — |
+| Lifecycle hook timeout (`hooks[].timeoutSeconds`) | 300 s | 1800 s (30 min) |
+| Lifecycle hooks per phase (`hooks.preRun` / `hooks.postRun`) | — | 32 |
 
 The `temperature` default is resolved unconditionally for every
 provider call; it is not sent on the wire to Claude Opus 4.7+, Claude

--- a/docs/cloud-run-jobs.md
+++ b/docs/cloud-run-jobs.md
@@ -265,7 +265,20 @@ Salient points for stirrup:
 - **SIGTERM grace** is 10 seconds before SIGKILL. Stirrup's signal
   handler at `harness/cmd/stirrup/cmd/root.go::setupSignalHandler`
   cancels the run context on SIGTERM, which lets the trace emitter
-  flush and `workspaceExportTo` upload before the kill.
+  flush and `workspaceExportTo` upload before the kill. A run
+  configuring `postRun` lifecycle hooks (issue #461) is a partial
+  exception: those hooks deliberately run on a context detached from
+  the run's own deadline/cancellation so an in-flight artifact upload
+  can survive it, but the harness still observes SIGTERM directly on
+  that detached context (`AgenticLoop.Shutdown`) and cuts a `postRun`
+  hook short promptly rather than letting it run for its full
+  configured budget (up to 1830s). A background watchdog additionally
+  bounds executor teardown to 5 seconds after SIGTERM even if `Run()`
+  has not yet returned, so the container is stopped and removed well
+  inside the 10-second grace window regardless of what an in-flight
+  `postRun` hook is doing. Operators sizing a tighter task-level
+  timeout around a run with long `postRun` hooks should still budget
+  for the 10-second SIGTERM grace on top of the run's own `timeout`.
 - **Max task timeout** is 7 days (1 hour with GPU); see [Cloud Run
   quotas](https://cloud.google.com/run/quotas). The fixture's
   `timeout: 600` is well inside that envelope.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -698,6 +698,15 @@ already exists for exec outside the tool surface in read-only modes
 (the test-runner verifier's command, the `deterministic` git strategy's
 branch creation).
 
+A hook is not restricted to read-only actions in any mode, including a
+read-only-named one: a `postRun` hook in a `planning`-mode run can
+`git push`, open a pull request, or otherwise mutate state outside the
+workspace, exactly as it could in `execution` mode. "Read-only mode"
+describes what the *model* can do through its tools, not a guarantee
+that the run as a whole has no side effects — a template author
+inheriting hooks into a `planning` config should not assume the run is
+side-effect-free on that basis alone.
+
 Hooks add no agent-reachable capability, so they play no part in the
 Rule of Two: their output never enters the model's context, and they
 share the run's existing egress posture rather than opening a new

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -623,6 +623,103 @@ did not resolve to a known tool under a non-default profile". The active
 `tools.profile` is recorded in the trace's attached `RunConfig`, so the
 two cases are distinguishable by reading it alongside the record.
 
+## Lifecycle hooks
+
+`hooks` configures operator-authored, deterministic shell commands that
+run around the agentic session (issue #461): `preRun` before the
+session starts, `postRun` after it ends. A hook is exec, not a tool —
+it runs through the same `Executor` the agent's tools use, and its
+output is trace-only and never enters the model's context.
+
+```json
+"hooks": {
+  "preRun":  [ { "type": "command", "name": "...", "command": "...", "timeoutSeconds": 300, "continueOnError": false } ],
+  "postRun": [ { "command": "...", "runOn": "always", "continueOnError": false } ]
+}
+```
+
+| Field | Meaning | Default / bound |
+|---|---|---|
+| `type` | Hook kind. Closed set. | `""` (defaults to `"command"`, the only value v1 accepts) |
+| `name` | Trace label. Purely descriptive. | `""`; ≤ 64 bytes, printable, no control characters |
+| `command` | Shell command run via `sh -c` through the run's `Executor`. Required. | ≤ 16 KB; rejected outright if it contains a `secret://` reference |
+| `timeoutSeconds` | Per-hook timeout. | `0` → 300 s; max 1800 s (30 minutes) |
+| `continueOnError` | A non-zero exit or timeout is recorded as a warning instead of failing the phase. | `false` |
+| `runOn` | `postRun` only: filters this hook by the run's outcome. Closed set: `""` / `"always"`, `"success"`, `"failure"`. Rejected outright on a `preRun` hook. | `""` (runs regardless of outcome) |
+
+Each phase is capped at 32 hooks. The sum of every `postRun` hook's
+effective timeout must not exceed 1800 s — it sizes the detached
+budget the loop grants `postRun` after the run's own wall-clock
+timeout may have already expired (see
+[`architecture.md`](architecture.md)). A `preRun` sum that exceeds the
+run's own `timeout` is a warning, not a validation error: `preRun`
+hooks run serially inside the same budget as the rest of the run, so
+this usually still succeeds but is very likely to blow the timeout.
+
+Credentials never belong in a hook `command` — `command` is operator
+config recorded verbatim in the trace, the same treatment
+`verifier.command` gets, so a `secret://` reference there would defeat
+the `SecretStore` contract. `ValidateRunConfig` rejects it structurally.
+Resolve clone/deploy credentials via control-plane runtime bindings
+instead.
+
+### Failure semantics
+
+| Situation | Outcome | Notes |
+|---|---|---|
+| A `preRun` hook without `continueOnError` fails or times out | `setup_failed` | The session never starts; zero turns run. `postRun` is skipped entirely — `Run()` returns before reaching it. |
+| The run's own context is already dead (timeout/cancel) when the `preRun` failure is observed | The ctx-cause outcome (`timeout` / `cancelled`), not `setup_failed` | The hook almost certainly failed *because* the deadline hit or a control-plane cancel arrived mid-exec — that is the more useful outcome to report. |
+| A `postRun` hook without `continueOnError` fails or times out, and the run would otherwise report `success` | `hook_failed` | Overrides `success` only. |
+| Same, but the run's outcome was already non-`success` (e.g. `max_turns`, `error`) | The original outcome, unchanged | A `postRun` failure never masks the primary failure cause; it is still visible in `RunTrace.HookResults` and `RunResult.hookFailures`. |
+| A hook with `continueOnError: true` fails or times out | The phase's outcome is unaffected | Recorded as a transport `warning` event and in `HookResults`; the remaining hooks in the phase still run. |
+
+`postRun` hooks run on every outcome by default (`runOn: ""` /
+`"always"`) — including `timeout` and `cancelled` — on a context
+detached from the run's own cancellation and deadline
+(`context.WithoutCancel`), so an artifact upload can still finish after
+wall-clock expiry. `runOn: "success"` / `"failure"` scope a hook to one
+branch. See [`security.md`](security.md) for the heartbeat caveat this
+detachment carries.
+
+Lifecycle hooks are **file / stdin / gRPC only** — there are no `--`
+flags to select or configure a hook, matching the composite-config
+convention already used for `tools.mcpServers` and multi-provider
+routing (see [Component-selection limits](#component-selection-limits)
+above). Set `hooks` in a `--config` file, over stdin, or in the
+`task_assignment` a control plane sends over gRPC.
+
+Hooks are allowed in every mode, including the read-only modes
+(`planning`, `review`, `research`, `toil`). The [read-only-modes
+invariant](#read-only-modes) bounds the *agent's* tools — what the
+model can reach mid-conversation — not operator-authored, deterministic
+commands declared in reviewable `RunConfig`. A `preRun` clone hook is
+exactly what a planning run needs to have something to read; precedent
+already exists for exec outside the tool surface in read-only modes
+(the test-runner verifier's command, the `deterministic` git strategy's
+branch creation).
+
+Hooks add no agent-reachable capability, so they play no part in the
+Rule of Two: their output never enters the model's context, and they
+share the run's existing egress posture rather than opening a new
+external-communication surface.
+
+A worked example — clone the repository and install dependencies
+before the session starts, submit an artifact after it ends:
+
+```json
+{
+  "hooks": {
+    "preRun": [
+      { "name": "clone", "command": "git clone https://github.com/example/repo.git .", "timeoutSeconds": 60 },
+      { "name": "bundle-install", "command": "bundle install", "timeoutSeconds": 900 }
+    ],
+    "postRun": [
+      { "name": "submit-artifact", "command": "curl -sf -X POST -T build/output.tar.gz https://artifacts.example.com/upload", "runOn": "success", "continueOnError": true }
+    ]
+  }
+}
+```
+
 ## Limits and budgets
 
 `ValidateRunConfig` enforces hard caps on values that could otherwise
@@ -636,6 +733,10 @@ be unbounded:
 | `maxTokenBudget` | 50 M |
 | `maxCostBudget` | $100 |
 | `temperature` | `0.0` ≤ `t` ≤ `2.0` |
+| `hooks.preRun` / `hooks.postRun` | 32 hooks per phase |
+| `hooks[].command` | 16 KB |
+| `hooks[].timeoutSeconds` | 1800 s (30 min) per hook |
+| sum of `hooks.postRun[].timeoutSeconds` | 1800 s (30 min) |
 
 Read-only modes additionally require the tool list to be set.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,11 +96,19 @@ IMDS, GitHub Actions OIDC). See
 7. **Done.** A final `HarnessEvent{type:"done", stop_reason, trace}`
    carries the run metrics and the reason the loop ended
    (`end_turn`, `max_turns`, `timeout`, `stalled`, `tool_failures`,
-   `cancelled`, `budget_exceeded`). The nested `trace.outcome` is the
-   canonical terminal status for downstream analytics — the full
-   `RunTrace.Outcome` set, which adds `success`, `verification_failed`,
-   `verification_error`, and `max_tokens` on top of the loop's stop
-   reasons. `trace.stop_reason` mirrors it for backward compatibility.
+   `cancelled`, `budget_exceeded`, `error`, `setup_failed`,
+   `hook_failed`). `error`, `setup_failed`, and `hook_failed` are the
+   early-termination outcomes — a build-system-prompt failure, a
+   `GitStrategy.Setup` failure, or (issue #461) a fatal `preRun` /
+   `postRun` lifecycle hook failure — and, like every other outcome,
+   are always paired with a `done` event and a `RunResult` on the
+   configured `resultSink`, even though the harness process's own Go
+   error return is also non-nil for these. The nested `trace.outcome`
+   is the canonical terminal status for downstream analytics — the
+   full `RunTrace.Outcome` set, which adds `success`,
+   `verification_failed`, `verification_error`, and `max_tokens` on
+   top of the loop's stop reasons. `trace.stop_reason` mirrors it for
+   backward compatibility.
 8. **Follow-up grace** *(optional)*. If `STIRRUP_FOLLOWUP_GRACE > 0`,
    the stream stays open for that many seconds so the control plane
    can deliver `user_response` events that resume the loop.

--- a/docs/executors/k8s.md
+++ b/docs/executors/k8s.md
@@ -459,6 +459,30 @@ Two requirements are easy to miss:
   orchestrator Pod needs `runtimeClassName: gvisor` (which injects the pool
   toleration) or a dedicated untainted pool.
 
+**`terminationGracePeriodSeconds` on the orchestrator Pod.** Kubernetes
+sends SIGTERM to the orchestrator process on Pod deletion/eviction/scale-
+down, then SIGKILL after the grace period — 30 seconds by default when
+the field is unset. Stirrup's signal handler
+(`harness/cmd/stirrup/cmd/root.go::setupSignalHandler`) cancels the run
+context on SIGTERM, letting the trace emitter flush and
+`workspaceExportTo` upload before the kill. A run configuring `postRun`
+lifecycle hooks (issue #461) is a partial exception: those hooks
+deliberately run on a context detached from the run's own deadline/
+cancellation so an in-flight artifact upload can survive it, but the
+harness still observes SIGTERM directly on that detached context
+(`AgenticLoop.Shutdown`) and cuts a `postRun` hook short promptly rather
+than letting it run for its full configured budget (up to 1830s). A
+background watchdog additionally bounds executor teardown — deleting
+the sandbox Pod and its egress `NetworkPolicy` — to 5 seconds after
+SIGTERM even if `Run()` has not yet returned, so cleanup completes well
+inside the default 30-second grace window regardless of what an
+in-flight `postRun` hook is doing. Set `terminationGracePeriodSeconds`
+explicitly on the orchestrator Pod spec when running with long `postRun`
+hooks, sized for the run's own `timeout` plus normal shutdown overhead —
+the default 30 seconds is ample headroom over the harness's own 5-second
+proactive-teardown bound, but a cluster with a tighter eviction/
+preemption grace period should account for it.
+
 Provider auth is **orthogonal to sandbox egress**. The orchestrator's
 provider call (to Anthropic / Vertex / an OpenAI-compatible endpoint) is
 made from the orchestrator Pod, not the sandbox, so a sandbox

--- a/docs/safety-rings.md
+++ b/docs/safety-rings.md
@@ -934,6 +934,18 @@ exist; they are not claimed to cover them.
   channel. The `LogScrubber` covers some patterns; the
   `no-secret-in-input.cedar` starter covers some more. Neither is
   exhaustive.
+- **Lifecycle hooks are outside Rings 3, 4, and 5.** `preRun` / `postRun`
+  hooks (issue #461) run operator-authored exec outside the model's
+  turn-by-turn control entirely: Cedar (Ring 3) never evaluates a hook
+  command, the Rule of Two (Ring 4) deliberately ignores `HooksConfig`
+  (hooks add no agent-reachable capability), and the code scanner
+  (Ring 5) never inspects a file a hook writes. Only Rings 1 and 2
+  apply — hooks dispatch through the run's own `Executor`, so they
+  inherit the same container runtime class and egress posture as every
+  agent tool call. A Cedar deny-policy or a strict `permissionPolicy`
+  does not gate a hook the way it gates a tool call. See
+  [`security.md`](security.md#lifecycle-hooks) for the full trust-
+  boundary writeup.
 
 For reporting a finding that *is* in scope, see
 [`SECURITY.md`](../SECURITY.md).

--- a/docs/safety-rings.md
+++ b/docs/safety-rings.md
@@ -935,15 +935,15 @@ exist; they are not claimed to cover them.
   `no-secret-in-input.cedar` starter covers some more. Neither is
   exhaustive.
 - **Lifecycle hooks are outside Rings 3, 4, and 5.** `preRun` / `postRun`
-  hooks (issue #461) run operator-authored exec outside the model's
-  turn-by-turn control entirely: Cedar (Ring 3) never evaluates a hook
-  command, the Rule of Two (Ring 4) deliberately ignores `HooksConfig`
-  (hooks add no agent-reachable capability), and the code scanner
-  (Ring 5) never inspects a file a hook writes. Only Rings 1 and 2
-  apply — hooks dispatch through the run's own `Executor`, so they
+  hooks (issue #461) run operator-authored shell commands outside the
+  model's turn-by-turn control entirely: Cedar (Ring 3) never evaluates
+  a hook command, the Rule of Two (Ring 4) deliberately ignores
+  `HooksConfig` (hooks add no agent-reachable capability), and the code
+  scanner (Ring 5) never inspects a file a hook writes. Only Rings 1
+  and 2 apply — hooks dispatch through the run's own `Executor`, so they
   inherit the same container runtime class and egress posture as every
-  agent tool call. A Cedar deny-policy or a strict `permissionPolicy`
-  does not gate a hook the way it gates a tool call. See
+  agent tool call. Cedar deny-policies and strict `permissionPolicy`
+  do not gate hooks the way they gate tool calls. See
   [`security.md`](security.md#lifecycle-hooks) for the full trust-
   boundary writeup.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -344,6 +344,19 @@ everything else in this document, and worth being explicit about:
   in control-plane runtime bindings (e.g. a pre-provisioned SSH agent
   or short-lived deploy token injected into the workspace before the
   hook runs), never in `RunConfig`.
+
+  This pattern moves the credential to a different trust boundary, not
+  out of the agent's reach: anything a hook leaves on disk as a side
+  effect — an SSH private key, a `.netrc`, a deploy token embedded in
+  `.git/config` — is readable by every agent tool for the remainder of
+  the run, `run_command` in particular, which is not confined to the
+  workspace-relative path containment `read_file` / `write_file`
+  enforce. "Trace-only output" above covers hook stdout/stderr, not
+  files a hook writes. Prefer a short-lived, narrowly-scoped credential
+  (so exposure is bounded even if the agent reads it) and have the
+  hook clean up the material before returning (e.g. `rm` the key,
+  `git config --unset` the embedded token) rather than relying on
+  workspace boundaries to hide it.
 - **Hooks do not interact with the Rule of Two.** The invariant bounds
   what the *agent* can simultaneously hold (untrusted input, sensitive
   data, external communication); hooks add none of those — they run

--- a/docs/security.md
+++ b/docs/security.md
@@ -310,6 +310,72 @@ turn budget executing the same destructive call until something
 else trips. The loop also surfaces a warning to the transport so
 the control plane can react.
 
+## Lifecycle hooks
+
+`hooks.preRun` / `hooks.postRun` (issue #461) run operator-authored
+shell commands around the agentic session — outside the model's
+turn-by-turn control entirely, not through the tool layer the rest of
+this document gates. That is a different trust boundary from
+everything else in this document, and worth being explicit about:
+
+- **Hook commands are operator config, not agent output.** They come
+  from `RunConfig` — a file, stdin, or the control plane's
+  `task_assignment` — the same trust level as `verifier.command` or
+  the `deterministic` git strategy's branch-naming logic. The model
+  never sees hook commands and cannot construct or influence one; the
+  per-tool-call gates (input validator, `PermissionPolicy`, `GuardRail`
+  pre-tool) do not apply because hooks never reach the tool dispatch
+  path.
+- **Hook output is trace-only.** `HookExecution.OutputTail` (scrubbed,
+  capped at 4 KB, tail not head) and `Error` are recorded for
+  operator/control-plane visibility and never appended to the model's
+  message history. A hook cannot smuggle content into the
+  conversation the way a tool result can.
+- **Hooks share the run's existing egress posture.** They dispatch
+  through the same `Executor` as every agent tool call, so a `preRun`
+  clone inherits the same network mode, allowlist, and egress proxy
+  the rest of the run uses — there is no separate hook-specific
+  network surface to configure or audit.
+- **`secret://` is structurally rejected in `command`.**
+  `ValidateRunConfig` rejects any hook `command` containing a
+  `secret://` reference before the harness boots, so a credential can
+  never be resolved and inlined into a hook's `sh -c` invocation the
+  way `apiKeyRef` is for a provider. Clone/deploy credentials belong
+  in control-plane runtime bindings (e.g. a pre-provisioned SSH agent
+  or short-lived deploy token injected into the workspace before the
+  hook runs), never in `RunConfig`.
+- **Hooks do not interact with the Rule of Two.** The invariant bounds
+  what the *agent* can simultaneously hold (untrusted input, sensitive
+  data, external communication); hooks add none of those — they run
+  outside the conversation, their output is trace-only, and they share
+  rather than expand the run's egress posture. `HooksConfig` is
+  therefore absent from all three Rule-of-Two legs.
+- **Read-only modes allow hooks.** The read-only invariant
+  (`planning`, `review`, `research`, `toil` reject `write_file`,
+  `run_command`, `edit_file`) bounds *agent-reachable* tools;
+  operator-authored, reviewable exec outside the tool surface already
+  has precedent there (the test-runner verifier's command, the
+  `deterministic` git strategy). See [`configuration.md` "Lifecycle
+  hooks"](configuration.md#lifecycle-hooks) for the full schema and
+  failure semantics.
+
+**Heartbeat caveat:** the agentic loop's `heartbeat` transport event
+(every 30 s, see [`architecture.md`
+"Heartbeat and health probes"](architecture.md#heartbeat-and-health-probes))
+is emitted on `runCtx` — the run's own wall-clock-bounded context — and
+stops the instant that context is done, at the run's `timeout` deadline
+or a control-plane cancel. `postRun` hooks execute afterwards on a
+*detached* context (`context.WithoutCancel`) specifically so they can
+outlive that deadline. This means a run whose `postRun` hooks are still
+uploading an artifact after wall-clock expiry emits **no heartbeats**
+for up to the detached budget (sum of configured `postRun` timeouts
+plus a 30 s margin, capped at 1830 s). A control plane that treats a
+heartbeat gap as "orphaned and safe to reap" may kill the process
+mid-upload. Operators relying on heartbeat-based liveness for runs with
+`postRun` hooks should account for this gap in their reap timeout;
+re-arming heartbeats for the detached post-hook phase is tracked as a
+follow-up if this proves disruptive in practice.
+
 ## Where each control sits
 
 ```text
@@ -317,7 +383,14 @@ Controls layered from outside in:
 
   ── RunConfig load ────────────────────────────────────────
    ValidateRunConfig: bounded budgets, read-only invariants,
-   credential consistency, Cedar policy path checks.
+   credential consistency, Cedar policy path checks, hook
+   command bounds + secret:// rejection.
+
+  ── Pre-session (outside the turn loop) ───────────────────
+   preRun hooks: operator exec via the run's own Executor,
+   before GitStrategy.Setup. Trace-only output; never reaches
+   the model. Fatal failure -> outcome "setup_failed", zero
+   turns.
 
   ── Provider boundary ─────────────────────────────────────
    SecretStore + LogScrubber: secrets resolve lazily and never
@@ -347,6 +420,13 @@ Controls layered from outside in:
   ── Run lifetime ──────────────────────────────────────────
    Stall detection: bounded consecutive identical calls /
    failures.
+
+  ── Post-session (outside the turn loop) ──────────────────
+   postRun hooks: operator exec via the run's own Executor,
+   after GitStrategy.Finalise, on a detached context so
+   wall-clock expiry does not cut them off. Trace-only
+   output. Fatal failure overrides outcome to "hook_failed"
+   only when the run would otherwise report success.
 
   ── Persistence ──────────────────────────────────────────
    RunConfig.Redact(): strips secret refs from anything

--- a/docs/security.md
+++ b/docs/security.md
@@ -366,8 +366,8 @@ everything else in this document, and worth being explicit about:
 - **Read-only modes allow hooks.** The read-only invariant
   (`planning`, `review`, `research`, `toil` reject `write_file`,
   `run_command`, `edit_file`) bounds *agent-reachable* tools;
-  operator-authored, reviewable exec outside the tool surface already
-  has precedent there (the test-runner verifier's command, the
+  operator-authored, reviewable shell commands outside the tool surface
+  already have precedent there (the test-runner verifier's command, the
   `deterministic` git strategy). See [`configuration.md` "Lifecycle
   hooks"](configuration.md#lifecycle-hooks) for the full schema and
   failure semantics.

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -630,7 +630,11 @@ type RunConfig struct {
 	// so unset is wire-distinguishable from explicit 0.0 (proto3's scalar
 	// default would otherwise silently coerce greedy decoding to the
 	// harness default).
-	Temperature   *float64 `protobuf:"fixed64,31,opt,name=temperature,proto3,oneof" json:"temperature,omitempty"`
+	Temperature *float64 `protobuf:"fixed64,31,opt,name=temperature,proto3,oneof" json:"temperature,omitempty"`
+	// Optional. Operator-authored lifecycle hooks that run before the
+	// agentic session starts and after it ends. See HooksConfig for the
+	// pre_run / post_run semantics.
+	Hooks         *HooksConfig `protobuf:"bytes,32,opt,name=hooks,proto3" json:"hooks,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -882,6 +886,13 @@ func (x *RunConfig) GetTemperature() float64 {
 	return 0
 }
 
+func (x *RunConfig) GetHooks() *HooksConfig {
+	if x != nil {
+		return x.Hooks
+	}
+	return nil
+}
+
 // DynamicContextValue is a single dynamic-context value with metadata.
 // The control plane / operator populates these from outside the
 // immutable prompt — issue bodies, PR comments, retrieved documents,
@@ -1005,6 +1016,179 @@ func (x *ToolDispatchConfig) GetMaxParallel() int32 {
 	return 0
 }
 
+// HooksConfig configures operator-authored lifecycle hooks that run
+// around the agentic session (issue #461): pre_run executes before the
+// session starts (after the harness builds the system prompt, before
+// GitStrategy.Setup); post_run executes after the session ends (after
+// GitStrategy.Finalise, before the run reports done). Hook output is
+// trace-only and never enters the model's context; hooks run through
+// the same Executor the agent's tools use and so share the run's
+// sandbox and network egress posture.
+type HooksConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional. Hooks executed, in order, before the agentic session
+	// starts. A fatal failure (a hook without continue_on_error exits
+	// non-zero or times out) fails the run with outcome "setup_failed"
+	// before any turn runs.
+	PreRun []*HookConfig `protobuf:"bytes,1,rep,name=pre_run,json=preRun,proto3" json:"pre_run,omitempty"`
+	// Optional. Hooks executed, in order, after the agentic session ends
+	// and GitStrategy.Finalise completes. Runs on every outcome by
+	// default; see HookConfig.run_on to scope a hook to success or
+	// failure only. A fatal failure overrides an otherwise-successful
+	// run's outcome to "hook_failed"; it never masks an existing
+	// non-success outcome.
+	PostRun       []*HookConfig `protobuf:"bytes,2,rep,name=post_run,json=postRun,proto3" json:"post_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HooksConfig) Reset() {
+	*x = HooksConfig{}
+	mi := &file_harness_v1_harness_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HooksConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HooksConfig) ProtoMessage() {}
+
+func (x *HooksConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_harness_v1_harness_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HooksConfig.ProtoReflect.Descriptor instead.
+func (*HooksConfig) Descriptor() ([]byte, []int) {
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *HooksConfig) GetPreRun() []*HookConfig {
+	if x != nil {
+		return x.PreRun
+	}
+	return nil
+}
+
+func (x *HooksConfig) GetPostRun() []*HookConfig {
+	if x != nil {
+		return x.PostRun
+	}
+	return nil
+}
+
+// HookConfig is a single operator-authored lifecycle hook: an ordered
+// shell command executed via "sh -c" through the run's Executor.
+type HookConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional. The hook kind. Empty defaults to "command" — the only
+	// value accepted in v1. Present so a future typed step (e.g. a
+	// declarative git-clone source) can land additively.
+	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	// Optional. A short trace label (<= 64 bytes, printable, no control
+	// characters). Purely descriptive.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Required. The shell command executed via "sh -c". Must not contain
+	// a "secret://" reference — hook commands are recorded verbatim in
+	// the trace like VerifierConfig.command, so credentials must come
+	// from control-plane runtime bindings instead. Max 16 KB.
+	Command string `protobuf:"bytes,3,opt,name=command,proto3" json:"command,omitempty"`
+	// Optional. Timeout in seconds for this hook. Zero resolves to the
+	// 300s harness default; max 1800 (30 minutes).
+	TimeoutSeconds int32 `protobuf:"varint,4,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	// Optional. When true, a non-zero exit or timeout is recorded as a
+	// warning and does not fail the phase — the remaining hooks in the
+	// phase still run and the run's outcome is unaffected.
+	ContinueOnError bool `protobuf:"varint,5,opt,name=continue_on_error,json=continueOnError,proto3" json:"continue_on_error,omitempty"`
+	// Optional. post_run only: filters this hook by the run's outcome.
+	// Valid values: "" / "always" (default), "success", "failure". Must
+	// be empty on a pre_run hook.
+	RunOn         string `protobuf:"bytes,6,opt,name=run_on,json=runOn,proto3" json:"run_on,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HookConfig) Reset() {
+	*x = HookConfig{}
+	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HookConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HookConfig) ProtoMessage() {}
+
+func (x *HookConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HookConfig.ProtoReflect.Descriptor instead.
+func (*HookConfig) Descriptor() ([]byte, []int) {
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *HookConfig) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *HookConfig) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *HookConfig) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *HookConfig) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+func (x *HookConfig) GetContinueOnError() bool {
+	if x != nil {
+		return x.ContinueOnError
+	}
+	return false
+}
+
+func (x *HookConfig) GetRunOn() string {
+	if x != nil {
+		return x.RunOn
+	}
+	return ""
+}
+
 // RuleOfTwoConfig carries the operator override for the Rule-of-Two
 // structural invariant. The invariant: a single run must not
 // simultaneously hold (a) untrusted input, (b) sensitive data, and
@@ -1031,7 +1215,7 @@ type RuleOfTwoConfig struct {
 
 func (x *RuleOfTwoConfig) Reset() {
 	*x = RuleOfTwoConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[6]
+	mi := &file_harness_v1_harness_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1043,7 +1227,7 @@ func (x *RuleOfTwoConfig) String() string {
 func (*RuleOfTwoConfig) ProtoMessage() {}
 
 func (x *RuleOfTwoConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[6]
+	mi := &file_harness_v1_harness_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1056,7 +1240,7 @@ func (x *RuleOfTwoConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleOfTwoConfig.ProtoReflect.Descriptor instead.
 func (*RuleOfTwoConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{6}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *RuleOfTwoConfig) GetEnforce() bool {
@@ -1113,7 +1297,7 @@ type RuleOfTwoRuntimeConfig struct {
 
 func (x *RuleOfTwoRuntimeConfig) Reset() {
 	*x = RuleOfTwoRuntimeConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	mi := &file_harness_v1_harness_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1125,7 +1309,7 @@ func (x *RuleOfTwoRuntimeConfig) String() string {
 func (*RuleOfTwoRuntimeConfig) ProtoMessage() {}
 
 func (x *RuleOfTwoRuntimeConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[7]
+	mi := &file_harness_v1_harness_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1138,7 +1322,7 @@ func (x *RuleOfTwoRuntimeConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleOfTwoRuntimeConfig.ProtoReflect.Descriptor instead.
 func (*RuleOfTwoRuntimeConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{7}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RuleOfTwoRuntimeConfig) GetClassifier() string {
@@ -1198,7 +1382,7 @@ type CodeScannerConfig struct {
 
 func (x *CodeScannerConfig) Reset() {
 	*x = CodeScannerConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[8]
+	mi := &file_harness_v1_harness_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1210,7 +1394,7 @@ func (x *CodeScannerConfig) String() string {
 func (*CodeScannerConfig) ProtoMessage() {}
 
 func (x *CodeScannerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[8]
+	mi := &file_harness_v1_harness_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1223,7 +1407,7 @@ func (x *CodeScannerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeScannerConfig.ProtoReflect.Descriptor instead.
 func (*CodeScannerConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{8}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CodeScannerConfig) GetType() string {
@@ -1324,7 +1508,7 @@ type GuardRailConfig struct {
 
 func (x *GuardRailConfig) Reset() {
 	*x = GuardRailConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[9]
+	mi := &file_harness_v1_harness_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1336,7 +1520,7 @@ func (x *GuardRailConfig) String() string {
 func (*GuardRailConfig) ProtoMessage() {}
 
 func (x *GuardRailConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[9]
+	mi := &file_harness_v1_harness_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1349,7 +1533,7 @@ func (x *GuardRailConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GuardRailConfig.ProtoReflect.Descriptor instead.
 func (*GuardRailConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{9}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GuardRailConfig) GetType() string {
@@ -1463,7 +1647,7 @@ type ObservabilityConfig struct {
 
 func (x *ObservabilityConfig) Reset() {
 	*x = ObservabilityConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[10]
+	mi := &file_harness_v1_harness_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1475,7 +1659,7 @@ func (x *ObservabilityConfig) String() string {
 func (*ObservabilityConfig) ProtoMessage() {}
 
 func (x *ObservabilityConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[10]
+	mi := &file_harness_v1_harness_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1488,7 +1672,7 @@ func (x *ObservabilityConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObservabilityConfig.ProtoReflect.Descriptor instead.
 func (*ObservabilityConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{10}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ObservabilityConfig) GetEnvironment() string {
@@ -1543,7 +1727,7 @@ type RunTrace struct {
 
 func (x *RunTrace) Reset() {
 	*x = RunTrace{}
-	mi := &file_harness_v1_harness_proto_msgTypes[11]
+	mi := &file_harness_v1_harness_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1555,7 +1739,7 @@ func (x *RunTrace) String() string {
 func (*RunTrace) ProtoMessage() {}
 
 func (x *RunTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[11]
+	mi := &file_harness_v1_harness_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1568,7 +1752,7 @@ func (x *RunTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTrace.ProtoReflect.Descriptor instead.
 func (*RunTrace) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{11}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RunTrace) GetRunId() string {
@@ -1718,7 +1902,7 @@ type ProviderConfig struct {
 
 func (x *ProviderConfig) Reset() {
 	*x = ProviderConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	mi := &file_harness_v1_harness_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1730,7 +1914,7 @@ func (x *ProviderConfig) String() string {
 func (*ProviderConfig) ProtoMessage() {}
 
 func (x *ProviderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[12]
+	mi := &file_harness_v1_harness_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +1927,7 @@ func (x *ProviderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderConfig.ProtoReflect.Descriptor instead.
 func (*ProviderConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{12}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ProviderConfig) GetType() string {
@@ -1886,7 +2070,7 @@ type BatchProviderConfig struct {
 
 func (x *BatchProviderConfig) Reset() {
 	*x = BatchProviderConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[13]
+	mi := &file_harness_v1_harness_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1898,7 +2082,7 @@ func (x *BatchProviderConfig) String() string {
 func (*BatchProviderConfig) ProtoMessage() {}
 
 func (x *BatchProviderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[13]
+	mi := &file_harness_v1_harness_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1911,7 +2095,7 @@ func (x *BatchProviderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchProviderConfig.ProtoReflect.Descriptor instead.
 func (*BatchProviderConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{13}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *BatchProviderConfig) GetEnabled() bool {
@@ -2120,7 +2304,7 @@ type CredentialConfig struct {
 
 func (x *CredentialConfig) Reset() {
 	*x = CredentialConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[14]
+	mi := &file_harness_v1_harness_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2132,7 +2316,7 @@ func (x *CredentialConfig) String() string {
 func (*CredentialConfig) ProtoMessage() {}
 
 func (x *CredentialConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[14]
+	mi := &file_harness_v1_harness_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2145,7 +2329,7 @@ func (x *CredentialConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CredentialConfig.ProtoReflect.Descriptor instead.
 func (*CredentialConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{14}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CredentialConfig) GetType() string {
@@ -2312,7 +2496,7 @@ type TokenSourceConfig struct {
 
 func (x *TokenSourceConfig) Reset() {
 	*x = TokenSourceConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[15]
+	mi := &file_harness_v1_harness_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2324,7 +2508,7 @@ func (x *TokenSourceConfig) String() string {
 func (*TokenSourceConfig) ProtoMessage() {}
 
 func (x *TokenSourceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[15]
+	mi := &file_harness_v1_harness_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2337,7 +2521,7 @@ func (x *TokenSourceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TokenSourceConfig.ProtoReflect.Descriptor instead.
 func (*TokenSourceConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{15}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *TokenSourceConfig) GetType() string {
@@ -2405,7 +2589,7 @@ type GeminiSafetySetting struct {
 
 func (x *GeminiSafetySetting) Reset() {
 	*x = GeminiSafetySetting{}
-	mi := &file_harness_v1_harness_proto_msgTypes[16]
+	mi := &file_harness_v1_harness_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2417,7 +2601,7 @@ func (x *GeminiSafetySetting) String() string {
 func (*GeminiSafetySetting) ProtoMessage() {}
 
 func (x *GeminiSafetySetting) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[16]
+	mi := &file_harness_v1_harness_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2430,7 +2614,7 @@ func (x *GeminiSafetySetting) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GeminiSafetySetting.ProtoReflect.Descriptor instead.
 func (*GeminiSafetySetting) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{16}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GeminiSafetySetting) GetCategory() string {
@@ -2472,7 +2656,7 @@ type ProviderRetryConfig struct {
 
 func (x *ProviderRetryConfig) Reset() {
 	*x = ProviderRetryConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[17]
+	mi := &file_harness_v1_harness_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2484,7 +2668,7 @@ func (x *ProviderRetryConfig) String() string {
 func (*ProviderRetryConfig) ProtoMessage() {}
 
 func (x *ProviderRetryConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[17]
+	mi := &file_harness_v1_harness_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2497,7 +2681,7 @@ func (x *ProviderRetryConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderRetryConfig.ProtoReflect.Descriptor instead.
 func (*ProviderRetryConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{17}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ProviderRetryConfig) GetMaxAttempts() int32 {
@@ -2571,7 +2755,7 @@ type ModelRouterConfig struct {
 
 func (x *ModelRouterConfig) Reset() {
 	*x = ModelRouterConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[18]
+	mi := &file_harness_v1_harness_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2583,7 +2767,7 @@ func (x *ModelRouterConfig) String() string {
 func (*ModelRouterConfig) ProtoMessage() {}
 
 func (x *ModelRouterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[18]
+	mi := &file_harness_v1_harness_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2596,7 +2780,7 @@ func (x *ModelRouterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelRouterConfig.ProtoReflect.Descriptor instead.
 func (*ModelRouterConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{18}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ModelRouterConfig) GetType() string {
@@ -2694,7 +2878,7 @@ type PromptBuilderConfig struct {
 
 func (x *PromptBuilderConfig) Reset() {
 	*x = PromptBuilderConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[19]
+	mi := &file_harness_v1_harness_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2706,7 +2890,7 @@ func (x *PromptBuilderConfig) String() string {
 func (*PromptBuilderConfig) ProtoMessage() {}
 
 func (x *PromptBuilderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[19]
+	mi := &file_harness_v1_harness_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2719,7 +2903,7 @@ func (x *PromptBuilderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromptBuilderConfig.ProtoReflect.Descriptor instead.
 func (*PromptBuilderConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{19}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *PromptBuilderConfig) GetType() string {
@@ -2758,7 +2942,7 @@ type ContextStrategyConfig struct {
 
 func (x *ContextStrategyConfig) Reset() {
 	*x = ContextStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[20]
+	mi := &file_harness_v1_harness_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2770,7 +2954,7 @@ func (x *ContextStrategyConfig) String() string {
 func (*ContextStrategyConfig) ProtoMessage() {}
 
 func (x *ContextStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[20]
+	mi := &file_harness_v1_harness_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2783,7 +2967,7 @@ func (x *ContextStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContextStrategyConfig.ProtoReflect.Descriptor instead.
 func (*ContextStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{20}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ContextStrategyConfig) GetType() string {
@@ -2856,7 +3040,7 @@ type ExecutorConfig struct {
 
 func (x *ExecutorConfig) Reset() {
 	*x = ExecutorConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[21]
+	mi := &file_harness_v1_harness_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2868,7 +3052,7 @@ func (x *ExecutorConfig) String() string {
 func (*ExecutorConfig) ProtoMessage() {}
 
 func (x *ExecutorConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[21]
+	mi := &file_harness_v1_harness_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2881,7 +3065,7 @@ func (x *ExecutorConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorConfig.ProtoReflect.Descriptor instead.
 func (*ExecutorConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{21}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ExecutorConfig) GetType() string {
@@ -2986,7 +3170,7 @@ type VcsBackendConfig struct {
 
 func (x *VcsBackendConfig) Reset() {
 	*x = VcsBackendConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[22]
+	mi := &file_harness_v1_harness_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2998,7 +3182,7 @@ func (x *VcsBackendConfig) String() string {
 func (*VcsBackendConfig) ProtoMessage() {}
 
 func (x *VcsBackendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[22]
+	mi := &file_harness_v1_harness_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3011,7 +3195,7 @@ func (x *VcsBackendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VcsBackendConfig.ProtoReflect.Descriptor instead.
 func (*VcsBackendConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{22}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *VcsBackendConfig) GetType() string {
@@ -3059,7 +3243,7 @@ type NetworkConfig struct {
 
 func (x *NetworkConfig) Reset() {
 	*x = NetworkConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[23]
+	mi := &file_harness_v1_harness_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3071,7 +3255,7 @@ func (x *NetworkConfig) String() string {
 func (*NetworkConfig) ProtoMessage() {}
 
 func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[23]
+	mi := &file_harness_v1_harness_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3084,7 +3268,7 @@ func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkConfig.ProtoReflect.Descriptor instead.
 func (*NetworkConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{23}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *NetworkConfig) GetMode() string {
@@ -3118,7 +3302,7 @@ type ResourceLimits struct {
 
 func (x *ResourceLimits) Reset() {
 	*x = ResourceLimits{}
-	mi := &file_harness_v1_harness_proto_msgTypes[24]
+	mi := &file_harness_v1_harness_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3130,7 +3314,7 @@ func (x *ResourceLimits) String() string {
 func (*ResourceLimits) ProtoMessage() {}
 
 func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[24]
+	mi := &file_harness_v1_harness_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3143,7 +3327,7 @@ func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceLimits.ProtoReflect.Descriptor instead.
 func (*ResourceLimits) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{24}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ResourceLimits) GetCpus() float64 {
@@ -3198,7 +3382,7 @@ type EditStrategyConfig struct {
 
 func (x *EditStrategyConfig) Reset() {
 	*x = EditStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[25]
+	mi := &file_harness_v1_harness_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3210,7 +3394,7 @@ func (x *EditStrategyConfig) String() string {
 func (*EditStrategyConfig) ProtoMessage() {}
 
 func (x *EditStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[25]
+	mi := &file_harness_v1_harness_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3223,7 +3407,7 @@ func (x *EditStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditStrategyConfig.ProtoReflect.Descriptor instead.
 func (*EditStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{25}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *EditStrategyConfig) GetType() string {
@@ -3271,7 +3455,7 @@ type VerifierConfig struct {
 
 func (x *VerifierConfig) Reset() {
 	*x = VerifierConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[26]
+	mi := &file_harness_v1_harness_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3283,7 +3467,7 @@ func (x *VerifierConfig) String() string {
 func (*VerifierConfig) ProtoMessage() {}
 
 func (x *VerifierConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[26]
+	mi := &file_harness_v1_harness_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3296,7 +3480,7 @@ func (x *VerifierConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifierConfig.ProtoReflect.Descriptor instead.
 func (*VerifierConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{26}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *VerifierConfig) GetType() string {
@@ -3393,7 +3577,7 @@ type PermissionPolicyConfig struct {
 
 func (x *PermissionPolicyConfig) Reset() {
 	*x = PermissionPolicyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[27]
+	mi := &file_harness_v1_harness_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3405,7 +3589,7 @@ func (x *PermissionPolicyConfig) String() string {
 func (*PermissionPolicyConfig) ProtoMessage() {}
 
 func (x *PermissionPolicyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[27]
+	mi := &file_harness_v1_harness_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3418,7 +3602,7 @@ func (x *PermissionPolicyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PermissionPolicyConfig.ProtoReflect.Descriptor instead.
 func (*PermissionPolicyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{27}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *PermissionPolicyConfig) GetType() string {
@@ -3465,7 +3649,7 @@ type GitStrategyConfig struct {
 
 func (x *GitStrategyConfig) Reset() {
 	*x = GitStrategyConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[28]
+	mi := &file_harness_v1_harness_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3477,7 +3661,7 @@ func (x *GitStrategyConfig) String() string {
 func (*GitStrategyConfig) ProtoMessage() {}
 
 func (x *GitStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[28]
+	mi := &file_harness_v1_harness_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3490,7 +3674,7 @@ func (x *GitStrategyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitStrategyConfig.ProtoReflect.Descriptor instead.
 func (*GitStrategyConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{28}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GitStrategyConfig) GetType() string {
@@ -3562,7 +3746,7 @@ type TraceEmitterConfig struct {
 
 func (x *TraceEmitterConfig) Reset() {
 	*x = TraceEmitterConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[29]
+	mi := &file_harness_v1_harness_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3574,7 +3758,7 @@ func (x *TraceEmitterConfig) String() string {
 func (*TraceEmitterConfig) ProtoMessage() {}
 
 func (x *TraceEmitterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[29]
+	mi := &file_harness_v1_harness_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3587,7 +3771,7 @@ func (x *TraceEmitterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceEmitterConfig.ProtoReflect.Descriptor instead.
 func (*TraceEmitterConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{29}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *TraceEmitterConfig) GetType() string {
@@ -3684,7 +3868,7 @@ type ToolsConfig struct {
 
 func (x *ToolsConfig) Reset() {
 	*x = ToolsConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[30]
+	mi := &file_harness_v1_harness_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3696,7 +3880,7 @@ func (x *ToolsConfig) String() string {
 func (*ToolsConfig) ProtoMessage() {}
 
 func (x *ToolsConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[30]
+	mi := &file_harness_v1_harness_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3709,7 +3893,7 @@ func (x *ToolsConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolsConfig.ProtoReflect.Descriptor instead.
 func (*ToolsConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{30}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ToolsConfig) GetBuiltIn() []string {
@@ -3744,7 +3928,7 @@ type MCPServerConfig struct {
 
 func (x *MCPServerConfig) Reset() {
 	*x = MCPServerConfig{}
-	mi := &file_harness_v1_harness_proto_msgTypes[31]
+	mi := &file_harness_v1_harness_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3756,7 +3940,7 @@ func (x *MCPServerConfig) String() string {
 func (*MCPServerConfig) ProtoMessage() {}
 
 func (x *MCPServerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_harness_v1_harness_proto_msgTypes[31]
+	mi := &file_harness_v1_harness_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3769,7 +3953,7 @@ func (x *MCPServerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerConfig.ProtoReflect.Descriptor instead.
 func (*MCPServerConfig) Descriptor() ([]byte, []int) {
-	return file_harness_v1_harness_proto_rawDescGZIP(), []int{31}
+	return file_harness_v1_harness_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *MCPServerConfig) GetName() string {
@@ -3826,7 +4010,7 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\acontent\x18\a \x01(\tR\acontent\x12;\n" +
 	"\bis_error\x18\b \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aisError\"$\n" +
 	"\fOptionalBool\x12\x14\n" +
-	"\x05value\x18\x01 \x01(\bR\x05value\"\xe7\x10\n" +
+	"\x05value\x18\x01 \x01(\bR\x05value\"\x9e\x11\n" +
 	"\tRunConfig\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\tR\x04mode\x12\x16\n" +
@@ -3860,7 +4044,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"guard_rail\x18\x1c \x01(\v2#.stirrup.harness.v1.GuardRailConfigR\tguardRail\x12M\n" +
 	"\robservability\x18\x1d \x01(\v2'.stirrup.harness.v1.ObservabilityConfigR\robservability\x12K\n" +
 	"\rtool_dispatch\x18\x1e \x01(\v2&.stirrup.harness.v1.ToolDispatchConfigR\ftoolDispatch\x12%\n" +
-	"\vtemperature\x18\x1f \x01(\x01H\x06R\vtemperature\x88\x01\x01\x1aj\n" +
+	"\vtemperature\x18\x1f \x01(\x01H\x06R\vtemperature\x88\x01\x01\x125\n" +
+	"\x05hooks\x18  \x01(\v2\x1f.stirrup.harness.v1.HooksConfigR\x05hooks\x1aj\n" +
 	"\x13DynamicContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12=\n" +
 	"\x05value\x18\x02 \x01(\v2'.stirrup.harness.v1.DynamicContextValueR\x05value:\x028\x01\x1a`\n" +
@@ -3879,7 +4064,18 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\x05value\x18\x01 \x01(\tR\x05value\x12\x1c\n" +
 	"\tsensitive\x18\x02 \x01(\bR\tsensitive\"7\n" +
 	"\x12ToolDispatchConfig\x12!\n" +
-	"\fmax_parallel\x18\x01 \x01(\x05R\vmaxParallel\"\x82\x01\n" +
+	"\fmax_parallel\x18\x01 \x01(\x05R\vmaxParallel\"\x81\x01\n" +
+	"\vHooksConfig\x127\n" +
+	"\apre_run\x18\x01 \x03(\v2\x1e.stirrup.harness.v1.HookConfigR\x06preRun\x129\n" +
+	"\bpost_run\x18\x02 \x03(\v2\x1e.stirrup.harness.v1.HookConfigR\apostRun\"\xba\x01\n" +
+	"\n" +
+	"HookConfig\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
+	"\acommand\x18\x03 \x01(\tR\acommand\x12'\n" +
+	"\x0ftimeout_seconds\x18\x04 \x01(\x05R\x0etimeoutSeconds\x12*\n" +
+	"\x11continue_on_error\x18\x05 \x01(\bR\x0fcontinueOnError\x12\x15\n" +
+	"\x06run_on\x18\x06 \x01(\tR\x05runOn\"\x82\x01\n" +
 	"\x0fRuleOfTwoConfig\x12\x1d\n" +
 	"\aenforce\x18\x01 \x01(\bH\x00R\aenforce\x88\x01\x01\x12D\n" +
 	"\aruntime\x18\x02 \x01(\v2*.stirrup.harness.v1.RuleOfTwoRuntimeConfigR\aruntimeB\n" +
@@ -4109,7 +4305,7 @@ func file_harness_v1_harness_proto_rawDescGZIP() []byte {
 	return file_harness_v1_harness_proto_rawDescData
 }
 
-var file_harness_v1_harness_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_harness_v1_harness_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_harness_v1_harness_proto_goTypes = []any{
 	(*HarnessEvent)(nil),           // 0: stirrup.harness.v1.HarnessEvent
 	(*ControlEvent)(nil),           // 1: stirrup.harness.v1.ControlEvent
@@ -4117,89 +4313,94 @@ var file_harness_v1_harness_proto_goTypes = []any{
 	(*RunConfig)(nil),              // 3: stirrup.harness.v1.RunConfig
 	(*DynamicContextValue)(nil),    // 4: stirrup.harness.v1.DynamicContextValue
 	(*ToolDispatchConfig)(nil),     // 5: stirrup.harness.v1.ToolDispatchConfig
-	(*RuleOfTwoConfig)(nil),        // 6: stirrup.harness.v1.RuleOfTwoConfig
-	(*RuleOfTwoRuntimeConfig)(nil), // 7: stirrup.harness.v1.RuleOfTwoRuntimeConfig
-	(*CodeScannerConfig)(nil),      // 8: stirrup.harness.v1.CodeScannerConfig
-	(*GuardRailConfig)(nil),        // 9: stirrup.harness.v1.GuardRailConfig
-	(*ObservabilityConfig)(nil),    // 10: stirrup.harness.v1.ObservabilityConfig
-	(*RunTrace)(nil),               // 11: stirrup.harness.v1.RunTrace
-	(*ProviderConfig)(nil),         // 12: stirrup.harness.v1.ProviderConfig
-	(*BatchProviderConfig)(nil),    // 13: stirrup.harness.v1.BatchProviderConfig
-	(*CredentialConfig)(nil),       // 14: stirrup.harness.v1.CredentialConfig
-	(*TokenSourceConfig)(nil),      // 15: stirrup.harness.v1.TokenSourceConfig
-	(*GeminiSafetySetting)(nil),    // 16: stirrup.harness.v1.GeminiSafetySetting
-	(*ProviderRetryConfig)(nil),    // 17: stirrup.harness.v1.ProviderRetryConfig
-	(*ModelRouterConfig)(nil),      // 18: stirrup.harness.v1.ModelRouterConfig
-	(*PromptBuilderConfig)(nil),    // 19: stirrup.harness.v1.PromptBuilderConfig
-	(*ContextStrategyConfig)(nil),  // 20: stirrup.harness.v1.ContextStrategyConfig
-	(*ExecutorConfig)(nil),         // 21: stirrup.harness.v1.ExecutorConfig
-	(*VcsBackendConfig)(nil),       // 22: stirrup.harness.v1.VcsBackendConfig
-	(*NetworkConfig)(nil),          // 23: stirrup.harness.v1.NetworkConfig
-	(*ResourceLimits)(nil),         // 24: stirrup.harness.v1.ResourceLimits
-	(*EditStrategyConfig)(nil),     // 25: stirrup.harness.v1.EditStrategyConfig
-	(*VerifierConfig)(nil),         // 26: stirrup.harness.v1.VerifierConfig
-	(*PermissionPolicyConfig)(nil), // 27: stirrup.harness.v1.PermissionPolicyConfig
-	(*GitStrategyConfig)(nil),      // 28: stirrup.harness.v1.GitStrategyConfig
-	(*TraceEmitterConfig)(nil),     // 29: stirrup.harness.v1.TraceEmitterConfig
-	(*ToolsConfig)(nil),            // 30: stirrup.harness.v1.ToolsConfig
-	(*MCPServerConfig)(nil),        // 31: stirrup.harness.v1.MCPServerConfig
-	nil,                            // 32: stirrup.harness.v1.RunConfig.DynamicContextEntry
-	nil,                            // 33: stirrup.harness.v1.RunConfig.ProvidersEntry
-	nil,                            // 34: stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
-	nil,                            // 35: stirrup.harness.v1.ProviderConfig.QueryParamsEntry
-	nil,                            // 36: stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
-	nil,                            // 37: stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
-	nil,                            // 38: stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
+	(*HooksConfig)(nil),            // 6: stirrup.harness.v1.HooksConfig
+	(*HookConfig)(nil),             // 7: stirrup.harness.v1.HookConfig
+	(*RuleOfTwoConfig)(nil),        // 8: stirrup.harness.v1.RuleOfTwoConfig
+	(*RuleOfTwoRuntimeConfig)(nil), // 9: stirrup.harness.v1.RuleOfTwoRuntimeConfig
+	(*CodeScannerConfig)(nil),      // 10: stirrup.harness.v1.CodeScannerConfig
+	(*GuardRailConfig)(nil),        // 11: stirrup.harness.v1.GuardRailConfig
+	(*ObservabilityConfig)(nil),    // 12: stirrup.harness.v1.ObservabilityConfig
+	(*RunTrace)(nil),               // 13: stirrup.harness.v1.RunTrace
+	(*ProviderConfig)(nil),         // 14: stirrup.harness.v1.ProviderConfig
+	(*BatchProviderConfig)(nil),    // 15: stirrup.harness.v1.BatchProviderConfig
+	(*CredentialConfig)(nil),       // 16: stirrup.harness.v1.CredentialConfig
+	(*TokenSourceConfig)(nil),      // 17: stirrup.harness.v1.TokenSourceConfig
+	(*GeminiSafetySetting)(nil),    // 18: stirrup.harness.v1.GeminiSafetySetting
+	(*ProviderRetryConfig)(nil),    // 19: stirrup.harness.v1.ProviderRetryConfig
+	(*ModelRouterConfig)(nil),      // 20: stirrup.harness.v1.ModelRouterConfig
+	(*PromptBuilderConfig)(nil),    // 21: stirrup.harness.v1.PromptBuilderConfig
+	(*ContextStrategyConfig)(nil),  // 22: stirrup.harness.v1.ContextStrategyConfig
+	(*ExecutorConfig)(nil),         // 23: stirrup.harness.v1.ExecutorConfig
+	(*VcsBackendConfig)(nil),       // 24: stirrup.harness.v1.VcsBackendConfig
+	(*NetworkConfig)(nil),          // 25: stirrup.harness.v1.NetworkConfig
+	(*ResourceLimits)(nil),         // 26: stirrup.harness.v1.ResourceLimits
+	(*EditStrategyConfig)(nil),     // 27: stirrup.harness.v1.EditStrategyConfig
+	(*VerifierConfig)(nil),         // 28: stirrup.harness.v1.VerifierConfig
+	(*PermissionPolicyConfig)(nil), // 29: stirrup.harness.v1.PermissionPolicyConfig
+	(*GitStrategyConfig)(nil),      // 30: stirrup.harness.v1.GitStrategyConfig
+	(*TraceEmitterConfig)(nil),     // 31: stirrup.harness.v1.TraceEmitterConfig
+	(*ToolsConfig)(nil),            // 32: stirrup.harness.v1.ToolsConfig
+	(*MCPServerConfig)(nil),        // 33: stirrup.harness.v1.MCPServerConfig
+	nil,                            // 34: stirrup.harness.v1.RunConfig.DynamicContextEntry
+	nil,                            // 35: stirrup.harness.v1.RunConfig.ProvidersEntry
+	nil,                            // 36: stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
+	nil,                            // 37: stirrup.harness.v1.ProviderConfig.QueryParamsEntry
+	nil,                            // 38: stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
+	nil,                            // 39: stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
+	nil,                            // 40: stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
 }
 var file_harness_v1_harness_proto_depIdxs = []int32{
-	11, // 0: stirrup.harness.v1.HarnessEvent.trace:type_name -> stirrup.harness.v1.RunTrace
+	13, // 0: stirrup.harness.v1.HarnessEvent.trace:type_name -> stirrup.harness.v1.RunTrace
 	3,  // 1: stirrup.harness.v1.ControlEvent.task:type_name -> stirrup.harness.v1.RunConfig
 	2,  // 2: stirrup.harness.v1.ControlEvent.allowed:type_name -> stirrup.harness.v1.OptionalBool
 	2,  // 3: stirrup.harness.v1.ControlEvent.is_error:type_name -> stirrup.harness.v1.OptionalBool
-	32, // 4: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
-	12, // 5: stirrup.harness.v1.RunConfig.provider:type_name -> stirrup.harness.v1.ProviderConfig
-	33, // 6: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
-	18, // 7: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
-	19, // 8: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
-	20, // 9: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
-	21, // 10: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
-	25, // 11: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
-	26, // 12: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
-	27, // 13: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
-	28, // 14: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
-	29, // 15: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
-	30, // 16: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
-	6,  // 17: stirrup.harness.v1.RunConfig.rule_of_two:type_name -> stirrup.harness.v1.RuleOfTwoConfig
-	8,  // 18: stirrup.harness.v1.RunConfig.code_scanner:type_name -> stirrup.harness.v1.CodeScannerConfig
-	9,  // 19: stirrup.harness.v1.RunConfig.guard_rail:type_name -> stirrup.harness.v1.GuardRailConfig
-	10, // 20: stirrup.harness.v1.RunConfig.observability:type_name -> stirrup.harness.v1.ObservabilityConfig
+	34, // 4: stirrup.harness.v1.RunConfig.dynamic_context:type_name -> stirrup.harness.v1.RunConfig.DynamicContextEntry
+	14, // 5: stirrup.harness.v1.RunConfig.provider:type_name -> stirrup.harness.v1.ProviderConfig
+	35, // 6: stirrup.harness.v1.RunConfig.providers:type_name -> stirrup.harness.v1.RunConfig.ProvidersEntry
+	20, // 7: stirrup.harness.v1.RunConfig.model_router:type_name -> stirrup.harness.v1.ModelRouterConfig
+	21, // 8: stirrup.harness.v1.RunConfig.prompt_builder:type_name -> stirrup.harness.v1.PromptBuilderConfig
+	22, // 9: stirrup.harness.v1.RunConfig.context_strategy:type_name -> stirrup.harness.v1.ContextStrategyConfig
+	23, // 10: stirrup.harness.v1.RunConfig.executor:type_name -> stirrup.harness.v1.ExecutorConfig
+	27, // 11: stirrup.harness.v1.RunConfig.edit_strategy:type_name -> stirrup.harness.v1.EditStrategyConfig
+	28, // 12: stirrup.harness.v1.RunConfig.verifier:type_name -> stirrup.harness.v1.VerifierConfig
+	29, // 13: stirrup.harness.v1.RunConfig.permission_policy:type_name -> stirrup.harness.v1.PermissionPolicyConfig
+	30, // 14: stirrup.harness.v1.RunConfig.git_strategy:type_name -> stirrup.harness.v1.GitStrategyConfig
+	31, // 15: stirrup.harness.v1.RunConfig.trace_emitter:type_name -> stirrup.harness.v1.TraceEmitterConfig
+	32, // 16: stirrup.harness.v1.RunConfig.tools:type_name -> stirrup.harness.v1.ToolsConfig
+	8,  // 17: stirrup.harness.v1.RunConfig.rule_of_two:type_name -> stirrup.harness.v1.RuleOfTwoConfig
+	10, // 18: stirrup.harness.v1.RunConfig.code_scanner:type_name -> stirrup.harness.v1.CodeScannerConfig
+	11, // 19: stirrup.harness.v1.RunConfig.guard_rail:type_name -> stirrup.harness.v1.GuardRailConfig
+	12, // 20: stirrup.harness.v1.RunConfig.observability:type_name -> stirrup.harness.v1.ObservabilityConfig
 	5,  // 21: stirrup.harness.v1.RunConfig.tool_dispatch:type_name -> stirrup.harness.v1.ToolDispatchConfig
-	7,  // 22: stirrup.harness.v1.RuleOfTwoConfig.runtime:type_name -> stirrup.harness.v1.RuleOfTwoRuntimeConfig
-	9,  // 23: stirrup.harness.v1.GuardRailConfig.stages:type_name -> stirrup.harness.v1.GuardRailConfig
-	34, // 24: stirrup.harness.v1.GuardRailConfig.custom_criteria:type_name -> stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
-	14, // 25: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
-	35, // 26: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
-	16, // 27: stirrup.harness.v1.ProviderConfig.gemini_safety_settings:type_name -> stirrup.harness.v1.GeminiSafetySetting
-	17, // 28: stirrup.harness.v1.ProviderConfig.retry:type_name -> stirrup.harness.v1.ProviderRetryConfig
-	13, // 29: stirrup.harness.v1.ProviderConfig.batch:type_name -> stirrup.harness.v1.BatchProviderConfig
-	15, // 30: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
-	36, // 31: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
-	22, // 32: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
-	23, // 33: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
-	24, // 34: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
-	37, // 35: stirrup.harness.v1.ExecutorConfig.k8s_node_selector:type_name -> stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
-	26, // 36: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
-	38, // 37: stirrup.harness.v1.TraceEmitterConfig.headers:type_name -> stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
-	31, // 38: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
-	4,  // 39: stirrup.harness.v1.RunConfig.DynamicContextEntry.value:type_name -> stirrup.harness.v1.DynamicContextValue
-	12, // 40: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
-	0,  // 41: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
-	1,  // 42: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
-	42, // [42:43] is the sub-list for method output_type
-	41, // [41:42] is the sub-list for method input_type
-	41, // [41:41] is the sub-list for extension type_name
-	41, // [41:41] is the sub-list for extension extendee
-	0,  // [0:41] is the sub-list for field type_name
+	6,  // 22: stirrup.harness.v1.RunConfig.hooks:type_name -> stirrup.harness.v1.HooksConfig
+	7,  // 23: stirrup.harness.v1.HooksConfig.pre_run:type_name -> stirrup.harness.v1.HookConfig
+	7,  // 24: stirrup.harness.v1.HooksConfig.post_run:type_name -> stirrup.harness.v1.HookConfig
+	9,  // 25: stirrup.harness.v1.RuleOfTwoConfig.runtime:type_name -> stirrup.harness.v1.RuleOfTwoRuntimeConfig
+	11, // 26: stirrup.harness.v1.GuardRailConfig.stages:type_name -> stirrup.harness.v1.GuardRailConfig
+	36, // 27: stirrup.harness.v1.GuardRailConfig.custom_criteria:type_name -> stirrup.harness.v1.GuardRailConfig.CustomCriteriaEntry
+	16, // 28: stirrup.harness.v1.ProviderConfig.credential:type_name -> stirrup.harness.v1.CredentialConfig
+	37, // 29: stirrup.harness.v1.ProviderConfig.query_params:type_name -> stirrup.harness.v1.ProviderConfig.QueryParamsEntry
+	18, // 30: stirrup.harness.v1.ProviderConfig.gemini_safety_settings:type_name -> stirrup.harness.v1.GeminiSafetySetting
+	19, // 31: stirrup.harness.v1.ProviderConfig.retry:type_name -> stirrup.harness.v1.ProviderRetryConfig
+	15, // 32: stirrup.harness.v1.ProviderConfig.batch:type_name -> stirrup.harness.v1.BatchProviderConfig
+	17, // 33: stirrup.harness.v1.CredentialConfig.token_source:type_name -> stirrup.harness.v1.TokenSourceConfig
+	38, // 34: stirrup.harness.v1.ModelRouterConfig.mode_models:type_name -> stirrup.harness.v1.ModelRouterConfig.ModeModelsEntry
+	24, // 35: stirrup.harness.v1.ExecutorConfig.vcs_backend:type_name -> stirrup.harness.v1.VcsBackendConfig
+	25, // 36: stirrup.harness.v1.ExecutorConfig.network:type_name -> stirrup.harness.v1.NetworkConfig
+	26, // 37: stirrup.harness.v1.ExecutorConfig.resources:type_name -> stirrup.harness.v1.ResourceLimits
+	39, // 38: stirrup.harness.v1.ExecutorConfig.k8s_node_selector:type_name -> stirrup.harness.v1.ExecutorConfig.K8sNodeSelectorEntry
+	28, // 39: stirrup.harness.v1.VerifierConfig.verifiers:type_name -> stirrup.harness.v1.VerifierConfig
+	40, // 40: stirrup.harness.v1.TraceEmitterConfig.headers:type_name -> stirrup.harness.v1.TraceEmitterConfig.HeadersEntry
+	33, // 41: stirrup.harness.v1.ToolsConfig.mcp_servers:type_name -> stirrup.harness.v1.MCPServerConfig
+	4,  // 42: stirrup.harness.v1.RunConfig.DynamicContextEntry.value:type_name -> stirrup.harness.v1.DynamicContextValue
+	14, // 43: stirrup.harness.v1.RunConfig.ProvidersEntry.value:type_name -> stirrup.harness.v1.ProviderConfig
+	0,  // 44: stirrup.harness.v1.HarnessService.RunTask:input_type -> stirrup.harness.v1.HarnessEvent
+	1,  // 45: stirrup.harness.v1.HarnessService.RunTask:output_type -> stirrup.harness.v1.ControlEvent
+	45, // [45:46] is the sub-list for method output_type
+	44, // [44:45] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_harness_v1_harness_proto_init() }
@@ -4208,18 +4409,18 @@ func file_harness_v1_harness_proto_init() {
 		return
 	}
 	file_harness_v1_harness_proto_msgTypes[3].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[6].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[9].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[12].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[13].OneofWrappers = []any{}
-	file_harness_v1_harness_proto_msgTypes[25].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[8].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[11].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[14].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[15].OneofWrappers = []any{}
+	file_harness_v1_harness_proto_msgTypes[27].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_harness_v1_harness_proto_rawDesc), len(file_harness_v1_harness_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   39,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -1989,15 +1989,31 @@ type runOptions struct {
 // RunConfig — ValidateRunConfig rejects nil Timeout, so the dereference
 // below is safe.
 func runWithConfig(config *types.RunConfig, opts runOptions) error {
+	// shutdownCtx carries only the process-level shutdown signal
+	// (SIGINT/SIGTERM), deliberately independent of ctx's run-deadline
+	// cancellation below. The agentic loop's detached postRun hook
+	// phase (issue #461) is built to survive ctx's own deadline but
+	// must still observe a genuine process shutdown promptly — see
+	// AgenticLoop.Shutdown and docs/cloud-run-jobs.md.
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*config.Timeout)*time.Second)
 	defer cancel()
-	setupSignalHandler(cancel)
+	setupSignalHandler(func() {
+		shutdownCancel()
+		cancel()
+	})
 
 	loop, err := core.BuildLoop(ctx, config)
 	if err != nil {
 		return fmt.Errorf("building harness: %w", err)
 	}
 	defer func() { _ = loop.Close() }()
+
+	loop.Shutdown = shutdownCtx
+	stopShutdownWatchdog := armShutdownWatchdog(shutdownCtx, loop, shutdownCloseGrace)
+	defer stopShutdownWatchdog()
 
 	runTrace, err := loop.Run(ctx, config)
 	if err != nil {

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -2015,9 +2015,12 @@ func runWithConfig(config *types.RunConfig, opts runOptions) error {
 	stopShutdownWatchdog := armShutdownWatchdog(shutdownCtx, loop, shutdownCloseGrace)
 	defer stopShutdownWatchdog()
 
-	runTrace, err := loop.Run(ctx, config)
-	if err != nil {
-		return fmt.Errorf("running harness: %w", err)
+	runTrace, runErr := loop.Run(ctx, config)
+	if runTrace == nil {
+		// No trace was produced at all (e.g. the trace emitter itself
+		// failed inside finishWithOutcome/finishWithError) — there is
+		// nothing to emit.
+		return fmt.Errorf("running harness: %w", runErr)
 	}
 
 	// emitRunOutput must not inherit ctx: by the time we reach here ctx
@@ -2032,6 +2035,21 @@ func runWithConfig(config *types.RunConfig, opts runOptions) error {
 	emitCtx, emitCancel := context.WithTimeout(context.Background(), postRunEmitTimeout)
 	defer emitCancel()
 	emitRunOutput(emitCtx, config, runTrace, opts.outputMode)
+
+	if runErr != nil {
+		// A RunTrace was produced even though Run() returned a fatal
+		// error: finishWithOutcome's early-return paths (build-system-
+		// prompt failure, git setup failure, and — issue #461 — a
+		// fatal preRun hook failure) return a valid trace alongside a
+		// non-nil error. The RunResult/resultSink emission above must
+		// still run for these — skipping it made the run's own
+		// structured outcome (and RunResult.HookFailures) unreachable
+		// on the most common trigger for setup_failed/hook_failed —
+		// but a failed run has nothing further to do, so still return
+		// the error here rather than continuing to workspace export /
+		// follow-up grace.
+		return fmt.Errorf("running harness: %w", runErr)
+	}
 
 	// Workspace export (issue #164). Called after the trace and
 	// resultSink so a failed upload's slog warning lands after the

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -5943,6 +5943,42 @@ func TestPrintRunSummary_NilTraceDoesNotPanic(t *testing.T) {
 	}
 }
 
+// TestPrintRunSummary_HooksLinePrintedWhenPresent pins the issue #461
+// summary line: present and correctly counted when the trace carries
+// HookResults, counting only executed (non-Skipped) entries and only
+// those with a non-empty Error as failures.
+func TestPrintRunSummary_HooksLinePrintedWhenPresent(t *testing.T) {
+	rt := outputModeRunTrace()
+	rt.HookResults = []types.HookExecution{
+		{Phase: "preRun", Index: 0, Command: "true"},
+		{Phase: "postRun", Index: 0, Command: "false", Error: "exit code 1"},
+		{Phase: "postRun", Index: 1, Command: "true", Skipped: true},
+	}
+
+	stderrDone := captureStderr(t)
+	printRunSummary(rt)
+	stderr := stderrDone()
+
+	if !strings.Contains(stderr, "Hooks: 2 run, 1 failed") {
+		t.Errorf("stderr should report \"Hooks: 2 run, 1 failed\", got: %q", stderr)
+	}
+}
+
+// TestPrintRunSummary_HooksLineOmittedWhenAbsent pins that a hookless
+// run's summary carries no "Hooks:" line at all, preserving the
+// pre-#461 stderr shape byte-for-byte.
+func TestPrintRunSummary_HooksLineOmittedWhenAbsent(t *testing.T) {
+	rt := outputModeRunTrace()
+
+	stderrDone := captureStderr(t)
+	printRunSummary(rt)
+	stderr := stderrDone()
+
+	if strings.Contains(stderr, "Hooks:") {
+		t.Errorf("stderr should have no Hooks: line for a hookless run, got: %q", stderr)
+	}
+}
+
 // TestEmitRunOutput_CancelledContextStillEmits pins the M2 fix:
 // emitRunOutput must be reachable with a usable context even when the
 // run's primary context has already been cancelled. The synthesizer's

--- a/harness/cmd/stirrup/cmd/hooks_cmd_test.go
+++ b/harness/cmd/stirrup/cmd/hooks_cmd_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fatalPreRunHookConfig builds a minimal, valid RunConfig whose single
+// preRun hook fails fatally ("exit 1", no continueOnError). Because
+// preRun hooks run before Git.Setup and before any turn — and
+// therefore before the loop ever streams from the provider — this
+// config drives runWithConfig end-to-end without needing a live (or
+// mocked) provider endpoint: BuildLoop only constructs the adapter, it
+// never calls it.
+func fatalPreRunHookConfig(t *testing.T) *types.RunConfig {
+	t.Helper()
+	t.Setenv("TEST_HOOKS_CMD_KEY", "unused-never-called")
+	timeout := 30
+	return &types.RunConfig{
+		RunID:            "cmd-hooks-fatal-test",
+		Mode:             "planning",
+		Prompt:           "irrelevant, never reached",
+		Provider:         types.ProviderConfig{Type: "anthropic", APIKeyRef: "secret://TEST_HOOKS_CMD_KEY"},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"read_file"}},
+		MaxTurns:         2,
+		Timeout:          &timeout,
+		Hooks: &types.HooksConfig{
+			PreRun: []types.HookConfig{{Name: "boom", Command: "exit 1"}},
+		},
+	}
+}
+
+// TestRunWithConfig_FatalPreRunHookFailure_StillEmitsRunResult pins
+// issue #461 finding #2's cmd-layer half: runWithConfig previously
+// short-circuited on any non-nil error from loop.Run(), skipping
+// emitRunOutput entirely — so a preRun hook failure (outcome
+// "setup_failed", a RunResult.HookFailures-bearing case) produced no
+// STIRRUP_RESULT line at all despite loop.Run() having returned a
+// valid RunTrace. runWithConfig must still emit it, and must still
+// return a non-nil error (the CLI's own exit-status contract is
+// unchanged).
+func TestRunWithConfig_FatalPreRunHookFailure_StillEmitsRunResult(t *testing.T) {
+	config := fatalPreRunHookConfig(t)
+
+	stdoutDone := captureStdout(t)
+	runErr := runWithConfig(config, runOptions{outputMode: "json"})
+	stdout := stdoutDone()
+
+	if runErr == nil {
+		t.Fatal("expected a non-nil error from a fatal preRun hook failure")
+	}
+
+	// stdout also carries the default stdio transport's own JSON event
+	// stream (the "error"/"done" HarnessEvents finding #2 also fixed —
+	// see TestLoop_Hooks_PreRunFatalFailure_EmitsDoneEvent), so the
+	// STIRRUP_RESULT line is not necessarily the first line; find it.
+	var resultLine string
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.HasPrefix(line, "STIRRUP_RESULT ") {
+			resultLine = line
+			break
+		}
+	}
+	if resultLine == "" {
+		t.Fatalf("expected a STIRRUP_RESULT line despite the fatal error, got stdout: %q", stdout)
+	}
+	payload := strings.TrimPrefix(resultLine, "STIRRUP_RESULT ")
+	var result types.RunResult
+	if err := json.Unmarshal([]byte(payload), &result); err != nil {
+		t.Fatalf("STIRRUP_RESULT payload should parse as RunResult: %v\npayload: %s", err, payload)
+	}
+	if result.Outcome != "setup_failed" {
+		t.Errorf("RunResult.Outcome = %q, want setup_failed", result.Outcome)
+	}
+	if result.HookFailures == 0 {
+		t.Error("RunResult.HookFailures = 0, want non-zero")
+	}
+}

--- a/harness/cmd/stirrup/cmd/job.go
+++ b/harness/cmd/stirrup/cmd/job.go
@@ -41,11 +41,24 @@ func runJob(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("CONTROL_PLANE_ADDR environment variable is required")
 	}
 
+	// shutdownCtx carries only the process-level shutdown signal
+	// (SIGINT/SIGTERM/pod deletion), deliberately independent of ctx's
+	// lifecycle below. The agentic loop's detached postRun hook phase
+	// (issue #461) is built to survive ctx's own run-deadline/
+	// control-plane cancel but must still observe a genuine process
+	// shutdown promptly — see AgenticLoop.Shutdown and
+	// docs/cloud-run-jobs.md.
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+
 	// Top-level context with signal handling. The timeout is applied later
 	// once we receive the RunConfig (which carries the wall-clock timeout).
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	setupSignalHandler(cancel)
+	setupSignalHandler(func() {
+		shutdownCancel()
+		cancel()
+	})
 
 	// 1. Dial the control plane.
 	tp, err := transport.NewGRPCTransport(ctx, addr)
@@ -123,6 +136,10 @@ func runJob(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("building harness: %w", err)
 	}
 	defer func() { _ = loop.Close() }()
+
+	loop.Shutdown = shutdownCtx
+	stopShutdownWatchdog := armShutdownWatchdog(shutdownCtx, loop, shutdownCloseGrace)
+	defer stopShutdownWatchdog()
 
 	runTrace, err := loop.Run(ctx, config)
 	if err != nil {

--- a/harness/cmd/stirrup/cmd/job.go
+++ b/harness/cmd/stirrup/cmd/job.go
@@ -141,9 +141,12 @@ func runJob(cmd *cobra.Command, args []string) error {
 	stopShutdownWatchdog := armShutdownWatchdog(shutdownCtx, loop, shutdownCloseGrace)
 	defer stopShutdownWatchdog()
 
-	runTrace, err := loop.Run(ctx, config)
-	if err != nil {
-		return fmt.Errorf("running harness: %w", err)
+	runTrace, runErr := loop.Run(ctx, config)
+	if runTrace == nil {
+		// No trace was produced at all (e.g. the trace emitter itself
+		// failed inside finishWithOutcome/finishWithError) — there is
+		// nothing to emit.
+		return fmt.Errorf("running harness: %w", runErr)
 	}
 	printRunSummary(runTrace)
 	// resultSink emission mirrors the harness command path so a Cloud
@@ -157,6 +160,22 @@ func runJob(cmd *cobra.Command, args []string) error {
 	emitCtx, emitCancel := context.WithTimeout(context.Background(), postRunEmitTimeout)
 	defer emitCancel()
 	emitRunResult(emitCtx, config, runTrace)
+
+	if runErr != nil {
+		// A RunTrace was produced even though Run() returned a fatal
+		// error: finishWithOutcome's early-return paths (build-system-
+		// prompt failure, git setup failure, and — issue #461 — a
+		// fatal preRun hook failure) return a valid trace, and now also
+		// emit the terminal "done" HarnessEvent (see loop.go), alongside
+		// a non-nil error. printRunSummary/emitRunResult above must
+		// still run for these — skipping them made the run's own
+		// structured outcome (and RunResult.HookFailures) unreachable
+		// on the most common trigger for setup_failed/hook_failed — but
+		// a failed run has nothing further to do, so still return the
+		// error here rather than continuing to workspace export /
+		// follow-up grace.
+		return fmt.Errorf("running harness: %w", runErr)
+	}
 
 	// Workspace export. The job entrypoint has no equivalent of the
 	// CLI's --export-workspace-required, so the control plane decides

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -354,4 +355,50 @@ func setupSignalHandler(cancel context.CancelFunc) {
 		fmt.Fprintln(os.Stderr, "\nReceived interrupt, shutting down...")
 		cancel()
 	}()
+}
+
+// shutdownCloseGrace bounds how long armShutdownWatchdog waits after a
+// process shutdown signal (SIGINT/SIGTERM/pod deletion) before
+// proactively closing the loop, even if Run() has not returned yet —
+// e.g. because a detached postRun lifecycle hook (issue #461) is still
+// winding down after its ctx was cancelled. Chosen comfortably under
+// the shortest documented orchestrator SIGKILL escalation (10s on
+// Cloud Run and `docker stop`; see docs/cloud-run-jobs.md) so the
+// executor's sandbox (container, or K8s Pod + egress NetworkPolicy)
+// has a real chance to be torn down before the process is killed
+// outright, which bypasses every deferred cleanup entirely.
+const shutdownCloseGrace = 5 * time.Second
+
+// armShutdownWatchdog starts a background goroutine that proactively
+// closes loop grace after shutdownCtx is done, unless the returned
+// stop function is called first (Run() already returned through the
+// normal path, so the caller's own `defer loop.Close()` handles
+// teardown). This exists because relying solely on `defer` is not
+// enough: if the orchestrator's SIGKILL escalation fires before Run()
+// returns — e.g. while a postRun hook is still being killed via ctx
+// cancellation, or a slow trace flush is in flight — the deferred
+// Close() never runs at all, orphaning the executor's sandbox.
+// Close() is safe to invoke more than once: every executor's Close()
+// is either explicitly idempotent (K8sExecutor: a NotFound pod delete
+// is treated as success) or a harmless no-op whose error the normal
+// `defer func() { _ = loop.Close() }()` already discards. Production
+// call sites pass shutdownCloseGrace; tests pass a short duration to
+// exercise the fire path without a real multi-second sleep.
+func armShutdownWatchdog(shutdownCtx context.Context, loop io.Closer, grace time.Duration) (stop func()) {
+	runDone := make(chan struct{})
+	go func() {
+		select {
+		case <-runDone:
+			return
+		case <-shutdownCtx.Done():
+		}
+		select {
+		case <-runDone:
+		case <-time.After(grace):
+			if err := loop.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: proactive shutdown close: %v\n", err)
+			}
+		}
+	}()
+	return func() { close(runDone) }
 }

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -104,6 +104,31 @@ func printRunSummary(runTrace *types.RunTrace) {
 	fmt.Fprintf(os.Stderr, "Tokens: %d in / %d out\n", runTrace.TokenUsage.Input, runTrace.TokenUsage.Output)
 	fmt.Fprintf(os.Stderr, "Tool calls: %d\n", len(runTrace.ToolCalls))
 	fmt.Fprintf(os.Stderr, "Duration: %s\n", runTrace.CompletedAt.Sub(runTrace.StartedAt).Round(time.Millisecond))
+	if len(runTrace.HookResults) > 0 {
+		ran, failed := hookSummaryCounts(runTrace.HookResults)
+		fmt.Fprintf(os.Stderr, "Hooks: %d run, %d failed\n", ran, failed)
+	}
+}
+
+// hookSummaryCounts reports how many lifecycle hooks (issue #461)
+// actually ran and how many of those failed, for printRunSummary and
+// buildRunResult. "Ran" excludes entries with Skipped=true — a hook
+// skipped by a postRun runOn filter or after a prior fatal failure in
+// the same phase never executed, so it should not count toward either
+// number. Skipped entries never set Error (see hook.ExecRunner), so
+// counting Error != "" alone is sufficient for "failed" without a
+// second Skipped check.
+func hookSummaryCounts(results []types.HookExecution) (ran, failed int) {
+	for _, r := range results {
+		if r.Skipped {
+			continue
+		}
+		ran++
+		if r.Error != "" {
+			failed++
+		}
+	}
+	return ran, failed
 }
 
 // buildRunResult constructs the small RunResult payload from the
@@ -148,6 +173,10 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 			Feedback: last.Feedback,
 		}
 	}
+	// HookFailures (issue #461): hookSummaryCounts is nil-safe (ranges
+	// over a nil/empty HookResults are no-ops), so this is always safe
+	// to compute and naturally resolves to 0 for a hookless run.
+	_, res.HookFailures = hookSummaryCounts(rt.HookResults)
 	return res
 }
 

--- a/harness/cmd/stirrup/cmd/root_test.go
+++ b/harness/cmd/stirrup/cmd/root_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -211,6 +212,90 @@ func TestBuildRunResult_NoHookResultsLeavesHookFailuresZero(t *testing.T) {
 	got := buildRunResult(rt)
 	if got.HookFailures != 0 {
 		t.Errorf("HookFailures = %d, want 0", got.HookFailures)
+	}
+}
+
+// fakeCloser is an io.Closer test double that records whether/how many
+// times Close was called, for armShutdownWatchdog tests.
+type fakeCloser struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (f *fakeCloser) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.err
+}
+
+func (f *fakeCloser) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// TestArmShutdownWatchdog_ClosesAfterGraceWhenRunNeverReturns pins the
+// proactive-teardown path (issue #461 finding #1): if shutdownCtx fires
+// and the caller never calls stop() (simulating Run() still blocked
+// past the grace window — e.g. the orchestrator's SIGKILL is about to
+// land), the watchdog closes the loop on its own.
+func TestArmShutdownWatchdog_ClosesAfterGraceWhenRunNeverReturns(t *testing.T) {
+	closer := &fakeCloser{}
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+
+	armShutdownWatchdog(shutdownCtx, closer, 10*time.Millisecond)
+	shutdownCancel()
+
+	deadline := time.After(1 * time.Second)
+	for closer.callCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("watchdog never closed the loop within the deadline")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	if closer.callCount() != 1 {
+		t.Errorf("Close called %d times, want 1", closer.callCount())
+	}
+}
+
+// TestArmShutdownWatchdog_StopPreventsClose pins the normal-return path:
+// calling stop() before the grace window elapses (Run() returned
+// through the ordinary path) must prevent the watchdog from ever
+// calling Close — the caller's own `defer loop.Close()` owns teardown
+// in that case.
+func TestArmShutdownWatchdog_StopPreventsClose(t *testing.T) {
+	closer := &fakeCloser{}
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+
+	stop := armShutdownWatchdog(shutdownCtx, closer, 20*time.Millisecond)
+	shutdownCancel()
+	stop()
+
+	time.Sleep(50 * time.Millisecond)
+	if closer.callCount() != 0 {
+		t.Errorf("Close called %d times, want 0 (stop() must prevent the proactive close)", closer.callCount())
+	}
+}
+
+// TestArmShutdownWatchdog_NoShutdownNeverCloses pins the no-signal path:
+// a watchdog whose shutdownCtx never fires must never close the loop,
+// regardless of how long it runs.
+func TestArmShutdownWatchdog_NoShutdownNeverCloses(t *testing.T) {
+	closer := &fakeCloser{}
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+
+	stop := armShutdownWatchdog(shutdownCtx, closer, 5*time.Millisecond)
+	defer stop()
+
+	time.Sleep(30 * time.Millisecond)
+	if closer.callCount() != 0 {
+		t.Errorf("Close called %d times, want 0 (no shutdown signal was ever sent)", closer.callCount())
 	}
 }
 

--- a/harness/cmd/stirrup/cmd/root_test.go
+++ b/harness/cmd/stirrup/cmd/root_test.go
@@ -184,6 +184,36 @@ func TestBuildRunResult_NoVerificationResultsLeavesVerdictNil(t *testing.T) {
 	}
 }
 
+// TestBuildRunResult_HookFailuresCounted pins the issue #461 field: a
+// non-zero HookFailures count when the trace carries failed (but not
+// skipped) lifecycle hook executions, computed across both phases.
+func TestBuildRunResult_HookFailuresCounted(t *testing.T) {
+	rt := &types.RunTrace{
+		ID:      "run-hooks",
+		Outcome: "hook_failed",
+		HookResults: []types.HookExecution{
+			{Phase: "preRun", Index: 0, Command: "true"},                         // succeeded
+			{Phase: "postRun", Index: 0, Command: "false", Error: "exit code 1"}, // failed
+			{Phase: "postRun", Index: 1, Command: "true", Skipped: true},         // skipped, not a failure
+		},
+	}
+	got := buildRunResult(rt)
+	if got.HookFailures != 1 {
+		t.Errorf("HookFailures = %d, want 1 (skipped entries must not count)", got.HookFailures)
+	}
+}
+
+// TestBuildRunResult_NoHookResultsLeavesHookFailuresZero pins the
+// hookless-run default: an empty/nil HookResults must not panic and
+// must resolve HookFailures to zero.
+func TestBuildRunResult_NoHookResultsLeavesHookFailuresZero(t *testing.T) {
+	rt := &types.RunTrace{ID: "run-no-hooks", Outcome: "success"}
+	got := buildRunResult(rt)
+	if got.HookFailures != 0 {
+		t.Errorf("HookFailures = %d, want 0", got.HookFailures)
+	}
+}
+
 // TestExportWorkspace_NoopWhenEmpty pins the WorkspaceExportTo=="" path:
 // no exporter is constructed and no HTTP call is made. Tested by
 // asserting the factory closure is never invoked, so a regression that

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
 	"github.com/rxbynerd/stirrup/harness/internal/git"
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
+	"github.com/rxbynerd/stirrup/harness/internal/hook"
 	"github.com/rxbynerd/stirrup/harness/internal/mcp"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
@@ -292,6 +293,13 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	// 11. Git strategy.
 	gs := buildGitStrategy(config.GitStrategy)
 
+	// 11b. Lifecycle hook runner (issue #461). Noop when the run has no
+	// HooksConfig so the loop's Hooks field is never a bare nil
+	// interface and a bare run pays no cost — the same pattern as
+	// GuardRail. Shares the run's Executor so hooks run inside the same
+	// sandbox and network egress posture as every agent tool call.
+	hooksRunner := buildHookRunner(config.Hooks, exec, logger)
+
 	// 13. OTel metrics.
 	var metrics *observability.Metrics
 	metricsEndpoint := config.TraceEmitter.MetricsEndpoint
@@ -558,6 +566,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		GuardRail:    gr,
 		RuleOfTwo:    rot,
 		Escalation:   escalation,
+		Hooks:        hooksRunner,
 		Transport:    tp,
 		Trace:        te,
 		Tracer:       tracer,
@@ -1625,6 +1634,19 @@ func buildGitStrategy(cfg types.GitStrategyConfig) git.GitStrategy {
 	default:
 		return git.NewNoneGitStrategy()
 	}
+}
+
+// buildHookRunner constructs the lifecycle hook runner (issue #461).
+// Returns hook.Noop when cfg is nil or configures no hooks in either
+// phase, so a bare run pays no cost and AgenticLoop.Hooks is never a
+// bare nil interface. exec is the run's own Executor — hooks run
+// through it so they share the run's sandbox and network egress posture
+// with every agent tool call.
+func buildHookRunner(cfg *types.HooksConfig, exec executor.Executor, logger *slog.Logger) hook.Runner {
+	if cfg == nil || (len(cfg.PreRun) == 0 && len(cfg.PostRun) == 0) {
+		return hook.NewNoop()
+	}
+	return &hook.ExecRunner{Hooks: cfg, Exec: exec, Logger: logger}
 }
 
 // resourceOptionsFromConfig assembles the OTel ResourceOptions for this run

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
 	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/hook"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
@@ -875,6 +876,42 @@ func TestBuildGitStrategy_UnknownFallsBack(t *testing.T) {
 	}
 }
 
+// --- buildHookRunner (issue #461) ---
+
+func TestBuildHookRunner_NilConfigReturnsNoop(t *testing.T) {
+	r := buildHookRunner(nil, nil, nil)
+	if _, ok := r.(*hook.Noop); !ok {
+		t.Fatalf("expected hook.Noop for a nil HooksConfig, got %T", r)
+	}
+}
+
+func TestBuildHookRunner_EmptyConfigReturnsNoop(t *testing.T) {
+	r := buildHookRunner(&types.HooksConfig{}, nil, nil)
+	if _, ok := r.(*hook.Noop); !ok {
+		t.Fatalf("expected hook.Noop for an empty HooksConfig, got %T", r)
+	}
+}
+
+func TestBuildHookRunner_PreRunOnlyReturnsExecRunner(t *testing.T) {
+	cfg := &types.HooksConfig{PreRun: []types.HookConfig{{Command: "true"}}}
+	r := buildHookRunner(cfg, nil, nil)
+	execRunner, ok := r.(*hook.ExecRunner)
+	if !ok {
+		t.Fatalf("expected *hook.ExecRunner, got %T", r)
+	}
+	if execRunner.Hooks != cfg {
+		t.Error("ExecRunner.Hooks must be the same HooksConfig instance passed in")
+	}
+}
+
+func TestBuildHookRunner_PostRunOnlyReturnsExecRunner(t *testing.T) {
+	cfg := &types.HooksConfig{PostRun: []types.HookConfig{{Command: "true"}}}
+	r := buildHookRunner(cfg, nil, nil)
+	if _, ok := r.(*hook.ExecRunner); !ok {
+		t.Fatalf("expected *hook.ExecRunner, got %T", r)
+	}
+}
+
 // --- buildTraceEmitter ---
 
 func TestBuildTraceEmitter_JSONLWithoutPath(t *testing.T) {
@@ -1500,6 +1537,12 @@ func TestBuildLoopWithTransport_MinimalValidConfig(t *testing.T) {
 	if loop.Git == nil {
 		t.Fatal("Git is nil")
 	}
+	if loop.Hooks == nil {
+		t.Fatal("Hooks is nil")
+	}
+	if _, ok := loop.Hooks.(*hook.Noop); !ok {
+		t.Errorf("expected hook.Noop for a config with no HooksConfig, got %T", loop.Hooks)
+	}
 	if loop.Transport == nil {
 		t.Fatal("Transport is nil")
 	}
@@ -1517,6 +1560,56 @@ func TestBuildLoopWithTransport_MinimalValidConfig(t *testing.T) {
 	}
 	if loop.Logger == nil {
 		t.Fatal("Logger is nil")
+	}
+}
+
+// TestBuildLoopWithTransport_HooksWiredAsExecRunner pins that a config
+// carrying a non-empty HooksConfig (issue #461) wires an *hook.ExecRunner
+// sharing the run's own Executor, rather than the Noop fallback.
+func TestBuildLoopWithTransport_HooksWiredAsExecRunner(t *testing.T) {
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:            "factory-hooks-test",
+		Mode:             "execution",
+		Prompt:           "hello",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+		Hooks: &types.HooksConfig{
+			PreRun: []types.HookConfig{{Command: "true", TimeoutSeconds: 5}},
+		},
+	}
+
+	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	execRunner, ok := loop.Hooks.(*hook.ExecRunner)
+	if !ok {
+		t.Fatalf("expected *hook.ExecRunner, got %T", loop.Hooks)
+	}
+	if execRunner.Exec != loop.Executor {
+		t.Error("ExecRunner.Exec must be the run's own Executor")
+	}
+	if execRunner.Hooks != config.Hooks {
+		t.Error("ExecRunner.Hooks must be the config's own HooksConfig instance")
 	}
 }
 

--- a/harness/internal/core/hooks_loop_test.go
+++ b/harness/internal/core/hooks_loop_test.go
@@ -34,6 +34,12 @@ type fakeHookRunner struct {
 	preCalls    int
 	postCalls   []string
 	postCtxErrs []error
+
+	// onPost, when set, is invoked synchronously at the start of
+	// RunPost with the ctx the loop handed in — used by tests that
+	// need to observe or block on that ctx (e.g. simulating an
+	// in-flight hook that only returns once its ctx is cancelled).
+	onPost func(ctx context.Context)
 }
 
 var _ hook.Runner = (*fakeHookRunner)(nil)
@@ -46,6 +52,9 @@ func (f *fakeHookRunner) RunPre(_ context.Context) ([]types.HookExecution, error
 func (f *fakeHookRunner) RunPost(ctx context.Context, outcome string) ([]types.HookExecution, error) {
 	f.postCalls = append(f.postCalls, outcome)
 	f.postCtxErrs = append(f.postCtxErrs, ctx.Err())
+	if f.onPost != nil {
+		f.onPost(ctx)
+	}
 	return f.postResults, f.postErr
 }
 
@@ -194,6 +203,66 @@ func TestLoop_Hooks_PostRunRunsOnTimeout(t *testing.T) {
 	}
 	if hooks.postCtxErrs[0] != nil {
 		t.Errorf("RunPost ctx.Err() = %v, want nil (the detached post-hook ctx must not inherit the expired run ctx)", hooks.postCtxErrs[0])
+	}
+}
+
+// TestLoop_Hooks_PostRunCutShortByShutdownSignal pins the SIGTERM/SIGINT
+// remediation (issue #461 finding #1): a detached postRun hook survives
+// the run's own wall-clock deadline/control-plane cancel (covered by
+// the timeout test above), but a distinct process-shutdown signal on
+// l.Shutdown must still cut it off well before its full configured
+// budget, rather than the hook running unconditionally for up to that
+// budget while an orchestrator's SIGKILL escalation counts down.
+func TestLoop_Hooks_PostRunCutShortByShutdownSignal(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	loop.Shutdown = shutdownCtx
+
+	hookCtxCancelled := make(chan struct{})
+	hooks := &fakeHookRunner{
+		onPost: func(ctx context.Context) {
+			// Simulate a long-running hook (e.g. an artifact upload)
+			// that only returns once its ctx is cancelled — exactly
+			// what a real Executor.Exec does via exec.CommandContext.
+			<-ctx.Done()
+			close(hookCtxCancelled)
+		},
+	}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	// A generous budget the hook would otherwise be entitled to run
+	// for; the shutdown signal must cut it short well before this
+	// elapses.
+	config.Hooks = &types.HooksConfig{PostRun: []types.HookConfig{
+		{Command: "true", TimeoutSeconds: 60},
+	}}
+
+	// Fire the shutdown signal shortly after Run() starts, simulating
+	// a SIGTERM arriving while the postRun hook is in flight.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		shutdownCancel()
+	}()
+
+	start := time.Now()
+	runTrace, err := loop.Run(context.Background(), config)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("Outcome = %q, want success", runTrace.Outcome)
+	}
+	select {
+	case <-hookCtxCancelled:
+	default:
+		t.Error("the in-flight hook's postCtx was never cancelled by the shutdown signal")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Run() took %v, want well under the 60s configured hook timeout (shutdown must cut postRun short)", elapsed)
 	}
 }
 

--- a/harness/internal/core/hooks_loop_test.go
+++ b/harness/internal/core/hooks_loop_test.go
@@ -102,6 +102,53 @@ func TestLoop_Hooks_PreRunFatalFailure_SetsSetupFailedZeroTurns(t *testing.T) {
 	}
 }
 
+// TestLoop_Hooks_PreRunFatalFailure_EmitsDoneEvent pins issue #461
+// finding #2: a fatal preRun hook failure — routed through
+// finishWithOutcome — must emit a terminal "done" HarnessEvent
+// (StopReason=outcome), not just the pre-existing "error" event.
+// Without this, a control plane watching for the documented terminal
+// "done" event (docs/deployment.md) never sees one for this outcome,
+// and the CLI entrypoints' RunResult/resultSink emission — gated on a
+// non-nil RunTrace, not on this event — was a separate but related gap
+// fixed alongside it (see cmd/harness.go, cmd/job.go).
+func TestLoop_Hooks_PreRunFatalFailure_EmitsDoneEvent(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+	rec := &recordingTransport{}
+	loop.Transport = rec
+	hooks := &fakeHookRunner{preErr: errSentinelPreHookFailure}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(context.Background(), config)
+	if err == nil {
+		t.Fatal("expected non-nil error from Run() on a fatal pre-run hook failure")
+	}
+	if runTrace.Outcome != "setup_failed" {
+		t.Fatalf("prerequisite: Outcome = %q, want setup_failed", runTrace.Outcome)
+	}
+
+	var sawError, sawDone bool
+	var doneStopReason string
+	for _, ev := range rec.events {
+		switch ev.Type {
+		case "error":
+			sawError = true
+		case "done":
+			sawDone = true
+			doneStopReason = ev.StopReason
+		}
+	}
+	if !sawError {
+		t.Error("expected an \"error\" event on the transport (pre-existing behaviour)")
+	}
+	if !sawDone {
+		t.Fatal("expected a \"done\" event on the transport, got none")
+	}
+	if doneStopReason != "setup_failed" {
+		t.Errorf("done event StopReason = %q, want setup_failed", doneStopReason)
+	}
+}
+
 // TestLoop_Hooks_PreRunFatalFailure_CtxDeadWinsOverSetupFailed pins that
 // a ctx already dead (deadline/cancel) at pre-hook failure time is
 // reported via classifyCtxOutcome, not the generic "setup_failed" — the

--- a/harness/internal/core/hooks_loop_test.go
+++ b/harness/internal/core/hooks_loop_test.go
@@ -291,3 +291,45 @@ func TestLoop_Hooks_RecordedViaHookRecorder(t *testing.T) {
 type discardWriter struct{}
 
 func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestPostHookBudget pins postHookBudget's sizing directly: every
+// loop-level hooks test above drives it only through a nil
+// config.Hooks (the fakeHookRunner tests never set buildTestConfig's
+// Hooks field), which only exercises the "just the 30s margin" branch.
+// This pins the sum-of-effective-timeouts branch that actually sizes
+// the detached post-hook ctx.
+func TestPostHookBudget(t *testing.T) {
+	cases := []struct {
+		name  string
+		hooks *types.HooksConfig
+		want  time.Duration
+	}{
+		{"nil config", nil, 30 * time.Second},
+		{"empty config", &types.HooksConfig{}, 30 * time.Second},
+		{
+			"sums effective postRun timeouts plus margin",
+			&types.HooksConfig{PostRun: []types.HookConfig{
+				{Command: "true", TimeoutSeconds: 120},
+				{Command: "true", TimeoutSeconds: 60},
+			}},
+			(120 + 60 + 30) * time.Second,
+		},
+		{
+			"zero timeout resolves to default before summing",
+			&types.HooksConfig{PostRun: []types.HookConfig{{Command: "true"}}},
+			(time.Duration(types.DefaultHookTimeoutSeconds) + 30) * time.Second,
+		},
+		{
+			"preRun entries do not contribute",
+			&types.HooksConfig{PreRun: []types.HookConfig{{Command: "true", TimeoutSeconds: 900}}},
+			30 * time.Second,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := postHookBudget(tc.hooks); got != tc.want {
+				t.Errorf("postHookBudget(%+v) = %v, want %v", tc.hooks, got, tc.want)
+			}
+		})
+	}
+}

--- a/harness/internal/core/hooks_loop_test.go
+++ b/harness/internal/core/hooks_loop_test.go
@@ -1,0 +1,293 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/hook"
+	"github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// errSentinelPreHookFailure / errSentinelPostHookFailure are the fixed
+// errors fakeHookRunner returns to simulate a fatal hook failure in the
+// lifecycle-hook integration tests below.
+var (
+	errSentinelPreHookFailure  = errors.New("preRun hook: simulated fatal failure")
+	errSentinelPostHookFailure = errors.New("postRun hook: simulated fatal failure")
+)
+
+// fakeHookRunner is a test double for hook.Runner used by the agentic
+// loop's lifecycle-hook integration tests (issue #461). It records every
+// RunPost call's outcome argument (and the ctx's own Err() at call time,
+// so tests can assert the detached post-hook ctx is not already dead)
+// without needing a real Executor.
+type fakeHookRunner struct {
+	preResults  []types.HookExecution
+	preErr      error
+	postResults []types.HookExecution
+	postErr     error
+
+	preCalls    int
+	postCalls   []string
+	postCtxErrs []error
+}
+
+var _ hook.Runner = (*fakeHookRunner)(nil)
+
+func (f *fakeHookRunner) RunPre(_ context.Context) ([]types.HookExecution, error) {
+	f.preCalls++
+	return f.preResults, f.preErr
+}
+
+func (f *fakeHookRunner) RunPost(ctx context.Context, outcome string) ([]types.HookExecution, error) {
+	f.postCalls = append(f.postCalls, outcome)
+	f.postCtxErrs = append(f.postCtxErrs, ctx.Err())
+	return f.postResults, f.postErr
+}
+
+func simpleSuccessProvider() *mockProvider {
+	return &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "done"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+}
+
+// TestLoop_Hooks_PreRunFatalFailure_SetsSetupFailedZeroTurns pins the
+// preRun-fatal-failure path: outcome is "setup_failed", zero turns ran
+// (Run() returns before Git.Setup / the inner loop), and RunPost is
+// never called since Run() returns early.
+func TestLoop_Hooks_PreRunFatalFailure_SetsSetupFailedZeroTurns(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+	hooks := &fakeHookRunner{preErr: errSentinelPreHookFailure}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(context.Background(), config)
+	// finishWithOutcome mirrors finishWithError's existing contract
+	// (see TestLoop_PromptBuildError): the underlying hook error is
+	// still surfaced as Run()'s Go error, alongside the populated
+	// RunTrace reporting the classified outcome.
+	if err == nil {
+		t.Fatal("expected non-nil error from Run() on a fatal pre-run hook failure")
+	}
+	if !strings.Contains(err.Error(), "pre-run hooks") {
+		t.Errorf("error must mention pre-run hooks, got: %v", err)
+	}
+	if runTrace.Outcome != "setup_failed" {
+		t.Errorf("Outcome = %q, want setup_failed", runTrace.Outcome)
+	}
+	if runTrace.Turns != 0 {
+		t.Errorf("Turns = %d, want 0 (the inner loop must never start)", runTrace.Turns)
+	}
+	if hooks.preCalls != 1 {
+		t.Errorf("RunPre called %d times, want 1", hooks.preCalls)
+	}
+	if len(hooks.postCalls) != 0 {
+		t.Errorf("RunPost called %d times, want 0 (post is skipped after a pre-run failure)", len(hooks.postCalls))
+	}
+}
+
+// TestLoop_Hooks_PreRunFatalFailure_CtxDeadWinsOverSetupFailed pins that
+// a ctx already dead (deadline/cancel) at pre-hook failure time is
+// reported via classifyCtxOutcome, not the generic "setup_failed" — the
+// hook almost certainly failed because the deadline hit.
+func TestLoop_Hooks_PreRunFatalFailure_CtxDeadWinsOverSetupFailed(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+	hooks := &fakeHookRunner{preErr: errSentinelPreHookFailure}
+	loop.Hooks = hooks
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // plain cancel, no cause -> classifyCtxOutcome resolves "cancelled"
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(ctx, config)
+	if err == nil {
+		t.Fatal("expected non-nil error from Run() on a fatal pre-run hook failure")
+	}
+	if runTrace.Outcome != "cancelled" {
+		t.Errorf("Outcome = %q, want cancelled (ctx-cause classification must win over setup_failed)", runTrace.Outcome)
+	}
+}
+
+// TestLoop_Hooks_PostRunFatalFailure_OverridesSuccessOnly pins the
+// outcome-override rule: a fatal postRun failure turns an otherwise-
+// successful run's outcome into "hook_failed".
+func TestLoop_Hooks_PostRunFatalFailure_OverridesSuccessOnly(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+	hooks := &fakeHookRunner{postErr: errSentinelPostHookFailure}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "hook_failed" {
+		t.Errorf("Outcome = %q, want hook_failed", runTrace.Outcome)
+	}
+	if len(hooks.postCalls) != 1 || hooks.postCalls[0] != "success" {
+		t.Errorf("RunPost outcomes = %v, want [\"success\"]", hooks.postCalls)
+	}
+}
+
+// TestLoop_Hooks_PostRunFatalFailure_DoesNotMaskNonSuccessOutcome pins
+// the "never mask the primary failure cause" rule: when the run's own
+// outcome is already non-success (max_turns here), a fatal postRun
+// failure must not overwrite it with "hook_failed".
+func TestLoop_Hooks_PostRunFatalFailure_DoesNotMaskNonSuccessOutcome(t *testing.T) {
+	loop := buildTestLoop(nil)
+	loop.Provider = &infiniteToolCallProvider{}
+	hooks := &fakeHookRunner{postErr: errSentinelPostHookFailure}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	config.MaxTurns = 3
+
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "max_turns" {
+		t.Errorf("Outcome = %q, want max_turns (must not be masked by the post-hook failure)", runTrace.Outcome)
+	}
+	if len(hooks.postCalls) != 1 || hooks.postCalls[0] != "max_turns" {
+		t.Errorf("RunPost outcomes = %v, want [\"max_turns\"] (post still runs on every outcome by default)", hooks.postCalls)
+	}
+}
+
+// TestLoop_Hooks_PostRunRunsOnTimeout pins two things at once: postRun
+// hooks run on every outcome by default (including "timeout"), and the
+// detached ctx handed to RunPost is not already dead even though the
+// run's own wall-clock ctx has already expired by that point.
+func TestLoop_Hooks_PostRunRunsOnTimeout(t *testing.T) {
+	loop := buildTestLoop(nil)
+	loop.Provider = &fireAndCloseProvider{
+		onStream: func() {
+			// Block long enough for the 50ms deadline below to fire
+			// before the next turn boundary ctx check, matching the
+			// existing TestLoop_CancelAttribute_Deadline pattern.
+			time.Sleep(150 * time.Millisecond)
+		},
+	}
+	hooks := &fakeHookRunner{}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	runTrace, err := loop.Run(ctx, config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "timeout" {
+		t.Fatalf("prerequisite: Outcome = %q, want timeout", runTrace.Outcome)
+	}
+	if len(hooks.postCalls) != 1 || hooks.postCalls[0] != "timeout" {
+		t.Fatalf("RunPost outcomes = %v, want [\"timeout\"]", hooks.postCalls)
+	}
+	if hooks.postCtxErrs[0] != nil {
+		t.Errorf("RunPost ctx.Err() = %v, want nil (the detached post-hook ctx must not inherit the expired run ctx)", hooks.postCtxErrs[0])
+	}
+}
+
+// TestLoop_Hooks_ContinueOnError_EmitsWarningTransportEvent pins that a
+// continueOnError hook failure surfaces as a transport "warning" event
+// and never touches the run's outcome.
+func TestLoop_Hooks_ContinueOnError_EmitsWarningTransportEvent(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+	rec := &recordingTransport{}
+	loop.Transport = rec
+	hooks := &fakeHookRunner{
+		postResults: []types.HookExecution{
+			{Phase: "postRun", Index: 0, Name: "flaky", ContinuedOnError: true, Error: "exit code 1"},
+		},
+	}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("Outcome = %q, want success (continueOnError must never touch outcome)", runTrace.Outcome)
+	}
+
+	var warnings []types.HarnessEvent
+	for _, ev := range rec.events {
+		if ev.Type == "warning" {
+			warnings = append(warnings, ev)
+		}
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warning events = %d, want 1", len(warnings))
+	}
+	if !strings.Contains(warnings[0].Message, "flaky") {
+		t.Errorf("warning message = %q, want it to name the hook", warnings[0].Message)
+	}
+}
+
+// TestLoop_Hooks_HooklessUnchanged pins the byte-for-byte-unchanged
+// guarantee: a run with Hooks left nil (a hand-assembled loop that
+// never configured lifecycle hooks) emits no hooks.* spans and no
+// warning events, and behaves exactly like a pre-#461 run.
+func TestLoop_Hooks_HooklessUnchanged(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+	rec := &recordingTransport{}
+	loop.Transport = rec
+	// loop.Hooks intentionally left nil.
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if runTrace.Outcome != "success" {
+		t.Errorf("Outcome = %q, want success", runTrace.Outcome)
+	}
+	for _, ev := range rec.events {
+		if ev.Type == "warning" {
+			t.Errorf("unexpected warning event on a hookless run: %+v", ev)
+		}
+	}
+}
+
+// TestLoop_Hooks_RecordedViaHookRecorder pins that hook results reach
+// RunTrace.HookResults end-to-end through the real JSONL emitter's
+// optional HookRecorder capability, not just through the fake in these
+// other tests.
+func TestLoop_Hooks_RecordedViaHookRecorder(t *testing.T) {
+	loop := buildTestLoop(simpleSuccessProvider())
+	loop.Trace = trace.NewJSONLTraceEmitter(discardWriter{})
+	hooks := &fakeHookRunner{
+		preResults:  []types.HookExecution{{Phase: "preRun", Index: 0, Name: "clone", ExitCode: 0}},
+		postResults: []types.HookExecution{{Phase: "postRun", Index: 0, Name: "smoke", ExitCode: 0}},
+	}
+	loop.Hooks = hooks
+
+	config := buildTestConfig()
+	runTrace, err := loop.Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(runTrace.HookResults) != 2 {
+		t.Fatalf("HookResults = %d entries, want 2", len(runTrace.HookResults))
+	}
+	if runTrace.HookResults[0].Name != "clone" || runTrace.HookResults[1].Name != "smoke" {
+		t.Errorf("HookResults = %+v, want [clone, smoke] in order", runTrace.HookResults)
+	}
+}
+
+// discardWriter is a minimal io.Writer that discards everything, used
+// where a test needs a real JSONLTraceEmitter but does not care about
+// the on-disk bytes.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -197,6 +197,36 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 		recorder.RecordSystemInstructions(systemPrompt)
 	}
 
+	// Pre-run lifecycle hooks (issue #461): operator-authored setup
+	// (clone, provision a runtime) that must complete before
+	// Git.Setup — the deterministic git strategy assumes an existing
+	// checkout, so a clone hook has to create it first. Runs under
+	// runCtx: it counts against the run's wall-clock timeout and
+	// heartbeats are already flowing (started above). A nil Hooks (no
+	// HooksConfig, or a hand-assembled loop that left it unset) is a
+	// no-op, mirroring GuardRail/RuleOfTwo.
+	if l.Hooks != nil {
+		_, preHookSpan := l.Tracer.Start(l.traceCtx(runCtx), "hooks.preRun")
+		preResults, preErr := l.Hooks.RunPre(runCtx)
+		l.recordHookExecutions(preResults)
+		if preErr != nil {
+			preHookSpan.RecordError(preErr)
+			preHookSpan.SetStatus(codes.Error, preErr.Error())
+		}
+		preHookSpan.End()
+		if preErr != nil {
+			// A dead run ctx (timeout/cancel) wins over setup_failed:
+			// the hook almost certainly failed *because* the deadline
+			// hit or a control-plane cancel arrived mid-exec, and that
+			// is the more useful outcome to report.
+			outcome := "setup_failed"
+			if runCtx.Err() != nil {
+				outcome = classifyCtxOutcome(context.Cause(runCtx))
+			}
+			return l.finishWithOutcome(runCtx, outcome, fmt.Errorf("pre-run hooks: %w", preErr))
+		}
+	}
+
 	// Set up git workspace.
 	_, gitSetupSpan := l.Tracer.Start(l.traceCtx(runCtx), "git.setup")
 	if err := l.Git.Setup(runCtx, config.Executor.Workspace, config.RunID); err != nil {
@@ -345,6 +375,35 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 		})
 	}
 	finaliseSpan.End()
+
+	// Post-run lifecycle hooks (issue #461): artifact submission, smoke
+	// tests. Runs after outcome classification and Git.Finalise, before
+	// the "done" event, on a ctx detached from the run's wall-clock
+	// timeout/cancellation (context.WithoutCancel) so a hook that
+	// outlives the deadline (e.g. uploading a large artifact) can still
+	// finish; bounded by the sum of the configured postRun timeouts
+	// plus a 30s margin so a misbehaving hook cannot hang the process
+	// forever. Skipped entirely when the pre-run phase already failed —
+	// Run() returned above in that case, so this point is never
+	// reached. A fatal post-hook failure overrides outcome to
+	// "hook_failed" only when outcome was "success": the primary
+	// failure cause must never be masked, and it stays visible via
+	// HookResults / RunResult.HookFailures regardless.
+	if l.Hooks != nil {
+		postCtx, postCancel := context.WithTimeout(context.WithoutCancel(ctx), postHookBudget(config.Hooks))
+		_, postHookSpan := l.Tracer.Start(l.traceCtx(ctx), "hooks.postRun")
+		postResults, postErr := l.Hooks.RunPost(postCtx, outcome)
+		l.recordHookExecutions(postResults)
+		if postErr != nil {
+			postHookSpan.RecordError(postErr)
+			postHookSpan.SetStatus(codes.Error, postErr.Error())
+		}
+		postHookSpan.End()
+		postCancel()
+		if postErr != nil && outcome == "success" {
+			outcome = "hook_failed"
+		}
+	}
 
 	l.Logger.Info("run finished", "outcome", outcome)
 
@@ -1639,15 +1698,82 @@ func lastAssistantText(blocks []types.ContentBlock) string {
 	return strings.TrimRight(sb.String(), "\n")
 }
 
-// finishWithError records an error outcome and finishes the trace.
+// recordHookExecutions forwards each lifecycle hook result (issue #461)
+// to the trace emitter's optional HookRecorder capability and surfaces a
+// transport "warning" event for any hook that failed but was configured
+// with continueOnError: true — visible to the control plane even though
+// the failure never touches the run's outcome. Mirrors the
+// git.Finalise-failure -> "warning" event precedent elsewhere in Run().
+func (l *AgenticLoop) recordHookExecutions(execs []types.HookExecution) {
+	recorder, hasRecorder := l.Trace.(trace.HookRecorder)
+	for _, exec := range execs {
+		if hasRecorder {
+			recorder.RecordHookExecution(exec)
+		}
+		if !exec.ContinuedOnError {
+			continue
+		}
+		if err := l.Transport.Emit(types.HarnessEvent{
+			Type:    "warning",
+			Message: formatHookWarning(exec),
+		}); err != nil {
+			l.Logger.Warn("transport emit failed", "event", "warning", "error", err)
+		}
+	}
+}
+
+// formatHookWarning renders the transport "warning" message for a
+// continueOnError hook failure. The full Command is deliberately
+// omitted (it can be up to 16KB); Name identifies the hook when the
+// operator supplied one.
+func formatHookWarning(exec types.HookExecution) string {
+	label := fmt.Sprintf("%s hook %d", exec.Phase, exec.Index)
+	if exec.Name != "" {
+		label = fmt.Sprintf("%s (%s)", label, exec.Name)
+	}
+	if exec.Error == "" {
+		return label + " failed and continued"
+	}
+	return fmt.Sprintf("%s failed and continued: %s", label, exec.Error)
+}
+
+// postHookBudget returns the wall-clock budget granted to the detached
+// post-hook ctx (issue #461): the sum of every postRun hook's effective
+// timeout (the worst case where every hook actually runs to its own
+// timeout) plus a 30s margin, so artifact submission and smoke tests can
+// still complete even after the run's own wall-clock timeout has
+// expired. A nil or hookless config resolves to just the 30s margin so
+// the detached ctx is never unbounded. ValidateRunConfig bounds the sum
+// to types.MaxHookTimeoutSeconds, so this is bounded regardless of
+// operator input.
+func postHookBudget(hooks *types.HooksConfig) time.Duration {
+	sum := 0
+	if hooks != nil {
+		for _, h := range hooks.PostRun {
+			sum += types.EffectiveHookTimeout(h)
+		}
+	}
+	return time.Duration(sum)*time.Second + 30*time.Second
+}
+
+// finishWithError records an "error" outcome and finishes the trace.
 func (l *AgenticLoop) finishWithError(ctx context.Context, err error) (*types.RunTrace, error) {
+	return l.finishWithOutcome(ctx, "error", err)
+}
+
+// finishWithOutcome is finishWithError's generalisation (issue #461): it
+// records the given outcome — rather than always "error" — and finishes
+// the trace. Used by the preRun hook fatal-failure path, which reports
+// "setup_failed" (or a ctx-cause outcome if the run's own wall-clock
+// timeout/cancel raced the hook failure) instead of the generic "error".
+func (l *AgenticLoop) finishWithOutcome(ctx context.Context, outcome string, err error) (*types.RunTrace, error) {
 	if emitErr := l.Transport.Emit(types.HarnessEvent{
 		Type:    "error",
 		Message: err.Error(),
 	}); emitErr != nil {
 		l.Logger.Warn("transport emit failed", "event", "error", "error", emitErr)
 	}
-	runTrace, traceErr := l.Trace.Finish(ctx, "error")
+	runTrace, traceErr := l.Trace.Finish(ctx, outcome)
 	if traceErr != nil {
 		l.Logger.Warn("trace finish failed", "error", traceErr)
 	}

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -1796,6 +1796,23 @@ func (l *AgenticLoop) finishWithOutcome(ctx context.Context, outcome string, err
 	}); emitErr != nil {
 		l.Logger.Warn("transport emit failed", "event", "error", "error", emitErr)
 	}
+	// Emit "done" with StopReason=outcome, matching the shape of the
+	// normal end-of-Run() emission (loop.go's Run(), immediately before
+	// stopHeartbeat) — this early-return path previously emitted only
+	// "error", so a control plane never saw the terminal "done" event
+	// documented as the definitive end-of-stream signal for a run this
+	// path terminates, and the CLI entrypoints' `if err != nil { return
+	// }` shortcut (see cmd/harness.go, cmd/job.go) meant an operator's
+	// preRun hook failure — outcome "setup_failed" — produced no
+	// structured RunResult at all despite a valid RunTrace existing.
+	// See finishWithOutcome's own doc comment and the cmd-layer fix
+	// this pairs with.
+	if emitErr := l.Transport.Emit(types.HarnessEvent{
+		Type:       "done",
+		StopReason: outcome,
+	}); emitErr != nil {
+		l.Logger.Warn("transport emit failed", "event", "done", "error", emitErr)
+	}
 	runTrace, traceErr := l.Trace.Finish(ctx, outcome)
 	if traceErr != nil {
 		l.Logger.Warn("trace finish failed", "error", traceErr)

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -389,8 +389,31 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	// "hook_failed" only when outcome was "success": the primary
 	// failure cause must never be masked, and it stays visible via
 	// HookResults / RunResult.HookFailures regardless.
+	//
+	// context.WithoutCancel(ctx) detaches postCtx from the run's own
+	// wall-clock deadline / control-plane cancel ONLY — those are the
+	// signals a postRun hook is meant to survive. A genuine process
+	// shutdown (SIGTERM/SIGINT/pod deletion) must still cut it short:
+	// unconditionally surviving up to the full budget while the
+	// orchestrator's SIGKILL escalation counts down (10s on Cloud Run
+	// and `docker stop`, see docs/cloud-run-jobs.md) orphans the
+	// sandbox and drops the trace. l.Shutdown carries that distinct
+	// signal in from the cmd layer; racing postCancel against it keeps
+	// the loop itself free of any signal/env read (CLAUDE.md
+	// invariant) while still terminating promptly. Nil-safe: a
+	// hand-assembled loop (tests, embedders) with no Shutdown set
+	// keeps the budget-only behaviour.
 	if l.Hooks != nil {
 		postCtx, postCancel := context.WithTimeout(context.WithoutCancel(ctx), postHookBudget(config.Hooks))
+		if l.Shutdown != nil {
+			go func() {
+				select {
+				case <-l.Shutdown.Done():
+					postCancel()
+				case <-postCtx.Done():
+				}
+			}()
+		}
 		_, postHookSpan := l.Tracer.Start(l.traceCtx(ctx), "hooks.postRun")
 		postResults, postErr := l.Hooks.RunPost(postCtx, outcome)
 		l.recordHookExecutions(postResults)

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -11,6 +11,7 @@ import (
 
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/git"
+	"github.com/rxbynerd/stirrup/harness/internal/hook"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/harness/internal/trace"
@@ -117,6 +118,12 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 	childConfig.Mode = mode
 	childConfig.MaxTurns = maxTurns
 	childConfig.GitStrategy = types.GitStrategyConfig{Type: "none"}
+	// Lifecycle hooks are parent-run-only (#461): the child gets
+	// hook.Noop regardless of what childConfig.Hooks carries (see
+	// below), so clear the field here too — otherwise a persisted child
+	// trace would carry a HooksConfig the sub-agent never actually ran,
+	// misleading a trace consumer into thinking it did.
+	childConfig.Hooks = nil
 
 	// Permissions: when the parent is a Cedar policy-engine policy, the
 	// sub-agent gets its own clone with parentRunId populated. This is
@@ -150,12 +157,16 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 		Verifier:    verifier.NewNoneVerifier(),
 		Permissions: childPermissions,
 		Git:         git.NewNoneGitStrategy(),
-		Transport:   captureTp,
-		Trace:       childTrace,
-		Tracer:      tracer,
-		Metrics:     parent.Metrics,
-		Logger:      parent.Logger,
-		Security:    parent.Security,
+		// Hooks are parent-run-only (#461): a sub-agent never runs
+		// lifecycle hooks, regardless of what the parent's RunConfig
+		// configured.
+		Hooks:     hook.NewNoop(),
+		Transport: captureTp,
+		Trace:     childTrace,
+		Tracer:    tracer,
+		Metrics:   parent.Metrics,
+		Logger:    parent.Logger,
+		Security:  parent.Security,
 		// Inherit the parent's GuardRail so spawned sub-agents are
 		// not a silent escape hatch around the configured guards.
 		// Without this, an indirect-injection payload could route

--- a/harness/internal/core/subagent_test.go
+++ b/harness/internal/core/subagent_test.go
@@ -407,6 +407,54 @@ func TestSpawnSubAgent_InheritsGuardRail(t *testing.T) {
 	}
 }
 
+// TestSpawnSubAgent_HooksNeverInvokedOnChild pins the inverse of
+// TestSpawnSubAgent_InheritsGuardRail: lifecycle hooks (issue #461) are
+// parent-run-only and must NOT propagate to a spawned sub-agent,
+// regardless of what the parent's AgenticLoop.Hooks or RunConfig.Hooks
+// carry. subagent.go enforces this two ways — childConfig.Hooks is
+// nilled out and the child AgenticLoop is unconditionally given
+// hook.NewNoop() — but SpawnSubAgent exposes neither the child loop nor
+// its resolved config, so there was previously no seam to catch a
+// regression (e.g. an accidental `Hooks: parent.Hooks` on the child
+// literal) without reading source. fakeHookRunner is observably
+// distinguishable from hook.Noop via its call counters; installing it
+// on the *parent* loop and asserting it is never invoked during the
+// child's own Run() proves the child's hook phase is genuinely inert,
+// not just nil-checked away.
+func TestSpawnSubAgent_HooksNeverInvokedOnChild(t *testing.T) {
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "Sub-agent output."},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+
+	parentLoop := buildSubAgentTestLoop(prov)
+	parentHooks := &fakeHookRunner{}
+	parentLoop.Hooks = parentHooks
+
+	parentConfig := buildTestConfig()
+	parentConfig.Hooks = &types.HooksConfig{
+		PreRun: []types.HookConfig{{Name: "clone", Command: "git clone . ."}},
+	}
+
+	result, err := SpawnSubAgent(context.Background(), parentLoop, parentConfig, SubAgentConfig{
+		Prompt: "Do a subtask",
+	})
+	if err != nil {
+		t.Fatalf("SpawnSubAgent() error: %v", err)
+	}
+	if result.Outcome != "success" {
+		t.Fatalf("prerequisite: expected outcome 'success', got %q", result.Outcome)
+	}
+	if parentHooks.preCalls != 0 {
+		t.Errorf("parent's hook.Runner.RunPre called %d times during sub-agent spawn, want 0", parentHooks.preCalls)
+	}
+	if len(parentHooks.postCalls) != 0 {
+		t.Errorf("parent's hook.Runner.RunPost called %d times during sub-agent spawn, want 0", len(parentHooks.postCalls))
+	}
+}
+
 func TestCaptureTransport_RecordsTextDeltas(t *testing.T) {
 	ct := newCaptureTransport()
 

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
 	"github.com/rxbynerd/stirrup/harness/internal/git"
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
+	"github.com/rxbynerd/stirrup/harness/internal/hook"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/permission"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
@@ -90,8 +91,15 @@ type AgenticLoop struct {
 	// ruleoftwo.NewNoop() when the run is unarmed so loop call sites
 	// stay unconditional; hand-assembled loops (tests, embedders) may
 	// leave it nil and the observe helpers no-op, mirroring GuardRail.
-	RuleOfTwo    ruleoftwo.Monitor
-	Escalation   EscalationPolicy // tool-choice missed-tool recovery (#230); nil = disabled
+	RuleOfTwo  ruleoftwo.Monitor
+	Escalation EscalationPolicy // tool-choice missed-tool recovery (#230); nil = disabled
+	// Hooks runs the run's configured lifecycle hooks (#461). Optional,
+	// like GuardRail/RuleOfTwo/Escalation: Run() nil-checks it before
+	// every call, so a hand-assembled loop (tests, embedders) that
+	// leaves it unset sees no behaviour change. The factory always
+	// injects a non-nil value (hook.Noop when the run has no
+	// HooksConfig, or is a sub-agent); *hook.ExecRunner otherwise.
+	Hooks        hook.Runner
 	Transport    transport.Transport
 	Trace        trace.TraceEmitter
 	Tracer       oteltrace.Tracer         // OTel tracer for loop-level spans (noop when not using OTel)

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -99,7 +99,23 @@ type AgenticLoop struct {
 	// leaves it unset sees no behaviour change. The factory always
 	// injects a non-nil value (hook.Noop when the run has no
 	// HooksConfig, or is a sub-agent); *hook.ExecRunner otherwise.
-	Hooks        hook.Runner
+	Hooks hook.Runner
+	// Shutdown, when non-nil, is a process-lifetime context that is
+	// done when the harness has received a process-level shutdown
+	// signal (SIGTERM/SIGINT/pod deletion) — deliberately independent
+	// of the ctx passed to Run(), which carries the run's own
+	// wall-clock deadline and control-plane "cancel" ControlEvent.
+	// The detached postRun hook phase (#461) races its bounded budget
+	// against Shutdown so it can survive a run-deadline/control-plane
+	// cancel (the documented intent) while still observing a genuine
+	// process shutdown promptly, rather than running unconditionally
+	// for up to its full budget while the orchestrator's SIGKILL
+	// escalation counts down. The cmd/factory layer constructs and
+	// injects this — the loop must not read signals or env directly
+	// (CLAUDE.md invariant). Nil-safe: a hand-assembled loop (tests,
+	// embedders) that leaves it unset sees the pre-remediation
+	// behaviour (postRun bounded only by its own budget).
+	Shutdown     context.Context
 	Transport    transport.Transport
 	Trace        trace.TraceEmitter
 	Tracer       oteltrace.Tracer         // OTel tracer for loop-level spans (noop when not using OTel)

--- a/harness/internal/executor/k8s_execcore.go
+++ b/harness/internal/executor/k8s_execcore.go
@@ -462,10 +462,11 @@ func (w *writeCapBuffer) String() string { return w.buf.String() }
 // on a nil network.
 //
 // MaxTimeout deliberately mirrors container.go and local.go (maxTimeout =
-// 5 min). Returning 0 would silently disable timeout clamping in callers
-// that compare against MaxTimeout — and Exec clamps against it. The cap is
-// identical across executors so a caller written against the Executor
-// interface clamps uniformly regardless of which implementation is active.
+// 30 min, raised from 5 min for lifecycle hooks — #461). Returning 0 would
+// silently disable timeout clamping in callers that compare against
+// MaxTimeout — and Exec clamps against it. The cap is identical across
+// executors so a caller written against the Executor interface clamps
+// uniformly regardless of which implementation is active.
 func (e *podExecCore) Capabilities() ExecutorCapabilities {
 	canNetwork := e.network != nil && e.network.Mode != "none"
 	return ExecutorCapabilities{

--- a/harness/internal/executor/local.go
+++ b/harness/internal/executor/local.go
@@ -32,6 +32,13 @@ const (
 	maxTimeout = 30 * time.Minute
 
 	truncatedSuffix = "\n[output truncated at 1MB]"
+
+	// shortCommandKillGrace bounds exec.Cmd.WaitDelay: how long Wait()
+	// blocks on the stdout/stderr pipes after the process is killed on
+	// ctx cancellation, before forcibly closing them. Short — this is
+	// purely to unblock Wait() from an orphaned grandchild holding a
+	// pipe open, not a meaningful timeout in its own right.
+	shortCommandKillGrace = 500 * time.Millisecond
 )
 
 // SecurityEventEmitter is an optional interface for emitting structured security events.
@@ -220,6 +227,19 @@ func (e *LocalExecutor) Exec(ctx context.Context, command string, timeout time.D
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = e.workspace
 	cmd.Env = filteredCommandEnv()
+	// WaitDelay bounds how long Wait() blocks on the stdout/stderr
+	// pipes after the process is killed on ctx cancellation. Without
+	// it, a compound command ("cmd1; sleep N; cmd2") whose later stage
+	// forks a child that inherits the pipe file descriptors leaves
+	// that child as an orphan holding the pipe open after "sh" itself
+	// is SIGKILLed — Wait() then blocks for EOF until the orphan exits
+	// on its own, defeating prompt cancellation entirely (issue #461:
+	// this is what let a postRun hook's shell script outlive a SIGTERM
+	// by the length of its own sleep, discovered via manual E2E
+	// verification of the shutdown-signal fix). shortCommandKillGrace
+	// forcibly closes the pipes shortly after the kill signal so Wait()
+	// returns promptly regardless of what an orphaned grandchild does.
+	cmd.WaitDelay = shortCommandKillGrace
 
 	// Stream into capped writers so peak memory is bounded to ~maxOutputSize
 	// per stream rather than buffering all output. This mirrors

--- a/harness/internal/executor/local.go
+++ b/harness/internal/executor/local.go
@@ -14,10 +14,23 @@ import (
 )
 
 const (
-	maxFileSize     = 10 * 1024 * 1024 // 10 MB
-	maxOutputSize   = 1 * 1024 * 1024  // 1 MB
-	defaultTimeout  = 30 * time.Second
-	maxTimeout      = 5 * time.Minute
+	maxFileSize    = 10 * 1024 * 1024 // 10 MB
+	maxOutputSize  = 1 * 1024 * 1024  // 1 MB
+	defaultTimeout = 30 * time.Second
+
+	// maxTimeout is the hard cap every Executor.Exec implementation
+	// clamps its caller-supplied timeout to. Raised from 5 to 30 minutes
+	// for lifecycle hooks (#461): a cold `bundle install` / dependency
+	// restore in a preRun hook routinely exceeds 5 minutes. Safe to
+	// raise because the *agent-reachable* path (run_command, via
+	// builtins/shell.go's independent 300s clamp) is unaffected — that
+	// clamp is enforced at the tool layer, not derived from this
+	// constant, so raising it does not hand the model any more exec
+	// budget. The test-runner verifier (verifier/testrunner.go) also
+	// gets the extra headroom since it calls Exec directly with its own
+	// timeout, uncapped except by this constant.
+	maxTimeout = 30 * time.Minute
+
 	truncatedSuffix = "\n[output truncated at 1MB]"
 )
 

--- a/harness/internal/executor/local_test.go
+++ b/harness/internal/executor/local_test.go
@@ -253,6 +253,41 @@ func TestExec_Timeout(t *testing.T) {
 	}
 }
 
+// TestExec_KillsOrphanedGrandchildPromptly is a regression test for
+// issue #461's finding #1 remediation: a compound command
+// ("cmd1; sleep N; cmd2") runs its later stages as children the shell
+// forks and waits on, not an exec-replaced process. Without
+// cmd.WaitDelay, killing only the direct "sh" child on ctx cancellation
+// leaves the still-running "sleep" grandchild holding the stdout pipe
+// open, so Exec blocks until the grandchild exits on its own — the
+// exact bug a manual end-to-end SIGTERM test surfaced (a postRun hook
+// outlived its process-shutdown signal by the length of its own
+// sleep). A single-command "sleep N" (see TestExec_Timeout) does not
+// reproduce this: sh execs directly into it with no fork.
+func TestExec_KillsOrphanedGrandchildPromptly(t *testing.T) {
+	exec, _ := newTestExecutor(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := exec.Exec(ctx, "echo start; sleep 30; echo finished", 60*time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the cancelled command")
+	}
+	// Bounded well under the 30s grandchild sleep; generous enough to
+	// be non-flaky (200ms cancel delay + shortCommandKillGrace + CI
+	// scheduling slack), but nowhere near the un-fixed ~30s.
+	if elapsed > 5*time.Second {
+		t.Errorf("Exec took %v after ctx cancellation, want well under 5s (orphaned grandchild must not block Wait())", elapsed)
+	}
+}
+
 func TestExec_MaxTimeoutCapped(t *testing.T) {
 	exec, _ := newTestExecutor(t)
 

--- a/harness/internal/executor/local_test.go
+++ b/harness/internal/executor/local_test.go
@@ -512,3 +512,16 @@ func TestCapabilities(t *testing.T) {
 		t.Errorf("MaxTimeout: got %v, want %v", caps.MaxTimeout, maxTimeout)
 	}
 }
+
+// TestMaxTimeout_Is30Minutes pins the literal cap value itself (issue
+// #461 raised it from 5 to 30 minutes so a cold `bundle install` in a
+// preRun hook has headroom). The other Capabilities() tests across
+// local/container/k8s only compare caps.MaxTimeout against this same
+// package-level maxTimeout constant, which would pass even if the raise
+// were silently reverted; this test is the actual regression tripwire
+// for the cap value.
+func TestMaxTimeout_Is30Minutes(t *testing.T) {
+	if maxTimeout != 30*time.Minute {
+		t.Errorf("maxTimeout = %v, want 30m (issue #461 raised the shared executor cap from 5m)", maxTimeout)
+	}
+}

--- a/harness/internal/hook/hook.go
+++ b/harness/internal/hook/hook.go
@@ -1,0 +1,47 @@
+// Package hook implements lifecycle hooks: operator-authored exec
+// commands that run before the agentic session starts (preRun — clone a
+// repo, provision a runtime) and after it ends (postRun — submit
+// artifacts, run a smoke test). See issue #461.
+//
+// Hook output is trace-only: it is recorded on types.HookExecution and
+// never enters the model's context. Hooks run through the same Executor
+// the agent's tools use, so they share the run's sandbox and network
+// egress posture — there is no separate credential or network surface.
+package hook
+
+import (
+	"context"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// Phase names recorded on types.HookExecution.Phase, and used as the
+// OTel span name suffix ("hooks."+Phase) by the agentic loop.
+const (
+	PhasePreRun  = "preRun"
+	PhasePostRun = "postRun"
+)
+
+// Runner executes a run's configured lifecycle hooks. Injected onto
+// AgenticLoop.Hooks by the factory (Noop when the run has none
+// configured, or is a sub-agent) so the loop's call sites need only a
+// nil-interface check, the same optional-component pattern as
+// GuardRail/RuleOfTwo.
+type Runner interface {
+	// RunPre executes every configured preRun hook, in order, before
+	// GitStrategy.Setup. Returns every hook's result — including any
+	// skipped after a fatal failure, so Index stays aligned with the
+	// configured list — and a non-nil error the instant a
+	// non-continueOnError hook fails. The caller treats a non-nil error
+	// as a fatal phase failure (outcome "setup_failed").
+	RunPre(ctx context.Context) ([]types.HookExecution, error)
+
+	// RunPost executes every configured postRun hook whose RunOn filter
+	// matches outcome, in order, after GitStrategy.Finalise. Returns
+	// every hook's result — runOn-filtered and post-fatal-failure
+	// entries are recorded as Skipped rather than omitted, so Index
+	// stays aligned with the configured list — and a non-nil error the
+	// instant a non-continueOnError hook fails. The caller overrides
+	// outcome to "hook_failed" only when outcome was "success".
+	RunPost(ctx context.Context, outcome string) ([]types.HookExecution, error)
+}

--- a/harness/internal/hook/noop.go
+++ b/harness/internal/hook/noop.go
@@ -1,0 +1,27 @@
+package hook
+
+import (
+	"context"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// Noop is a Runner that executes no hooks. Injected for sub-agent loops
+// (hooks are parent-run-only) and for any run with no HooksConfig, so
+// AgenticLoop.Hooks is never a bare nil interface in production.
+type Noop struct{}
+
+// NewNoop returns a Runner that never dispatches a hook.
+func NewNoop() *Noop {
+	return &Noop{}
+}
+
+// RunPre is a no-op.
+func (*Noop) RunPre(_ context.Context) ([]types.HookExecution, error) {
+	return nil, nil
+}
+
+// RunPost is a no-op.
+func (*Noop) RunPost(_ context.Context, _ string) ([]types.HookExecution, error) {
+	return nil, nil
+}

--- a/harness/internal/hook/noop_test.go
+++ b/harness/internal/hook/noop_test.go
@@ -1,0 +1,25 @@
+package hook
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNoop_ImplementsRunner is a compile-time satisfaction guard.
+func TestNoop_ImplementsRunner(t *testing.T) {
+	var _ Runner = NewNoop()
+}
+
+func TestNoop_RunPreAndRunPostAreNoOps(t *testing.T) {
+	n := NewNoop()
+
+	preResults, preErr := n.RunPre(context.Background())
+	if preErr != nil || preResults != nil {
+		t.Errorf("RunPre() = (%v, %v), want (nil, nil)", preResults, preErr)
+	}
+
+	postResults, postErr := n.RunPost(context.Background(), "success")
+	if postErr != nil || postResults != nil {
+		t.Errorf("RunPost() = (%v, %v), want (nil, nil)", postResults, postErr)
+	}
+}

--- a/harness/internal/hook/runner.go
+++ b/harness/internal/hook/runner.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
@@ -211,5 +212,23 @@ func scrubbedTail(stdout, stderr string) (tail string, truncated bool) {
 	if len(scrubbed) <= maxOutputTailBytes {
 		return scrubbed, false
 	}
-	return scrubbed[len(scrubbed)-maxOutputTailBytes:], true
+	// The byte-index cut below can land mid-rune when a multi-byte UTF-8
+	// character straddles the boundary; trimToRuneBoundary drops the
+	// resulting leading continuation bytes so OutputTail is always valid
+	// UTF-8 rather than json.Marshal silently substituting U+FFFD at the
+	// start of the persisted tail.
+	return trimToRuneBoundary(scrubbed[len(scrubbed)-maxOutputTailBytes:]), true
+}
+
+// trimToRuneBoundary drops any leading bytes of s that are UTF-8
+// continuation bytes (i.e. cannot start a rune), so a caller that
+// sliced s at an arbitrary byte offset gets back a string that starts
+// on a rune boundary. Bounded to at most utf8.UTFMax-1 bytes dropped —
+// the longest a valid rune's continuation-byte run can be.
+func trimToRuneBoundary(s string) string {
+	i := 0
+	for i < len(s) && i < utf8.UTFMax && !utf8.RuneStart(s[i]) {
+		i++
+	}
+	return s[i:]
 }

--- a/harness/internal/hook/runner.go
+++ b/harness/internal/hook/runner.go
@@ -1,0 +1,215 @@
+package hook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// maxOutputTailBytes caps the trace-recorded tail of a hook's combined
+// stdout+stderr. Bounded because hook results are trace-only and
+// persisted verbatim; "tail" (not head) because a failing command's most
+// useful diagnostic — the error summary — is usually printed last.
+const maxOutputTailBytes = 4 * 1024
+
+// ExecRunner is the production hook.Runner: it executes every configured
+// hook via the run's Executor, in order, honouring per-hook timeout
+// resolution, continueOnError, and (for postRun) the RunOn outcome
+// filter. Mirrors the GitStrategy injection pattern: constructed and
+// owned by the factory, held on AgenticLoop.Hooks as the Runner
+// interface.
+type ExecRunner struct {
+	// Hooks is the run's configured HooksConfig. Must be non-nil; the
+	// factory only constructs an ExecRunner when at least one hook is
+	// configured (see buildHookRunner), otherwise it injects Noop.
+	Hooks *types.HooksConfig
+
+	// Exec is the run's Executor. Hooks dispatch through it so they
+	// share the run's sandbox and network egress posture with every
+	// agent tool call.
+	Exec executor.Executor
+
+	// Logger receives per-hook diagnostics. Optional; nil falls back to
+	// slog.Default().
+	Logger *slog.Logger
+}
+
+// RunPre executes every configured preRun hook in order.
+func (r *ExecRunner) RunPre(ctx context.Context) ([]types.HookExecution, error) {
+	if r.Hooks == nil {
+		return nil, nil
+	}
+	return r.run(ctx, PhasePreRun, r.Hooks.PreRun, "", false)
+}
+
+// RunPost executes every configured postRun hook whose RunOn matches
+// outcome, in order.
+func (r *ExecRunner) RunPost(ctx context.Context, outcome string) ([]types.HookExecution, error) {
+	if r.Hooks == nil {
+		return nil, nil
+	}
+	return r.run(ctx, PhasePostRun, r.Hooks.PostRun, outcome, true)
+}
+
+// run executes hooks in order against ctx, applying the RunOn filter
+// (postRun only — applyRunOnFilter is false for preRun, where RunOn is
+// always empty per ValidateRunConfig) and skip-and-mark once a fatal
+// (non-continueOnError) failure occurs. Every hook produces exactly one
+// types.HookExecution — including runOn-filtered and post-fatal-failure
+// entries, marked Skipped — so Index always stays aligned with the
+// configured list. Returns a non-nil error the instant a fatal failure
+// occurs; RunPre/RunPost callers treat that as phase failure.
+func (r *ExecRunner) run(ctx context.Context, phase string, hooks []types.HookConfig, outcome string, applyRunOnFilter bool) ([]types.HookExecution, error) {
+	results := make([]types.HookExecution, 0, len(hooks))
+	var fatalErr error
+
+	for i, h := range hooks {
+		if applyRunOnFilter && !hookRuns(h.RunOn, outcome) {
+			results = append(results, types.HookExecution{
+				Phase: phase, Index: i, Name: h.Name, Command: h.Command, Skipped: true,
+			})
+			continue
+		}
+		if fatalErr != nil {
+			results = append(results, types.HookExecution{
+				Phase: phase, Index: i, Name: h.Name, Command: h.Command, Skipped: true,
+			})
+			continue
+		}
+
+		exec := r.runOne(ctx, phase, i, h)
+		results = append(results, exec)
+
+		if exec.Error != "" && !h.ContinueOnError {
+			fatalErr = fmt.Errorf("%s hook %d (%s) failed: %s", phase, i, hookLabel(h), exec.Error)
+		}
+	}
+
+	return results, fatalErr
+}
+
+// runOne dispatches a single hook through the Executor and builds its
+// types.HookExecution result. Never returns an error directly — failure
+// is reported via the result's Error/TimedOut fields so run's
+// skip-and-mark bookkeeping has a uniform shape to inspect.
+func (r *ExecRunner) runOne(ctx context.Context, phase string, index int, h types.HookConfig) types.HookExecution {
+	result := types.HookExecution{
+		Phase:   phase,
+		Index:   index,
+		Name:    h.Name,
+		Command: h.Command,
+	}
+
+	if r.Exec == nil {
+		result.Error = "hook runner misconfigured: no executor"
+		return result
+	}
+
+	timeout := time.Duration(types.EffectiveHookTimeout(h)) * time.Second
+	if caps := r.Exec.Capabilities(); caps.MaxTimeout > 0 && timeout > caps.MaxTimeout {
+		timeout = caps.MaxTimeout
+	}
+
+	start := time.Now()
+	execResult, err := r.Exec.Exec(ctx, h.Command, timeout)
+	result.DurationMs = time.Since(start).Milliseconds()
+
+	if execResult != nil {
+		result.ExitCode = execResult.ExitCode
+		result.OutputTail, result.Truncated = scrubbedTail(execResult.Stdout, execResult.Stderr)
+	}
+
+	switch {
+	case err != nil:
+		result.TimedOut = isTimeoutErr(err)
+		result.Error = err.Error()
+		result.ContinuedOnError = h.ContinueOnError
+		r.logger().Warn("lifecycle hook failed", "phase", phase, "index", index, "name", h.Name, "error", err)
+	case execResult.ExitCode != 0:
+		result.Error = fmt.Sprintf("exit code %d", execResult.ExitCode)
+		result.ContinuedOnError = h.ContinueOnError
+		r.logger().Warn("lifecycle hook exited non-zero", "phase", phase, "index", index, "name", h.Name, "exitCode", execResult.ExitCode)
+	default:
+		r.logger().Debug("lifecycle hook succeeded", "phase", phase, "index", index, "name", h.Name, "durationMs", result.DurationMs)
+	}
+
+	return result
+}
+
+func (r *ExecRunner) logger() *slog.Logger {
+	if r.Logger != nil {
+		return r.Logger
+	}
+	return slog.Default()
+}
+
+// hookRuns reports whether a postRun hook with the given RunOn value
+// should execute for outcome. Empty and "always" run unconditionally;
+// "success" / "failure" gate on whether outcome == "success".
+func hookRuns(runOn, outcome string) bool {
+	switch runOn {
+	case "success":
+		return outcome == "success"
+	case "failure":
+		return outcome != "success"
+	default:
+		// "" and "always"; ValidateRunConfig rejects any other value,
+		// but default-to-run is the safe interpretation for an
+		// unrecognised value reaching here regardless.
+		return true
+	}
+}
+
+// hookLabel returns the identifier used in fatalErr messages: the
+// operator-supplied Name when present, otherwise a positional fallback
+// (the full Command can be up to 16KB and is not suitable for an error
+// string).
+func hookLabel(h types.HookConfig) string {
+	if h.Name != "" {
+		return h.Name
+	}
+	return "unnamed"
+}
+
+// isTimeoutErr reports whether err represents a hook execution that was
+// killed by its timeout rather than failing on its own. Executor
+// implementations signal this differently: k8s_execcore.go returns the
+// context error verbatim (context.DeadlineExceeded), while local.go and
+// container.go wrap it in a formatted "command timed out after %s"
+// string with no %w. The substring check covers the latter shape.
+func isTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return strings.Contains(err.Error(), "timed out")
+}
+
+// scrubbedTail returns the scrubbed (security.Scrub), 4KB-tail-capped
+// combined stdout+stderr for a hook result, along with whether the
+// persisted (scrubbed) output exceeded the cap. Scrubbing runs over the
+// full combined text before truncation so a secret pattern straddling
+// the truncation boundary is still matched.
+func scrubbedTail(stdout, stderr string) (tail string, truncated bool) {
+	combined := stdout
+	if stderr != "" {
+		if combined != "" {
+			combined += "\n"
+		}
+		combined += stderr
+	}
+	scrubbed := security.Scrub(combined)
+	if len(scrubbed) <= maxOutputTailBytes {
+		return scrubbed, false
+	}
+	return scrubbed[len(scrubbed)-maxOutputTailBytes:], true
+}

--- a/harness/internal/hook/runner_test.go
+++ b/harness/internal/hook/runner_test.go
@@ -1,0 +1,410 @@
+package hook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeExecCall records one Exec invocation for assertions on dispatch
+// order and the timeout ExecRunner resolved for it.
+type fakeExecCall struct {
+	command string
+	timeout time.Duration
+}
+
+// fakeExecutor implements executor.Executor for hook.Runner unit tests.
+// Only Exec and Capabilities are exercised by ExecRunner; the file-I/O
+// methods are unreachable from this package and simply error if called.
+type fakeExecutor struct {
+	caps     executor.ExecutorCapabilities
+	execFunc func(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error)
+	calls    []fakeExecCall
+}
+
+func newFakeExecutor() *fakeExecutor {
+	return &fakeExecutor{
+		caps: executor.ExecutorCapabilities{
+			CanRead: true, CanWrite: true, CanExec: true, CanNetwork: true,
+			MaxTimeout: 30 * time.Minute,
+		},
+	}
+}
+
+func (f *fakeExecutor) ReadFile(context.Context, string) (string, error) {
+	return "", errors.New("fakeExecutor: ReadFile not implemented")
+}
+
+func (f *fakeExecutor) WriteFile(context.Context, string, string) error {
+	return errors.New("fakeExecutor: WriteFile not implemented")
+}
+
+func (f *fakeExecutor) ListDirectory(context.Context, string) ([]string, error) {
+	return nil, errors.New("fakeExecutor: ListDirectory not implemented")
+}
+
+func (f *fakeExecutor) ResolvePath(relativePath string) (string, error) {
+	return relativePath, nil
+}
+
+func (f *fakeExecutor) Capabilities() executor.ExecutorCapabilities {
+	return f.caps
+}
+
+func (f *fakeExecutor) Exec(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error) {
+	f.calls = append(f.calls, fakeExecCall{command: command, timeout: timeout})
+	if f.execFunc != nil {
+		return f.execFunc(ctx, command, timeout)
+	}
+	return &executor.ExecResult{ExitCode: 0}, nil
+}
+
+func succeedingHook(name string) types.HookConfig {
+	return types.HookConfig{Name: name, Command: "echo " + name}
+}
+
+// TestExecRunner_ImplementsRunner is a compile-time satisfaction guard.
+func TestExecRunner_ImplementsRunner(t *testing.T) {
+	var _ Runner = (*ExecRunner)(nil)
+}
+
+func TestExecRunner_RunPre_Ordering(t *testing.T) {
+	exec := newFakeExecutor()
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{
+			succeedingHook("first"), succeedingHook("second"), succeedingHook("third"),
+		}},
+		Exec: exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err != nil {
+		t.Fatalf("RunPre() error = %v, want nil", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	wantOrder := []string{"echo first", "echo second", "echo third"}
+	for i, call := range exec.calls {
+		if call.command != wantOrder[i] {
+			t.Errorf("call[%d].command = %q, want %q", i, call.command, wantOrder[i])
+		}
+	}
+	for i, res := range results {
+		if res.Phase != PhasePreRun {
+			t.Errorf("results[%d].Phase = %q, want %q", i, res.Phase, PhasePreRun)
+		}
+		if res.Index != i {
+			t.Errorf("results[%d].Index = %d, want %d", i, res.Index, i)
+		}
+		if res.Skipped || res.Error != "" {
+			t.Errorf("results[%d] unexpectedly failed/skipped: %+v", i, res)
+		}
+	}
+}
+
+func TestExecRunner_RunPre_FatalFailureSkipsRemaining(t *testing.T) {
+	exec := newFakeExecutor()
+	exec.execFunc = func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+		if command == "false" {
+			return &executor.ExecResult{ExitCode: 1}, nil
+		}
+		return &executor.ExecResult{ExitCode: 0}, nil
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{
+			{Name: "ok", Command: "true"},
+			{Name: "boom", Command: "false"},
+			{Name: "never-runs", Command: "true"},
+		}},
+		Exec: exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err == nil {
+		t.Fatal("RunPre() error = nil, want non-nil after a fatal hook failure")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error must name the failing hook, got: %v", err)
+	}
+	if len(exec.calls) != 2 {
+		t.Fatalf("Exec called %d times, want 2 (dispatch must stop after the fatal failure)", len(exec.calls))
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3 (skipped entries still recorded, Index-aligned)", len(results))
+	}
+	if results[0].Skipped || results[0].Error != "" {
+		t.Errorf("results[0] must have succeeded: %+v", results[0])
+	}
+	if results[1].Skipped || results[1].Error == "" {
+		t.Errorf("results[1] must record the failure, not a skip: %+v", results[1])
+	}
+	if !results[2].Skipped {
+		t.Errorf("results[2] must be Skipped after the fatal failure: %+v", results[2])
+	}
+	if results[2].Name != "never-runs" {
+		t.Errorf("results[2].Name = %q, want %q (Index alignment)", results[2].Name, "never-runs")
+	}
+}
+
+func TestExecRunner_ContinueOnError_DispatchContinuesAndPhaseSucceeds(t *testing.T) {
+	exec := newFakeExecutor()
+	exec.execFunc = func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
+		if command == "false" {
+			return &executor.ExecResult{ExitCode: 1}, nil
+		}
+		return &executor.ExecResult{ExitCode: 0}, nil
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{
+			{Name: "soft-fail", Command: "false", ContinueOnError: true},
+			{Name: "still-runs", Command: "true"},
+		}},
+		Exec: exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err != nil {
+		t.Fatalf("RunPre() error = %v, want nil (only continueOnError hook failed)", err)
+	}
+	if len(exec.calls) != 2 {
+		t.Fatalf("Exec called %d times, want 2 (continueOnError must not stop the phase)", len(exec.calls))
+	}
+	if !results[0].ContinuedOnError || results[0].Error == "" {
+		t.Errorf("results[0] must record ContinuedOnError with an Error, got: %+v", results[0])
+	}
+	if results[1].Skipped {
+		t.Errorf("results[1] must not be skipped: %+v", results[1])
+	}
+}
+
+func TestExecRunner_TimedOut(t *testing.T) {
+	exec := newFakeExecutor()
+	exec.execFunc = func(_ context.Context, _ string, timeout time.Duration) (*executor.ExecResult, error) {
+		return &executor.ExecResult{ExitCode: -1}, fmt.Errorf("command timed out after %s", timeout)
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "slow", Command: "sleep 999", TimeoutSeconds: 1}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err == nil {
+		t.Fatal("RunPre() error = nil, want non-nil for a timed-out fatal hook")
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if !results[0].TimedOut {
+		t.Errorf("results[0].TimedOut = false, want true")
+	}
+	if !strings.Contains(results[0].Error, "timed out") {
+		t.Errorf("results[0].Error = %q, want it to mention the timeout", results[0].Error)
+	}
+}
+
+func TestExecRunner_DeadlineExceededTimedOut(t *testing.T) {
+	// k8s_execcore.go's Exec returns the context error verbatim rather
+	// than a formatted "timed out" string (see isTimeoutErr's doc
+	// comment) — pin that shape is also classified as TimedOut.
+	exec := newFakeExecutor()
+	exec.execFunc = func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+		return nil, context.DeadlineExceeded
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "slow", Command: "sleep 999"}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err == nil {
+		t.Fatal("RunPre() error = nil, want non-nil")
+	}
+	if !results[0].TimedOut {
+		t.Errorf("results[0].TimedOut = false, want true for context.DeadlineExceeded")
+	}
+}
+
+func TestExecRunner_TruncationAndScrub(t *testing.T) {
+	secret := "AKIAABCDEFGHIJKLMNOP" // matches the aws_access_key_id pattern
+	longOutput := strings.Repeat("x", maxOutputTailBytes*2) + secret
+
+	exec := newFakeExecutor()
+	exec.execFunc = func(context.Context, string, time.Duration) (*executor.ExecResult, error) {
+		return &executor.ExecResult{ExitCode: 0, Stdout: longOutput}, nil
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "chatty", Command: "true"}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err != nil {
+		t.Fatalf("RunPre() error = %v, want nil", err)
+	}
+	if !results[0].Truncated {
+		t.Error("results[0].Truncated = false, want true")
+	}
+	if len(results[0].OutputTail) > maxOutputTailBytes {
+		t.Errorf("len(OutputTail) = %d, want <= %d", len(results[0].OutputTail), maxOutputTailBytes)
+	}
+	if strings.Contains(results[0].OutputTail, secret) {
+		t.Errorf("OutputTail leaked the unscrubbed secret: %q", results[0].OutputTail)
+	}
+}
+
+func TestExecRunner_RunPost_RunOnMatrix(t *testing.T) {
+	cases := []struct {
+		runOn       string
+		outcome     string
+		wantSkipped bool
+	}{
+		{"", "success", false},
+		{"", "error", false},
+		{"always", "success", false},
+		{"always", "error", false},
+		{"success", "success", false},
+		{"success", "error", true},
+		{"failure", "success", true},
+		{"failure", "error", false},
+		{"failure", "timeout", false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("runOn=%s/outcome=%s", tc.runOn, tc.outcome), func(t *testing.T) {
+			exec := newFakeExecutor()
+			r := &ExecRunner{
+				Hooks: &types.HooksConfig{PostRun: []types.HookConfig{{Name: "h", Command: "true", RunOn: tc.runOn}}},
+				Exec:  exec,
+			}
+			results, err := r.RunPost(context.Background(), tc.outcome)
+			if err != nil {
+				t.Fatalf("RunPost() error = %v, want nil", err)
+			}
+			if results[0].Skipped != tc.wantSkipped {
+				t.Errorf("Skipped = %v, want %v", results[0].Skipped, tc.wantSkipped)
+			}
+			gotDispatched := len(exec.calls) == 1
+			if gotDispatched == tc.wantSkipped {
+				t.Errorf("dispatched = %v, want dispatched == !Skipped", gotDispatched)
+			}
+		})
+	}
+}
+
+// TestExecRunner_RunPost_DeadCtx pins that RunPost handles an
+// already-cancelled ctx (e.g. the loop's detached post-hook budget
+// expired mid-run) by surfacing the resulting error on the
+// HookExecution rather than panicking or hanging.
+func TestExecRunner_RunPost_DeadCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	exec := newFakeExecutor()
+	exec.execFunc = func(ctx context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+		return nil, ctx.Err()
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PostRun: []types.HookConfig{{Name: "artifact-submit", Command: "true"}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPost(ctx, "success")
+	if err == nil {
+		t.Fatal("RunPost() error = nil, want non-nil for a dead ctx")
+	}
+	if results[0].Error == "" {
+		t.Error("results[0].Error is empty, want the ctx-cancelled error surfaced")
+	}
+}
+
+// TestExecRunner_RunPost_BudgetExpiryMidHook pins the detached-ctx
+// budget-expiry scenario: a deadline that expires while the hook is
+// still "running" (from the fake executor's perspective) must surface
+// as a TimedOut result, not hang RunPost.
+func TestExecRunner_RunPost_BudgetExpiryMidHook(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond) // guarantee the deadline has passed
+
+	exec := newFakeExecutor()
+	exec.execFunc = func(ctx context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+		return nil, ctx.Err()
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PostRun: []types.HookConfig{{Name: "upload", Command: "true"}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPost(ctx, "success")
+	if err == nil {
+		t.Fatal("RunPost() error = nil, want non-nil")
+	}
+	if !results[0].TimedOut {
+		t.Errorf("results[0].TimedOut = false, want true for an expired detached-ctx budget")
+	}
+}
+
+func TestExecRunner_CapabilityGuard_ClampsToMaxTimeout(t *testing.T) {
+	exec := newFakeExecutor()
+	exec.caps.MaxTimeout = 10 * time.Second
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "h", Command: "true", TimeoutSeconds: 1800}}},
+		Exec:  exec,
+	}
+
+	if _, err := r.RunPre(context.Background()); err != nil {
+		t.Fatalf("RunPre() error = %v, want nil", err)
+	}
+	if len(exec.calls) != 1 {
+		t.Fatalf("Exec called %d times, want 1", len(exec.calls))
+	}
+	if exec.calls[0].timeout != exec.caps.MaxTimeout {
+		t.Errorf("dispatched timeout = %v, want clamped to Capabilities().MaxTimeout = %v", exec.calls[0].timeout, exec.caps.MaxTimeout)
+	}
+}
+
+func TestExecRunner_EffectiveTimeoutDefaultsWhenUnset(t *testing.T) {
+	exec := newFakeExecutor()
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "h", Command: "true"}}},
+		Exec:  exec,
+	}
+	if _, err := r.RunPre(context.Background()); err != nil {
+		t.Fatalf("RunPre() error = %v, want nil", err)
+	}
+	want := time.Duration(types.DefaultHookTimeoutSeconds) * time.Second
+	if exec.calls[0].timeout != want {
+		t.Errorf("dispatched timeout = %v, want default %v", exec.calls[0].timeout, want)
+	}
+}
+
+func TestExecRunner_NilExecutor(t *testing.T) {
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "h", Command: "true"}}},
+	}
+	results, err := r.RunPre(context.Background())
+	if err == nil {
+		t.Fatal("RunPre() error = nil, want non-nil for a misconfigured (nil Exec) runner")
+	}
+	if results[0].Error == "" {
+		t.Error("results[0].Error is empty, want a misconfiguration message")
+	}
+}
+
+func TestExecRunner_NilHooksConfig(t *testing.T) {
+	r := &ExecRunner{Exec: newFakeExecutor()}
+	preResults, preErr := r.RunPre(context.Background())
+	if preErr != nil || preResults != nil {
+		t.Errorf("RunPre() with nil Hooks = (%v, %v), want (nil, nil)", preResults, preErr)
+	}
+	postResults, postErr := r.RunPost(context.Background(), "success")
+	if postErr != nil || postResults != nil {
+		t.Errorf("RunPost() with nil Hooks = (%v, %v), want (nil, nil)", postResults, postErr)
+	}
+}

--- a/harness/internal/hook/runner_test.go
+++ b/harness/internal/hook/runner_test.go
@@ -259,6 +259,32 @@ func TestExecRunner_TruncationAndScrub(t *testing.T) {
 	}
 }
 
+// TestExecRunner_StderrOnlyOutput pins scrubbedTail's stderr-only
+// branch: when a hook writes nothing to stdout, the recorded OutputTail
+// must be exactly the (scrubbed) stderr text, with no spurious leading
+// newline from the stdout/stderr join logic.
+func TestExecRunner_StderrOnlyOutput(t *testing.T) {
+	exec := newFakeExecutor()
+	exec.execFunc = func(context.Context, string, time.Duration) (*executor.ExecResult, error) {
+		return &executor.ExecResult{ExitCode: 0, Stderr: "warning: something"}, nil
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "stderr-only", Command: "true"}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err != nil {
+		t.Fatalf("RunPre() error = %v, want nil", err)
+	}
+	if results[0].OutputTail != "warning: something" {
+		t.Errorf("OutputTail = %q, want %q (no leading newline for stderr-only output)", results[0].OutputTail, "warning: something")
+	}
+	if results[0].Truncated {
+		t.Error("Truncated = true, want false for short output")
+	}
+}
+
 func TestExecRunner_RunPost_RunOnMatrix(t *testing.T) {
 	cases := []struct {
 		runOn       string

--- a/harness/internal/hook/runner_test.go
+++ b/harness/internal/hook/runner_test.go
@@ -19,17 +19,17 @@ type fakeExecCall struct {
 	timeout time.Duration
 }
 
-// fakeExecutor implements executor.Executor for hook.Runner unit tests.
+// mockExecutor implements executor.Executor for hook.Runner unit tests.
 // Only Exec and Capabilities are exercised by ExecRunner; the file-I/O
 // methods are unreachable from this package and simply error if called.
-type fakeExecutor struct {
+type mockExecutor struct {
 	caps     executor.ExecutorCapabilities
 	execFunc func(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error)
 	calls    []fakeExecCall
 }
 
-func newFakeExecutor() *fakeExecutor {
-	return &fakeExecutor{
+func newMockExecutor() *mockExecutor {
+	return &mockExecutor{
 		caps: executor.ExecutorCapabilities{
 			CanRead: true, CanWrite: true, CanExec: true, CanNetwork: true,
 			MaxTimeout: 30 * time.Minute,
@@ -37,27 +37,27 @@ func newFakeExecutor() *fakeExecutor {
 	}
 }
 
-func (f *fakeExecutor) ReadFile(context.Context, string) (string, error) {
-	return "", errors.New("fakeExecutor: ReadFile not implemented")
+func (f *mockExecutor) ReadFile(context.Context, string) (string, error) {
+	return "", errors.New("mockExecutor: ReadFile not implemented")
 }
 
-func (f *fakeExecutor) WriteFile(context.Context, string, string) error {
-	return errors.New("fakeExecutor: WriteFile not implemented")
+func (f *mockExecutor) WriteFile(context.Context, string, string) error {
+	return errors.New("mockExecutor: WriteFile not implemented")
 }
 
-func (f *fakeExecutor) ListDirectory(context.Context, string) ([]string, error) {
-	return nil, errors.New("fakeExecutor: ListDirectory not implemented")
+func (f *mockExecutor) ListDirectory(context.Context, string) ([]string, error) {
+	return nil, errors.New("mockExecutor: ListDirectory not implemented")
 }
 
-func (f *fakeExecutor) ResolvePath(relativePath string) (string, error) {
+func (f *mockExecutor) ResolvePath(relativePath string) (string, error) {
 	return relativePath, nil
 }
 
-func (f *fakeExecutor) Capabilities() executor.ExecutorCapabilities {
+func (f *mockExecutor) Capabilities() executor.ExecutorCapabilities {
 	return f.caps
 }
 
-func (f *fakeExecutor) Exec(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error) {
+func (f *mockExecutor) Exec(ctx context.Context, command string, timeout time.Duration) (*executor.ExecResult, error) {
 	f.calls = append(f.calls, fakeExecCall{command: command, timeout: timeout})
 	if f.execFunc != nil {
 		return f.execFunc(ctx, command, timeout)
@@ -75,7 +75,7 @@ func TestExecRunner_ImplementsRunner(t *testing.T) {
 }
 
 func TestExecRunner_RunPre_Ordering(t *testing.T) {
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	r := &ExecRunner{
 		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{
 			succeedingHook("first"), succeedingHook("second"), succeedingHook("third"),
@@ -110,7 +110,7 @@ func TestExecRunner_RunPre_Ordering(t *testing.T) {
 }
 
 func TestExecRunner_RunPre_FatalFailureSkipsRemaining(t *testing.T) {
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
 		if command == "false" {
 			return &executor.ExecResult{ExitCode: 1}, nil
@@ -154,7 +154,7 @@ func TestExecRunner_RunPre_FatalFailureSkipsRemaining(t *testing.T) {
 }
 
 func TestExecRunner_ContinueOnError_DispatchContinuesAndPhaseSucceeds(t *testing.T) {
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(_ context.Context, command string, _ time.Duration) (*executor.ExecResult, error) {
 		if command == "false" {
 			return &executor.ExecResult{ExitCode: 1}, nil
@@ -185,7 +185,7 @@ func TestExecRunner_ContinueOnError_DispatchContinuesAndPhaseSucceeds(t *testing
 }
 
 func TestExecRunner_TimedOut(t *testing.T) {
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(_ context.Context, _ string, timeout time.Duration) (*executor.ExecResult, error) {
 		return &executor.ExecResult{ExitCode: -1}, fmt.Errorf("command timed out after %s", timeout)
 	}
@@ -213,7 +213,7 @@ func TestExecRunner_DeadlineExceededTimedOut(t *testing.T) {
 	// k8s_execcore.go's Exec returns the context error verbatim rather
 	// than a formatted "timed out" string (see isTimeoutErr's doc
 	// comment) — pin that shape is also classified as TimedOut.
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
 		return nil, context.DeadlineExceeded
 	}
@@ -235,7 +235,7 @@ func TestExecRunner_TruncationAndScrub(t *testing.T) {
 	secret := "AKIAABCDEFGHIJKLMNOP" // matches the aws_access_key_id pattern
 	longOutput := strings.Repeat("x", maxOutputTailBytes*2) + secret
 
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(context.Context, string, time.Duration) (*executor.ExecResult, error) {
 		return &executor.ExecResult{ExitCode: 0, Stdout: longOutput}, nil
 	}
@@ -264,7 +264,7 @@ func TestExecRunner_TruncationAndScrub(t *testing.T) {
 // must be exactly the (scrubbed) stderr text, with no spurious leading
 // newline from the stdout/stderr join logic.
 func TestExecRunner_StderrOnlyOutput(t *testing.T) {
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(context.Context, string, time.Duration) (*executor.ExecResult, error) {
 		return &executor.ExecResult{ExitCode: 0, Stderr: "warning: something"}, nil
 	}
@@ -303,7 +303,7 @@ func TestExecRunner_RunPost_RunOnMatrix(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("runOn=%s/outcome=%s", tc.runOn, tc.outcome), func(t *testing.T) {
-			exec := newFakeExecutor()
+			exec := newMockExecutor()
 			r := &ExecRunner{
 				Hooks: &types.HooksConfig{PostRun: []types.HookConfig{{Name: "h", Command: "true", RunOn: tc.runOn}}},
 				Exec:  exec,
@@ -331,7 +331,7 @@ func TestExecRunner_RunPost_DeadCtx(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(ctx context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
 		return nil, ctx.Err()
 	}
@@ -358,7 +358,7 @@ func TestExecRunner_RunPost_BudgetExpiryMidHook(t *testing.T) {
 	defer cancel()
 	time.Sleep(5 * time.Millisecond) // guarantee the deadline has passed
 
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.execFunc = func(ctx context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
 		return nil, ctx.Err()
 	}
@@ -377,7 +377,7 @@ func TestExecRunner_RunPost_BudgetExpiryMidHook(t *testing.T) {
 }
 
 func TestExecRunner_CapabilityGuard_ClampsToMaxTimeout(t *testing.T) {
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	exec.caps.MaxTimeout = 10 * time.Second
 	r := &ExecRunner{
 		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "h", Command: "true", TimeoutSeconds: 1800}}},
@@ -396,7 +396,7 @@ func TestExecRunner_CapabilityGuard_ClampsToMaxTimeout(t *testing.T) {
 }
 
 func TestExecRunner_EffectiveTimeoutDefaultsWhenUnset(t *testing.T) {
-	exec := newFakeExecutor()
+	exec := newMockExecutor()
 	r := &ExecRunner{
 		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "h", Command: "true"}}},
 		Exec:  exec,
@@ -424,7 +424,7 @@ func TestExecRunner_NilExecutor(t *testing.T) {
 }
 
 func TestExecRunner_NilHooksConfig(t *testing.T) {
-	r := &ExecRunner{Exec: newFakeExecutor()}
+	r := &ExecRunner{Exec: newMockExecutor()}
 	preResults, preErr := r.RunPre(context.Background())
 	if preErr != nil || preResults != nil {
 		t.Errorf("RunPre() with nil Hooks = (%v, %v), want (nil, nil)", preResults, preErr)

--- a/harness/internal/hook/runner_test.go
+++ b/harness/internal/hook/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
 	"github.com/rxbynerd/stirrup/types"
@@ -256,6 +257,49 @@ func TestExecRunner_TruncationAndScrub(t *testing.T) {
 	}
 	if strings.Contains(results[0].OutputTail, secret) {
 		t.Errorf("OutputTail leaked the unscrubbed secret: %q", results[0].OutputTail)
+	}
+}
+
+// TestExecRunner_TruncationTrimsUTF8RuneBoundary is a regression fixture
+// for a byte-index tail cut that landed mid-rune. "€" (U+20AC) encodes
+// as the 3-byte sequence E2 82 AC. combined = "€" + "\n" + 4093 "y"s has
+// length 3 + 1 + 4093 = maxOutputTailBytes+1, so the naive
+// len(scrubbed)-maxOutputTailBytes cut is exactly 1 — one byte into
+// "€" — leaving the bare continuation-byte pair (82 AC) at the start of
+// the slice before trimToRuneBoundary runs. Without the fix,
+// json.Marshal would silently substitute U+FFFD for that leading
+// partial rune when the trace is persisted.
+func TestExecRunner_TruncationTrimsUTF8RuneBoundary(t *testing.T) {
+	const euroSign = "€"
+	stderrFiller := strings.Repeat("y", maxOutputTailBytes-3)
+
+	exec := newMockExecutor()
+	exec.execFunc = func(context.Context, string, time.Duration) (*executor.ExecResult, error) {
+		return &executor.ExecResult{ExitCode: 0, Stdout: euroSign, Stderr: stderrFiller}, nil
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "utf8-boundary", Command: "true"}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err != nil {
+		t.Fatalf("RunPre() error = %v, want nil", err)
+	}
+	tail := results[0].OutputTail
+
+	if !results[0].Truncated {
+		t.Fatal("Truncated = false, want true")
+	}
+	if !utf8.ValidString(tail) {
+		t.Fatalf("OutputTail is not valid UTF-8: %q", tail)
+	}
+	if strings.ContainsRune(tail, utf8.RuneError) {
+		t.Errorf("OutputTail contains U+FFFD (replacement character), want none introduced: %q", tail)
+	}
+	want := "\n" + stderrFiller
+	if tail != want {
+		t.Errorf("OutputTail = %q, want %q (the straddled euro sign's continuation bytes trimmed)", tail, want)
 	}
 }
 

--- a/harness/internal/tool/builtins/shell_test.go
+++ b/harness/internal/tool/builtins/shell_test.go
@@ -1,6 +1,13 @@
 package builtins
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+)
 
 // TestFormatRunCommand_ExitCodeOnlyNoOutput locks the exact text for a command
 // that produced no stdout or stderr but exited non-zero. The "[exit code: N]"
@@ -13,5 +20,32 @@ func TestFormatRunCommand_ExitCodeOnlyNoOutput(t *testing.T) {
 	const want = "\n[exit code: 2]"
 	if got != want {
 		t.Fatalf("formatRunCommand(\"\", \"\", 2) = %q, want %q", got, want)
+	}
+}
+
+// TestRunCommandTool_TimeoutClampedTo300s pins the run_command tool's
+// independent 300s (5 min) timeout ceiling. Issue #461 raised the shared
+// executor.maxTimeout cap to 30 minutes so lifecycle hooks can run a cold
+// `bundle install`, but the model-reachable run_command tool must keep
+// its own tighter 300s clamp — the two are deliberately decoupled (see
+// the maxTimeout doc comment in executor/local.go) so raising the
+// executor cap does not silently hand the agent a longer exec budget.
+func TestRunCommandTool_TimeoutClampedTo300s(t *testing.T) {
+	var gotTimeout time.Duration
+	exec := &mockExecutor{
+		execFunc: func(_ context.Context, _ string, timeout time.Duration) (*executor.ExecResult, error) {
+			gotTimeout = timeout
+			return &executor.ExecResult{ExitCode: 0}, nil
+		},
+	}
+
+	tl := RunCommandTool(exec)
+	input := json.RawMessage(`{"command":"true","timeout":9000}`)
+	if _, err := tl.StructuredHandler(context.Background(), input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := 300 * time.Second; gotTimeout != want {
+		t.Errorf("Exec timeout = %v, want %v (tool-layer clamp must stay independent of the raised executor cap)", gotTimeout, want)
 	}
 }

--- a/harness/internal/trace/events.go
+++ b/harness/internal/trace/events.go
@@ -6,9 +6,11 @@
 // discriminator. A complete run produces:
 //
 //	{"kind":"run_started",      "schemaVersion":"1","runId":"...","config":{...redacted...},"startedAt":"..."}
+//	{"kind":"hook_record",      "hook":{"phase":"preRun","index":0,"command":"..."}}
 //	{"kind":"turn_record",      "turn":1,"modelInput":{...},"modelOutput":[...],"toolCalls":[...]}
 //	{"kind":"tool_call_record", "turn":1,"name":"read_file","input":{...},"output":"..."}
 //	...
+//	{"kind":"hook_record",      "hook":{"phase":"postRun","index":0,"command":"..."}}
 //	{"kind":"run_finished",     "trace":{...RunTrace summary...},"completedAt":"..."}
 //
 // turn_record carries the full transcript a sub-agent / replay path needs.
@@ -51,6 +53,12 @@ const (
 	// Carries the canonical RunTrace summary; backward-compatible with
 	// pre-streaming single-blob traces.
 	EventKindRunFinished EventKind = "run_finished"
+	// EventKindHookRecord captures one lifecycle hook's result (issue
+	// #461). Emitted as each PreRun/PostRun hook completes, in addition
+	// to the accumulated ToolCalls inside the embedded RunTrace at
+	// run_finished, so a live consumer sees each hook as soon as it
+	// lands (mirrors tool_call_record).
+	EventKindHookRecord EventKind = "hook_record"
 )
 
 // CurrentSchemaVersion is the streaming-trace schema version emitted in
@@ -79,6 +87,9 @@ type Event struct {
 	ModelOutput []types.ContentBlock   `json:"modelOutput,omitempty"`
 	ToolCalls   []types.ToolCallRecord `json:"toolCalls,omitempty"`
 	ToolCall    *types.ToolCallRecord  `json:"toolCall,omitempty"`
+
+	// Hook payload — populated for hook_record events.
+	Hook *types.HookExecution `json:"hook,omitempty"`
 
 	// Trace summary — populated for run_finished events. Embedding the
 	// full RunTrace here keeps the backward-compat reader's job trivial:

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -45,6 +45,7 @@ type JSONLTraceEmitter struct {
 	turns             []types.TurnTrace
 	toolCalls         []types.ToolCallTrace
 	permissionDenials int
+	hookResults       []types.HookExecution
 }
 
 // NewJSONLTraceEmitter creates a streaming trace emitter that writes to w.
@@ -91,6 +92,7 @@ func (e *JSONLTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.turns = nil
 	e.toolCalls = nil
 	e.permissionDenials = 0
+	e.hookResults = nil
 
 	startedAt := e.startedAt
 	var redacted types.RunConfig
@@ -185,6 +187,32 @@ func (e *JSONLTraceEmitter) RecordPermissionDenial() {
 	e.permissionDenials++
 }
 
+// RecordHookExecution appends a lifecycle hook result (issue #461) to
+// the in-memory accumulator AND streams an inline hook_record event,
+// mirroring RecordToolCall's tool_call_record. OutputTail and Error are
+// re-scrubbed here as defence-in-depth — the same posture RecordTurnRecord
+// applies to tool output — even though hook.ExecRunner already scrubs
+// OutputTail before returning the types.HookExecution; Command is
+// operator config (like VerifierConfig.Command) and is deliberately not
+// scrubbed, matching ValidateRunConfig's structural rejection of
+// "secret://" in a hook command.
+func (e *JSONLTraceEmitter) RecordHookExecution(exec types.HookExecution) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	scrubbed := exec
+	scrubbed.OutputTail = security.Scrub(exec.OutputTail)
+	scrubbed.Error = security.Scrub(exec.Error)
+
+	e.hookResults = append(e.hookResults, scrubbed)
+
+	ev := Event{
+		Kind: EventKindHookRecord,
+		Hook: &scrubbed,
+	}
+	_ = e.writeLineLocked(ev)
+}
+
 // Finish builds the canonical RunTrace summary, writes the
 // run_finished event, and returns the summary. A run with zero turns
 // still produces a valid run_finished line.
@@ -220,6 +248,7 @@ func (e *JSONLTraceEmitter) Finish(_ context.Context, outcome string) (*types.Ru
 		ToolCalls:         summaries,
 		PermissionDenials: e.permissionDenials,
 		Outcome:           outcome,
+		HookResults:       e.hookResults,
 	}
 
 	ev := Event{

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -631,6 +631,123 @@ func TestJSONLTraceEmitter_PartialStream(t *testing.T) {
 // the document unparseable after replacement. scrubRawJSON must then re-wrap
 // the scrubbed text as a JSON string literal so the on-disk line stays valid,
 // rather than emitting raw broken JSON.
+// TestJSONLTraceEmitter_ImplementsHookRecorder is a compile-time
+// satisfaction guard for the optional-capability interface.
+func TestJSONLTraceEmitter_ImplementsHookRecorder(t *testing.T) {
+	var _ HookRecorder = (*JSONLTraceEmitter)(nil)
+}
+
+// TestJSONLTraceEmitter_RecordHookExecution_StreamsAndAccumulates pins
+// the dual write RecordHookExecution performs: an inline hook_record
+// event per call (so a live consumer sees each hook as it lands,
+// mirroring tool_call_record) AND accumulation into RunTrace.HookResults
+// at Finish, in call order.
+func TestJSONLTraceEmitter_RecordHookExecution_StreamsAndAccumulates(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+	emitter.Start("run-hooks", nil)
+
+	emitter.RecordHookExecution(types.HookExecution{
+		Phase: "preRun", Index: 0, Name: "clone", Command: "git clone . .", ExitCode: 0, DurationMs: 10,
+	})
+	emitter.RecordHookExecution(types.HookExecution{
+		Phase: "postRun", Index: 0, Name: "smoke-test", Command: "test -f marker", ExitCode: 0, DurationMs: 5,
+	})
+
+	trace, err := emitter.Finish(context.Background(), "success")
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	if len(trace.HookResults) != 2 {
+		t.Fatalf("HookResults: got %d entries, want 2", len(trace.HookResults))
+	}
+	if trace.HookResults[0].Phase != "preRun" || trace.HookResults[0].Name != "clone" {
+		t.Errorf("HookResults[0] = %+v, want preRun/clone", trace.HookResults[0])
+	}
+	if trace.HookResults[1].Phase != "postRun" || trace.HookResults[1].Name != "smoke-test" {
+		t.Errorf("HookResults[1] = %+v, want postRun/smoke-test", trace.HookResults[1])
+	}
+
+	events := readEvents(t, buf.Bytes())
+	var hookEvents []Event
+	for _, ev := range events {
+		if ev.Kind == EventKindHookRecord {
+			hookEvents = append(hookEvents, ev)
+		}
+	}
+	if len(hookEvents) != 2 {
+		t.Fatalf("hook_record events: got %d, want 2", len(hookEvents))
+	}
+	if hookEvents[0].Hook == nil || hookEvents[0].Hook.Name != "clone" {
+		t.Errorf("hook_record[0] = %+v, want name=clone", hookEvents[0].Hook)
+	}
+	if hookEvents[1].Hook == nil || hookEvents[1].Hook.Name != "smoke-test" {
+		t.Errorf("hook_record[1] = %+v, want name=smoke-test", hookEvents[1].Hook)
+	}
+}
+
+// TestJSONLTraceEmitter_RecordHookExecution_Scrubs pins the
+// defence-in-depth scrub RecordHookExecution applies to OutputTail and
+// Error: even though hook.ExecRunner already scrubs OutputTail before
+// constructing the types.HookExecution, the emitter re-scrubs both
+// fields before they reach disk, the same posture RecordTurnRecord
+// applies to tool output.
+func TestJSONLTraceEmitter_RecordHookExecution_Scrubs(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+	emitter.Start("run-hook-scrub", nil)
+
+	emitter.RecordHookExecution(types.HookExecution{
+		Phase:      "preRun",
+		Index:      0,
+		Command:    "curl -H \"Authorization: Bearer $TOKEN\"", // no secret-shaped literal
+		OutputTail: "response included sk-ant-api03-leak in the body",
+		Error:      "request failed, token sk-ant-api03-leak rejected",
+	})
+	trace, err := emitter.Finish(context.Background(), "success")
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	onDisk := buf.String()
+	if strings.Contains(onDisk, "sk-ant-api03-leak") {
+		t.Errorf("scrubber missed hook secret in on-disk trace:\n%s", onDisk)
+	}
+	if strings.Contains(trace.HookResults[0].OutputTail, "sk-ant-api03-leak") {
+		t.Errorf("HookResults[0].OutputTail not scrubbed: %q", trace.HookResults[0].OutputTail)
+	}
+	if strings.Contains(trace.HookResults[0].Error, "sk-ant-api03-leak") {
+		t.Errorf("HookResults[0].Error not scrubbed: %q", trace.HookResults[0].Error)
+	}
+	// Command is operator config (like VerifierConfig.Command) and is
+	// deliberately not scrubbed — ValidateRunConfig structurally
+	// rejects "secret://" in a hook command instead.
+	if trace.HookResults[0].Command == "" {
+		t.Error("Command must survive unscrubbed")
+	}
+}
+
+// TestJSONLTraceEmitter_NoHooks_LeavesHookResultsEmpty pins that a run
+// with no lifecycle hooks configured produces no hook_record events and
+// a nil/empty HookResults, so the byte-for-byte-unchanged guarantee for
+// a hookless run extends to the JSONL trace shape.
+func TestJSONLTraceEmitter_NoHooks_LeavesHookResultsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+	emitter.Start("run-no-hooks", nil)
+	trace, err := emitter.Finish(context.Background(), "success")
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if len(trace.HookResults) != 0 {
+		t.Errorf("HookResults: got %d entries, want 0", len(trace.HookResults))
+	}
+	if strings.Contains(buf.String(), string(EventKindHookRecord)) {
+		t.Error("expected no hook_record events for a hookless run")
+	}
+}
+
 func TestScrubRawJSON_WrapsWhenScrubBreaksValidity(t *testing.T) {
 	// secret:// matches the secret_ref pattern; sitting as an unquoted value it
 	// is replaced by the bare "[REDACTED]" token, breaking JSON validity.

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -625,12 +625,6 @@ func TestJSONLTraceEmitter_PartialStream(t *testing.T) {
 	}
 }
 
-// TestScrubRawJSON_WrapsWhenScrubBreaksValidity exercises the branch where the
-// scrubbed byte stream is no longer valid JSON. The "[REDACTED]" placeholder is
-// a bare token, so a secret that was sitting as an unquoted JSON value leaves
-// the document unparseable after replacement. scrubRawJSON must then re-wrap
-// the scrubbed text as a JSON string literal so the on-disk line stays valid,
-// rather than emitting raw broken JSON.
 // TestJSONLTraceEmitter_ImplementsHookRecorder is a compile-time
 // satisfaction guard for the optional-capability interface.
 func TestJSONLTraceEmitter_ImplementsHookRecorder(t *testing.T) {
@@ -748,6 +742,12 @@ func TestJSONLTraceEmitter_NoHooks_LeavesHookResultsEmpty(t *testing.T) {
 	}
 }
 
+// TestScrubRawJSON_WrapsWhenScrubBreaksValidity exercises the branch where the
+// scrubbed byte stream is no longer valid JSON. The "[REDACTED]" placeholder is
+// a bare token, so a secret that was sitting as an unquoted JSON value leaves
+// the document unparseable after replacement. scrubRawJSON must then re-wrap
+// the scrubbed text as a JSON string literal so the on-disk line stays valid,
+// rather than emitting raw broken JSON.
 func TestScrubRawJSON_WrapsWhenScrubBreaksValidity(t *testing.T) {
 	// secret:// matches the secret_ref pattern; sitting as an unquoted value it
 	// is replaced by the bare "[REDACTED]" token, breaking JSON validity.

--- a/harness/internal/trace/trace.go
+++ b/harness/internal/trace/trace.go
@@ -55,3 +55,18 @@ type TraceEmitter interface {
 type SystemInstructionsRecorder interface {
 	RecordSystemInstructions(system string)
 }
+
+// HookRecorder is an optional capability a TraceEmitter can implement to
+// receive lifecycle hook results (issue #461) as they complete. The
+// agentic loop forwards each types.HookExecution via a type assertion
+// after hook.Runner.RunPre/RunPost returns — the same optional-
+// capability pattern as SystemInstructionsRecorder — so emitters that do
+// not record hook executions need no stub method.
+//
+// Today only the JSONL emitter implements it: it streams a hook_record
+// line per execution and folds the accumulated results into
+// RunTrace.HookResults at Finish, mirroring how RecordToolCall streams
+// tool_call_record lines and folds into RunTrace.ToolCalls.
+type HookRecorder interface {
+	RecordHookExecution(exec types.HookExecution)
+}

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -238,6 +238,10 @@ func runConfigFromProto(pc *pb.RunConfig) types.RunConfig {
 		// explicit ToolDispatchConfig{}.
 		rc.ToolDispatch = &types.ToolDispatchConfig{MaxParallel: int(pc.ToolDispatch.GetMaxParallel())}
 	}
+	if pc.Hooks != nil {
+		hooks := hooksConfigFromProto(pc.Hooks)
+		rc.Hooks = &hooks
+	}
 
 	rc.LogLevel = pc.LogLevel
 	rc.SystemPromptOverride = pc.SystemPromptOverride
@@ -452,6 +456,39 @@ func executorConfigFromProto(pc *pb.ExecutorConfig) types.ExecutorConfig {
 		}
 	}
 	return ec
+}
+
+// hooksConfigFromProto translates a proto HooksConfig to the internal
+// types form (issue #461). Called only when pc.Hooks is non-nil; the
+// caller wraps the returned value in a fresh pointer so an absent proto
+// sub-message stays wire-distinguishable from an explicit-but-empty one.
+func hooksConfigFromProto(pc *pb.HooksConfig) types.HooksConfig {
+	hc := types.HooksConfig{}
+	for _, h := range pc.PreRun {
+		hc.PreRun = append(hc.PreRun, hookConfigFromProto(h))
+	}
+	for _, h := range pc.PostRun {
+		hc.PostRun = append(hc.PostRun, hookConfigFromProto(h))
+	}
+	return hc
+}
+
+// hookConfigFromProto translates a single proto HookConfig. Every field
+// is a scalar (string/int32/bool), so a plain value copy is aliasing-safe
+// — there is no proto-owned slice or map to defensively re-copy, unlike
+// guardRailConfigFromProto's Stages/CustomCriteria.
+func hookConfigFromProto(pc *pb.HookConfig) types.HookConfig {
+	if pc == nil {
+		return types.HookConfig{}
+	}
+	return types.HookConfig{
+		Type:            pc.Type,
+		Name:            pc.Name,
+		Command:         pc.Command,
+		TimeoutSeconds:  int(pc.TimeoutSeconds),
+		ContinueOnError: pc.ContinueOnError,
+		RunOn:           pc.RunOn,
+	}
 }
 
 func verifierConfigFromProto(pc *pb.VerifierConfig) types.VerifierConfig {

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -1062,3 +1062,107 @@ func TestRunTraceToProto_OutcomePopulated(t *testing.T) {
 		})
 	}
 }
+
+// TestRunConfigFromProto_HooksAbsentStaysNil pins the nil/absent case:
+// a TaskAssignment with no hooks sub-message must not synthesise a
+// non-nil types.HooksConfig (issue #461) — matching the GuardRail
+// nil-stays-nil precedent (TestRunConfigProtoRoundTrip_GuardRailNilStaysNil).
+func TestRunConfigFromProto_HooksAbsentStaysNil(t *testing.T) {
+	rc := runConfigFromProto(&pb.RunConfig{})
+	if rc.Hooks != nil {
+		t.Errorf("Hooks should be nil when proto field absent; got %+v", rc.Hooks)
+	}
+}
+
+// TestRunConfigFromProto_HooksEmptyStaysNonNil pins the companion case:
+// an explicit-but-empty proto HooksConfig{} (e.g. a control plane that
+// always sets the sub-message) must translate to a non-nil, empty
+// types.HooksConfig — distinguishable from "field absent" the same way
+// ToolDispatch preserves the unset/explicit-zero distinction.
+func TestRunConfigFromProto_HooksEmptyStaysNonNil(t *testing.T) {
+	rc := runConfigFromProto(&pb.RunConfig{Hooks: &pb.HooksConfig{}})
+	if rc.Hooks == nil {
+		t.Fatal("Hooks should be non-nil for an explicit-but-empty proto sub-message")
+	}
+	if len(rc.Hooks.PreRun) != 0 || len(rc.Hooks.PostRun) != 0 {
+		t.Errorf("expected empty PreRun/PostRun, got %+v", rc.Hooks)
+	}
+}
+
+// TestRunConfigFromProto_HooksFieldsPreserved guards the translate hop
+// that copies every HookConfig field from the wire format into
+// types.HookConfig, across both phases (issue #461). Exercises the
+// actual Marshal -> Unmarshal wire path (not just an in-memory pointer
+// copy), matching the pattern
+// TestRunConfigFromProto_BatchProviderConfigPreserved established for
+// the analogous gh-95/gh-117/gh-118/gh-100 silent-drop failure class.
+func TestRunConfigFromProto_HooksFieldsPreserved(t *testing.T) {
+	original := &pb.RunConfig{
+		Hooks: &pb.HooksConfig{
+			PreRun: []*pb.HookConfig{
+				{Type: "command", Name: "clone", Command: "git clone . .", TimeoutSeconds: 120},
+			},
+			PostRun: []*pb.HookConfig{
+				{Command: "test -f marker", RunOn: "success", ContinueOnError: true},
+				{Command: "curl -X POST https://example.com", RunOn: "failure"},
+			},
+		},
+	}
+
+	raw, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded pb.RunConfig
+	if err := proto.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	rc := runConfigFromProto(&decoded)
+	if rc.Hooks == nil {
+		t.Fatal("Hooks dropped across the wire round-trip")
+	}
+	if len(rc.Hooks.PreRun) != 1 {
+		t.Fatalf("PreRun: got %d entries, want 1", len(rc.Hooks.PreRun))
+	}
+	pre := rc.Hooks.PreRun[0]
+	if pre.Type != "command" || pre.Name != "clone" || pre.Command != "git clone . ." || pre.TimeoutSeconds != 120 {
+		t.Errorf("PreRun[0] = %+v, want {command, clone, git clone . ., 120, false, \"\"}", pre)
+	}
+
+	if len(rc.Hooks.PostRun) != 2 {
+		t.Fatalf("PostRun: got %d entries, want 2", len(rc.Hooks.PostRun))
+	}
+	post0 := rc.Hooks.PostRun[0]
+	if post0.Command != "test -f marker" || post0.RunOn != "success" || !post0.ContinueOnError {
+		t.Errorf("PostRun[0] = %+v, want {test -f marker, success, true}", post0)
+	}
+	post1 := rc.Hooks.PostRun[1]
+	if post1.Command != "curl -X POST https://example.com" || post1.RunOn != "failure" || post1.ContinueOnError {
+		t.Errorf("PostRun[1] = %+v, want {curl -X POST https://example.com, failure, false}", post1)
+	}
+}
+
+// TestRunConfigFromProto_HooksNotAliased pins that mutating the source
+// *pb.RunConfig after translation does not reach the translated
+// types.RunConfig — hookConfigFromProto copies every field by value
+// (see its doc comment), so there is no proto-owned slice/map for this
+// hop to alias, unlike guardRailConfigFromProto's Stages/CustomCriteria.
+// This test would catch a future refactor that starts sharing the
+// proto's []*pb.HookConfig backing array instead of copying.
+func TestRunConfigFromProto_HooksNotAliased(t *testing.T) {
+	pc := &pb.RunConfig{
+		Hooks: &pb.HooksConfig{
+			PreRun: []*pb.HookConfig{{Command: "original"}},
+		},
+	}
+
+	rc := runConfigFromProto(pc)
+
+	pc.Hooks.PreRun[0].Command = "mutated-after-translate"
+
+	if rc.Hooks.PreRun[0].Command != "original" {
+		t.Errorf("translated HookConfig aliases the proto's backing data: got %q, want %q",
+			rc.Hooks.PreRun[0].Command, "original")
+	}
+}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -440,6 +440,11 @@ message RunConfig {
   // harness default).
   optional double temperature = 31;
 
+  // Optional. Operator-authored lifecycle hooks that run before the
+  // agentic session starts and after it ends. See HooksConfig for the
+  // pre_run / post_run semantics.
+  HooksConfig hooks = 32;
+
 }
 
 // DynamicContextValue is a single dynamic-context value with metadata.
@@ -477,6 +482,63 @@ message ToolDispatchConfig {
   // sub-message) resolves to the default at the harness; values outside
   // [1, 16] are rejected by ValidateRunConfig.
   int32 max_parallel = 1;
+}
+
+// HooksConfig configures operator-authored lifecycle hooks that run
+// around the agentic session (issue #461): pre_run executes before the
+// session starts (after the harness builds the system prompt, before
+// GitStrategy.Setup); post_run executes after the session ends (after
+// GitStrategy.Finalise, before the run reports done). Hook output is
+// trace-only and never enters the model's context; hooks run through
+// the same Executor the agent's tools use and so share the run's
+// sandbox and network egress posture.
+message HooksConfig {
+  // Optional. Hooks executed, in order, before the agentic session
+  // starts. A fatal failure (a hook without continue_on_error exits
+  // non-zero or times out) fails the run with outcome "setup_failed"
+  // before any turn runs.
+  repeated HookConfig pre_run = 1;
+
+  // Optional. Hooks executed, in order, after the agentic session ends
+  // and GitStrategy.Finalise completes. Runs on every outcome by
+  // default; see HookConfig.run_on to scope a hook to success or
+  // failure only. A fatal failure overrides an otherwise-successful
+  // run's outcome to "hook_failed"; it never masks an existing
+  // non-success outcome.
+  repeated HookConfig post_run = 2;
+}
+
+// HookConfig is a single operator-authored lifecycle hook: an ordered
+// shell command executed via "sh -c" through the run's Executor.
+message HookConfig {
+  // Optional. The hook kind. Empty defaults to "command" — the only
+  // value accepted in v1. Present so a future typed step (e.g. a
+  // declarative git-clone source) can land additively.
+  string type = 1;
+
+  // Optional. A short trace label (<= 64 bytes, printable, no control
+  // characters). Purely descriptive.
+  string name = 2;
+
+  // Required. The shell command executed via "sh -c". Must not contain
+  // a "secret://" reference — hook commands are recorded verbatim in
+  // the trace like VerifierConfig.command, so credentials must come
+  // from control-plane runtime bindings instead. Max 16 KB.
+  string command = 3;
+
+  // Optional. Timeout in seconds for this hook. Zero resolves to the
+  // 300s harness default; max 1800 (30 minutes).
+  int32 timeout_seconds = 4;
+
+  // Optional. When true, a non-zero exit or timeout is recorded as a
+  // warning and does not fail the phase — the remaining hooks in the
+  // phase still run and the run's outcome is unaffected.
+  bool continue_on_error = 5;
+
+  // Optional. post_run only: filters this hook by the run's outcome.
+  // Valid values: "" / "always" (default), "success", "failure". Must
+  // be empty on a pre_run hook.
+  string run_on = 6;
 }
 
 // RuleOfTwoConfig carries the operator override for the Rule-of-Two

--- a/types/evaloutcome.go
+++ b/types/evaloutcome.go
@@ -40,11 +40,12 @@ const (
 
 	// EvalInconclusive indicates the run terminated without enough
 	// signal to call it. Limit-hit terminations (`max_turns`,
-	// `budget_exceeded`, `timeout`, `max_tokens`, `stalled`) and
-	// non-result terminations (`cancelled`, `verification_error`) all
-	// produce inconclusive: the harness ran out of room or was
-	// interrupted, so the run is neither a quality win nor a quality
-	// loss.
+	// `budget_exceeded`, `timeout`, `max_tokens`, `stalled`),
+	// non-result terminations (`cancelled`, `verification_error`), and
+	// lifecycle-hook infra failures (`setup_failed`, `hook_failed`,
+	// issue #461) all produce inconclusive: the harness ran out of
+	// room, was interrupted, or never got a fair shot at the task, so
+	// the run is neither a quality win nor a quality loss.
 	EvalInconclusive EvalOutcome = "inconclusive"
 )
 
@@ -66,6 +67,8 @@ const (
 //	stalled              | any           | any       | inconclusive
 //	cancelled            | any           | any       | inconclusive
 //	verification_error   | any           | any       | inconclusive
+//	setup_failed         | any           | any       | inconclusive
+//	hook_failed          | any           | any       | inconclusive
 //	(empty / unknown)    | any           | any       | inconclusive
 //
 // The success-without-verifier branch is the load-bearing call here.
@@ -83,7 +86,7 @@ func EvalOutcomeFor(t RunTrace) EvalOutcome {
 	case "verification_failed", "error", "tool_failures":
 		return EvalFailed
 	case "max_turns", "budget_exceeded", "timeout", "max_tokens", "stalled",
-		"cancelled", "verification_error":
+		"cancelled", "verification_error", "setup_failed", "hook_failed":
 		return EvalInconclusive
 	default:
 		// Unknown / empty outcomes default to inconclusive so a future

--- a/types/evaloutcome_test.go
+++ b/types/evaloutcome_test.go
@@ -70,6 +70,14 @@ func TestEvalOutcomeFor(t *testing.T) {
 		{name: "cancelled", trace: RunTrace{Outcome: "cancelled"}, want: EvalInconclusive},
 		{name: "verification_error", trace: RunTrace{Outcome: "verification_error"}, want: EvalInconclusive},
 
+		// Lifecycle-hook infra failures (issue #461): a fatal preRun/postRun
+		// hook failure is an infra signal, not a quality verdict on the
+		// model's work — pinned explicitly (rather than relying on the
+		// unknown-outcome default below) so a future change to either
+		// bucket is caught by name.
+		{name: "setup_failed", trace: RunTrace{Outcome: "setup_failed"}, want: EvalInconclusive},
+		{name: "hook_failed", trace: RunTrace{Outcome: "hook_failed"}, want: EvalInconclusive},
+
 		// Unknown / empty outcomes fall through to inconclusive so a
 		// future outcome class added upstream cannot silently land in
 		// the wrong bucket.

--- a/types/result.go
+++ b/types/result.go
@@ -68,6 +68,16 @@ type RunResult struct {
 	// Error carries a short human-readable reason when Outcome is not
 	// "success". Omitted on success.
 	Error string `json:"error,omitempty"`
+
+	// HookFailures is the count of lifecycle hook executions (issue
+	// #461) whose Error is non-empty, across both phases. Zero (the
+	// default) when no hooks were configured or every hook succeeded.
+	// A non-zero count is possible even when Outcome is "success": a
+	// continueOnError hook that failed does not override the outcome
+	// but is still counted here so a consumer scanning RunResult alone
+	// (without the full trace) can see that setup or teardown was not
+	// entirely clean.
+	HookFailures int `json:"hookFailures,omitempty"`
 }
 
 // VerifierResult is the verifier outcome carried on RunResult. It

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -2752,7 +2752,12 @@ func validateHookConfig(path string, h HookConfig, isPostRun bool, errs *[]strin
 	} else if len(h.Command) > maxHookCommandBytes {
 		*errs = append(*errs, fmt.Sprintf("%s.command must be <= %d bytes, got %d", path, maxHookCommandBytes, len(h.Command)))
 	}
-	if strings.Contains(h.Command, "secret://") {
+	// Case-insensitive: a shell reads "secret://..." and "SECRET://..."
+	// identically, and the doc contract ("structurally rejected") would
+	// be a lie if `SECRET://FOO` slipped through untouched into the
+	// trace unscrubbed (HookExecution.Command is deliberately not
+	// scrubbed, on the premise that this check is airtight).
+	if strings.Contains(strings.ToLower(h.Command), "secret://") {
 		*errs = append(*errs, fmt.Sprintf(
 			"%s.command must not contain a \"secret://\" reference; resolve credentials via control-plane runtime bindings instead",
 			path))

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -219,6 +219,13 @@ type RunConfig struct {
 	// ToolChoiceEscalationConfig for the per-knob semantics and the
 	// mode-aware policy that decides when a no-tool answer is suspicious.
 	ToolChoiceEscalation *ToolChoiceEscalationConfig `json:"toolChoiceEscalation,omitempty"`
+
+	// Hooks configures operator-authored lifecycle hooks that run around
+	// the agentic session (#461): PreRun before the session starts (setup
+	// — clone, provision a runtime), PostRun after it ends (artifact
+	// submission, smoke tests). Nil means no hooks — a bare run is
+	// byte-for-byte unchanged. See HooksConfig for the full contract.
+	Hooks *HooksConfig `json:"hooks,omitempty"`
 }
 
 // ObservabilityConfig carries operator-supplied labels that are promoted to
@@ -1131,6 +1138,108 @@ func (rc *RunConfig) EffectiveToolChoiceEscalationMaxRetries() int {
 	return rc.ToolChoiceEscalation.MaxRetries
 }
 
+// HooksConfig configures operator-authored lifecycle hooks that run
+// around the agentic session (issue #461). PreRun executes after the
+// harness builds the system prompt and before GitStrategy.Setup — the
+// natural place to clone a repo or provision a runtime the deterministic
+// git strategy then assumes already exists; a fatal PreRun failure fails
+// the run with outcome "setup_failed" before any turn runs. PostRun
+// executes after GitStrategy.Finalise, once the run's outcome is known,
+// for artifact submission or smoke tests.
+//
+// Hook output is trace-only: it is recorded on types.HookExecution and
+// never enters the model's context. Hooks run through the same Executor
+// the agent's tools use, so they share the run's sandbox and network
+// egress posture — there is no separate credential or network surface to
+// configure.
+type HooksConfig struct {
+	// PreRun are hooks executed, in order, before the agentic session
+	// starts.
+	PreRun []HookConfig `json:"preRun,omitempty"`
+
+	// PostRun are hooks executed, in order, after the agentic session
+	// ends and GitStrategy.Finalise completes. Runs on every outcome by
+	// default; see HookConfig.RunOn to scope a hook to success or
+	// failure only.
+	PostRun []HookConfig `json:"postRun,omitempty"`
+}
+
+// HookConfig is a single operator-authored lifecycle hook: an ordered
+// shell command executed via "sh -c" through the run's Executor.
+type HookConfig struct {
+	// Type selects the hook kind. Empty defaults to "command" — the only
+	// value ValidateRunConfig accepts in v1. The field is present so a
+	// future typed step (e.g. a declarative git-clone source) can land
+	// additively without a schema break, matching the
+	// validateOptionalType convention used elsewhere in this file.
+	Type string `json:"type,omitempty"`
+
+	// Name is a short trace label (<=64 bytes, printable, no control
+	// characters). Purely descriptive — it never affects dispatch.
+	Name string `json:"name,omitempty"`
+
+	// Command is the shell command executed via "sh -c" through the
+	// run's Executor. Required, non-empty after TrimSpace, <=16KB. Must
+	// not contain a "secret://" reference: hook commands are operator
+	// config recorded verbatim in the trace — like
+	// VerifierConfig.Command — so embedding a secret reference here
+	// would defeat the SecretStore contract. Resolve credentials via
+	// control-plane runtime bindings instead (locked design decision,
+	// issue #461).
+	Command string `json:"command"`
+
+	// TimeoutSeconds bounds the hook's execution. Zero resolves to
+	// DefaultHookTimeoutSeconds via EffectiveHookTimeout; the hard
+	// ceiling is MaxHookTimeoutSeconds.
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
+
+	// ContinueOnError, when true, downgrades a non-zero exit (or
+	// timeout) from a fatal phase failure to a recorded warning: the
+	// remaining hooks in the phase still run and the run's outcome is
+	// unaffected.
+	ContinueOnError bool `json:"continueOnError,omitempty"`
+
+	// RunOn filters a PostRun hook by the run's classified outcome.
+	// Valid values: "" / "always" (default — run regardless of
+	// outcome), "success" (only when the primary run succeeded),
+	// "failure" (only when it did not). Must be empty on a PreRun hook
+	// — the concept has no meaning before the session starts.
+	RunOn string `json:"runOn,omitempty"`
+}
+
+const (
+	// DefaultHookTimeoutSeconds is the timeout applied to a hook whose
+	// TimeoutSeconds is left at zero.
+	DefaultHookTimeoutSeconds = 300
+
+	// MaxHookTimeoutSeconds is the hard ceiling ValidateRunConfig
+	// enforces on HookConfig.TimeoutSeconds, and the bound used to cap
+	// the sum of PostRun timeouts (the detached post-hook budget the
+	// agentic loop grants after Git.Finalise).
+	MaxHookTimeoutSeconds = 1800
+
+	// maxHookCommandBytes bounds HookConfig.Command.
+	maxHookCommandBytes = 16 * 1024
+
+	// maxHookNameBytes bounds HookConfig.Name.
+	maxHookNameBytes = 64
+
+	// maxHooksPerPhase caps the number of hooks in PreRun or PostRun,
+	// independently.
+	maxHooksPerPhase = 32
+)
+
+// EffectiveHookTimeout resolves the timeout a hook.Runner should apply
+// for h. ValidateRunConfig has already bounded TimeoutSeconds to
+// [0, MaxHookTimeoutSeconds]; zero means "unset" and resolves to
+// DefaultHookTimeoutSeconds, any other value is returned verbatim.
+func EffectiveHookTimeout(h HookConfig) int {
+	if h.TimeoutSeconds == 0 {
+		return DefaultHookTimeoutSeconds
+	}
+	return h.TimeoutSeconds
+}
+
 // EditStrategyConfig selects the edit strategy implementation.
 type EditStrategyConfig struct {
 	Type           string   `json:"type"`                     // "whole-file" | "search-replace" | "udiff" | "multi"
@@ -2007,7 +2116,16 @@ func ValidateRunConfig(config *RunConfig) error {
 		errs = append(errs, fmt.Sprintf("mode %q requires a restrictive permission policy", config.Mode))
 	}
 
-	// Read-only modes must not enable write-capable tools
+	// Read-only modes must not enable write-capable tools.
+	//
+	// Lifecycle hooks (#461) are deliberately NOT covered by this
+	// invariant: it bounds the *agent's* tools — what the model can
+	// reach mid-conversation — not operator-authored, deterministic
+	// commands declared in reviewable RunConfig. Precedent already
+	// exists for exec outside the tool surface in read-only modes (the
+	// test-runner verifier's command, the deterministic git strategy's
+	// branch creation); a pre-run hook that clones a repo is exactly
+	// what a planning run needs to have something to read.
 	if readOnlyModes[config.Mode] {
 		if len(config.Tools.BuiltIn) == 0 {
 			errs = append(errs, fmt.Sprintf(
@@ -2077,6 +2195,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateObservabilityConfig(config.Observability, &errs)
 	validateToolDispatchConfig(config.ToolDispatch, &errs)
 	validateToolChoiceEscalationConfig(config.ToolChoiceEscalation, &errs)
+	validateHooksConfig(config, &errs)
 	validateBatchConfig(config, &errs)
 
 	if len(errs) > 0 {
@@ -2220,6 +2339,15 @@ func RuleOfTwoState(config *RunConfig) (holdsUntrusted, holdsSensitive, canCommE
 //
 // The three booleans are deliberately crude in v1 (per the issue
 // brief). They will be refined as we collect eval-suite signal.
+//
+// Lifecycle hooks (#461) do not participate in any of the three legs:
+// they add no agent-reachable capability (they run outside the
+// conversation entirely), their output is trace-only and never enters
+// the model's context (so a hook cannot smuggle sensitive data into a
+// turn), and they share the run's existing egress posture rather than
+// opening a new external-communication surface. HooksConfig is
+// intentionally absent from ruleOfTwoUntrustedInput / ruleOfTwoSensitiveData
+// / ruleOfTwoExternalComm below.
 func validateRuleOfTwo(config *RunConfig, errs *[]string) {
 	holdsUntrusted := ruleOfTwoUntrustedInput(config)
 	holdsSensitive := ruleOfTwoSensitiveData(config)
@@ -2535,6 +2663,132 @@ func validateToolChoiceEscalationConfig(cfg *ToolChoiceEscalationConfig, errs *[
 	}
 	if cfg.MaxRetries < 0 || cfg.MaxRetries > MaxToolChoiceEscalationMaxRetries {
 		*errs = append(*errs, fmt.Sprintf("toolChoiceEscalation.maxRetries must be 0 (use default) or between 1 and %d", MaxToolChoiceEscalationMaxRetries))
+	}
+}
+
+// validHookTypes is the closed set of HookConfig.Type values. Empty
+// defaults to "command"; v1 supports no other kind.
+var validHookTypes = map[string]bool{"": true, "command": true}
+
+// validHookRunOnValues is the closed set of HookConfig.RunOn values.
+var validHookRunOnValues = map[string]bool{"": true, "always": true, "success": true, "failure": true}
+
+// validateHooksConfig enforces the HooksConfig invariants (issue #461):
+//
+//   - Hooks require an exec-capable executor — the "api" executor is
+//     read-only (CanExec=false) and cannot run them. types cannot import
+//     the executor package's Capabilities, so this checks the static
+//     discriminator instead.
+//   - Every hook's Command is non-empty (after TrimSpace), bounded, and
+//     free of "secret://" references (see HookConfig.Command).
+//   - Type, TimeoutSeconds, Name, and the per-phase hook count are
+//     bounded to a closed set / hard ceiling.
+//   - RunOn is a closed set and rejected outright on a PreRun hook.
+//   - The sum of effective PostRun timeouts is bounded to
+//     MaxHookTimeoutSeconds — it sizes the detached post-hook budget the
+//     agentic loop grants after the run's own wall-clock timeout may
+//     have already expired.
+//   - A PreRun phase whose summed effective timeout exceeds the run's
+//     own wall-clock Timeout is a WARN, not a hard error: pre hooks run
+//     serially inside the same budget as the rest of the run, so this
+//     usually still succeeds but is very likely to blow the timeout.
+//
+// Read-only modes are deliberately NOT rejected here (see the comment at
+// the read-only tool-list invariant site above), and Rule-of-Two is
+// untouched (see validateRuleOfTwo's doc comment): hooks are operator-
+// authored and add no agent-reachable capability.
+func validateHooksConfig(config *RunConfig, errs *[]string) {
+	if config.Hooks == nil {
+		return
+	}
+	hooks := config.Hooks
+
+	if (len(hooks.PreRun) > 0 || len(hooks.PostRun) > 0) && config.Executor.Type == "api" {
+		*errs = append(*errs, "hooks require an exec-capable executor; executor.type \"api\" is read-only")
+	}
+
+	if len(hooks.PreRun) > maxHooksPerPhase {
+		*errs = append(*errs, fmt.Sprintf("hooks.preRun must have <= %d entries, got %d", maxHooksPerPhase, len(hooks.PreRun)))
+	}
+	if len(hooks.PostRun) > maxHooksPerPhase {
+		*errs = append(*errs, fmt.Sprintf("hooks.postRun must have <= %d entries, got %d", maxHooksPerPhase, len(hooks.PostRun)))
+	}
+
+	var preSum, postSum int
+	for i, h := range hooks.PreRun {
+		validateHookConfig(fmt.Sprintf("hooks.preRun[%d]", i), h, false, errs)
+		preSum += EffectiveHookTimeout(h)
+	}
+	for i, h := range hooks.PostRun {
+		validateHookConfig(fmt.Sprintf("hooks.postRun[%d]", i), h, true, errs)
+		postSum += EffectiveHookTimeout(h)
+	}
+
+	if postSum > MaxHookTimeoutSeconds {
+		*errs = append(*errs, fmt.Sprintf("sum of hooks.postRun effective timeouts must be <= %d seconds, got %d", MaxHookTimeoutSeconds, postSum))
+	}
+
+	if config.Timeout != nil && preSum > *config.Timeout {
+		// Layering note: same "types-side slog.Warn" mechanism as the
+		// batch maxTurns latency warning above (gh-134 precedent) —
+		// spec-faithful but leaves callers without a way to observe or
+		// suppress the warning short of manipulating slog.Default.
+		slog.Warn(
+			"sum of hooks.preRun effective timeouts exceeds the run's wall-clock timeout",
+			"preRunTimeoutSumSeconds", preSum,
+			"timeoutSeconds", *config.Timeout,
+		)
+	}
+}
+
+// validateHookConfig enforces the per-hook invariants shared by both
+// phases, plus the RunOn constraint that differs by phase (rejected
+// outright on a PreRun hook; a closed set on a PostRun hook).
+func validateHookConfig(path string, h HookConfig, isPostRun bool, errs *[]string) {
+	validateOptionalType(path, h.Type, validHookTypes, errs)
+
+	if strings.TrimSpace(h.Command) == "" {
+		*errs = append(*errs, fmt.Sprintf("%s.command is required", path))
+	} else if len(h.Command) > maxHookCommandBytes {
+		*errs = append(*errs, fmt.Sprintf("%s.command must be <= %d bytes, got %d", path, maxHookCommandBytes, len(h.Command)))
+	}
+	if strings.Contains(h.Command, "secret://") {
+		*errs = append(*errs, fmt.Sprintf(
+			"%s.command must not contain a \"secret://\" reference; resolve credentials via control-plane runtime bindings instead",
+			path))
+	}
+
+	if h.TimeoutSeconds < 0 || h.TimeoutSeconds > MaxHookTimeoutSeconds {
+		*errs = append(*errs, fmt.Sprintf(
+			"%s.timeoutSeconds must be 0 (use default) or between 1 and %d, got %d",
+			path, MaxHookTimeoutSeconds, h.TimeoutSeconds))
+	}
+
+	if len(h.Name) > maxHookNameBytes {
+		*errs = append(*errs, fmt.Sprintf("%s.name must be <= %d bytes, got %d", path, maxHookNameBytes, len(h.Name)))
+	} else if h.Name != "" {
+		if !utf8.ValidString(h.Name) {
+			*errs = append(*errs, fmt.Sprintf("%s.name must be valid UTF-8", path))
+		} else {
+			for i, r := range h.Name {
+				if !unicode.IsPrint(r) {
+					*errs = append(*errs, fmt.Sprintf("%s.name contains non-printable character at byte %d (U+%04X)", path, i, r))
+					break
+				}
+			}
+		}
+	}
+
+	if !isPostRun {
+		if h.RunOn != "" {
+			*errs = append(*errs, fmt.Sprintf("%s.runOn must be empty on a preRun hook", path))
+		}
+		return
+	}
+	if !validHookRunOnValues[h.RunOn] {
+		*errs = append(*errs, fmt.Sprintf(
+			"%s.runOn %q is not valid; must be one of \"\", \"always\", \"success\", \"failure\"",
+			path, h.RunOn))
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -6768,3 +6768,403 @@ func TestValidateRunConfig_CompatProfile(t *testing.T) {
 		}
 	})
 }
+
+// --- HooksConfig (issue #461) ---
+
+func validHookConfig() HookConfig {
+	return HookConfig{Command: "echo ok"}
+}
+
+func TestValidateRunConfig_Hooks_NilIsValid(t *testing.T) {
+	c := validConfig()
+	c.Hooks = nil
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("nil Hooks must validate, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Hooks_MinimalAccepted(t *testing.T) {
+	c := validConfig()
+	c.Hooks = &HooksConfig{
+		PreRun:  []HookConfig{{Command: "git clone https://example.com/repo ."}},
+		PostRun: []HookConfig{{Command: "test -f marker", RunOn: "success"}},
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("minimal valid HooksConfig must validate, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Hooks_RejectsAPIExecutorWithHooks(t *testing.T) {
+	c := validConfig()
+	c.Executor = ExecutorConfig{Type: "api"}
+	c.Hooks = &HooksConfig{PreRun: []HookConfig{validHookConfig()}}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("hooks with executor.type=api must fail validation")
+	}
+	if !strings.Contains(err.Error(), "exec-capable executor") {
+		t.Errorf("error must mention exec-capable executor, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Hooks_EmptyHooksConfigAllowsAPIExecutor(t *testing.T) {
+	// An explicit-but-empty HooksConfig{} (e.g. an unmarshalled wire
+	// payload with an empty "hooks" sub-message) schedules nothing, so
+	// it must not trip the exec-capable-executor requirement.
+	c := validConfig()
+	c.Executor = ExecutorConfig{Type: "api"}
+	c.Hooks = &HooksConfig{}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("empty HooksConfig with executor.type=api must validate, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Hooks_CommandRequired(t *testing.T) {
+	for _, cmd := range []string{"", "   ", "\t\n"} {
+		t.Run(fmt.Sprintf("command=%q", cmd), func(t *testing.T) {
+			c := validConfig()
+			c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: cmd}}}
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatal("empty/whitespace command must fail validation")
+			}
+			if !strings.Contains(err.Error(), "hooks.preRun[0].command is required") {
+				t.Errorf("error must mention hooks.preRun[0].command is required, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_Hooks_CommandMaxLength(t *testing.T) {
+	c := validConfig()
+	c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: strings.Repeat("a", maxHookCommandBytes+1)}}}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("oversized command must fail validation")
+	}
+	if !strings.Contains(err.Error(), "hooks.preRun[0].command must be <=") {
+		t.Errorf("error must mention the command length bound, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Hooks_CommandRejectsSecretRef(t *testing.T) {
+	cases := []string{
+		"secret://API_KEY",
+		"curl -H \"Authorization: Bearer $(cat secret://API_KEY)\"",
+		"echo secret://ANYWHERE_IN_STRING",
+	}
+	for _, cmd := range cases {
+		t.Run(cmd, func(t *testing.T) {
+			c := validConfig()
+			c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: cmd}}}
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("command containing secret:// must fail validation: %q", cmd)
+			}
+			if !strings.Contains(err.Error(), "secret://") {
+				t.Errorf("error must mention secret://, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_Hooks_TypeClosedSet(t *testing.T) {
+	t.Run("empty-accepted", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: []HookConfig{{Type: "", Command: "true"}}}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Errorf("type=\"\" must validate, got: %v", err)
+		}
+	})
+	t.Run("command-accepted", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: []HookConfig{{Type: "command", Command: "true"}}}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Errorf("type=command must validate, got: %v", err)
+		}
+	})
+	t.Run("unknown-rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: []HookConfig{{Type: "gitSource", Command: "true"}}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("unknown hook type must fail validation")
+		}
+		if !strings.Contains(err.Error(), `unsupported hooks.preRun[0] type "gitSource"`) {
+			t.Errorf("error must name the offending type, got: %v", err)
+		}
+	})
+}
+
+func TestValidateRunConfig_Hooks_TimeoutBounds(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int
+		wantErr bool
+	}{
+		{"zero_uses_default", 0, false},
+		{"one_second", 1, false},
+		{"max_1800", MaxHookTimeoutSeconds, false},
+		{"over_max_rejected", MaxHookTimeoutSeconds + 1, true},
+		{"negative_rejected", -1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: "true", TimeoutSeconds: tc.seconds}}}
+			err := ValidateRunConfig(c)
+			if tc.wantErr && err == nil {
+				t.Fatalf("timeoutSeconds=%d must fail validation", tc.seconds)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("timeoutSeconds=%d must validate, got: %v", tc.seconds, err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_Hooks_NameBounds(t *testing.T) {
+	t.Run("within_bound_accepted", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: "true", Name: strings.Repeat("a", maxHookNameBytes)}}}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Errorf("64-byte name must validate, got: %v", err)
+		}
+	})
+	t.Run("over_bound_rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: "true", Name: strings.Repeat("a", maxHookNameBytes+1)}}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("65-byte name must fail validation")
+		}
+		if !strings.Contains(err.Error(), "hooks.preRun[0].name must be <=") {
+			t.Errorf("error must mention the name length bound, got: %v", err)
+		}
+	})
+	t.Run("control_byte_rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: "true", Name: "clone\x00repo"}}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("control byte in name must fail validation")
+		}
+		if !strings.Contains(err.Error(), "non-printable character") {
+			t.Errorf("error must mention non-printable character, got: %v", err)
+		}
+	})
+}
+
+func TestValidateRunConfig_Hooks_RunOnPreRunRejected(t *testing.T) {
+	for _, runOn := range []string{"always", "success", "failure"} {
+		t.Run(runOn, func(t *testing.T) {
+			c := validConfig()
+			c.Hooks = &HooksConfig{PreRun: []HookConfig{{Command: "true", RunOn: runOn}}}
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("runOn=%q on a preRun hook must fail validation", runOn)
+			}
+			if !strings.Contains(err.Error(), "hooks.preRun[0].runOn must be empty on a preRun hook") {
+				t.Errorf("error must mention preRun runOn, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_Hooks_RunOnPostRunClosedSet(t *testing.T) {
+	t.Run("valid_values_accepted", func(t *testing.T) {
+		for _, runOn := range []string{"", "always", "success", "failure"} {
+			t.Run(runOn, func(t *testing.T) {
+				c := validConfig()
+				c.Hooks = &HooksConfig{PostRun: []HookConfig{{Command: "true", RunOn: runOn}}}
+				if err := ValidateRunConfig(c); err != nil {
+					t.Errorf("runOn=%q on a postRun hook must validate, got: %v", runOn, err)
+				}
+			})
+		}
+	})
+	t.Run("unknown_rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PostRun: []HookConfig{{Command: "true", RunOn: "sometimes"}}}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("runOn=sometimes must fail validation")
+		}
+		if !strings.Contains(err.Error(), "hooks.postRun[0].runOn") {
+			t.Errorf("error must mention hooks.postRun[0].runOn, got: %v", err)
+		}
+	})
+}
+
+func TestValidateRunConfig_Hooks_MaxHooksPerPhase(t *testing.T) {
+	makeHooks := func(n int) []HookConfig {
+		hooks := make([]HookConfig, n)
+		for i := range hooks {
+			hooks[i] = HookConfig{Command: "true"}
+		}
+		return hooks
+	}
+	t.Run("at_limit_accepted", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: makeHooks(maxHooksPerPhase)}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Errorf("%d preRun hooks must validate, got: %v", maxHooksPerPhase, err)
+		}
+	})
+	t.Run("over_limit_rejected", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PreRun: makeHooks(maxHooksPerPhase + 1)}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatalf("%d preRun hooks must fail validation", maxHooksPerPhase+1)
+		}
+		if !strings.Contains(err.Error(), "hooks.preRun must have <=") {
+			t.Errorf("error must mention the per-phase hook count bound, got: %v", err)
+		}
+	})
+	t.Run("postRun_bounded_independently", func(t *testing.T) {
+		c := validConfig()
+		c.Hooks = &HooksConfig{PostRun: makeHooks(maxHooksPerPhase + 1)}
+		err := ValidateRunConfig(c)
+		if err == nil {
+			t.Fatal("oversized postRun list must fail validation")
+		}
+		if !strings.Contains(err.Error(), "hooks.postRun must have <=") {
+			t.Errorf("error must mention hooks.postRun, got: %v", err)
+		}
+	})
+}
+
+func TestValidateRunConfig_Hooks_PostRunTimeoutSumBounded(t *testing.T) {
+	c := validConfig()
+	c.Hooks = &HooksConfig{
+		PostRun: []HookConfig{
+			{Command: "true", TimeoutSeconds: 1000},
+			{Command: "true", TimeoutSeconds: 900},
+		},
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("postRun timeout sum > MaxHookTimeoutSeconds must fail validation")
+	}
+	if !strings.Contains(err.Error(), "sum of hooks.postRun effective timeouts") {
+		t.Errorf("error must mention the postRun timeout sum bound, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_Hooks_PostRunTimeoutSumAtBoundAccepted(t *testing.T) {
+	c := validConfig()
+	c.Hooks = &HooksConfig{
+		PostRun: []HookConfig{
+			{Command: "true", TimeoutSeconds: MaxHookTimeoutSeconds},
+		},
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("postRun timeout sum == MaxHookTimeoutSeconds must validate, got: %v", err)
+	}
+}
+
+// TestValidateRunConfig_Hooks_PreRunTimeoutSumWarnsOnly pins that a
+// preRun timeout sum exceeding the run's wall-clock Timeout is a
+// slog.Warn, not a hard validation error — the run is very likely to
+// blow the timeout, but that is a runtime concern, not a config-shape
+// error the harness should refuse to start.
+func TestValidateRunConfig_Hooks_PreRunTimeoutSumWarnsOnly(t *testing.T) {
+	c := validConfig()
+	timeout := 60
+	c.Timeout = &timeout
+	c.Hooks = &HooksConfig{
+		PreRun: []HookConfig{{Command: "true", TimeoutSeconds: 300}},
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("preRun timeout sum > timeout must only warn, not fail validation: %v", err)
+	}
+}
+
+func TestEffectiveHookTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  HookConfig
+		want int
+	}{
+		{"zero_resolves_to_default", HookConfig{TimeoutSeconds: 0}, DefaultHookTimeoutSeconds},
+		{"explicit_value_verbatim", HookConfig{TimeoutSeconds: 120}, 120},
+		{"max_value_verbatim", HookConfig{TimeoutSeconds: MaxHookTimeoutSeconds}, MaxHookTimeoutSeconds},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EffectiveHookTimeout(tc.cfg); got != tc.want {
+				t.Errorf("EffectiveHookTimeout(%+v) = %d, want %d", tc.cfg, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRedact_HooksPassThrough pins validation decision #9: hook commands
+// are operator config like VerifierConfig.Command/Prompt, so Redact()
+// must leave HooksConfig completely untouched — there is nothing to
+// redact because validateHooksConfig structurally forbids "secret://"
+// in a hook Command.
+func TestRedact_HooksPassThrough(t *testing.T) {
+	rc := RunConfig{
+		Hooks: &HooksConfig{
+			PreRun: []HookConfig{
+				{Type: "command", Name: "clone", Command: "git clone https://example.com/repo .", TimeoutSeconds: 120},
+			},
+			PostRun: []HookConfig{
+				{Command: "curl -X POST https://example.com/artifacts", RunOn: "success", ContinueOnError: true},
+			},
+		},
+	}
+	redacted := rc.Redact()
+
+	if redacted.Hooks == nil {
+		t.Fatal("Redact must not drop Hooks")
+	}
+	if len(redacted.Hooks.PreRun) != 1 || redacted.Hooks.PreRun[0].Command != "git clone https://example.com/repo ." {
+		t.Errorf("PreRun must pass through unchanged, got: %+v", redacted.Hooks.PreRun)
+	}
+	if len(redacted.Hooks.PostRun) != 1 || redacted.Hooks.PostRun[0].Command != "curl -X POST https://example.com/artifacts" {
+		t.Errorf("PostRun must pass through unchanged, got: %+v", redacted.Hooks.PostRun)
+	}
+	if !redacted.Hooks.PostRun[0].ContinueOnError {
+		t.Error("ContinueOnError must pass through unchanged")
+	}
+}
+
+func TestHooksConfig_JSONRoundTrip(t *testing.T) {
+	rc := RunConfig{
+		Hooks: &HooksConfig{
+			PreRun:  []HookConfig{{Command: "true"}},
+			PostRun: []HookConfig{{Command: "true", RunOn: "failure"}},
+		},
+	}
+	data, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got RunConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Hooks == nil {
+		t.Fatal("Hooks must survive JSON round-trip as non-nil")
+	}
+	if len(got.Hooks.PreRun) != 1 || got.Hooks.PreRun[0].Command != "true" {
+		t.Errorf("PreRun round-trip: got %+v", got.Hooks.PreRun)
+	}
+	if len(got.Hooks.PostRun) != 1 || got.Hooks.PostRun[0].RunOn != "failure" {
+		t.Errorf("PostRun round-trip: got %+v", got.Hooks.PostRun)
+	}
+}
+
+func TestRunConfig_HooksOmittedWhenNil(t *testing.T) {
+	rc := RunConfig{}
+	data, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), `"hooks"`) {
+		t.Errorf("expected no hooks key when Hooks is nil, got: %s", data)
+	}
+}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -6852,6 +6852,11 @@ func TestValidateRunConfig_Hooks_CommandRejectsSecretRef(t *testing.T) {
 		"secret://API_KEY",
 		"curl -H \"Authorization: Bearer $(cat secret://API_KEY)\"",
 		"echo secret://ANYWHERE_IN_STRING",
+		// Case-insensitive: a shell reads "secret://" and "SECRET://"
+		// identically, so the rejection must too.
+		"SECRET://API_KEY",
+		"Secret://API_KEY",
+		"echo sEcReT://mixed_case",
 	}
 	for _, cmd := range cases {
 		t.Run(cmd, func(t *testing.T) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -7100,8 +7100,8 @@ func TestEffectiveHookTimeout(t *testing.T) {
 	}
 }
 
-// TestRedact_HooksPassThrough pins validation decision #9: hook commands
-// are operator config like VerifierConfig.Command/Prompt, so Redact()
+// TestRedact_HooksPassThrough pins that hook commands are operator
+// config like VerifierConfig.Command/Prompt, so Redact()
 // must leave HooksConfig completely untouched — there is nothing to
 // redact because validateHooksConfig structurally forbids "secret://"
 // in a hook Command.

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -6873,6 +6873,71 @@ func TestValidateRunConfig_Hooks_CommandRejectsSecretRef(t *testing.T) {
 	}
 }
 
+// TestValidateRunConfig_Hooks_AcceptedInReadOnlyMode pins the
+// read-only-mode carve-out for lifecycle hooks: the invariant bounds
+// only the model's tool surface, not operator-authored, deterministic
+// commands declared in reviewable RunConfig, so hooks — including a
+// postRun hook that writes (git push) — validate cleanly in every
+// read-only mode. A silent regression risk if the read-only check is
+// ever tightened without remembering the exception.
+func TestValidateRunConfig_Hooks_AcceptedInReadOnlyMode(t *testing.T) {
+	readOnlyModes := []string{"planning", "review", "research", "toil"}
+	for _, mode := range readOnlyModes {
+		t.Run(mode, func(t *testing.T) {
+			c := validConfig()
+			c.Mode = mode
+			c.PermissionPolicy = PermissionPolicyConfig{Type: "deny-side-effects"}
+			c.Tools = ToolsConfig{BuiltIn: []string{"read_file"}}
+			c.Hooks = &HooksConfig{
+				PreRun:  []HookConfig{{Name: "clone", Command: "git clone https://example.com/repo ."}},
+				PostRun: []HookConfig{{Name: "push", Command: "git push", RunOn: "success"}},
+			}
+			if err := ValidateRunConfig(c); err != nil {
+				t.Errorf("hooks in read-only mode %q must validate, got: %v", mode, err)
+			}
+		})
+	}
+}
+
+// TestRuleOfTwoState_HooksNeverAffectLegs pins that Hooks plays no part
+// in any of the three Rule-of-Two legs: RuleOfTwoState must report
+// identical flags for two configs differing only in Hooks being nil vs.
+// populated with a network-touching, dynamic-context-referencing hook.
+// The base config is deliberately built to already trip all three legs
+// (DynamicContext with Sensitive:true trips untrusted-input and
+// sensitive-data; web_fetch trips external-comm) so the comparison is
+// meaningful rather than trivially false==false. Correct today (none of
+// ruleOfTwoUntrustedInput/ruleOfTwoSensitiveData/ruleOfTwoExternalComm
+// reference config.Hooks) but unprotected against a future change that
+// accidentally wires a postRun hook's network call into the
+// external-communication leg.
+func TestRuleOfTwoState_HooksNeverAffectLegs(t *testing.T) {
+	base := validConfig()
+	base.DynamicContext = map[string]DynamicContextValue{
+		"issue": {Value: "untrusted issue body", Sensitive: true},
+	}
+	base.Tools = ToolsConfig{BuiltIn: []string{"web_fetch"}}
+
+	withHooks := *base
+	withHooks.Hooks = &HooksConfig{
+		PreRun: []HookConfig{{Command: "curl -X POST https://example.com/webhook"}},
+		PostRun: []HookConfig{
+			{Command: "curl -X POST https://example.com/artifact", RunOn: "success"},
+		},
+	}
+
+	baseUntrusted, baseSensitive, baseExternal := RuleOfTwoState(base)
+	if !baseUntrusted || !baseSensitive || !baseExternal {
+		t.Fatalf("prerequisite: base config must trip all three legs, got (%v, %v, %v)", baseUntrusted, baseSensitive, baseExternal)
+	}
+
+	hooksUntrusted, hooksSensitive, hooksExternal := RuleOfTwoState(&withHooks)
+	if hooksUntrusted != baseUntrusted || hooksSensitive != baseSensitive || hooksExternal != baseExternal {
+		t.Errorf("RuleOfTwoState changed when only Hooks was populated: base=(%v,%v,%v) withHooks=(%v,%v,%v)",
+			baseUntrusted, baseSensitive, baseExternal, hooksUntrusted, hooksSensitive, hooksExternal)
+	}
+}
+
 func TestValidateRunConfig_Hooks_TypeClosedSet(t *testing.T) {
 	t.Run("empty-accepted", func(t *testing.T) {
 		c := validConfig()

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -29,7 +29,48 @@ type RunTrace struct {
 	ToolCalls           []ToolCallSummary    `json:"toolCalls"`
 	PermissionDenials   int                  `json:"permissionDenials,omitempty"`
 	VerificationResults []VerificationResult `json:"verificationResults"`
-	Outcome             string               `json:"outcome"` // "success" | "error" | "max_turns" | "verification_failed" | "verification_error" | "budget_exceeded" | "stalled" | "tool_failures" | "cancelled" | "timeout" | "max_tokens"
+	// Outcome is "success" | "error" | "max_turns" | "verification_failed" |
+	// "verification_error" | "budget_exceeded" | "stalled" | "tool_failures" |
+	// "cancelled" | "timeout" | "max_tokens" | "setup_failed" | "hook_failed".
+	// setup_failed and hook_failed (issue #461) report a fatal lifecycle-hook
+	// failure: setup_failed means a PreRun hook failed before the session
+	// started (zero turns ran); hook_failed means a PostRun hook failed after
+	// an otherwise-successful run (it never overrides a non-success outcome —
+	// the primary failure cause stays authoritative).
+	Outcome string `json:"outcome"`
+	// HookResults carries every lifecycle hook execution recorded during
+	// the run (issue #461), across both phases, in dispatch order. Empty
+	// when no hooks were configured. Populated by trace emitters that
+	// implement the optional trace.HookRecorder capability (today, the
+	// JSONL emitter).
+	HookResults []HookExecution `json:"hookResults,omitempty"`
+}
+
+// HookExecution records the outcome of a single lifecycle hook (issue
+// #461). Phase distinguishes "preRun" (before GitStrategy.Setup) from
+// "postRun" (after GitStrategy.Finalise); Index is the hook's position
+// within its phase's configured list (RunConfig.Hooks.PreRun /
+// .PostRun), so a trace consumer can correlate a result back to the
+// RunConfig entry that produced it even when Name is empty.
+//
+// OutputTail is the scrubbed (security.Scrub), tail-capped combined
+// stdout+stderr of the hook — trace-only, never surfaced to the model.
+// Truncated reports whether the persisted (scrubbed) output exceeded the
+// 4KB tail cap; truncation keeps the tail (not the head) because a
+// failing command's most useful diagnostic is usually printed last.
+type HookExecution struct {
+	Phase            string `json:"phase"` // "preRun" | "postRun"
+	Index            int    `json:"index"`
+	Name             string `json:"name,omitempty"`
+	Command          string `json:"command"`
+	ExitCode         int    `json:"exitCode"`
+	DurationMs       int64  `json:"durationMs"`
+	TimedOut         bool   `json:"timedOut,omitempty"`
+	Skipped          bool   `json:"skipped,omitempty"`
+	ContinuedOnError bool   `json:"continuedOnError,omitempty"`
+	Error            string `json:"error,omitempty"`
+	OutputTail       string `json:"outputTail,omitempty"`
+	Truncated        bool   `json:"truncated,omitempty"`
 }
 
 // ToolCallSummary records a single tool call's outcome for the trace.


### PR DESCRIPTION
Closes #461.

## What

`RunConfig` gains a `hooks` section: ordered, operator-authored shell commands executed in the sandbox through the run's `Executor` — `hooks.preRun` before turn 1 (repo clone, runtime provisioning, `bundle install`), `hooks.postRun` after the session (artifact submission, smoke tests). Deterministic setup/teardown stops consuming turns and tokens, and setup becomes expressible over the gRPC `task_assignment` path (proto field 32).

```json
{
  "hooks": {
    "preRun":  [{ "name": "clone", "command": "git clone https://… .", "timeoutSeconds": 300 }],
    "postRun": [{ "name": "smoke", "command": "bundle exec rake smoke", "runOn": "success" }]
  }
}
```

## Design decisions

- **Naming is per-run, not per-session** — `docs/sessions-spec-draft.md` reserves "session" for multi-run continuity.
- **Hook output is trace-only**: recorded as `hook_record` JSONL events and `RunTrace.HookResults` (scrubbed, 4 KB rune-safe tails), never injected into model context — no new prompt-injection surface.
- **Hooks share the run's network posture** (same egress allowlist / NetworkPolicy); no phase-specific egress.
- **Failure semantics**: fatal preRun failure → outcome `setup_failed`, session never starts; fatal postRun failure → `hook_failed`, only ever overriding `success` (a primary failure cause is never masked). Per-hook `continueOnError` and postRun `runOn: always|success|failure` for best-effort hooks.
- **postRun survives the run deadline but not process signals**: detached, budget-bounded context (≤1830 s) that still observes SIGTERM/SIGINT via an injected shutdown context plus a 5 s teardown watchdog — preserving the documented Cloud Run SIGTERM-grace contract and K8s sandbox teardown.
- **Read-only modes allow hooks** (consistent with test-runner verifier and deterministic git strategy precedent; documented in `docs/configuration.md` and pinned by test). **Rule-of-Two flags are untouched** by hooks (pinned by test).
- **Executor exec hard cap raised 5→30 min** for cold installs; the agent-reachable `run_command` path stays clamped at 300 s in the tool layer, pinned by a regression test.
- `secret://` is rejected (case-insensitively) inside hook commands; clone credentials arrive via control-plane runtime bindings per CONTROL_PLANE.md §2.7.

## Notable fixes shaken out along the way

- Fatal `Run()` errors carrying a trace (now including `setup_failed`) previously skipped `RunResult`/result-sink emission and the gRPC `done` event on both CLI entrypoints — fixed; `error` outcomes now also reach `done`.
- `LocalExecutor` exec left stdout pipes open to orphaned grandchildren after ctx cancellation, blocking `Exec` for the grandchild's lifetime — fixed via `cmd.WaitDelay` (SIGTERM response measured 27 s → 0.6 s).
- UTF-8 rune-boundary-safe truncation for persisted hook output tails.

## Verification

- Plan → implementation → 5-reviewer wave (code, security, spec-compliance, test-coverage, consistency) → synthesized remediation (14 findings fixed, 2 blocking) → fresh-context end-to-end verification of 8 runtime scenarios against the built binary, including live SIGTERM timing and `setup_failed` result emission.
- `just build`, `just test` (41 packages, `-race` clean on `harness/...`), `just lint` all green; new hook package at 94 % coverage.
- Docs: `configuration.md` (schema + worked example), `architecture.md`, `security.md`, `safety-rings.md` (hooks sit outside Rings 3/4/5), `cloud-run-jobs.md`, `executors/k8s.md` (`terminationGracePeriodSeconds`), `deployment.md`.

Follow-up issues for the six deferred review findings plus two verification observations are being filed and will be linked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gxw8GWTYdFraZWjmPk2SGt