### PR TITLE
hook, security: scrub hook commands and case-fold secret:// detection (S4)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -657,9 +657,11 @@ hooks run serially inside the same budget as the rest of the run, so
 this usually still succeeds but is very likely to blow the timeout.
 
 Credentials never belong in a hook `command` — `command` is operator
-config recorded verbatim in the trace, the same treatment
-`verifier.command` gets, so a `secret://` reference there would defeat
-the `SecretStore` contract. `ValidateRunConfig` rejects it structurally.
+config recorded in the trace, the same treatment `verifier.command`
+gets, so a `secret://` reference there would defeat the `SecretStore`
+contract. `ValidateRunConfig` rejects it structurally
+(case-insensitively), and the trace emitter also scrubs `command` for
+secret-shaped substrings before persistence as defence-in-depth.
 Resolve clone/deploy credentials via control-plane runtime bindings
 instead.
 

--- a/harness/internal/security/logscrubber.go
+++ b/harness/internal/security/logscrubber.go
@@ -46,7 +46,13 @@ var secretPatterns = []namedPattern{
 	{"basic_auth", regexp.MustCompile(`(?i)Basic\s+[A-Za-z0-9+/]+=*`)},
 	{"bearer_token", regexp.MustCompile(`(?i)Bearer\s+[A-Za-z0-9._~+/=-]+`)},
 	{"pem_private_key", regexp.MustCompile(`-----BEGIN[\s\w]+KEY-----`)},
-	{"secret_ref", regexp.MustCompile(`secret://[^\s"']+`)},
+	// Case-insensitive: a shell resolves "secret://" and "SECRET://"
+	// identically, and this pattern is the last line of defence for a
+	// hook command whose case-insensitive ValidateRunConfig rejection
+	// was bypassed (e.g. RunConfig built without going through
+	// validation) — matching lowercase only would let a case-varied
+	// reference ride into a persisted trace unredacted.
+	{"secret_ref", regexp.MustCompile(`(?i)secret://[^\s"']+`)},
 	// api_key_header matches the literal "<header>: <value>" forms used
 	// for non-Bearer auth on Azure OpenAI and APIM-fronted gateways. These
 	// keys do not have a distinctive prefix (Azure keys are hex-y but

--- a/harness/internal/security/logscrubber_test.go
+++ b/harness/internal/security/logscrubber_test.go
@@ -1,6 +1,9 @@
 package security
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func slackTokenFixture() string {
 	return "xox" + "b-123456789012-123456789012-abcdefghijklmnopqrstuvwx"
@@ -20,6 +23,36 @@ func TestScrub_AnthropicKey(t *testing.T) {
 	want := "key is [REDACTED]"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestScrub_SecretRefCaseInsensitive pins that the secret_ref pattern
+// redacts a "secret://" reference regardless of scheme case, including
+// mid-string. This is the belt-and-braces counterpart to
+// ValidateRunConfig's case-insensitive hook-command rejection: a
+// case-varied reference must not survive Scrub either, since a trace
+// consumer (e.g. RecordHookExecution) relies on Scrub as a second line
+// of defence rather than trusting the upstream guard alone.
+func TestScrub_SecretRefCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"uppercase_scheme", "SECRET://API_KEY"},
+		{"titlecase_scheme", "Secret://API_KEY"},
+		{"mixedcase_scheme", "sEcReT://mixed_case"},
+		{"mixedcase_scheme_embedded", "echo sEcReT://mixed_case"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Scrub(tc.input)
+			if strings.Contains(strings.ToLower(got), "secret://") {
+				t.Errorf("Scrub(%q) = %q, want the secret:// reference redacted", tc.input, got)
+			}
+			if !strings.Contains(got, "[REDACTED]") {
+				t.Errorf("Scrub(%q) = %q, want a [REDACTED] placeholder", tc.input, got)
+			}
+		})
 	}
 }
 

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -189,18 +189,22 @@ func (e *JSONLTraceEmitter) RecordPermissionDenial() {
 
 // RecordHookExecution appends a lifecycle hook result (issue #461) to
 // the in-memory accumulator AND streams an inline hook_record event,
-// mirroring RecordToolCall's tool_call_record. OutputTail and Error are
-// re-scrubbed here as defence-in-depth — the same posture RecordTurnRecord
-// applies to tool output — even though hook.ExecRunner already scrubs
-// OutputTail before returning the types.HookExecution; Command is
-// operator config (like VerifierConfig.Command) and is deliberately not
-// scrubbed, matching ValidateRunConfig's structural rejection of
-// "secret://" in a hook command.
+// mirroring RecordToolCall's tool_call_record. OutputTail, Error, and
+// Command are all re-scrubbed here as defence-in-depth — the same
+// posture RecordTurnRecord applies to tool output — even though
+// hook.ExecRunner already scrubs OutputTail before returning the
+// types.HookExecution and ValidateRunConfig structurally rejects a
+// "secret://" reference in Command before a hook is ever allowed to
+// run. Command is scrubbed too rather than trusted verbatim: the
+// persisted trace must not depend on that upstream guard being
+// airtight (e.g. a RunConfig assembled without going through
+// validation).
 func (e *JSONLTraceEmitter) RecordHookExecution(exec types.HookExecution) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	scrubbed := exec
+	scrubbed.Command = security.Scrub(exec.Command)
 	scrubbed.OutputTail = security.Scrub(exec.OutputTail)
 	scrubbed.Error = security.Scrub(exec.Error)
 

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -682,11 +682,13 @@ func TestJSONLTraceEmitter_RecordHookExecution_StreamsAndAccumulates(t *testing.
 }
 
 // TestJSONLTraceEmitter_RecordHookExecution_Scrubs pins the
-// defence-in-depth scrub RecordHookExecution applies to OutputTail and
-// Error: even though hook.ExecRunner already scrubs OutputTail before
-// constructing the types.HookExecution, the emitter re-scrubs both
-// fields before they reach disk, the same posture RecordTurnRecord
-// applies to tool output.
+// defence-in-depth scrub RecordHookExecution applies to Command,
+// OutputTail, and Error: even though hook.ExecRunner already scrubs
+// OutputTail before constructing the types.HookExecution and
+// ValidateRunConfig structurally rejects a "secret://" reference in
+// Command, the emitter re-scrubs all three fields before they reach
+// disk, the same posture RecordTurnRecord applies to tool output. A
+// Command with no secret-shaped literal survives intact.
 func TestJSONLTraceEmitter_RecordHookExecution_Scrubs(t *testing.T) {
 	var buf bytes.Buffer
 	emitter := NewJSONLTraceEmitter(&buf)
@@ -714,11 +716,54 @@ func TestJSONLTraceEmitter_RecordHookExecution_Scrubs(t *testing.T) {
 	if strings.Contains(trace.HookResults[0].Error, "sk-ant-api03-leak") {
 		t.Errorf("HookResults[0].Error not scrubbed: %q", trace.HookResults[0].Error)
 	}
-	// Command is operator config (like VerifierConfig.Command) and is
-	// deliberately not scrubbed — ValidateRunConfig structurally
-	// rejects "secret://" in a hook command instead.
-	if trace.HookResults[0].Command == "" {
-		t.Error("Command must survive unscrubbed")
+	wantCommand := "curl -H \"Authorization: Bearer $TOKEN\""
+	if trace.HookResults[0].Command != wantCommand {
+		t.Errorf("Command without a secret-shaped literal must survive intact: got %q, want %q",
+			trace.HookResults[0].Command, wantCommand)
+	}
+}
+
+// TestJSONLTraceEmitter_RecordHookExecution_ScrubsCaseVariedSecretRef
+// pins the belt-and-braces contract explicitly: even if a case-varied
+// "secret://" reference somehow reached RecordHookExecution — bypassing
+// ValidateRunConfig's case-insensitive rejection, e.g. a RunConfig
+// assembled programmatically without going through validation — the
+// trace emitter's own scrub still redacts it before it lands on disk or
+// in RunTrace.HookResults. The persisted trace must not depend solely
+// on the upstream guard being airtight.
+func TestJSONLTraceEmitter_RecordHookExecution_ScrubsCaseVariedSecretRef(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{"uppercase_scheme", "echo SECRET://API_KEY"},
+		{"titlecase_scheme", "echo Secret://API_KEY"},
+		{"mixedcase_scheme_embedded", "curl -H \"Authorization: Bearer $(cat sEcReT://mixed_case)\""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			emitter := NewJSONLTraceEmitter(&buf)
+			emitter.Start("run-hook-case-bypass", nil)
+
+			emitter.RecordHookExecution(types.HookExecution{
+				Phase:   "preRun",
+				Index:   0,
+				Command: tc.command,
+			})
+			trace, err := emitter.Finish(context.Background(), "success")
+			if err != nil {
+				t.Fatalf("Finish: %v", err)
+			}
+
+			onDisk := buf.String()
+			if strings.Contains(strings.ToLower(onDisk), "secret://") {
+				t.Errorf("scrubber missed case-varied secret:// reference in on-disk trace:\n%s", onDisk)
+			}
+			if strings.Contains(strings.ToLower(trace.HookResults[0].Command), "secret://") {
+				t.Errorf("HookResults[0].Command not scrubbed: %q", trace.HookResults[0].Command)
+			}
+		})
 	}
 }
 

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -2753,10 +2753,10 @@ func validateHookConfig(path string, h HookConfig, isPostRun bool, errs *[]strin
 		*errs = append(*errs, fmt.Sprintf("%s.command must be <= %d bytes, got %d", path, maxHookCommandBytes, len(h.Command)))
 	}
 	// Case-insensitive: a shell reads "secret://..." and "SECRET://..."
-	// identically, and the doc contract ("structurally rejected") would
-	// be a lie if `SECRET://FOO` slipped through untouched into the
-	// trace unscrubbed (HookExecution.Command is deliberately not
-	// scrubbed, on the premise that this check is airtight).
+	// identically, so the rejection must too. This is not the only line
+	// of defence — the trace emitter also re-scrubs HookExecution.Command
+	// (security.Scrub) before persistence — but a case-varied reference
+	// should never reach that point in the first place.
 	if strings.Contains(strings.ToLower(h.Command), "secret://") {
 		*errs = append(*errs, fmt.Sprintf(
 			"%s.command must not contain a \"secret://\" reference; resolve credentials via control-plane runtime bindings instead",

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -58,6 +58,12 @@ type RunTrace struct {
 // Truncated reports whether the persisted (scrubbed) output exceeded the
 // 4KB tail cap; truncation keeps the tail (not the head) because a
 // failing command's most useful diagnostic is usually printed last.
+//
+// Command is also scrubbed (security.Scrub) by the trace emitter before
+// persistence, as defence-in-depth alongside ValidateRunConfig's
+// structural, case-insensitive rejection of a "secret://" reference in
+// a hook command — the trace must not depend solely on that guard being
+// airtight.
 type HookExecution struct {
 	Phase            string `json:"phase"` // "preRun" | "postRun"
 	Index            int    `json:"index"`


### PR DESCRIPTION
## Summary

Closes out v0.1 security review item S4 (task #110).

Investigation found the described defect — the `secret://` guard
being case-sensitive — was already fixed on `main` in `0e5203a`
(`types.validateHookConfig` now does `strings.Contains(strings.ToLower(h.Command), "secret://")`,
with a pinning test covering `SECRET://`, `Secret://`, `sEcReT://`,
and mid-string embedding). What remained from S4 was the
belt-and-braces item: `HookExecution.Command` was recorded verbatim
in the trace on the explicit premise that the config-time guard is
airtight — a premise that does not hold for a `RunConfig` assembled
without going through `ValidateRunConfig` (e.g. programmatic
embedding via `harnessapi`).

Two gaps, now closed:

- `harness/internal/trace/jsonl.go`: `RecordHookExecution` now scrubs
  `Command` (via `security.Scrub`) the same way it already scrubs
  `OutputTail` and `Error`, so the persisted trace no longer depends
  solely on the upstream guard.
- `harness/internal/security/logscrubber.go`: the `secret_ref` pattern
  matched lowercase `secret://` only. Even with the emitter now
  calling `Scrub()` on `Command`, a `SECRET://...` reference would
  have sailed through undetected. Folded to `(?i)`, consistent with
  the other case-insensitive patterns already in the same pack
  (`aws_secret_access_key`, `basic_auth`, `bearer_token`, etc).

Also updated the doc comments in `types/runconfig.go` and
`types/runtrace.go` that explicitly documented the old "deliberately
not scrubbed, guard is airtight" premise, and the corresponding
paragraph in `docs/configuration.md`.

## Test plan

- [x] `just build`
- [x] `just test` (full suite, all packages)
- [x] `just lint` (0 issues)
- [x] New pinning tests added:
  - `TestScrub_SecretRefCaseInsensitive` (logscrubber_test.go) — uppercase,
    titlecase, mixed-case, and mid-string `secret://` variants
  - `TestJSONLTraceEmitter_RecordHookExecution_ScrubsCaseVariedSecretRef`
    (jsonl_test.go) — simulates a case-varied reference reaching the
    trace emitter directly (bypassing config validation) and asserts
    it is still redacted on disk and in `RunTrace.HookResults`
  - Updated `TestJSONLTraceEmitter_RecordHookExecution_Scrubs` to assert
    the new scrub-Command behavior instead of the old must-survive-unscrubbed
    contract
- [x] Verified both new tests are non-vacuous: temporarily reverted each
  fix in isolation (case-sensitive regex; Command left unscrubbed) and
  confirmed the corresponding new test fails, then restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ