### PR TITLE
executor: fix timeout/cancel misclassification and lost partial output

### DIFF
--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -498,12 +498,29 @@ func (e *ContainerExecutor) Exec(ctx context.Context, command string, timeout ti
 	result, err := e.execInContainer(ctx, []string{"sh", "-c", command}, e.workspace, timeout)
 	if err != nil {
 		if ctx.Err() != nil {
-			return &ExecResult{ExitCode: -1}, fmt.Errorf("command timed out after %s", timeout)
+			// execInContainer returns whatever it managed to capture before
+			// the ctx ended (nil only if the command never started, e.g. the
+			// exec create/start call itself was cut off) — preserve it
+			// rather than discarding the partial output an operator needs
+			// most when triaging a stalled command (#473).
+			if result == nil {
+				result = &ExecResult{}
+			}
+			result.ExitCode = -1
+			return e.truncateAndReport(command, result), classifyExecCtxErr(ctx, timeout)
 		}
 		return nil, err
 	}
 
-	// Truncate output.
+	return e.truncateAndReport(command, result), nil
+}
+
+// truncateAndReport caps result's stdout/stderr at maxOutputSize and, when a
+// SecurityEventEmitter is wired, reports OutputTruncated using the
+// pre-truncation combined size. Shared by the success and timeout/cancel
+// paths of Exec so partial output captured before a ctx ending is truncated
+// and reported identically to a clean run's output.
+func (e *ContainerExecutor) truncateAndReport(command string, result *ExecResult) *ExecResult {
 	originalStdoutLen := len(result.Stdout)
 	originalStderrLen := len(result.Stderr)
 	result.Stdout = truncate(result.Stdout, maxOutputSize)
@@ -516,7 +533,7 @@ func (e *ContainerExecutor) Exec(ctx context.Context, command string, timeout ti
 		}
 	}
 
-	return result, nil
+	return result
 }
 
 // Capabilities returns the capabilities of the container executor.
@@ -531,7 +548,13 @@ func (e *ContainerExecutor) Capabilities() ExecutorCapabilities {
 }
 
 // execInContainer runs a command inside the container using the exec API.
-// It handles the full create → start → read output → inspect flow.
+// It handles the full create → start → read output → inspect flow. On a
+// failure partway through — most commonly the ctx ending (deadline or
+// cancellation) while demuxDockerStream is blocked reading the exec
+// stream — the returned *ExecResult still carries whatever stdout/stderr
+// was captured before the failure, rather than nil; only a failure before
+// any output could exist (create/start exec) returns a nil result. Exec
+// relies on this to preserve partial output on timeout (#473).
 func (e *ContainerExecutor) execInContainer(ctx context.Context, cmd []string, workdir string, _ time.Duration) (*ExecResult, error) {
 	execID, err := e.api.createExec(ctx, e.containerID, cmd, workdir)
 	if err != nil {
@@ -545,20 +568,18 @@ func (e *ContainerExecutor) execInContainer(ctx context.Context, cmd []string, w
 	defer func() { _ = stream.Close() }()
 
 	stdout, stderr, err := demuxDockerStream(stream)
+	result := &ExecResult{Stdout: stdout, Stderr: stderr}
 	if err != nil {
-		return nil, fmt.Errorf("read exec output: %w", err)
+		return result, fmt.Errorf("read exec output: %w", err)
 	}
 
 	exitCode, err := e.api.inspectExec(ctx, execID)
 	if err != nil {
-		return nil, fmt.Errorf("inspect exec: %w", err)
+		return result, fmt.Errorf("inspect exec: %w", err)
 	}
+	result.ExitCode = exitCode
 
-	return &ExecResult{
-		ExitCode: exitCode,
-		Stdout:   stdout,
-		Stderr:   stderr,
-	}, nil
+	return result, nil
 }
 
 // demuxDockerStream reads the Docker multiplexed stream format.

--- a/harness/internal/executor/container_test.go
+++ b/harness/internal/executor/container_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -530,6 +531,92 @@ func TestContainerExecutor_Exec_OutputTruncation(t *testing.T) {
 	}
 	if !strings.HasSuffix(result.Stdout, truncatedSuffix) {
 		t.Error("expected truncation suffix on large output")
+	}
+}
+
+// hangingExecStartHandler returns a "POST /exec/*/start" handler that
+// writes one stdout frame, flushes it, then blocks until the request's ctx
+// ends (the client cancels or its deadline elapses) — simulating a stalled
+// command whose exec stream never closes on its own. Used to exercise both
+// the timeout and cancellation paths of ContainerExecutor.Exec against a
+// command that is genuinely still running when the ctx ends.
+func hangingExecStartHandler(partialOutput string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.raw-stream")
+		writeDockerFrame(w, 1, []byte(partialOutput))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	}
+}
+
+// TestContainerExecutor_Exec_Timeout is the #469/#473 regression: a genuine
+// per-call deadline expiry must be classified via errors.Is(err, ErrTimeout)
+// (not a substring match — #468) and must preserve whatever stdout was
+// captured before the deadline hit, matching local.go's pre-existing
+// behaviour (container.go used to discard it entirely).
+func TestContainerExecutor_Exec_Timeout(t *testing.T) {
+	exec, cleanup := newMockContainerExecutor(t, map[string]http.HandlerFunc{
+		"POST /containers/*/exec": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execCreateResponse{ID: "exec-timeout"})
+		},
+		"POST /exec/*/start": hangingExecStartHandler("partial output\n"),
+	})
+	defer cleanup()
+
+	start := time.Now()
+	result, err := exec.Exec(context.Background(), "sleep 30", 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("err = %v, want errors.Is(err, ErrTimeout)", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("Exec took %v after the 200ms deadline, want well under 5s", elapsed)
+	}
+	if result == nil || !strings.Contains(result.Stdout, "partial output") {
+		t.Errorf("result = %+v, want Stdout to preserve output captured before the timeout (#473)", result)
+	}
+}
+
+// TestContainerExecutor_Exec_CancelledContext_NotErrTimeout is the #469
+// regression on the container executor: a parent-context cancellation that
+// is not a deadline expiry must not be reported as (or satisfy
+// errors.Is against) ErrTimeout, even with a large configured timeout, and
+// partial output captured before the cancel must still be returned.
+func TestContainerExecutor_Exec_CancelledContext_NotErrTimeout(t *testing.T) {
+	exec, cleanup := newMockContainerExecutor(t, map[string]http.HandlerFunc{
+		"POST /containers/*/exec": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execCreateResponse{ID: "exec-cancel"})
+		},
+		"POST /exec/*/start": hangingExecStartHandler("partial output\n"),
+	})
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := exec.Exec(ctx, "sleep 30", 60*time.Second)
+	if err == nil {
+		t.Fatal("expected an error from the cancelled command")
+	}
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("err = %v, must not satisfy errors.Is(err, ErrTimeout): cancelled after 150ms, configured timeout was 60s", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("err = %v, must not claim the command timed out", err)
+	}
+	if result == nil || !strings.Contains(result.Stdout, "partial output") {
+		t.Errorf("result = %+v, want Stdout to preserve output captured before the cancel (#473)", result)
 	}
 }
 

--- a/harness/internal/executor/executor.go
+++ b/harness/internal/executor/executor.go
@@ -4,8 +4,41 @@ package executor
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 )
+
+// ErrTimeout is the sentinel every Executor implementation's Exec method
+// wraps (via %w) into the returned error when a command is killed because
+// its per-call deadline elapsed. It is the load-bearing distinction between
+// a genuine timeout and any other reason Exec's context ends — most
+// importantly a SIGTERM-driven parent-context cancellation, which must NOT
+// satisfy errors.Is(err, ErrTimeout). Callers (notably the hook runner,
+// harness/internal/hook/runner.go) match on this sentinel instead of the
+// error's formatted text, so a wording change in one executor can't
+// silently break TimedOut classification downstream (#468).
+var ErrTimeout = errors.New("command timed out")
+
+// classifyExecCtxErr builds the error an Executor's Exec method returns once
+// its ctx (a context.WithTimeout child of the caller's ctx) is Done after a
+// failed command. context.DeadlineExceeded means the per-call timeout
+// genuinely elapsed, so the result wraps both ErrTimeout and the underlying
+// context error. Any other ctx.Err() (context.Canceled, or a custom cause
+// propagated from an ancestor via context.WithCancelCause — e.g. the
+// control plane's cancel or a SIGTERM-driven shutdown) is reported as a
+// cancellation, not a timeout: previously local.go and container.go
+// reported *any* ctx cancellation as "command timed out after <configured
+// timeout>", corrupting HookExecution.TimedOut for a signal-killed hook and
+// misleading operators triaging traces (#469). Shared by local.go,
+// container.go, and k8s_execcore.go (and, via its embedded podExecCore, the
+// k8s-sandbox executor) so all executors classify identically.
+func classifyExecCtxErr(ctx context.Context, timeout time.Duration) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("%w after %s: %w", ErrTimeout, timeout, ctx.Err())
+	}
+	return fmt.Errorf("command cancelled: %w", ctx.Err())
+}
 
 // ExecResult holds the output of a command execution.
 type ExecResult struct {

--- a/harness/internal/executor/k8s_execcore.go
+++ b/harness/internal/executor/k8s_execcore.go
@@ -255,8 +255,12 @@ func (e *podExecCore) ListDirectory(ctx context.Context, dirPath string) ([]stri
 // Exec runs `command` via `/bin/sh -c` inside the agent container over the
 // pods/exec subresource. stdout and stderr are captured into separate
 // 10 MB-capped buffers. A zero timeout uses the default; timeouts are
-// clamped to MaxTimeout. On deadline the underlying context error is
-// returned verbatim. The exit code is extracted from the remotecommand
+// clamped to MaxTimeout. On deadline or cancellation, classifyExecCtxErr
+// distinguishes the two (errors.Is against executor.ErrTimeout for a
+// genuine deadline, plain context.Canceled otherwise) and whatever
+// stdout/stderr streamExec had already captured is preserved on the
+// returned result rather than discarded (#473) — mirroring local.go and
+// container.go. The exit code is extracted from the remotecommand
 // CodeExitError; a clean exit yields code 0.
 func (e *podExecCore) Exec(ctx context.Context, command string, timeout time.Duration) (*ExecResult, error) {
 	if timeout <= 0 {
@@ -275,8 +279,12 @@ func (e *podExecCore) Exec(ctx context.Context, command string, timeout time.Dur
 
 	err := e.streamExec(ctx, []string{"/bin/sh", "-c", command}, nil, &stdout, &stderr)
 
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return nil, ctxErr
+	if ctx.Err() != nil {
+		return &ExecResult{
+			ExitCode: -1,
+			Stdout:   stdout.String(),
+			Stderr:   stderr.String(),
+		}, classifyExecCtxErr(ctx, timeout)
 	}
 	if stdout.exceeded || stderr.exceeded {
 		if e.Security != nil {

--- a/harness/internal/executor/k8s_test.go
+++ b/harness/internal/executor/k8s_test.go
@@ -226,22 +226,60 @@ func TestK8sExec_NonZeroExit(t *testing.T) {
 	}
 }
 
-// TestK8sExec_Timeout verifies that a command exceeding the timeout returns
-// the context deadline error (verbatim) at roughly the timeout boundary,
-// not after the full sleep.
+// TestK8sExec_Timeout verifies that a command exceeding the timeout is
+// reported via the shared executor.ErrTimeout sentinel (still wrapping the
+// underlying context.DeadlineExceeded, so errors.Is against either matches)
+// at roughly the timeout boundary, not after the full sleep. Also asserts
+// the partial output captured before the deadline is preserved (#473),
+// rather than the blank result the pre-fix k8s Exec returned.
 func TestK8sExec_Timeout(t *testing.T) {
 	exec := newTestK8sExecutor(t)
 	ctx := context.Background()
 
 	start := time.Now()
-	_, err := exec.Exec(ctx, "sleep 5", 1*time.Second)
+	result, err := exec.Exec(ctx, "echo partial; sleep 5", 1*time.Second)
 	elapsed := time.Since(start)
 
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("Exec: err = %v, want errors.Is(err, ErrTimeout)", err)
+	}
 	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Exec: err = %v, want context.DeadlineExceeded", err)
+		t.Errorf("Exec: err = %v, want errors.Is(err, context.DeadlineExceeded)", err)
 	}
 	if elapsed > 3*time.Second {
 		t.Errorf("Exec took %s, expected ~1s (timeout not honoured)", elapsed)
+	}
+	if result == nil || !strings.Contains(result.Stdout, "partial") {
+		t.Errorf("result = %+v, want Stdout to preserve output captured before the timeout", result)
+	}
+}
+
+// TestK8sExec_Cancelled verifies that a parent-context cancellation (not a
+// deadline expiry) is reported distinctly from a timeout: it must satisfy
+// errors.Is(err, context.Canceled) but NOT errors.Is(err, ErrTimeout), even
+// though a large configured timeout is in play. This is the k8s-specific
+// facet of #469: the pre-fix Exec returned ctx.Err() verbatim on ANY ctx
+// ending, which happened to distinguish deadline from cancel correctly via
+// errors.Is(err, context.DeadlineExceeded) but discarded partial output
+// (#473) and gave hook.isTimeoutErr no shared sentinel to key off.
+func TestK8sExec_Cancelled(t *testing.T) {
+	exec := newTestK8sExecutor(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := exec.Exec(ctx, "echo partial; sleep 30", 60*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Exec: err = %v, want errors.Is(err, context.Canceled)", err)
+	}
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("Exec: err = %v, must not satisfy errors.Is(err, ErrTimeout): cancelled after 500ms, configured timeout was 60s", err)
+	}
+	if result == nil || !strings.Contains(result.Stdout, "partial") {
+		t.Errorf("result = %+v, want Stdout to preserve output captured before the cancel (#473)", result)
 	}
 }
 

--- a/harness/internal/executor/local.go
+++ b/harness/internal/executor/local.go
@@ -269,9 +269,10 @@ func (e *LocalExecutor) Exec(ctx context.Context, command string, timeout time.D
 
 	if err != nil {
 		// Check context cancellation first — a killed process also produces
-		// an ExitError, but the root cause is the timeout.
+		// an ExitError, but the root cause is the ctx ending (deadline or
+		// cancellation; classifyExecCtxErr tells them apart).
 		if ctx.Err() != nil {
-			return result, fmt.Errorf("command timed out after %s", timeout)
+			return result, classifyExecCtxErr(ctx, timeout)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/harness/internal/executor/local_test.go
+++ b/harness/internal/executor/local_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -250,6 +251,47 @@ func TestExec_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("unexpected error: %v", err)
+	}
+	// A genuine deadline expiry must satisfy errors.Is against the shared
+	// executor sentinel (#468: hook.isTimeoutErr keys off this instead of
+	// matching the formatted text).
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("err = %v, want errors.Is(err, ErrTimeout)", err)
+	}
+}
+
+// TestExec_CancelledContext_NotErrTimeout is the #469 regression: a
+// context cancellation that is NOT a deadline expiry (e.g. a SIGTERM-driven
+// parent-context cancel) must not be reported as a timeout, and it must not
+// satisfy errors.Is(err, ErrTimeout) — even though a large configured
+// timeout (60s) is in play, only 200ms actually elapsed. Output already
+// captured before the cancel must still be returned (matches local's
+// pre-existing partial-output behaviour; container.go and k8s_execcore.go
+// previously discarded it — see #473).
+func TestExec_CancelledContext_NotErrTimeout(t *testing.T) {
+	exec, _ := newTestExecutor(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := exec.Exec(ctx, "echo started; sleep 30", 60*time.Second)
+	if err == nil {
+		t.Fatal("expected an error from the cancelled command")
+	}
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("err = %v, must not satisfy errors.Is(err, ErrTimeout): the command was cancelled after 200ms, not deadline-expired after the configured 60s", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want errors.Is(err, context.Canceled)", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("err = %v, must not claim the command timed out", err)
+	}
+	if result == nil || !strings.Contains(result.Stdout, "started") {
+		t.Errorf("result = %+v, want Stdout to preserve output captured before the cancel", result)
 	}
 }
 

--- a/harness/internal/hook/runner.go
+++ b/harness/internal/hook/runner.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -180,19 +179,18 @@ func hookLabel(h types.HookConfig) string {
 }
 
 // isTimeoutErr reports whether err represents a hook execution that was
-// killed by its timeout rather than failing on its own. Executor
-// implementations signal this differently: k8s_execcore.go returns the
-// context error verbatim (context.DeadlineExceeded), while local.go and
-// container.go wrap it in a formatted "command timed out after %s"
-// string with no %w. The substring check covers the latter shape.
+// killed by its timeout rather than failing on its own. Every executor
+// implementation (local.go, container.go, k8s_execcore.go — and, via its
+// embedded podExecCore, the k8s-sandbox executor) wraps executor.ErrTimeout
+// into the error it returns on a genuine deadline expiry, so a single
+// errors.Is check classifies all of them uniformly. This replaces a
+// substring match on the formatted error text, which coupled the hook
+// package to exact executor wording and — more seriously — misclassified
+// any other context cancellation (e.g. a SIGTERM-driven parent-context
+// cancel) as a timeout too, since local.go/container.go used to report
+// *every* ctx cancellation as "command timed out ..." (#468, #469).
 func isTimeoutErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-	return strings.Contains(err.Error(), "timed out")
+	return errors.Is(err, executor.ErrTimeout)
 }
 
 // scrubbedTail returns the scrubbed (security.Scrub), 4KB-tail-capped

--- a/harness/internal/hook/runner_test.go
+++ b/harness/internal/hook/runner_test.go
@@ -185,10 +185,15 @@ func TestExecRunner_ContinueOnError_DispatchContinuesAndPhaseSucceeds(t *testing
 	}
 }
 
+// TestExecRunner_TimedOut pins the genuine-deadline shape every executor
+// (local.go, container.go, k8s_execcore.go) now produces via the shared
+// classifyExecCtxErr helper: executor.ErrTimeout wrapped together with the
+// underlying context.DeadlineExceeded. isTimeoutErr must classify it as a
+// timeout via errors.Is, not by matching the formatted text (#468).
 func TestExecRunner_TimedOut(t *testing.T) {
 	exec := newMockExecutor()
 	exec.execFunc = func(_ context.Context, _ string, timeout time.Duration) (*executor.ExecResult, error) {
-		return &executor.ExecResult{ExitCode: -1}, fmt.Errorf("command timed out after %s", timeout)
+		return &executor.ExecResult{ExitCode: -1}, fmt.Errorf("%w after %s: %w", executor.ErrTimeout, timeout, context.DeadlineExceeded)
 	}
 	r := &ExecRunner{
 		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "slow", Command: "sleep 999", TimeoutSeconds: 1}}},
@@ -210,10 +215,14 @@ func TestExecRunner_TimedOut(t *testing.T) {
 	}
 }
 
+// TestExecRunner_DeadlineExceededTimedOut pins that a bare, unwrapped
+// context.DeadlineExceeded — not itself wrapping executor.ErrTimeout — is
+// NOT classified as a timeout. Every production executor now wraps
+// ErrTimeout on a genuine deadline (see TestExecRunner_TimedOut); a raw
+// context.DeadlineExceeded reaching the hook runner would mean some other
+// code path (or a future executor) bypassed that contract, and TimedOut
+// should reflect the sentinel, not a coincidentally-named stdlib error.
 func TestExecRunner_DeadlineExceededTimedOut(t *testing.T) {
-	// k8s_execcore.go's Exec returns the context error verbatim rather
-	// than a formatted "timed out" string (see isTimeoutErr's doc
-	// comment) — pin that shape is also classified as TimedOut.
 	exec := newMockExecutor()
 	exec.execFunc = func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
 		return nil, context.DeadlineExceeded
@@ -227,8 +236,44 @@ func TestExecRunner_DeadlineExceededTimedOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("RunPre() error = nil, want non-nil")
 	}
-	if !results[0].TimedOut {
-		t.Errorf("results[0].TimedOut = false, want true for context.DeadlineExceeded")
+	if results[0].TimedOut {
+		t.Errorf("results[0].TimedOut = true, want false: a bare context.DeadlineExceeded does not wrap executor.ErrTimeout")
+	}
+}
+
+// TestExecRunner_CancelledContext_NotTimedOut is the #469/#468 regression:
+// a hook killed by a parent-context cancellation (e.g. a SIGTERM-driven
+// shutdown or a control-plane cancel) must be recorded as a failure but
+// NOT as a timeout, and its error text must not claim the hook "timed
+// out" — that claim is both false and misleading to an operator triaging
+// the trace. This mirrors the error shape classifyExecCtxErr produces for
+// ctx.Err() == context.Canceled across local.go, container.go, and
+// k8s_execcore.go.
+func TestExecRunner_CancelledContext_NotTimedOut(t *testing.T) {
+	exec := newMockExecutor()
+	exec.execFunc = func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+		return &executor.ExecResult{ExitCode: -1}, fmt.Errorf("command cancelled: %w", context.Canceled)
+	}
+	r := &ExecRunner{
+		Hooks: &types.HooksConfig{PreRun: []types.HookConfig{{Name: "slow", Command: "sleep 999", TimeoutSeconds: 120}}},
+		Exec:  exec,
+	}
+
+	results, err := r.RunPre(context.Background())
+	if err == nil {
+		t.Fatal("RunPre() error = nil, want non-nil for a cancelled fatal hook")
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].TimedOut {
+		t.Errorf("results[0].TimedOut = true, want false: a parent-context cancel is not a timeout")
+	}
+	if results[0].Error == "" {
+		t.Error("results[0].Error is empty, want the cancellation surfaced")
+	}
+	if strings.Contains(results[0].Error, "timed out") {
+		t.Errorf("results[0].Error = %q, must not claim the hook timed out (it was cancelled, not deadline-expired)", results[0].Error)
 	}
 }
 
@@ -391,19 +436,30 @@ func TestExecRunner_RunPost_DeadCtx(t *testing.T) {
 	if results[0].Error == "" {
 		t.Error("results[0].Error is empty, want the ctx-cancelled error surfaced")
 	}
+	// A plain cancel (not a deadline) must not be classified as a timeout
+	// — the #469/#468 regression this task fixes.
+	if results[0].TimedOut {
+		t.Error("results[0].TimedOut = true, want false: an explicitly cancelled ctx is not a timeout")
+	}
 }
 
 // TestExecRunner_RunPost_BudgetExpiryMidHook pins the detached-ctx
 // budget-expiry scenario: a deadline that expires while the hook is
 // still "running" (from the fake executor's perspective) must surface
-// as a TimedOut result, not hang RunPost.
+// as a TimedOut result, not hang RunPost. The mock wraps executor.ErrTimeout
+// the way a real executor's Exec would once its own context.WithTimeout
+// child inherits the expired parent deadline (ctx.Err() ==
+// context.DeadlineExceeded propagates through the child unchanged).
 func TestExecRunner_RunPost_BudgetExpiryMidHook(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	time.Sleep(5 * time.Millisecond) // guarantee the deadline has passed
 
 	exec := newMockExecutor()
-	exec.execFunc = func(ctx context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+	exec.execFunc = func(ctx context.Context, _ string, timeout time.Duration) (*executor.ExecResult, error) {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w after %s: %w", executor.ErrTimeout, timeout, ctx.Err())
+		}
 		return nil, ctx.Err()
 	}
 	r := &ExecRunner{


### PR DESCRIPTION
## Summary

Fixes #468
Fixes #469
Fixes #473

Fixes the timeout/cancel-reporting batch from the v0.1 executor review (task #108):

- **#469** — `local.go` and `container.go` reported *any* context cancellation as `command timed out after <configured timeout>`, regardless of the real cause. A SIGTERM-driven parent-context cancel (or a control-plane cancel) was misreported as a timeout with the *configured* duration, not the actual elapsed time. The k8s executor already distinguished deadline from cancel correctly (`errors.Is(err, context.DeadlineExceeded)`), so it's the reference behaviour this PR generalizes to local/container.
- **#468** — `hook.isTimeoutErr` matched on `errors.Is(err, context.DeadlineExceeded)` OR a `strings.Contains(err.Error(), "timed out")` fallback, coupling the hook package to the exact wording of unrelated executor packages.
- **#473** — `container.go`'s `Exec` discarded all captured stdout/stderr on any ctx ending (timeout or cancel); `local.go` already preserved it. `podExecCore.Exec` (k8s, and k8s-sandbox via the shared core) had the same gap despite getting the classification right.

## Sentinel design

`executor.ErrTimeout` (`harness/internal/executor/executor.go`) is a new sentinel every `Executor.Exec` implementation wraps via `%w` when its per-call deadline genuinely expires:

```go
var ErrTimeout = errors.New("command timed out")

func classifyExecCtxErr(ctx context.Context, timeout time.Duration) error {
	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
		return fmt.Errorf("%w after %s: %w", ErrTimeout, timeout, ctx.Err())
	}
	return fmt.Errorf("command cancelled: %w", ctx.Err())
}
```

- Genuine deadline expiry → wraps both `ErrTimeout` and the underlying `context.DeadlineExceeded`, so `errors.Is` matches either.
- Any other ctx ending (`context.Canceled`, or a custom cause propagated via `context.WithCancelCause` — e.g. the control plane's cancel or a SIGTERM shutdown) → reported as `"command cancelled: %w"`, which does **not** satisfy `errors.Is(err, ErrTimeout)`.

`harness/internal/hook/runner.go`'s `isTimeoutErr` is now a single `errors.Is(err, executor.ErrTimeout)` check, replacing the substring match.

## Per-executor behaviour changes

| Executor | Before | After |
|---|---|---|
| `local.go` | Any ctx-end → `"command timed out after %s"` (partial output already preserved) | `classifyExecCtxErr`; partial output unchanged (already correct) |
| `container.go` | Any ctx-end → `"command timed out after %s"`, output discarded (`&ExecResult{ExitCode: -1}`, no stdout/stderr) | `classifyExecCtxErr`; `execInContainer` now returns whatever it captured before the failure (only nil if the command never started, e.g. create/start exec itself was cut off), truncated/reported via the same path a clean run uses |
| `k8s_execcore.go` (`podExecCore`, shared by `K8sExecutor` and the Agent Sandbox/`k8s-sandbox` executor) | Any ctx-end → raw `ctx.Err()` verbatim, output discarded (`return nil, ctxErr`) | `classifyExecCtxErr`; stdout/stderr from the capped buffers preserved on the returned result |

`k8s-sandbox` gets both fixes automatically — it embeds `podExecCore` and does not override `Exec`.

## Issue citations re-verified against current `main`

- #469's `local.go`/`container.go` citations matched current code exactly (`command timed out after %s`, no `%w`).
- #468's `isTimeoutErr` substring-match citation matched current code exactly.
- #473's citation covered only `container.go`; confirmed the k8s executor (`podExecCore.Exec`) has the identical partial-output-discard bug (`return nil, ctxErr`) and fixed it too, per the task brief's explicit ask to check the shared core.

No drift found — all three issues' bodies were current.

## Coordination

- No overlap with PR #484 (branch `fix/secret-guard-case`): did not touch `harness/internal/trace/jsonl.go` or `harness/internal/security/logscrubber.go`. `RecordHookExecution` calls `security.Scrub(exec.Error)` generically (not keyed on specific wording), so the changed error text (`"command timed out after Xs: context deadline exceeded"` / `"command cancelled: context canceled"`) is scrubbed identically — no functional interaction, flagging per the coordination note since `exec.Error` content did change.
- Did not touch container file I/O deadlines / Docker client timeouts (task #109, deliberately separate).
- Did not touch clamp logging (#470) or span naming (#471) — explicitly deferred.

## Test plan

- [x] `just build` — passes
- [x] `just test` — passes (`go test ./harness/... ./types/... ./eval/...`)
- [x] `just lint` — passes (`golangci-lint v2`, 0 issues)
- [x] `go vet -tags integration_k8s ./harness/...` — compiles cleanly
- [x] New regression tests, verified to fail against pre-fix code via a stash round-trip (production-code-only stash, keeping the new tests): `harness/internal/executor/local_test.go`, `harness/internal/executor/container_test.go` failed to even **compile** pre-fix (`undefined: ErrTimeout`), confirming the tests are load-bearing on the fix.
  - `TestExec_Timeout` / `TestExec_CancelledContext_NotErrTimeout` (local)
  - `TestContainerExecutor_Exec_Timeout` / `TestContainerExecutor_Exec_CancelledContext_NotErrTimeout` (container, via a fake Engine API server whose exec-start handler streams partial output then hangs until ctx ends)
  - `TestK8sExec_Timeout` / `TestK8sExec_Cancelled` (k8s; gated by `//go:build integration_k8s` + `STIRRUP_TEST_KUBECONFIG`, matching the existing suite's pattern — client-go fakes don't cover `pods/exec` streaming, so this suite has always required a live cluster; not run in this environment, but compiles clean under the build tag)
  - `TestExecRunner_TimedOut` / `TestExecRunner_DeadlineExceededTimedOut` / `TestExecRunner_CancelledContext_NotTimedOut` (hook), plus strengthened assertions on the existing `TestExecRunner_RunPost_DeadCtx` and `TestExecRunner_RunPost_BudgetExpiryMidHook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ
