### PR TITLE
core: scale response reserve to small context budgets

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -88,18 +88,26 @@ end-to-end against LM Studio. The operationally relevant behaviours:
 - **Set `temperature` to 0.6.** Qwen recommends 0.6 for thinking-mode
   coding and warns against greedy decoding (`temperature: 0`), which can
   trigger repetition. The harness default is 0.1; the example raises it.
-- **Raise the LM Studio context window, and keep `contextStrategy.maxTokens`
-  above the response reserve.** LM Studio loads models with a
-  conservative context window that is usually far below the model's
-  native ceiling. The harness reserves a fixed 64k tokens for the
-  response, so `contextStrategy.maxTokens` must comfortably exceed 64k —
-  set below it and the sliding window has negative room for the prompt,
-  truncates to the last two messages every turn, and the model returns a
-  malformed turn that surfaces as an `empty stop reason` error. Set
-  `contextStrategy.maxTokens` above 64k (the example uses 131072) and
-  configure the LM Studio context window to hold at least that much.
-  Small-context local deployments (≤64k) are a known limitation: the
-  fixed 64k reserve leaves them no usable prompt budget.
+- **`contextStrategy.maxTokens` scales its response reserve to fit
+  small windows.** LM Studio loads models with a conservative context
+  window that is usually far below the model's native ceiling. Above
+  64k, the harness reserves a flat 64k tokens for the response, same as
+  always. At or below 64k, the reserve scales down to a quarter of
+  `contextStrategy.maxTokens` instead of staying flat — a fixed 64k
+  reserve on a small window used to leave negative room for the prompt,
+  truncating to the last two messages every turn and surfacing as an
+  `empty stop reason` error; the scaled reserve keeps a real, usable
+  prompt budget regardless of window size. The harness logs a WARN and
+  emits a transport `warning` event on the run's first turn whenever
+  this scaling kicks in, naming the configured `maxTokens` and the
+  resulting reserve, so a run against an unexpectedly small LM Studio
+  window is diagnosable rather than silent. Setting
+  `contextStrategy.maxTokens` well above 64k (the example uses 131072)
+  and configuring the LM Studio context window to hold at least that
+  much remains the best choice when the model's native context
+  supports it — a larger prompt budget is strictly more useful than a
+  scaled-down one — but is no longer required for small-context local
+  deployments to work.
 - **Vendor-prefixed model ids.** LM Studio serves some models under
   `vendor/model` ids (e.g. `qwen/qwen3.6-27b`). The quirks registry
   advertises the openai-compatible tool surface for one level of prefix,

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -61,8 +61,19 @@ const (
 	defaultMaxContextTokens = 200_000
 
 	// defaultReserveForResponse is the number of tokens reserved for the
-	// model's response within the context window.
+	// model's response within the context window, for any budget large
+	// enough to absorb it. See effectiveReserveForResponse for the
+	// small-budget case.
 	defaultReserveForResponse = 64_000
+
+	// smallContextReserveDivisor is the fraction of a small
+	// ContextStrategy.MaxTokens budget reserved for the model's response
+	// once the flat defaultReserveForResponse would consume the whole
+	// window (see effectiveReserveForResponse). Skewed toward history
+	// over completion length: an agentic coding turn's context is
+	// typically dominated by file contents and tool output, not the
+	// model's own response.
+	smallContextReserveDivisor = 4
 
 	// defaultTemperature is the sampling temperature applied to every
 	// provider call when RunConfig.Temperature is nil. A low value
@@ -101,6 +112,40 @@ const (
 	// wrapping each tool definition (type, function wrapper, field keys).
 	toolDefinitionOverheadTokens = 10
 )
+
+// effectiveReserveForResponse resolves the response-token reserve
+// subtracted from maxTokens before the context strategy packs message
+// history, and the max output tokens requested from the provider.
+//
+// Historically both call sites used the flat defaultReserveForResponse
+// (64k) unconditionally. For any config.ContextStrategy.MaxTokens at or
+// below that constant, `available := budget.MaxTokens -
+// budget.ReserveForResponse` (computed by every context strategy) goes
+// non-positive, and the strategy short-circuits to its
+// minimum-preserved-messages branch on every turn — silently dropping
+// the run's actual history, including the original user prompt on
+// turns after the first (#444). This is squarely in the small-context
+// local-model regime (LM Studio / Ollama commonly run 4k-32k windows).
+//
+// Below the flat-reserve threshold, scale the reserve down to a
+// quarter of maxTokens instead: the resulting budget is always
+// positive, and — because a quarter of even a very small window still
+// leaves the majority for history — the context strategy gets a real,
+// useful budget rather than a degenerate one. Configs whose maxTokens
+// is 0 (unset — the loop assumes defaultMaxContextTokens) or above
+// defaultReserveForResponse are untouched byte-for-byte, so this is
+// not a behaviour change for any config that did not already hit the
+// bug.
+func effectiveReserveForResponse(maxTokens int) int {
+	if maxTokens <= 0 || maxTokens > defaultReserveForResponse {
+		return defaultReserveForResponse
+	}
+	reserve := maxTokens / smallContextReserveDivisor
+	if reserve < 1 {
+		reserve = 1
+	}
+	return reserve
+}
 
 // Run executes the agentic loop:
 //
@@ -647,6 +692,25 @@ func (l *AgenticLoop) runInnerLoop(
 		if config.ContextStrategy.MaxTokens > 0 {
 			maxTokens = config.ContextStrategy.MaxTokens
 		}
+		responseReserve := effectiveReserveForResponse(maxTokens)
+		if turn == 0 && responseReserve < defaultReserveForResponse {
+			// One warning per run (turn 0 only): maxTokens is constant
+			// across turns, so re-emitting this every turn would just be
+			// noise. See effectiveReserveForResponse for why the reserve
+			// is scaled down instead of left at the flat default.
+			l.Logger.Warn("context response reserve scaled down for small context budget",
+				"maxTokens", maxTokens,
+				"reserve", responseReserve,
+				"defaultReserve", defaultReserveForResponse,
+			)
+			_ = l.Transport.Emit(types.HarnessEvent{
+				Type: "warning",
+				Message: fmt.Sprintf(
+					"contextStrategy.maxTokens=%d is at or below the default response reserve (%d); scaling the reserve down to %d tokens so history packing keeps a usable budget",
+					maxTokens, defaultReserveForResponse, responseReserve,
+				),
+			})
+		}
 		_, contextSpan := l.Tracer.Start(l.traceCtx(ctx), "context.prepare",
 			oteltrace.WithAttributes(
 				attribute.Int("messages.before", len(messages)),
@@ -656,7 +720,7 @@ func (l *AgenticLoop) runInnerLoop(
 		preparedMessages, err := l.Context.Prepare(ctx, messages, contextpkg.TokenBudget{
 			MaxTokens:          maxTokens,
 			CurrentTokens:      currentTokens,
-			ReserveForResponse: defaultReserveForResponse,
+			ReserveForResponse: responseReserve,
 		})
 		if err != nil {
 			contextSpan.RecordError(err)
@@ -767,7 +831,7 @@ func (l *AgenticLoop) runInnerLoop(
 			System:      systemPrompt,
 			Messages:    preparedMessages,
 			Tools:       l.Tools.List(),
-			MaxTokens:   defaultReserveForResponse,
+			MaxTokens:   responseReserve,
 			Temperature: temperature,
 			ToolChoice:  turnToolChoice,
 		})

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -1040,6 +1040,120 @@ func TestEstimateTokens_OverheadSignificance(t *testing.T) {
 	}
 }
 
+// TestEffectiveReserveForResponse pins the reserve-scaling boundary
+// introduced for #444: any maxTokens above defaultReserveForResponse
+// (including the unset/negative sentinels, which resolve through the
+// loop's own defaultMaxContextTokens fallback before reaching this
+// function) is untouched byte-for-byte, so this must never change
+// behaviour for a config that did not already hit the bug. At and below
+// the boundary the reserve scales down to smallContextReserveDivisor's
+// fraction of maxTokens, floored at 1 token so the provider is never
+// asked for a zero-token completion.
+func TestEffectiveReserveForResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      int
+	}{
+		{"unset (zero) uses the flat default", 0, defaultReserveForResponse},
+		{"negative uses the flat default", -1, defaultReserveForResponse},
+		{"the assumed default window is untouched", defaultMaxContextTokens, defaultReserveForResponse},
+		{"just above the boundary is untouched", defaultReserveForResponse + 1, defaultReserveForResponse},
+		{"at the boundary scales down", defaultReserveForResponse, defaultReserveForResponse / smallContextReserveDivisor},
+		{"issue #444's own repro value", 32768, 32768 / smallContextReserveDivisor},
+		{"small local-model window", 8192, 8192 / smallContextReserveDivisor},
+		{"sub-divisor budget floors at 1 token, never 0", 2, 1},
+		{"single-token budget floors at 1 token", 1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveReserveForResponse(tt.maxTokens); got != tt.want {
+				t.Errorf("effectiveReserveForResponse(%d) = %d, want %d", tt.maxTokens, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoop_SmallContextBudgetScalesProviderMaxTokens asserts the other
+// half of #444's root cause: the provider Stream() request's MaxTokens
+// (max_completion_tokens on the wire) was hardwired to the flat
+// defaultReserveForResponse regardless of ContextStrategy.MaxTokens, so
+// a small-context server was always asked to generate up to 64k
+// completion tokens — a request its own window cannot honour. The
+// provider must now see the same scaled-down reserve the context
+// strategy uses.
+func TestLoop_SmallContextBudgetScalesProviderMaxTokens(t *testing.T) {
+	prov := &mockProvider{
+		events: []types.StreamEvent{
+			{Type: "text_delta", Text: "ok"},
+			{Type: "message_complete", StopReason: "end_turn"},
+		},
+	}
+	loop := buildTestLoop(prov)
+
+	config := buildTestConfig()
+	config.ContextStrategy = types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 32768}
+
+	if _, err := loop.Run(context.Background(), config); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	want := 32768 / smallContextReserveDivisor
+	if prov.lastParams.MaxTokens != want {
+		t.Errorf("provider StreamParams.MaxTokens = %d, want %d (scaled reserve, not the flat %d default)",
+			prov.lastParams.MaxTokens, want, defaultReserveForResponse)
+	}
+}
+
+// TestLoop_SmallContextBudgetWarnsOnce asserts item 3 of #444's fix: an
+// operator running a small-context config gets an actionable warning
+// (slog + a transport "warning" event, mirroring the provider-error
+// surfacing added by "core: surface provider errors via slog and
+// transport warning") instead of the silent truncation the issue
+// reports. maxTokens is constant for the life of a run, so the warning
+// must fire exactly once — a per-turn repeat would just be noise.
+func TestLoop_SmallContextBudgetWarnsOnce(t *testing.T) {
+	var transportBuf, logBuf bytes.Buffer
+
+	prov := &multiCallProvider{
+		calls: [][]types.StreamEvent{
+			{
+				{Type: "tool_call", ID: "tc_1", Name: "test_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "Done!"},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+	loop := buildTestLoop(nil)
+	loop.Provider = prov
+	loop.Transport = transport.NewStdioTransport(&transportBuf, &bytes.Buffer{})
+	loop.Logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
+
+	config := buildTestConfig()
+	config.ContextStrategy = types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 32768}
+
+	if _, err := loop.Run(context.Background(), config); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	const needle = "context response reserve scaled down"
+	if !strings.Contains(logBuf.String(), needle) {
+		t.Errorf("expected a slog warning about the scaled-down reserve; got:\n%s", logBuf.String())
+	}
+	if n := strings.Count(logBuf.String(), needle); n != 1 {
+		t.Errorf("expected exactly 1 reserve-scaling warning log line across the run's 2 turns, got %d:\n%s", n, logBuf.String())
+	}
+	if !strings.Contains(transportBuf.String(), `"type":"warning"`) {
+		t.Errorf("expected a warning event on the transport stream for a scaled-down reserve; got:\n%s", transportBuf.String())
+	}
+	if !strings.Contains(transportBuf.String(), "32768") {
+		t.Errorf("expected the transport warning to name the configured maxTokens; got:\n%s", transportBuf.String())
+	}
+}
+
 func TestBuildLoop_InvalidConfig(t *testing.T) {
 	config := buildTestConfig()
 	config.MaxTurns = 200 // exceeds the maximum of 100
@@ -1266,12 +1380,14 @@ func TestDispatchToolCall_EmitsPrototypePollutionBlocked(t *testing.T) {
 type recordingContextStrategy struct {
 	inner    contextpkg.ContextStrategy
 	loop     *AgenticLoop
+	inputs   []int   // number of messages passed in per Prepare invocation
 	prepared []int   // number of messages returned per Prepare invocation
 	atomics  []int64 // value of loop.lastContextTokens AFTER each Prepare
 }
 
 func (r *recordingContextStrategy) Prepare(ctx context.Context, messages []types.Message, budget contextpkg.TokenBudget) ([]types.Message, error) {
 	out, err := r.inner.Prepare(ctx, messages, budget)
+	r.inputs = append(r.inputs, len(messages))
 	r.prepared = append(r.prepared, len(out))
 	// The loop stores lastContextTokens *after* Prepare returns, so
 	// snapshot via a deferred read-back at the start of the NEXT
@@ -1307,11 +1423,17 @@ func (r *recordingContextStrategy) LastCompaction() *contextpkg.CompactionEvent 
 func TestLoop_ContextTokensGaugeReflectsCompaction(t *testing.T) {
 	// We need a multi-turn run where the OLDEST messages dominate the
 	// token count and get dropped by compaction. Strategy: a heavy user
-	// prompt followed by short assistant turns. With MaxTokens far
-	// below defaultReserveForResponse, the sliding-window strategy
-	// preserves only the last minPreservedMessages on every Prepare call
-	// where len(messages) > 2 — and after enough short turns the heavy
-	// prompt falls off the kept window, shrinking the absolute count.
+	// prompt followed by short assistant turns. MaxTokens (50) is small
+	// enough that even effectiveReserveForResponse's quartered reserve
+	// (12) leaves only a 38-token available budget — nowhere near
+	// enough to hold the ~2000-token heavy prompt — so the sliding-
+	// window strategy still preserves only the last minPreservedMessages
+	// on every Prepare call where len(messages) > 2, and after enough
+	// short turns the heavy prompt falls off the kept window, shrinking
+	// the absolute count. This exercises the strategy's genuinely-
+	// impossible-budget path (see TestLoop_SmallContextBudgetRetainsHistory
+	// below for the case #444 fixed: a small-but-workable budget that
+	// must NOT collapse to 2 messages).
 	prov := &multiCallProvider{
 		calls: [][]types.StreamEvent{
 			{
@@ -1349,9 +1471,13 @@ func TestLoop_ContextTokensGaugeReflectsCompaction(t *testing.T) {
 	// heavy prompt dominates the early absolute count and gets dropped
 	// by sliding-window compaction once it falls off the preserved tail.
 	config.Prompt = strings.Repeat("a", 8000) // ~2000 tokens worth of chars
-	// available = MaxTokens (50) - defaultReserveForResponse (64000) < 0.
-	// SlidingWindow returns the last minPreservedMessages (2) when
-	// available <= 0 and len(messages) > minPreservedMessages.
+	// effectiveReserveForResponse(50) = 50/4 = 12 (quartered, since 50 is
+	// far below defaultReserveForResponse). available = 50 - 12 = 38,
+	// still positive but far too small to hold the ~2000-token heavy
+	// prompt, so SlidingWindow still drops down to minPreservedMessages
+	// once len(messages) > minPreservedMessages — same observable
+	// behaviour as the pre-#444-fix flat reserve, because at this
+	// magnitude no split of the budget is workable.
 	config.ContextStrategy = types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 50}
 
 	if _, err := loop.Run(context.Background(), config); err != nil {
@@ -1402,6 +1528,80 @@ func TestLoop_ContextTokensGaugeReflectsCompaction(t *testing.T) {
 	// preserves only 2 small messages out of the larger history).
 	if finalValue >= afterTurn0 {
 		t.Errorf("expected final gauge value < afterTurn0; got final=%d afterTurn0=%d", finalValue, afterTurn0)
+	}
+}
+
+// TestLoop_SmallContextBudgetRetainsHistory is the regression test for
+// #444: with the harness's old flat 64k response reserve, ANY
+// ContextStrategy.MaxTokens at or below 64000 drove the sliding-window
+// budget (MaxTokens - ReserveForResponse) non-positive, so every
+// Prepare call past the first collapsed to the last minPreservedMessages
+// (2) — silently dropping the original user prompt from turn 2 onward,
+// every turn, regardless of how much of the real budget was actually
+// unused. 32768 matches the issue's own small-local-model reproduction
+// (LM Studio / Ollama commonly run 4k-32k windows).
+//
+// With effectiveReserveForResponse scaling the reserve down to a
+// quarter of maxTokens (8192) instead of leaving it flat, available
+// (32768-8192 = 24576) comfortably holds this test's modest message
+// history, so the fix under test is that NOTHING gets dropped — the
+// same scenario that used to force every Prepare call down to 2
+// messages (see TestLoop_ContextTokensGaugeReflectsCompaction, which
+// pins the still-genuinely-impossible-budget case) must now return the
+// history unchanged.
+func TestLoop_SmallContextBudgetRetainsHistory(t *testing.T) {
+	prov := &multiCallProvider{
+		calls: [][]types.StreamEvent{
+			{
+				{Type: "text_delta", Text: "ok1"},
+				{Type: "tool_call", ID: "tc_1", Name: "test_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "ok2"},
+				{Type: "tool_call", ID: "tc_2", Name: "test_tool", Input: map[string]any{}},
+				{Type: "message_complete", StopReason: "tool_use"},
+			},
+			{
+				{Type: "text_delta", Text: "Done!"},
+				{Type: "message_complete", StopReason: "end_turn"},
+			},
+		},
+	}
+	loop := buildTestLoop(nil)
+	loop.Provider = prov
+
+	rec := &recordingContextStrategy{
+		inner: contextpkg.NewSlidingWindowStrategy(),
+		loop:  loop,
+	}
+	loop.Context = rec
+
+	config := buildTestConfig()
+	// Same heavy prompt as TestLoop_ContextTokensGaugeReflectsCompaction
+	// (~2000 tokens), but a realistic small-context-model window instead
+	// of a pathologically tiny one.
+	config.Prompt = strings.Repeat("a", 8000)
+	config.ContextStrategy = types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 32768}
+
+	if _, err := loop.Run(context.Background(), config); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(rec.prepared) < 3 {
+		t.Fatalf("expected >= 3 Prepare invocations, got %v", rec.prepared)
+	}
+	t.Logf("input lengths: %v, prepared lengths: %v", rec.inputs, rec.prepared)
+
+	for i := range rec.prepared {
+		if rec.prepared[i] != rec.inputs[i] {
+			t.Errorf("Prepare call %d truncated history from %d to %d messages (full sequence in=%v out=%v); a small-but-workable context budget must not silently drop real history (#444)",
+				i, rec.inputs[i], rec.prepared[i], rec.inputs, rec.prepared)
+		}
+	}
+	last := rec.prepared[len(rec.prepared)-1]
+	if last <= 2 {
+		t.Fatalf("expected the final Prepare call to retain more than the minimum-preserved 2 messages, got %d (full sequence=%v)", last, rec.prepared)
 	}
 }
 

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -28,6 +28,22 @@ const (
 	// maxTokenBudget is the maximum allowed token budget.
 	maxTokenBudget = 50_000_000
 
+	// minContextStrategyMaxTokens is the smallest ContextStrategyConfig.MaxTokens
+	// ValidateRunConfig accepts once the field is set; 0 keeps its
+	// "unset, use the harness default window" meaning and validates
+	// cleanly regardless. harness/internal/core scales its response
+	// reserve down proportionally for small budgets (issue #444), so
+	// almost any positive maxTokens is numerically workable — this floor
+	// exists only to reject values so small that no split of the budget
+	// could hold a system prompt, a tool definition list, and a single
+	// message. It is deliberately far below the old, since-removed hard
+	// floor of 64000 (the harness's flat response reserve): rejecting
+	// every maxTokens at or under that constant is the exact footgun
+	// #444 reports for small-context local models. It is also kept
+	// below the 1000-token fixtures used by existing config-plumbing
+	// tests that are not exercising real runs.
+	minContextStrategyMaxTokens = 512
+
 	// maxTemperature is the upper bound on RunConfig.Temperature.
 	// Chosen as the union of provider-side ranges: Anthropic accepts
 	// [0, 1], OpenAI and Gemini accept [0, 2]. Values inside the union
@@ -2086,6 +2102,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateOptionalType("modelRouter", config.ModelRouter.Type, validModelRouterTypes, &errs)
 	validateOptionalType("promptBuilder", config.PromptBuilder.Type, validPromptBuilderTypes, &errs)
 	validateOptionalType("contextStrategy", config.ContextStrategy.Type, validContextStrategyTypes, &errs)
+	validateContextStrategyBudget(config.ContextStrategy, &errs)
 	validateOptionalType("executor", config.Executor.Type, validExecutorTypes, &errs)
 	validateExecutorRegistryAllowlist(config.Executor, &errs)
 	validateExecutorRuntime(config.Executor, &errs)
@@ -2218,6 +2235,23 @@ func validateOptionalType(name, value string, valid map[string]bool, errs *[]str
 	}
 	if !valid[value] {
 		*errs = append(*errs, fmt.Sprintf("unsupported %s type %q", name, value))
+	}
+}
+
+// validateContextStrategyBudget rejects a ContextStrategyConfig.MaxTokens
+// value that cannot possibly work, while leaving every other positive
+// value — however small — to run: see minContextStrategyMaxTokens for
+// why a low floor, not a high one, is the correct fix for #444. Negative
+// values are always rejected; MaxTokens has no meaning below zero and
+// silently treating it as "unset" would mask a caller bug.
+func validateContextStrategyBudget(cfg ContextStrategyConfig, errs *[]string) {
+	switch {
+	case cfg.MaxTokens < 0:
+		*errs = append(*errs, fmt.Sprintf("contextStrategy.maxTokens must be >= 0, got %d", cfg.MaxTokens))
+	case cfg.MaxTokens > 0 && cfg.MaxTokens < minContextStrategyMaxTokens:
+		*errs = append(*errs, fmt.Sprintf(
+			"contextStrategy.maxTokens must be 0 (use the default context window) or >= %d, got %d",
+			minContextStrategyMaxTokens, cfg.MaxTokens))
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -820,6 +820,48 @@ func TestValidateRunConfig_NilBudgetsPass(t *testing.T) {
 	}
 }
 
+// TestValidateRunConfig_ContextStrategyMaxTokens is the regression test
+// for #444: a hard floor at the harness's old flat response reserve
+// (64000) would reject exactly the small-context local-model configs
+// the issue is about, so the accepted range is deliberately wide —
+// only structurally-impossible budgets (negative, or too small to hold
+// a system prompt and a single message under any split) are rejected.
+func TestValidateRunConfig_ContextStrategyMaxTokens(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		wantErr   bool
+	}{
+		{"unset uses default window", 0, false},
+		{"negative rejected", -1, true},
+		{"one token rejected", 1, true},
+		{"just below floor rejected", minContextStrategyMaxTokens - 1, true},
+		{"floor boundary accepted", minContextStrategyMaxTokens, false},
+		// Matches the fixture value used by several harness/cmd/stirrup/cmd
+		// config-plumbing tests that are not exercising a real run — must
+		// stay accepted so this validation does not regress them.
+		{"small-context fixture value accepted", 1000, false},
+		{"small local-model window accepted", 32768, false},
+		{"default window accepted", 200000, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validConfig()
+			c.ContextStrategy = ContextStrategyConfig{Type: "sliding-window", MaxTokens: tt.maxTokens}
+			err := ValidateRunConfig(c)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ValidateRunConfig(maxTokens=%d) = nil, want error", tt.maxTokens)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ValidateRunConfig(maxTokens=%d) = %v, want nil", tt.maxTokens, err)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "contextStrategy.maxTokens") {
+				t.Errorf("expected error to mention contextStrategy.maxTokens, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateRunConfig_TemperatureBounds(t *testing.T) {
 	// Out-of-range: negative.
 	c := validConfig()


### PR DESCRIPTION
## Summary

Fixes #444 (v0.1 release blocker B2; #429 closed as duplicate).

- `defaultReserveForResponse` (64k) was subtracted from the context budget unconditionally, both for history packing (sliding-window / summarise / offload-to-file) and for the provider's requested `max_completion_tokens`. Any `contextStrategy.maxTokens` at or below 64k drove the packing budget non-positive, so every strategy silently collapsed to its last-2-messages branch on *every* turn — dropping the original user prompt from turn 2 onward with no error, surfacing only as a confusing `provider returned empty stop reason` outcome. This is exactly the small-context local-model path (LM Studio / Ollama, #443) stirrup just shipped support for.
- `effectiveReserveForResponse` scales the reserve down to a quarter of `maxTokens` once the flat 64k reserve would consume the whole window, so the available budget is always positive. Configs whose `maxTokens` is unset or above 64k are untouched byte-for-byte — not a behaviour change for any config that did not already hit the bug. The same computed reserve now also bounds the provider's requested `MaxTokens`, so a small-context server is no longer asked for up to 64k completion tokens it cannot honour.
- `ValidateRunConfig` gains a floor (`minContextStrategyMaxTokens = 512`) that rejects only genuinely-impossible budgets (negative, or too small for any split to hold a system prompt + one message) — deliberately *not* a hard reject at the old 64k threshold, since that would just re-create the exact block #444 reports.
- A one-per-run `slog.Warn` + transport `warning` event fires when the reserve is scaled down, mirroring the surfacing added by `core: surface provider errors via slog and transport warning`, so an operator sees *why* history looks smaller than expected instead of hitting a silent truncation.
- `docs/providers.md`'s LM Studio section, which documented the old 64k requirement as a hard, unfixable limitation, is updated to describe the new behaviour.

## Reserve formula + rationale

```
effectiveReserveForResponse(maxTokens):
  if maxTokens <= 0 or maxTokens > 64_000: return 64_000   # unset / already-generous budgets: unchanged
  return max(1, maxTokens / 4)                              # small budgets: scale down, floor at 1 token
```

A quarter of the (small) budget is reserved for the response, leaving three quarters for history — an agentic coding turn's context is typically dominated by file contents and tool output, not the model's own response length. The crossover point (exactly the old flat 64k constant) means every config that already worked is untouched; only the previously-broken `maxTokens <= 64000` regime changes.

## Test plan

- [x] `TestEffectiveReserveForResponse` — table test pinning the boundary (unset/negative/above-64k untouched; at-or-below-64k scales; floors at 1 token).
- [x] `TestLoop_SmallContextBudgetRetainsHistory` — regression test: `maxTokens: 32768` (issue's own repro value) with a multi-turn tool-using conversation retains full history at every `Prepare` call (previously collapsed to 2 messages every turn).
- [x] `TestLoop_SmallContextBudgetScalesProviderMaxTokens` — provider `Stream()` receives the scaled reserve, not the flat 64k constant.
- [x] `TestLoop_SmallContextBudgetWarnsOnce` — slog + transport warning fires exactly once per run (not per-turn) and names the configured `maxTokens`.
- [x] `TestLoop_ContextTokensGaugeReflectsCompaction` — existing test updated (comments only) to reflect the new math; a `maxTokens: 50` budget is still small enough to be genuinely unworkable, so its 2-message-collapse assertion is unchanged.
- [x] `TestValidateRunConfig_ContextStrategyMaxTokens` — new `ValidateRunConfig` test: negative rejected, `[1, 511]` rejected, `512` and up accepted, including the `1000`-token fixture value used by several existing `harness/cmd/stirrup/cmd` config-plumbing tests (confirmed those still pass).
- [x] `just build`, `just test`, `just lint` all pass.

Not merging — opening for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ