### PR TITLE
docs: close the v0.1 documentation-gap batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.
 | LLM-based safety classifier (`GuardRail`) | [`docs/guardrails.md`](docs/guardrails.md) |
 | Eval framework (`stirrup-eval`) | [`docs/eval.md`](docs/eval.md) |
 | Provider adapters | [`docs/providers.md`](docs/providers.md) |
-| Batch mode | [`docs/sandbox.md`](docs/batch.md) |
+| Batch mode | [`docs/batch.md`](docs/batch.md) |
 | Cross-cloud credential federation | [`docs/credential-federation.md`](docs/credential-federation.md) |
 | Anthropic Workload Identity Federation | [`docs/anthropic-wif.md`](docs/anthropic-wif.md) |
 | Azure Workload Identity Federation | [`docs/azure-workload-identity.md`](docs/azure-workload-identity.md) |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ post-mortem replays or pinning a stable configuration. See
 
 ### Executors
 
-The agent runs inside one of four executors, selected with
+The agent runs inside one of five executors, selected with
 `--executor` / `executor.type`:
 
 | Executor | Boundary | Notes |
@@ -84,13 +84,14 @@ The agent runs inside one of four executors, selected with
 | `local` | none (host process) | Trusted local iteration. |
 | `container` | a Docker/Podman container | Single-host sandbox with an in-process egress proxy. |
 | `k8s` | a Pod on a Kubernetes cluster | Pod-per-run with a hardened `securityContext`, per-tenant RuntimeClass, and `NetworkPolicy` egress. See [`docs/executors/k8s.md`](docs/executors/k8s.md). |
+| `k8s-sandbox` | a Pod provisioned via the Agent Sandbox CRD | Variant of `k8s`: the GKE Agent Sandbox controller creates the Pod from an `agents.x-k8s.io` `Sandbox` resource; gVisor-only. See [`docs/executors/k8s-agent-sandbox.md`](docs/executors/k8s-agent-sandbox.md). |
 | `api` | no shell (VCS-backed, read-only) | Reviews/plans against a Git host without a workspace. |
 
 The relevant executor flags are:
 
 | Flag | Notes |
 |---|---|
-| `--executor` | `local` (default), `container`, `k8s`, or `api`. |
+| `--executor` | `local` (default), `container`, `k8s`, `k8s-sandbox`, or `api`. |
 | `--image` | Sandbox container image (`container` / `k8s`). |
 | `--container-runtime` | OCI runtime (`container`) or Pod `RuntimeClassName` (`k8s`): `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh`, `runc`. |
 | `--k8s-namespace` | Namespace for the `k8s` sandbox Pod (required for `k8s`). |
@@ -144,6 +145,7 @@ See [`.github/workflows/smoke-anthropic.yml`](.github/workflows/smoke-anthropic.
 | CLI flags, `RunConfig` precedence, examples | [`docs/configuration.md`](docs/configuration.md) |
 | Production deployment via `stirrup job` (K8s, gRPC) | [`docs/deployment.md`](docs/deployment.md) |
 | Kubernetes executor (Pod-per-run sandbox) | [`docs/executors/k8s.md`](docs/executors/k8s.md) |
+| Kubernetes Agent Sandbox executor (`k8s-sandbox`) | [`docs/executors/k8s-agent-sandbox.md`](docs/executors/k8s-agent-sandbox.md) |
 | Running stirrup as a Google Cloud Run job | [`docs/cloud-run-jobs.md`](docs/cloud-run-jobs.md) |
 | Five safety rings (operator guide) | [`docs/safety-rings.md`](docs/safety-rings.md) |
 | In-harness security foundations | [`docs/security.md`](docs/security.md) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,14 @@ reference.
 | `--temperature` | (unset → `0.1`) | Sampling temperature forwarded to the provider on every turn. Range `0.0`–`2.0` (the union of provider-side ranges; see [Limits and budgets](#limits-and-budgets)). Omit the flag to inherit the harness default; pass an explicit `0` for greedy decoding. The runtime distinguishes "flag absent" from `--temperature=0` via cobra's `Changed()` bit. |
 | `--log-level` | `info` | One of `debug`, `info`, `warn`, `error`. |
 
+### Loop behaviour
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--max-tool-parallel` | `0` | Maximum async tool calls dispatched concurrently in a single turn. Range `1`–`16` (hard ceiling enforced by `ValidateRunConfig`); `0` resolves to the library default of `4`. JSON path: `toolDispatch.maxParallel`. |
+| `--escalate-tool-choice` | `false` | Recover from a first-turn no-tool answer on a workspace-dependent task by retrying with provider-native required tool choice (a stronger prompt where the provider does not support forcing). Off by default (issue #230). JSON path: `toolChoiceEscalation.enabled`. |
+| `--escalate-tool-choice-max-retries` | `0` | Maximum forced retries per inner-loop run. Range `1`–`3`; `0` resolves to the default of `1`. No effect unless `--escalate-tool-choice` is set. JSON path: `toolChoiceEscalation.maxRetries`. |
+
 ### Provider
 
 | Flag | Default | Notes |
@@ -394,6 +402,10 @@ The exchange audience is set on the `tokenSource` (canonically
 | `--git-strategy` | `none` | One of `none`, `deterministic`. |
 | `--permission-policy-file` | (none) | Path to a Cedar policy file. When set and the policy type is unset elsewhere, implies `permissionPolicy.type=policy-engine`. Starters live under [`examples/policies/`](../examples/policies/). |
 | `--code-scanner` | (none) | One of `none`, `patterns`, `semgrep`. `composite` is accepted only via `--config` (it requires `codeScanner.scanners`). Empty defers to the mode-aware default (`patterns` for execution, `none` for read-only modes). |
+| `--guardrail` | (none) | GuardRail classifier type: `none`, `granite-guardian`, `cloud-judge`, `composite`. `composite` requires `--config` (`guardRail.stages`). JSON path: `guardRail.type`. See [`guardrails.md`](guardrails.md). |
+| `--guardrail-endpoint` | (none) | Classifier endpoint URL for the `granite-guardian` or `cloud-judge` adapter (http/https; a path such as `/v1/chat/completions` is allowed). JSON path: `guardRail.endpoint`. |
+| `--guardrail-model` | (none) | Model identifier for the GuardRail classifier. Empty applies the adapter-defined default: `ibm-granite/granite-guardian-4.1-8b` for `granite-guardian`, `claude-haiku-4-5-20251001` for `cloud-judge`. The `cloud-judge` default is in Anthropic API format — when the primary provider is Bedrock, set the Bedrock-format ID (e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`). JSON path: `guardRail.model`. |
+| `--guardrail-fail-open` | `false` | When set, classifier transport errors / timeouts produce an allow verdict plus a `guard_error` security event instead of blocking the run. Default is fail-closed. Top-level only — governs the whole guardrail tree. JSON path: `guardRail.failOpen`. See [`guardrails.md`](guardrails.md#fail-open-posture). |
 | `--tools-profile` | (none) | Model-facing toolset profile. Closed enum: `""`/`default` (no aliasing, internal tool names) or `coding-classic` (terse coding-CLI aliases). Changes only the names the model sees; dispatch identities and gating are unchanged. JSON path: `tools.profile`. See [Toolset profiles](#toolset-profiles). |
 
 See also: [`docs/executors/k8s.md`](executors/k8s.md) for the `k8s`
@@ -528,6 +540,7 @@ configuration space — the common cases. Anything below requires
 | `verifier` | `composite` (chains other verifiers). |
 | `permissionPolicy` | `policy-engine` requires `policyFile`; the optional `fallback` field defaults to `deny-side-effects` when unset. Chained policy engines are rejected. |
 | `codeScanner` | `composite` requires `codeScanner.scanners` (each entry from the non-composite set). |
+| `guardRail` | `composite` requires `guardRail.stages`. Per-phase restriction (`phases`), bespoke criteria, and the classifier timeout are file-only. |
 | `traceEmitter` | `bucket` / `objectPrefix` / `credential` (the `gcs` emitter's routing — selectable via `--trace-emitter gcs` but configurable only by file). |
 | `provider` | Multi-provider routing via `providers{}` plus a `modelRouter` of type `dynamic` or `per-mode`. |
 | `tools.mcpServers` | Remote MCP server registration. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -382,13 +382,13 @@ The exchange audience is set on the `tokenSource` (canonically
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--executor` | `local` | One of `local`, `container`, `k8s`, `api`. |
-| `--container-runtime` | (none) | Per-`executor` closed set. For `container` (host OCI runtime): `runc`, `runsc` (gVisor), `kata`, `kata-qemu`, `kata-fc`, `kata-clh` — must be registered with the host Docker/Podman daemon. For `k8s` (Pod `RuntimeClassName`): `runc`, `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh` — note the name is `gvisor`, not `runsc`. Empty = engine default for `container`, cluster-default RuntimeClass for `k8s`. |
-| `--k8s-namespace` | (none) | Namespace for the `k8s` executor's sandbox Pod. Required when `--executor=k8s`. JSON path: `executor.k8sNamespace`. |
-| `--k8s-kubeconfig` | (none) | Path to a kubeconfig for the `k8s` executor. An explicit value wins even in-cluster; empty prefers in-cluster config, then `$KUBECONFIG`. JSON path: `executor.k8sKubeconfig`. |
-| `--k8s-node-selector` | (none) | Repeatable `key=value` `nodeSelector` constraining where the `k8s` Pod schedules (e.g. `--k8s-node-selector disktype=ssd`). JSON path: `executor.k8sNodeSelector`. |
-| `--k8s-service-account` | (none) | ServiceAccount name for the `k8s` Pod. Empty uses the namespace `default`. The token is never automounted regardless. JSON path: `executor.k8sServiceAccount`. |
-| `--k8s-egress-proxy-url` | (none) | URL the `k8s` sandbox Pod routes `HTTP_PROXY`/`HTTPS_PROXY` through. Required when `--executor=k8s` and the network mode is `allowlist`; rejected otherwise. JSON path: `executor.k8sEgressProxyUrl`. |
+| `--executor` | `local` | One of `local`, `container`, `k8s`, `k8s-sandbox`, `api`. `k8s-sandbox` is the [Agent Sandbox CRD variant](executors/k8s-agent-sandbox.md) of `k8s`. |
+| `--container-runtime` | (none) | Per-`executor` closed set. For `container` (host OCI runtime): `runc`, `runsc` (gVisor), `kata`, `kata-qemu`, `kata-fc`, `kata-clh` — must be registered with the host Docker/Podman daemon. For `k8s` (Pod `RuntimeClassName`): `runc`, `gvisor`, `kata-qemu`, `kata-fc`, `kata-clh` — note the name is `gvisor`, not `runsc`. `k8s-sandbox` is gVisor-only: empty or `gvisor`, any other value is rejected. Empty = engine default for `container`, cluster-default RuntimeClass for `k8s`. |
+| `--k8s-namespace` | (none) | Namespace for the `k8s` / `k8s-sandbox` sandbox Pod. Required when `--executor=k8s` or `--executor=k8s-sandbox`. JSON path: `executor.k8sNamespace`. |
+| `--k8s-kubeconfig` | (none) | Path to a kubeconfig for the `k8s` / `k8s-sandbox` executors. An explicit value wins even in-cluster; empty prefers in-cluster config, then `$KUBECONFIG`. JSON path: `executor.k8sKubeconfig`. |
+| `--k8s-node-selector` | (none) | Repeatable `key=value` `nodeSelector` constraining where the `k8s` / `k8s-sandbox` Pod schedules (e.g. `--k8s-node-selector disktype=ssd`). JSON path: `executor.k8sNodeSelector`. |
+| `--k8s-service-account` | (none) | ServiceAccount name for the `k8s` / `k8s-sandbox` Pod. Empty uses the namespace `default`. The token is never automounted regardless. JSON path: `executor.k8sServiceAccount`. |
+| `--k8s-egress-proxy-url` | (none) | URL the `k8s` / `k8s-sandbox` Pod routes `HTTP_PROXY`/`HTTPS_PROXY` through. Required when the executor is `k8s` or `k8s-sandbox` and the network mode is `allowlist`; rejected otherwise. JSON path: `executor.k8sEgressProxyUrl`. |
 | `--edit-strategy` | `multi` | One of `whole-file`, `search-replace`, `udiff`, `multi`. `composite` is reachable only via `--config`. |
 | `--verifier` | `none` | One of `none`, `test-runner`, `llm-judge`. `composite` is reachable only via `--config`. |
 | `--git-strategy` | `none` | One of `none`, `deterministic`. |
@@ -398,7 +398,10 @@ The exchange audience is set on the `tokenSource` (canonically
 
 See also: [`docs/executors/k8s.md`](executors/k8s.md) for the `k8s`
 executor's architecture, deployment recipes, egress model, and the full
-`executor.k8s*` field reference.
+`executor.k8s*` field reference, and
+[`docs/executors/k8s-agent-sandbox.md`](executors/k8s-agent-sandbox.md)
+for the `k8s-sandbox` deltas (Sandbox CRD provisioning, gVisor-only
+runtime, RBAC).
 
 ### Transport
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -452,6 +452,25 @@ stdout. The default JSONL trace writes to a file (or to nothing when
 `STIRRUP_RESULT` line. A future JSONL emitter that writes to stdout
 would conflict with `--output=json`.
 
+### Workspace export
+
+At end-of-run the executor's workspace can be tarred, gzipped, and
+uploaded to a GCS URI — the result-collection surface for serverless
+targets with no persistent filesystem (see
+[`cloud-run-jobs.md`](cloud-run-jobs.md#shape-b-workspace-tarball-from-gcs)
+for the operator walkthrough).
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--export-workspace-to` | (none) | Destination URI for the workspace tarball (e.g. `gs://bucket/runs/<runId>/workspace.tar.gz`). Only `gs://` is supported in v1. Overrides `executor.workspaceExportTo` from `--config` when explicitly set; an explicit empty value clears the field. JSON path: `executor.workspaceExportTo`. |
+| `--export-workspace-required` | `false` | When set, a failed workspace export exits the run non-zero — suitable for jobs whose downstream automation depends on the artifact. When unset (default), upload failures are logged and the run's exit code is unchanged. CLI-behaviour flag only: it does not round-trip through `RunConfig`. |
+
+The export runs even when the run itself failed, so the workspace
+state stays inspectable after a non-zero exit. Uploads authenticate
+via the `gcp-workload-identity` credential source — the GCE/GKE
+metadata server that Cloud Run, GKE Workload Identity, and plain GCE
+VMs expose. There is no credential override for the exporter in v1.
+
 ### Dry-run
 
 The preflight flags. See [Dry-run preflight](#dry-run-preflight) for the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,6 +44,42 @@ shared filesystem with the control plane. The only inputs are the
 environment variables passed at Pod creation time and whatever the
 control plane sends over the bidi stream.
 
+## Transport security posture (v0.1)
+
+> **The gRPC transport is plaintext and unauthenticated.** The
+> harness dials the control plane with
+> `insecure.NewCredentials()`, and `TransportConfig` exposes only
+> `{type, address}` — there is no TLS, token, or mTLS knob on the
+> config surface in v0.1.
+
+v0.1 targets single-operator, self-hosted deployment. The design
+assumes a trusted network path between job Pods and the control
+plane; acceptable shapes are:
+
+- **Same host** — control plane and harness on one machine,
+  dialling over loopback.
+- **Private network** — a private VPC / cluster network where the
+  control-plane address is not reachable from untrusted networks.
+- **Mesh-provided mTLS** — a service mesh (Istio, Linkerd) that
+  transparently encrypts and authenticates Pod-to-Pod traffic
+  outside the harness process.
+
+Do not point `--transport-addr` / `CONTROL_PLANE_ADDR` across an
+untrusted network: everything on the stream — prompts, tool
+results, permission responses — would transit in cleartext, and
+any endpoint that can reach the harness's dial target could pose
+as the control plane. Secrets are less exposed than they appear
+(API keys travel as `secret://` references, never raw values, and
+the transport scrubs secret-shaped strings from outbound events),
+but the stream contents and the control channel itself are
+unprotected.
+
+Transport TLS configuration is planned post-v0.1. The internal
+transport constructor already accepts TLS credentials
+(`transport.WithTLSCredentials`); what is missing is the
+`RunConfig` / CLI surface to reach it, so today the option is
+available only to Go embedders wiring the transport directly.
+
 ## The `stirrup job` subcommand
 
 `stirrup job` is the K8s entrypoint. It takes no flags — everything
@@ -210,6 +246,10 @@ Before deploying:
 5. Enforce a `Job.spec.activeDeadlineSeconds` slightly larger than
    `RunConfig.timeout` so K8s reaps any stuck Pod even if the
    harness's own wall-clock timeout fails to fire.
+6. Confirm the network path between job Pods and the control plane
+   is trusted (private network or mesh mTLS) — the gRPC transport
+   itself is plaintext and unauthenticated in v0.1. See
+   [Transport security posture](#transport-security-posture-v01).
 
 ## Embedding the harness
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -38,7 +38,7 @@ Enabling guardrails is opt-in per run.
 
 The guard is a *probability reducer*, not an authoriser. A
 `VerdictAllow` from the guard does **not** override a deny from
-the [Cedar policy engine](safety-rings.md#ring-3--cedar-policy-engine-per-tool-call).
+the [Cedar policy engine](safety-rings.md#ring-3--cedar-policy-engine-per-call-authorization).
 The two questions are different:
 
 - **PermissionPolicy** asks: *is this tool call permitted to run?*
@@ -90,7 +90,7 @@ Pre-tool catches three things:
 2. **Coerced tool calls** — a prompt-injected model emits a
    syntactically valid call that semantically does the attacker's
    bidding. Note: deciding whether a syntactically valid call is
-   *safe* is the [PermissionPolicy](safety-rings.md#ring-3--cedar-policy-engine-per-tool-call)'s
+   *safe* is the [PermissionPolicy](safety-rings.md#ring-3--cedar-policy-engine-per-call-authorization)'s
    job, not the guard's. They overlap in practice; neither replaces
    the other.
 3. **Compromised gateway rewrites** — anything between the harness

--- a/examples/runconfig/README.md
+++ b/examples/runconfig/README.md
@@ -101,7 +101,7 @@ active and Rule of Two is enforced.
   //   - `allowInteractiveModes` opts in to batch with
   //     `mode: "planning"` / `mode: "review"`; `mode: "execution"`
   //     always rejects batch regardless of this flag.
-  // The full operator walkthrough lands in docs/sandbox.md (phase 3).
+  // The full operator walkthrough is docs/batch.md.
   // Batch on a named providers map entry is a hard error in v1; only
   // the top-level provider's batch block is consulted.
   "provider": {

--- a/harness/cmd/stirrup/cmd/harness_batch_flag_test.go
+++ b/harness/cmd/stirrup/cmd/harness_batch_flag_test.go
@@ -179,7 +179,7 @@ func TestHarnessCmd_BatchFlagHelpText(t *testing.T) {
 		"24h latency",
 		"transport=grpc",
 		"harnessSidePolling=true",
-		"docs/sandbox.md",
+		"docs/batch.md",
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(usage, want) {

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -102,7 +102,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.Bool("escalate-tool-choice", false, "Recover from a first-turn no-tool answer on a workspace-dependent task by retrying with provider-native required tool choice (or a stronger prompt where unsupported). OFF by default. See issue #230.")
 	f.Int("escalate-tool-choice-max-retries", 0, "Maximum forced retries per inner-loop run when --escalate-tool-choice is set. Range: 1-3. 0 uses the default (1). No effect unless --escalate-tool-choice is set.")
 
-	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/sandbox.md.")
+	f.Bool("batch", false, "Use async batch submission for provider turns (50% cost reduction, up to 24h latency). Requires transport=grpc or --config with harnessSidePolling=true for stdio. See docs/batch.md.")
 
 	addRunConfigFlagCompletions(cmd)
 }


### PR DESCRIPTION
Closes the six documentation gaps flagged in the v0.1 release readiness review. Every claim was re-verified against the code before writing; one small code edit (help text) rides along.

## Changes

1. **Transport security posture (`docs/deployment.md`)** — new prominent section documenting the v0.1 release decision: the `stirrup job` gRPC transport is plaintext and unauthenticated (`insecure.NewCredentials()` in `harness/internal/transport/grpc.go`; `TransportConfig` exposes only `{type, address}`). v0.1 targets single-operator / self-hosted deployment and assumes a trusted network path (same host, private VPC, or mesh mTLS such as Istio/Linkerd); transport TLS config is planned post-v0.1 (`transport.WithTLSCredentials` already exists, only the config surface is missing). Also added a checklist item pointing at the section.
2. **`k8s-sandbox` executor (`README.md`, `docs/configuration.md`)** — added to the README executor table ("one of five executors"), the README flag/doc tables, and configuration.md's `--executor` enum, all linking `docs/executors/k8s-agent-sandbox.md`. The `--container-runtime` and `--k8s-*` rows now state the gVisor-only constraint and that the `--k8s-*` flags serve both executors, matching their `--help` text.
3. **Workspace-export flags (`docs/configuration.md`)** — new "Workspace export" subsection documenting `--export-workspace-to` (`executor.workspaceExportTo`, `gs://`-only in v1) and `--export-workspace-required` (CLI-behaviour flag, flips upload failure to a non-zero exit). Semantics verified against `harness.go`, `runconfigflags.go`, and `harness/internal/workspaceexport/` (including the metadata-server-only auth path).
4. **Four undocumented CLI flags (`docs/configuration.md`)** — `--max-tool-parallel`, `--escalate-tool-choice`, `--escalate-tool-choice-max-retries` in a new "Loop behaviour" subsection; `--guardrail-model` as part of a complete `--guardrail*` block in the Components table (none of the guardrail flags were in the reference, so documenting the model flag alone would have dangled). Ranges/defaults verified against `types/runconfig.go` constants; a `guardRail` row joins the component-selection-limits table.
5. **Stale `docs/sandbox.md` references** — the batch-mode doc shipped as `docs/batch.md`; retargeted the four stale references: `--batch` help text in `runconfigflags.go` (visible in `--help` output — verified end-to-end against the built binary), the test pinning that help text, the README docs-table link text, and a stale phase-3 forward reference in `examples/runconfig/README.md`.
6. **Two broken anchors (`docs/guardrails.md`)** — both links into safety-rings.md used `#ring-3--cedar-policy-engine-per-tool-call`; the heading's actual anchor is `#ring-3--cedar-policy-engine-per-call-authorization`. A full-repo anchor check now reports zero broken anchors (the previously flagged directory-style links and double-hyphen anchors are GitHub-valid and were left untouched).

## Testing

- `just build` — clean
- `just test` — all packages pass
- `just lint` — 0 issues
- `./stirrup harness --help` shows the corrected `docs/batch.md` reference
- Anchor check over all repo markdown: 0 broken links/anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ