### PR TITLE
cli: exit non-zero when the run outcome is not success

### DIFF
--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -2069,5 +2069,10 @@ func runWithConfig(config *types.RunConfig, opts runOptions) error {
 	if config.FollowUpGrace != nil && *config.FollowUpGrace > 0 {
 		core.RunFollowUpLoop(ctx, loop, config, *config.FollowUpGrace)
 	}
-	return nil
+	// A non-success outcome reached here (runErr == nil but, e.g.,
+	// Outcome == "error" from a provider failure, or "hook_failed" from
+	// a fatal postRun hook) must still fail the process — see
+	// runOutcomeError. The RunResult/stderr summary above already
+	// carries the real outcome; this only affects the exit code.
+	return runOutcomeError(runTrace)
 }

--- a/harness/cmd/stirrup/cmd/job.go
+++ b/harness/cmd/stirrup/cmd/job.go
@@ -209,5 +209,10 @@ func runJob(cmd *cobra.Command, args []string) error {
 		core.RunFollowUpLoop(ctx, loop, config, graceSecs)
 	}
 
-	return nil
+	// A non-success outcome reached here (runErr == nil but, e.g.,
+	// Outcome == "error" from a provider failure, or "hook_failed" from
+	// a fatal postRun hook) must still fail the process — this is what
+	// a Cloud Run / K8s Jobs orchestrator observes to decide whether to
+	// retry or alert. See runOutcomeError in root.go.
+	return runOutcomeError(runTrace)
 }

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -181,6 +181,51 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 	return res
 }
 
+// runSuccessOutcomes is the closed set of RunTrace.Outcome values that
+// count as a successful run for process exit-code purposes (issue
+// #101, v0.1 release blocker B4). "success" is the only member: every
+// other documented value on types.RunTrace.Outcome — "error",
+// "tool_failures", "verification_failed", "verification_error",
+// "max_turns", "max_tokens", "budget_exceeded", "stalled",
+// "cancelled", "timeout", "setup_failed", "hook_failed" — means the
+// run did not complete its task, whether via a hard failure, an
+// exhausted resource limit, or an interruption. docs/configuration.md
+// draws the same line ("a failed or cancelled run still exits
+// non-zero"); the Cloud Run / K8s Jobs failure-signalling story this
+// feeds needs the same binary classification so an orchestrator
+// retries or alerts on any run that was not a genuine success, not
+// only the ones that hit a hard error.
+//
+// Deliberately not reusing EvalOutcomeFor's passed/failed/inconclusive
+// split (types/evaloutcome.go): that taxonomy answers "was the change
+// any good", which folds limit-hit and cancelled runs into a distinct
+// "inconclusive" bucket so eval aggregates don't punish a run that
+// never got a fair shot. Process exit code answers a narrower
+// question — "did this invocation produce a usable result" — where
+// inconclusive and failed both mean no.
+var runSuccessOutcomes = map[string]bool{
+	"success": true,
+}
+
+// runOutcomeError reports whether rt's outcome falls outside
+// runSuccessOutcomes, returning a descriptive error if so. Called at
+// the tail of runWithConfig and runJob once every non-fatal post-run
+// step (result emission, workspace export, follow-up grace) has run,
+// so a non-success outcome always yields a non-zero process exit via
+// classifyExitCode's untyped-error default (exit 1) — the same code
+// docs/configuration.md documents for "a failed or cancelled run".
+//
+// A nil trace returns nil: both call sites already return a dedicated
+// error for runTrace == nil before reaching this check, so this branch
+// only exists as a defensive default against a future caller that
+// skips that guard.
+func runOutcomeError(rt *types.RunTrace) error {
+	if rt == nil || runSuccessOutcomes[rt.Outcome] {
+		return nil
+	}
+	return fmt.Errorf("run outcome %q is not success", rt.Outcome)
+}
+
 // newResultSink is the seam tests use to inject a stub ResultSink so
 // the forward-compatibility branches in emitRunOutput (non-stdout-json
 // sink paths under --output=json and --output=none) can be exercised

--- a/harness/cmd/stirrup/cmd/runoutcome_test.go
+++ b/harness/cmd/stirrup/cmd/runoutcome_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestRunOutcomeError_EnumeratedOutcomes pins the outcome→exit mapping
+// (issue #101, v0.1 release blocker B4) against every value documented
+// on types.RunTrace.Outcome. "success" is the only outcome that must
+// not produce an error; every other documented value — including the
+// limit-hit and lifecycle-hook classes, not just "error" — must, so a
+// future outcome added to the enum without updating runSuccessOutcomes
+// fails this test rather than silently exiting 0.
+func TestRunOutcomeError_EnumeratedOutcomes(t *testing.T) {
+	nonSuccessOutcomes := []string{
+		"error",
+		"max_turns",
+		"verification_failed",
+		"verification_error",
+		"budget_exceeded",
+		"stalled",
+		"tool_failures",
+		"cancelled",
+		"timeout",
+		"max_tokens",
+		"setup_failed",
+		"hook_failed",
+		"", // empty/unknown outcome must not be treated as success
+		"some_future_outcome_not_yet_invented",
+	}
+	for _, outcome := range nonSuccessOutcomes {
+		t.Run(outcome, func(t *testing.T) {
+			err := runOutcomeError(&types.RunTrace{Outcome: outcome})
+			if err == nil {
+				t.Fatalf("runOutcomeError(Outcome=%q) = nil, want a non-nil error", outcome)
+			}
+			if classifyExitCode(err) != 1 {
+				t.Errorf("classifyExitCode(runOutcomeError(%q)) = %d, want 1 (the documented default for a failed or cancelled run)", outcome, classifyExitCode(err))
+			}
+		})
+	}
+
+	if err := runOutcomeError(&types.RunTrace{Outcome: "success"}); err != nil {
+		t.Errorf("runOutcomeError(Outcome=\"success\") = %v, want nil", err)
+	}
+
+	if err := runOutcomeError(nil); err != nil {
+		t.Errorf("runOutcomeError(nil) = %v, want nil (nil-trace callers return their own error before reaching this check)", err)
+	}
+}
+
+// openAICompatibleErrorServer replies to every request with a 401,
+// mirroring an invalid API key against a real provider — the same
+// failure class as the live ANTHROPIC_API_KEY=fake repro for issue
+// #101, just against the openai-compatible adapter so the test needs
+// no live credentials or network access.
+func openAICompatibleErrorServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"invalid api key"}}`)
+	}))
+}
+
+// openAICompatibleSuccessServer replies to every request with a single
+// streamed turn that emits a text answer and finishes cleanly, driving
+// the loop to outcome "success" without a tool call or a second turn.
+func openAICompatibleSuccessServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: "+
+			`{"id":"resp","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`+
+			"\n\n")
+		_, _ = fmt.Fprint(w, "data: "+
+			`{"id":"resp","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`+
+			"\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+}
+
+// runOutcomeTestConfig builds a minimal, valid RunConfig pointed at an
+// openai-compatible server under test. Mirrors fatalPreRunHookConfig's
+// shape (read-only planning mode, deny-side-effects, no git) so the
+// only variable between the error and success cases is the fake
+// server's response.
+func runOutcomeTestConfig(t *testing.T, baseURL string) *types.RunConfig {
+	t.Helper()
+	t.Setenv("TEST_RUNOUTCOME_KEY", "unused-fake-key")
+	timeout := 30
+	return &types.RunConfig{
+		RunID:            "cmd-runoutcome-test",
+		Mode:             "planning",
+		Prompt:           "Say hello.",
+		Provider:         types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_RUNOUTCOME_KEY", BaseURL: baseURL},
+		ModelRouter:      types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "gpt-4o-mini"},
+		PromptBuilder:    types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy:  types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor:         types.ExecutorConfig{Type: "local", Workspace: t.TempDir()},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "deny-side-effects"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		Tools:            types.ToolsConfig{BuiltIn: []string{"read_file"}},
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+}
+
+// TestRunWithConfig_ProviderErrorOutcome_ExitsNonZero is the cmd-layer
+// regression for issue #101 / v0.1 release blocker B4: AgenticLoop.Run
+// returns (trace, nil) for a mid-run provider failure — only the trace
+// carries the failure via Outcome=="error" — so runWithConfig must
+// convert that into a non-nil error itself, or the process exits 0 on
+// a failed run (the ANTHROPIC_API_KEY=fake live repro this pins).
+func TestRunWithConfig_ProviderErrorOutcome_ExitsNonZero(t *testing.T) {
+	srv := openAICompatibleErrorServer(t)
+	defer srv.Close()
+
+	config := runOutcomeTestConfig(t, srv.URL)
+
+	stdoutDone := captureStdout(t)
+	runErr := runWithConfig(config, runOptions{outputMode: "json"})
+	stdout := stdoutDone()
+
+	if runErr == nil {
+		t.Fatal("expected a non-nil error from a provider-error outcome, got nil (this is the B4 regression: outcome=error must still fail the process)")
+	}
+	if classifyExitCode(runErr) != 1 {
+		t.Errorf("classifyExitCode(runErr) = %d, want 1", classifyExitCode(runErr))
+	}
+
+	result := decodeStirrupResult(t, stdout)
+	if result.Outcome != "error" {
+		t.Errorf("STIRRUP_RESULT outcome = %q, want \"error\"", result.Outcome)
+	}
+}
+
+// TestRunWithConfig_SuccessOutcome_ExitsZero is the success-path
+// counterpart: a run that completes normally must still return a nil
+// error (and therefore exit 0) after the B4 fix, proving the new
+// outcome check does not regress the happy path.
+func TestRunWithConfig_SuccessOutcome_ExitsZero(t *testing.T) {
+	srv := openAICompatibleSuccessServer(t)
+	defer srv.Close()
+
+	config := runOutcomeTestConfig(t, srv.URL)
+
+	stdoutDone := captureStdout(t)
+	runErr := runWithConfig(config, runOptions{outputMode: "json"})
+	stdout := stdoutDone()
+
+	if runErr != nil {
+		t.Fatalf("expected a nil error from a successful run, got: %v", runErr)
+	}
+	if classifyExitCode(runErr) != 0 {
+		t.Errorf("classifyExitCode(runErr) = %d, want 0", classifyExitCode(runErr))
+	}
+
+	result := decodeStirrupResult(t, stdout)
+	if result.Outcome != "success" {
+		t.Errorf("STIRRUP_RESULT outcome = %q, want \"success\"", result.Outcome)
+	}
+}
+
+// decodeStirrupResult finds and parses the STIRRUP_RESULT line out of
+// captured stdout. Shared by the two runOutcome tests above; stdout
+// also carries the stdio transport's own JSON event stream, so the
+// result line is not necessarily first.
+func decodeStirrupResult(t *testing.T, stdout string) types.RunResult {
+	t.Helper()
+	var resultLine string
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.HasPrefix(line, "STIRRUP_RESULT ") {
+			resultLine = line
+			break
+		}
+	}
+	if resultLine == "" {
+		t.Fatalf("expected a STIRRUP_RESULT line, got stdout: %q", stdout)
+	}
+	payload := strings.TrimPrefix(resultLine, "STIRRUP_RESULT ")
+	var result types.RunResult
+	if err := json.Unmarshal([]byte(payload), &result); err != nil {
+		t.Fatalf("STIRRUP_RESULT payload should parse as RunResult: %v\npayload: %s", err, payload)
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

Fixes v0.1 release blocker B4 (task #101): `ANTHROPIC_API_KEY=fake ./stirrup harness --prompt hello -o json` emitted `"outcome":"error"` in the STIRRUP_RESULT line but exited **0**. `AgenticLoop.Run` returns `(trace, nil)` for any mid-run failure — a provider error, a verifier disagreement, an exhausted turn/token/budget limit, a cancellation, or a fatal postRun hook — recording the failure only in `RunTrace.Outcome`, not in the Go error. `runWithConfig` (harness path) and `runJob` (Cloud Run / K8s Jobs path — what the orchestrator actually observes) only went non-zero on a non-nil `runErr`, so any mid-run failure looked like a successful job: never retried, never alerted on. This contradicts `docs/configuration.md`'s documented contract: "a failed or cancelled run still exits non-zero."

## The fix

- Added `runOutcomeError` (`harness/cmd/stirrup/cmd/root.go`), called at the tail of both `runWithConfig` (harness.go) and `runJob` (job.go) — after result emission, workspace export, and follow-up grace have already run, so those side effects are unchanged. Only the final process exit code differs.
- `runOutcomeError` returns an (untyped, exit-1-by-default) error whenever `RunTrace.Outcome` is not in `runSuccessOutcomes`.
- Pre-run construction-error behaviour (`core.BuildLoop` failures) is untouched — those already returned non-zero.

### Outcome → exit mapping (deliberate, not just "error")

Enumerated every documented value of `types.RunTrace.Outcome` (`types/runtrace.go`) and classified each:

| Outcome | Exit |
|---|---|
| `success` | **0** |
| `error`, `tool_failures`, `verification_failed`, `verification_error` | 1 |
| `max_turns`, `max_tokens`, `budget_exceeded`, `stalled` | 1 |
| `cancelled`, `timeout` | 1 |
| `setup_failed`, `hook_failed` | 1 |
| unknown / empty | 1 |

`success` is the only member of the success set. `docs/configuration.md`'s exit-code table documents exit `1` as "the default for any failure not in a more specific class" and states explicitly that "a failed or cancelled run still exits non-zero" — so this uses the untyped-error default (exit 1) rather than inventing a new code. Deliberately **not** reusing `EvalOutcomeFor`'s passed/failed/inconclusive split (`types/evaloutcome.go`): that taxonomy answers "was the change any good" and folds limit-hit/cancelled runs into "inconclusive" so eval aggregates don't punish a run that never got a fair shot. Process exit code answers a narrower question — "did this invocation produce a usable result" — where inconclusive and failed both mean no, matching the Cloud Run / K8s Jobs retry-or-alert semantics this feeds.

## Test plan

- [x] `just build` — passes
- [x] `just test` — passes (all packages)
- [x] `just lint` — 0 issues
- [x] Live repro: `ANTHROPIC_API_KEY=fake ./stirrup harness --prompt hello -o json` now exits **1** (previously 0); STIRRUP_RESULT still carries `"outcome":"error"`
- [x] Live success-adjacent surface unaffected: `--dry-run` still exits 0
- [x] New regression tests in `harness/cmd/stirrup/cmd/runoutcome_test.go`:
  - `TestRunOutcomeError_EnumeratedOutcomes` — table test over every documented outcome value (including empty/unknown) confirming the mapping and that `classifyExitCode` resolves to 1
  - `TestRunWithConfig_ProviderErrorOutcome_ExitsNonZero` — drives `runWithConfig` end-to-end against a local `httptest` fake `openai-compatible` server returning 401 (the same failure class as the live fake-key repro, without needing live credentials), confirms non-nil error / exit 1 / STIRRUP_RESULT outcome
  - `TestRunWithConfig_SuccessOutcome_ExitsZero` — same shape against a fake server returning a valid canned SSE turn, confirms the happy path still returns nil / exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ
