### PR TITLE
build: publish stirrup-sandbox image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,3 +282,56 @@ jobs:
           build-args: |
             VERSION=${{ steps.ver.outputs.label }}
             COMMIT=${{ steps.ver.outputs.sha }}
+
+  publish-sandbox-container:
+    name: Publish Sandbox Container
+    runs-on: ubuntu-latest
+    needs: verify
+    # Same guard and GHCR-only posture as publish-container above (see
+    # the comments there for the GAR cost rationale). The sandbox image
+    # (Dockerfile.sandbox) is what the container/k8s/k8s-sandbox
+    # executors run agent workloads in — it contains no Go build, so
+    # there is no VERSION/COMMIT build-arg step to mirror.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'rxbynerd/stirrup'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      # Action pins below mirror publish-container above; see the
+      # comments there for the SHA-verification provenance.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: |
+            ghcr.io/rxbynerd/stirrup-sandbox
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=sha,prefix=sha-
+
+      - name: Build and push sandbox image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile.sandbox
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -563,6 +563,139 @@ jobs:
             --source "${SBOM_FILE}" \
             --uri "${IMAGE_URI}"
 
+  # Release-time publish of the sandbox image (Dockerfile.sandbox) —
+  # the `--image` the container/k8s/k8s-sandbox executors run agent
+  # workloads in. Mirrors publish-container's GHCR + GAR dual-publish,
+  # semver tagging, and SBOM posture; see the comments there for the
+  # action-pin provenance and the WIF/GAR authentication rationale.
+  # Deltas from publish-container: no VERSION/COMMIT build-args (the
+  # image contains no Go build), and the GAR image name is
+  # `${GAR_IMAGE}-sandbox` alongside the harness image in the same
+  # repository.
+  publish-sandbox-container:
+    name: Publish Sandbox Container
+    needs: [validate-tag, verify]
+    runs-on: ubuntu-latest
+    if: github.repository == 'rxbynerd/stirrup'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.docker-push.outputs.digest }}
+    env:
+      TAG: ${{ needs.validate-tag.outputs.tag }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Authenticate to Google Cloud (WIF + SA impersonation)
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GAR_PUBLISHER_SA }}
+          token_format: access_token
+
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
+          # GAR demands the literal string "oauth2accesstoken" as the
+          # username when the password is a short-lived access token —
+          # see publish-container above.
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: |
+            ghcr.io/rxbynerd/stirrup-sandbox
+            ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}-sandbox
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(needs.validate-tag.outputs.tag, '-') }}
+
+      - name: Build and push sandbox image
+        id: docker-push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile.sandbox
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          version: '>= 502.0.0'
+
+      # Image SBOMs matter more for the sandbox than for the distroless
+      # harness image: the Debian base is where the CVEs live. Same
+      # digest-form URI requirement and IAM posture as publish-container.
+      - name: Generate image SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}-sandbox@${{ steps.docker-push.outputs.digest }}
+          format: spdx-json
+          output-file: stirrup-sandbox-${{ needs.validate-tag.outputs.tag }}.image.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+          github-token: ""
+
+      - name: Generate image CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}-sandbox@${{ steps.docker-push.outputs.digest }}
+          format: cyclonedx-json
+          output-file: stirrup-sandbox-${{ needs.validate-tag.outputs.tag }}.image.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+          github-token: ""
+
+      - name: Upload image SPDX SBOM to Artifact Analysis
+        env:
+          IMAGE_URI: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}-sandbox@${{ steps.docker-push.outputs.digest }}
+          SBOM_FILE: stirrup-sandbox-${{ needs.validate-tag.outputs.tag }}.image.spdx.json
+        run: |
+          set -euo pipefail
+          gcloud artifacts sbom load \
+            --source "${SBOM_FILE}" \
+            --uri "${IMAGE_URI}"
+
+      - name: Upload image CycloneDX SBOM to Artifact Analysis
+        env:
+          IMAGE_URI: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}-sandbox@${{ steps.docker-push.outputs.digest }}
+          SBOM_FILE: stirrup-sandbox-${{ needs.validate-tag.outputs.tag }}.image.cdx.json
+        run: |
+          set -euo pipefail
+          gcloud artifacts sbom load \
+            --source "${SBOM_FILE}" \
+            --uri "${IMAGE_URI}"
+
   # Phase 3 of issue #159: query Artifact Analysis for vulnerabilities
   # on the just-pushed image and emit a summary. CURRENT MODE IS WARN
   # — the gate never fails the workflow, regardless of how many
@@ -612,9 +745,28 @@ jobs:
       tag: ${{ needs.validate-tag.outputs.tag }}
       mode: warn
 
+  # Same warn-only gate for the sandbox image. The `-sandbox` suffix on
+  # the tag label keeps its tracking issues distinguishable from the
+  # harness image's, and means an operator setting
+  # vars.STIRRUP_RELEASE_VULN_OVERRIDE for the release tag bypasses only
+  # the harness gate — the sandbox gate needs its own suffixed override.
+  vulnerability-gate-sandbox:
+    name: Vulnerability gate — sandbox (warn mode)
+    needs: [validate-tag, publish-sandbox-container]
+    if: github.repository == 'rxbynerd/stirrup'
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    uses: ./.github/workflows/_vuln-scan.yml
+    with:
+      image_uri: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.GAR_IMAGE }}-sandbox@${{ needs.publish-sandbox-container.outputs.digest }}
+      tag: ${{ needs.validate-tag.outputs.tag }}-sandbox
+      mode: warn
+
   release:
     name: Publish Release
-    needs: [validate-tag, verify, build-binaries, sbom, changelog, publish-container]
+    needs: [validate-tag, verify, build-binaries, sbom, changelog, publish-container, publish-sandbox-container]
     runs-on: ubuntu-latest
     # Only the publish step needs write access to releases. Granting it at
     # the job level (rather than the workflow level) keeps the blast radius

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.7
+
+# Sandbox image for agent workloads — the `--image` the container, k8s,
+# and k8s-sandbox executors run commands in. Distinct from ./Dockerfile
+# (the distroless harness image), which ships no shell and cannot satisfy
+# the executors' exec contract: a POSIX shell at /bin/sh plus tar, ls,
+# and mkdir on PATH (harness/internal/executor/container.go,
+# k8s_execcore.go; operator doc docs/executors/k8s.md). Debian slim
+# already carries the shell and coreutils; git and ca-certificates are
+# added so agents can operate on checkouts and fetch over HTTPS.
+FROM debian:trixie-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# 65532 is the UID the k8s executor enforces via RunAsUser (the
+# distroless "nonroot" convention). The container executor execs as
+# 65534:65534 (nobody:nogroup), which Debian's passwd already carries.
+RUN groupadd --gid 65532 nonroot \
+    && useradd --uid 65532 --gid 65532 --create-home --shell /bin/sh nonroot
+
+# Both executors exec as fixed non-root UIDs that generally do not own
+# the mounted workspace (the container executor bind-mounts a host
+# directory that keeps host ownership), and git refuses to operate on a
+# repository owned by another UID ("dubious ownership"). The whole
+# filesystem is a single-purpose sandbox, so the ownership check
+# protects nothing here.
+RUN git config --system safe.directory '*'
+
+USER 65532:65532
+
+# Both executors override the command with their own `sleep infinity`;
+# this default keeps ad-hoc `docker run` inspection usable.
+CMD ["sleep", "infinity"]

--- a/docs/container-publishing.md
+++ b/docs/container-publishing.md
@@ -6,6 +6,20 @@ Registry (GAR). This document is the operator walkthrough for the
 GCP-side bootstrap, the GitHub-side configuration, and the verification
 steps that confirm the dual-publish is working.
 
+Two images ride the same pipeline:
+
+- **`stirrup`** (`./Dockerfile`) — the distroless harness image.
+- **`stirrup-sandbox`** (`./Dockerfile.sandbox`) — the Debian-based
+  sandbox image agent workloads run in. It ships the `/bin/sh`, `tar`,
+  `ls`, and `git` the container/k8s executors exec (see
+  [`executors/k8s.md`](executors/k8s.md)). Published to GHCR as
+  `ghcr.io/rxbynerd/stirrup-sandbox` with the same tag scheme, and to
+  GAR under the `${GAR_IMAGE}-sandbox` image name at release time.
+
+The registry, IAM, and gating walkthrough below is written against the
+harness image; everything applies to the sandbox image identically
+unless a difference is called out.
+
 The architectural sibling is [`credential-federation.md`](credential-federation.md);
 this doc covers a Workload Identity Federation deployment in the
 specific shape stirrup's CI workflow consumes.

--- a/examples/runconfig/README.md
+++ b/examples/runconfig/README.md
@@ -142,7 +142,11 @@ active and Rule of Two is enforced.
   // applied regardless of what the file says.
   "executor": {
     "type": "container",
-    "image": "ghcr.io/rxbynerd/stirrup:latest",
+    "image": "ghcr.io/rxbynerd/stirrup-sandbox:latest",
+    // The default registry allowlist admits only ghcr.io/stirrup/*
+    // and docker.io/library/*; the project's images live under
+    // ghcr.io/rxbynerd/, so the allowlist must say so explicitly.
+    "registryAllowlist": ["ghcr.io/rxbynerd/*"],
     "runtime": "runsc",
     "network": { "mode": "none" },
     "resources": { "cpus": 2.0, "memoryMb": 2048, "diskMb": 8192, "pids": 256 }

--- a/examples/runconfig/full.json
+++ b/examples/runconfig/full.json
@@ -39,7 +39,8 @@
   },
   "executor": {
     "type": "container",
-    "image": "ghcr.io/rxbynerd/stirrup:latest",
+    "image": "ghcr.io/rxbynerd/stirrup-sandbox:latest",
+    "registryAllowlist": ["ghcr.io/rxbynerd/*"],
     "runtime": "runsc",
     "network": {
       "mode": "none"


### PR DESCRIPTION
## Release blocker B1: the documented sandbox image does not exist

Every Kubernetes example (README quick-start, all of `docs/executors/k8s.md`) tells users to run `--image ghcr.io/rxbynerd/stirrup-sandbox:latest`, but no Dockerfile or CI job ever built that image — it 404s on GHCR and the quick-start ends in ImagePullBackOff. Compounding, `examples/runconfig/full.json` pointed the container executor at the distroless `stirrup:latest`, which ships none of the binaries the executors exec (`sh -c`, `ls`, `tar`, `mkdir`).

## What this PR does

1. **`Dockerfile.sandbox`** — Debian trixie-slim + git + ca-certificates. The base already carries the executors' full exec contract (`/bin/sh`, `tar`, `ls`, `mkdir`, `sleep infinity` — cross-checked against `harness/internal/executor/container.go`, `k8s_execcore.go`, and the requirements list in `docs/executors/k8s.md`). Adds a `nonroot` 65532 user matching the k8s executor's enforced `RunAsUser`, and disables git's `safe.directory` check system-wide because both executors exec as fixed non-root UIDs (65532 k8s / 65534:65534 container) that rarely own the mounted workspace.
2. **`ci.yml`** — new `publish-sandbox-container` job mirroring `publish-container`: main-push only, GHCR-only (dev tags stay out of GAR to bound the billed auto-scan surface), same pinned actions, same tag scheme (`:latest`, `:main`, `:sha-<7>`), multi-arch amd64+arm64. Matching the existing harness-image job, there is no PR-time docker build — the publish path first exercises for real on the next push to main / next release tag.
3. **`release.yml`** — new `publish-sandbox-container` job mirroring the harness image's GHCR + GAR dual-publish: semver tags, OCI SBOM attestation, image SBOM loads into Artifact Analysis, plus its own warn-mode `vulnerability-gate-sandbox` (the Debian base is where CVEs will actually live). GAR name is `${GAR_IMAGE}-sandbox` in the same repository, so no new bootstrap or IAM bindings. `release.needs` now includes the sandbox publish so a GitHub Release cannot be minted with a failed sandbox push.
4. **`examples/runconfig/full.json`** (+ its annotated mirror in `examples/runconfig/README.md`) — container executor now points at `ghcr.io/rxbynerd/stirrup-sandbox:latest`, and gains `"registryAllowlist": ["ghcr.io/rxbynerd/*"]`: the default allowlist admits only `ghcr.io/stirrup/*` + `docker.io/library/*`, so the example was rejected at construction even before the image question. (Whether `defaultRegistryAllowlist` in `container_registry.go` should itself admit `ghcr.io/rxbynerd/*` is a separate security-default decision, deliberately not touched here.)
5. **`docs/container-publishing.md`** — names both images the pipeline ships.

## Verification

- Image built locally (podman 5.8.2) and spot-checked: `sh`/`ls`/`tar`/`git`/`mkdir`/`sleep` all resolve; the exact executor exec forms (`tar -C / -cf - --`, `ls -A1 --`, `mkdir -p --`, `sleep infinity`) succeed under both UID 65532 and 65534:65534; `git init` works on a directory owned by another UID.
- `just build`, `just test`, `just lint` — all pass.
- `actionlint` on both workflows — no new findings (two pre-existing SC2094 infos in the release-assets aggregation step exist identically on main).
- `./stirrup run-config --config examples/runconfig/full.json --validate` — passes.

**Note:** the publish path itself first exercises for real on the next main push (GHCR dev tags) / next `v*` tag (GHCR+GAR release publish + SBOM loads + sandbox vuln gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ
