### PR TITLE
provider: raise SSE scanner buffers to 16 MiB uniformly

### DIFF
--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -648,6 +648,7 @@ func (a *AnthropicAdapter) consumeSSE(ctx context.Context, resp *http.Response, 
 	blocks := make(map[int]*blockState)
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), maxSSEScannerBuffer)
 	var currentEvent string
 
 	for scanner.Scan() {

--- a/harness/internal/provider/anthropic_test.go
+++ b/harness/internal/provider/anthropic_test.go
@@ -93,6 +93,58 @@ func TestAnthropicAdapter_StreamTextDelta(t *testing.T) {
 	}
 }
 
+// TestAnthropicAdapter_LongSSELineRoundTrips guards against a regression to
+// bufio.Scanner's default 64 KB per-line budget: a single SSE data line
+// larger than that (long reasoning_content, or a large write_file
+// tool-call args delta) must round-trip as ordinary content instead of
+// aborting the scan with bufio.ErrTooLong. 200 KB is comfortably over the
+// old default and comfortably under the 16 MiB maxSSEScannerBuffer cap.
+func TestAnthropicAdapter_LongSSELineRoundTrips(t *testing.T) {
+	longText := strings.Repeat("a", 200*1024)
+	encoded, err := json.Marshal(longText)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	body := joinLines(
+		makeSSE("content_block_start", `{"index":0,"content_block":{"type":"text","text":""}}`),
+		makeSSE("content_block_delta", fmt.Sprintf(`{"index":0,"delta":{"type":"text_delta","text":%s}}`, encoded)),
+		makeSSE("content_block_stop", `{"index":0}`),
+		makeSSE("message_delta", `{"delta":{"stop_reason":"end_turn"}}`),
+		makeSSE("message_stop", `{}`),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewAnthropicAdapter(staticBearer("test-key"), AuthModeAPIKey)
+	adapter.baseURL = srv.URL
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "text_delta" || len(events[0].Text) != len(longText) {
+		t.Errorf("event[0] = type %q text-len %d, want text_delta len %d", events[0].Type, len(events[0].Text), len(longText))
+	}
+	if events[1].Type != "message_complete" || events[1].StopReason != "end_turn" {
+		t.Errorf("event[1] = %+v, want message_complete/end_turn", events[1])
+	}
+}
+
 func TestAnthropicAdapter_StreamToolUse(t *testing.T) {
 	body := joinLines(
 		makeSSE("content_block_start", `{"index":0,"content_block":{"type":"tool_use","id":"toolu_123","name":"read_file"}}`),

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -45,6 +45,14 @@ const (
 	openaiDefaultBaseURL   = "https://api.openai.com/v1"
 	openaiMaxToolInputSize = 10 * 1024 * 1024 // 10 MB cap on streamed tool argument JSON
 
+	// maxSSEScannerBuffer caps the per-line buffer for the openai and
+	// anthropic SSE scanners (bufio.Scanner's default is 64 KB). A single
+	// SSE line can legitimately exceed that — large reasoning_content or a
+	// big write_file tool-call args blob, worst on the local-model path —
+	// and without this the scanner errors and aborts the turn. 16 MiB
+	// matches geminiMaxScannerBuffer's precedent in gemini.go.
+	maxSSEScannerBuffer = 16 * 1024 * 1024
+
 	// maxReplayFieldBytes bounds the per-stream ReplayFields capture
 	// accumulator across all paths — 512 kB is generous for any real
 	// chain-of-thought field. Without a cap, a malicious or
@@ -1434,6 +1442,7 @@ func (o *OpenAICompatibleAdapter) consumeSSE(ctx context.Context, resp *http.Res
 	}()
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), maxSSEScannerBuffer)
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():

--- a/harness/internal/provider/openai_test.go
+++ b/harness/internal/provider/openai_test.go
@@ -81,6 +81,55 @@ func TestOpenAIAdapter_StreamTextDelta(t *testing.T) {
 	}
 }
 
+// TestOpenAIAdapter_LongSSELineRoundTrips guards against a regression to
+// bufio.Scanner's default 64 KB per-line budget: a single SSE data line
+// larger than that (long reasoning_content, or a large write_file
+// tool-call args delta) must round-trip as ordinary content instead of
+// aborting the scan with bufio.ErrTooLong. 200 KB is comfortably over the
+// old default and comfortably under the 16 MiB maxSSEScannerBuffer cap.
+func TestOpenAIAdapter_LongSSELineRoundTrips(t *testing.T) {
+	longText := strings.Repeat("a", 200*1024)
+	encoded, err := json.Marshal(longText)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	body := strings.Join([]string{
+		makeOpenAIChunk(fmt.Sprintf(`{"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":%s},"finish_reason":null}]}`, encoded)),
+		makeOpenAIChunk(`{"id":"chatcmpl-1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`),
+		"data: [DONE]\n\n",
+	}, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	adapter := NewOpenAICompatibleAdapter(staticBearer("test-key"), srv.URL, OpenAIAuthConfig{}, RetryPolicy{})
+
+	ch, err := adapter.Stream(context.Background(), types.StreamParams{
+		Model:     "gpt-4o",
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+
+	events := collectEvents(t, ch)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "text_delta" || len(events[0].Text) != len(longText) {
+		t.Errorf("event[0] = type %q text-len %d, want text_delta len %d", events[0].Type, len(events[0].Text), len(longText))
+	}
+	if events[1].Type != "message_complete" || events[1].StopReason != "end_turn" {
+		t.Errorf("event[1] = %+v, want message_complete/end_turn", events[1])
+	}
+}
+
 func TestOpenAIAdapter_StreamToolCall(t *testing.T) {
 	body := strings.Join([]string{
 		makeOpenAIChunk(`{"id":"chatcmpl-2","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"read_file","arguments":""}}]},"finish_reason":null}]}`),


### PR DESCRIPTION
## Summary

- `openai.go:1436` and `anthropic.go:650` used `bufio.Scanner`'s default 64 KB per-line buffer for SSE streams, while `gemini.go` was already raised to 16 MiB (`geminiMaxScannerBuffer`). A single SSE line over 64 KB - large `reasoning_content`, or a big `write_file` tool-call args delta, worst on the local-model path - made the scanner error with `bufio.Scanner: token too long` and abort the turn.
- Swept every scanner in `harness/internal/provider/` for stragglers on the default buffer: `openai.go` and `anthropic.go` were the only two; `openai_responses.go` (10 MiB, tied to `openaiMaxToolInputSize`) and `batchpoll.go` (4 MiB, tied to `maxBatchResponseBytes`) already have deliberate non-default caps for different semantics and were left untouched.
- Hoisted a shared `maxSSEScannerBuffer` constant (16 MiB) in `openai.go` rather than duplicating the magic number a third time, reused by `anthropic.go` - mirrors the existing `maxReplayFieldBytes` shared-constant pattern already in this package.

## Test plan

- [x] Added `TestAnthropicAdapter_LongSSELineRoundTrips` and `TestOpenAIAdapter_LongSSELineRoundTrips`: a 200 KB single SSE `data:` line round-trips as ordinary content.
- [x] Verified both new tests fail with `bufio.Scanner: token too long` when the fix is reverted, and pass with it applied.
- [x] `just build`
- [x] `just test`
- [x] `just lint` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ
