### PR TITLE
types: validate edit fuzzyThreshold range

### DIFF
--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -1322,6 +1322,23 @@ func buildEditStrategy(cfg types.EditStrategyConfig) edit.EditStrategy {
 	if cfg.FuzzyThreshold != nil {
 		fuzzyThreshold = *cfg.FuzzyThreshold
 	}
+	// Same defence-in-depth rationale as the unknown-Type fallback below:
+	// types.ValidateRunConfig rejects fuzzyThreshold outside (0, 1], but a
+	// caller that bypasses validation (gRPC / embedders constructing a
+	// RunConfig directly) can still reach here with a value <= 0. That
+	// defeats the udiff fuzzy-match "no match found" sentinel check
+	// (harness/internal/edit/udiff.go: findFuzzyMatch's bestSim=0/bestPos=-1
+	// zero value passes an unguarded `>= 0` comparison) and panics on a
+	// negative slice index. Clamp to the documented default instead of
+	// letting a bad config take the run down mid-edit.
+	if fuzzyThreshold <= 0 || fuzzyThreshold > 1 {
+		slog.Default().Warn("edit strategy fuzzyThreshold out of range; falling back to default",
+			slog.Float64("attempted_fuzzy_threshold", fuzzyThreshold),
+			slog.Float64("selected_fuzzy_threshold", 0.80),
+			slog.String("hint", "route the RunConfig through types.ValidateRunConfig to reject out-of-range values"),
+		)
+		fuzzyThreshold = 0.80
+	}
 
 	switch cfg.Type {
 	case "whole-file":

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -348,6 +348,46 @@ func TestBuildEditStrategy_CustomFuzzyThreshold(t *testing.T) {
 	}
 }
 
+// TestBuildEditStrategy_OutOfRangeFuzzyThresholdClamped exercises the
+// defence-in-depth guard for callers that construct a RunConfig without
+// going through types.ValidateRunConfig (which otherwise rejects a
+// fuzzyThreshold <= 0). Before the guard, a zero-or-negative threshold
+// reached edit.NewUdiffStrategy unclamped and panicked on the first hunk
+// with no fuzzy match (harness/internal/edit/udiff.go's findFuzzyMatch
+// sentinel bestPos=-1 passed an unguarded `bestSim >= threshold` check and
+// then indexed a slice at -1). This drives Apply end-to-end with a diff
+// that cannot match anywhere in the file, so it would panic if the guard
+// were removed.
+func TestBuildEditStrategy_OutOfRangeFuzzyThresholdClamped(t *testing.T) {
+	exec, err := executor.NewLocalExecutor(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalExecutor: %v", err)
+	}
+	if err := exec.WriteFile(context.Background(), "file.txt", "aaaa\nbbbb\ncccc\n"); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	badThreshold := 0.0
+	es := buildEditStrategy(types.EditStrategyConfig{Type: "udiff", FuzzyThreshold: &badThreshold})
+
+	diff := "--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-zzzz\n+yyyy\n"
+	input, marshalErr := json.Marshal(struct {
+		Path string `json:"path"`
+		Diff string `json:"diff"`
+	}{Path: "file.txt", Diff: diff})
+	if marshalErr != nil {
+		t.Fatalf("marshal input: %v", marshalErr)
+	}
+
+	result, err := es.Apply(context.Background(), input, exec)
+	if err != nil {
+		t.Fatalf("Apply returned error (want a clean no-match result, not a panic-adjacent error): %v", err)
+	}
+	if result.Applied {
+		t.Fatalf("expected Applied=false (diff cannot match aaaa/bbbb/cccc), got Applied=true")
+	}
+}
+
 func TestBuildEditStrategy_UnknownFallsBack(t *testing.T) {
 	es := buildEditStrategy(types.EditStrategyConfig{Type: "nonexistent"})
 	if _, ok := es.(*edit.MultiStrategy); !ok {

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -2092,6 +2092,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateK8sExecutor(config.Executor, &errs)
 	validateResourceLimits(config.Executor.Resources, &errs)
 	validateOptionalType("editStrategy", config.EditStrategy.Type, validEditStrategyTypes, &errs)
+	validateEditStrategyFuzzyThreshold(config.EditStrategy, &errs)
 	validateOptionalType("permissionPolicy", config.PermissionPolicy.Type, validPermissionPolicyTypes, &errs)
 	validatePermissionPolicyFields(config.PermissionPolicy, &errs)
 	validateOptionalType("gitStrategy", config.GitStrategy.Type, validGitStrategyTypes, &errs)
@@ -2599,6 +2600,23 @@ func applyCodeScannerDefault(config *RunConfig) {
 func applyEditStrategyDefault(config *RunConfig) {
 	if config.EditStrategy.Type == "" {
 		config.EditStrategy.Type = "multi"
+	}
+}
+
+// validateEditStrategyFuzzyThreshold bounds FuzzyThreshold to (0, 1]. The
+// udiff/multi strategies (harness/internal/edit) treat it as a similarity
+// ratio: a value <= 0 defeats the "no fuzzy match found" sentinel check in
+// applyHunk (findFuzzyMatch returns bestSim=0 with bestPos=-1 when nothing
+// matches, and 0 >= threshold is trivially true for threshold <= 0), which
+// then splices at index -1 and panics. Values > 1 are merely a similarity
+// ratio that can never be met, not a crash risk, but are still rejected as
+// a config error since they can never produce a fuzzy match.
+func validateEditStrategyFuzzyThreshold(cfg EditStrategyConfig, errs *[]string) {
+	if cfg.FuzzyThreshold == nil {
+		return
+	}
+	if t := *cfg.FuzzyThreshold; t <= 0 || t > 1 {
+		*errs = append(*errs, fmt.Sprintf("editStrategy.fuzzyThreshold must be > 0 and <= 1 (got %v)", t))
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -2744,6 +2744,65 @@ func TestValidateRunConfig_EditStrategyExplicitPreserved(t *testing.T) {
 	}
 }
 
+// TestValidateRunConfig_FuzzyThresholdBounds pins the previously-panicking
+// config (fuzzyThreshold <= 0) to a validation error instead of a runtime
+// crash. harness/internal/edit/udiff.go treats fuzzyThreshold as a
+// similarity ratio: applyHunk's fuzzy-match fallback compares the best
+// found similarity (0.0 when nothing matches, alongside a sentinel
+// position of -1) against the threshold with `>=`. A threshold <= 0 makes
+// that comparison trivially true even when no position actually matched,
+// so the strategy proceeds to splice at index -1 and panics. Legal range
+// is (0, 1]: the code's own doc comments describe the ratio as 0.0-1.0,
+// and 1.0 (exact matches only) is a legitimate, if extreme, configuration.
+func TestValidateRunConfig_FuzzyThresholdBounds(t *testing.T) {
+	// The exact previously-panicking shape from the defect report.
+	c := validConfig()
+	zero := 0.0
+	c.EditStrategy = EditStrategyConfig{Type: "udiff", FuzzyThreshold: &zero}
+	err := ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "fuzzyThreshold") {
+		t.Fatalf("expected fuzzyThreshold error for 0, got: %v", err)
+	}
+
+	neg := -0.5
+	c = validConfig()
+	c.EditStrategy = EditStrategyConfig{Type: "udiff", FuzzyThreshold: &neg}
+	err = ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "fuzzyThreshold") {
+		t.Fatalf("expected fuzzyThreshold error for negative value, got: %v", err)
+	}
+
+	aboveMax := 1.01
+	c = validConfig()
+	c.EditStrategy = EditStrategyConfig{Type: "udiff", FuzzyThreshold: &aboveMax}
+	err = ValidateRunConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "fuzzyThreshold") {
+		t.Fatalf("expected fuzzyThreshold error for value > 1, got: %v", err)
+	}
+
+	// Boundary and mid-range values must validate cleanly. 1.0 is the
+	// documented ceiling (exact-only fuzzy matches); 0.80 is the
+	// documented default; a value just above 0 is the open lower bound.
+	for _, v := range []float64{0.001, 0.5, 0.80, 1.0} {
+		t.Run(fmt.Sprintf("v=%v", v), func(t *testing.T) {
+			c := validConfig()
+			x := v
+			c.EditStrategy = EditStrategyConfig{Type: "udiff", FuzzyThreshold: &x}
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("expected no error for fuzzyThreshold=%v, got: %v", v, err)
+			}
+		})
+	}
+
+	// Nil (unset) falls back to the harness default and must validate
+	// cleanly.
+	c = validConfig()
+	c.EditStrategy = EditStrategyConfig{Type: "udiff", FuzzyThreshold: nil}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("expected no error for nil fuzzyThreshold, got: %v", err)
+	}
+}
+
 // --- Rule of Two ---
 
 // boolRef is a tiny helper for the *bool fields that gate a Rule-of-Two


### PR DESCRIPTION
## Summary

Fixes SF3 from the v0.1 core review (task #107): an unvalidated
`fuzzyThreshold <= 0` in `editStrategy` config panics at edit time, and
synchronous tool dispatch has no recover, so a bad config takes the whole
process down mid-run.

**Panic site**: `harness/internal/edit/udiff.go`, `applyHunk`'s fuzzy-match
fallback (line ~426, `if bestSim >= s.fuzzyThreshold`), leading to
`spliceLines` (line 596) indexing the file's line slice at `-1`.

`findFuzzyMatch` returns a `bestPos=-1, bestSim=0` sentinel when nothing in
the file resembles the hunk closely enough to update the running best (the
loop only updates on strict `sim > bestSim`, and `bestSim` starts at `0`).
For `fuzzyThreshold <= 0`, `bestSim(0) >= threshold` is trivially true even
though `bestPos` never left its `-1` sentinel, so the code proceeds to
`spliceLines(lines, -1, ...)` → `lines[:-1]` → `panic: slice bounds out of
range [:-1]`. Reproduced first with a throwaway test before touching any
production code (see commit `17519bc` description); confirmed via commit
bisection (stashing the fix) that both new tests fail without their
respective changes.

**Legal range enforced**: `(0, 1]`. The code's own doc comments
(`udiff.go`) already describe `fuzzyThreshold` as a 0.0–1.0 similarity
ratio; `0` is the panic trigger (and has no useful fuzzy-match semantics —
"accept anything with similarity >= nothing" is not a meaningful
threshold), `1.0` is a legitimate exact-only configuration.

**Defense-in-depth**: yes. `harness/internal/core/factory.go`'s
`buildEditStrategy` already has an established, documented precedent for
this exact class of gap — the `default:` case in its Type switch is
explicitly commented as handling "callers that bypass
`types.ValidateRunConfig` (e.g. gRPC / embedders constructing a RunConfig
directly)" and falls back to a safe default with a `slog.Default().Warn`.
Added a matching guard for `fuzzyThreshold` right above it: values outside
`(0, 1]` are clamped to the documented `0.80` default with the same
warning shape (attempted/selected values + a hint to route through
`ValidateRunConfig`). This is judgment call #3 from the task — decided to
add it because the existing pattern in the same function makes it clearly
the established idiom here, not a novel defensive addition.

## Coordination note (PR #485)

Branched off `main` per instructions, which does not yet have PR #485's
`validateContextStrategyBudget` / its call site inside `ValidateRunConfig`
(`types/runconfig.go`). This PR's addition is a single new helper function
(`validateEditStrategyFuzzyThreshold`, placed next to
`applyEditStrategyDefault`) plus one call site (next to the existing
`validateOptionalType("editStrategy", ...)` line) — a different line than
where #485's `contextStrategy` call would land, so whichever PR merges
second should be a trivial rebase.

## Test plan

- [x] `types.TestValidateRunConfig_FuzzyThresholdBounds` — the exact
      previously-panicking config (`fuzzyThreshold: 0`) now fails
      validation with an error naming `fuzzyThreshold`; negative and
      `> 1` values also rejected; `0.001`, `0.5`, `0.80`, `1.0`, and `nil`
      all validate cleanly. Verified non-vacuous: stashing the
      `types/runconfig.go` change makes this test fail (`got: <nil>`).
- [x] `core.TestBuildEditStrategy_OutOfRangeFuzzyThresholdClamped` — a
      direct unit test on the built `UdiffStrategy` with a `0` threshold
      (constructed by `buildEditStrategy`, bypassing `ValidateRunConfig`)
      no longer panics; `Apply` returns a clean `Applied: false` for a
      diff with no match. Verified non-vacuous: stashing the
      `factory.go` change reproduces the original panic in this test.
- [x] `just build` — passes.
- [x] `just test` (`harness/... types/... eval/...`) — passes, all
      packages green.
- [x] `just lint` — `0 issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ
