### PR TITLE
executor: fix default registry allowlist to project GHCR namespace

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -247,7 +247,7 @@ The container executor applies these defaults regardless of what
   `network.mode == "allowlist"`, in which case the egress proxy
   enforces FQDN allowlisting on the way out)
 - A registry allowlist on `executor.image`. The default admits
-  only the project's own `ghcr.io/stirrup/*` images and Docker Hub
+  only the project's own `ghcr.io/rxbynerd/*` images and Docker Hub
   official `docker.io/library/*` images; any other reference is
   rejected before a container is created. Operators widen or
   replace the set via `executor.registryAllowlist` (a list of
@@ -255,12 +255,20 @@ The container executor applies these defaults regardless of what
   stripped, with the `index.docker.io` / `registry-1.docker.io`
   pull aliases folded to `docker.io`). Globs follow `path.Match`
   semantics, so `*` matches one path segment and does not cross
-  `/`: `ghcr.io/stirrup/*` admits `ghcr.io/stirrup/base` but not
-  `ghcr.io/stirrup/team/base` (use `ghcr.io/stirrup/*/*` for the
+  `/`: `ghcr.io/rxbynerd/*` admits `ghcr.io/rxbynerd/base` but not
+  `ghcr.io/rxbynerd/team/base` (use `ghcr.io/rxbynerd/*/*` for the
   deeper namespace). An explicit list *replaces* the default rather
   than extending it. Digest-pinned references (`@sha256:…`) are
   accepted and preferred; cryptographic verification of the digest
-  (cosign/Sigstore) is a deferred follow-up.
+  (cosign/Sigstore) is a deferred follow-up. This allowlist governs
+  only the container executor's own image pulls (via the Docker
+  Engine API); it is not consulted for the `k8s`/`k8s-sandbox`
+  executors, whose Pod image is scheduled by the cluster. A
+  deployment pulling container-executor images from Google Cloud
+  Artifact Registry (a `*.pkg.dev` host, including a GAR
+  remote/standard repository) must add that host to
+  `executor.registryAllowlist` explicitly — the default does not
+  admit any Artifact Registry host.
 - API keys and `secret://` references are resolved on the *host*
   before tool dispatch; they never enter the container's
   environment.

--- a/harness/internal/executor/container_registry.go
+++ b/harness/internal/executor/container_registry.go
@@ -13,7 +13,7 @@ import (
 // third-party reference is rejected by default so a misconfigured run cannot
 // silently pull an arbitrary image.
 var defaultRegistryAllowlist = []string{
-	"ghcr.io/stirrup/*",
+	"ghcr.io/rxbynerd/*",
 	"docker.io/library/*",
 }
 
@@ -30,7 +30,7 @@ func checkImageAllowed(image string, allowlist []string) error {
 
 	ref := normaliseImageRef(image)
 	// A normalised ref ending in "/" has an empty final path segment (e.g.
-	// "ghcr.io/stirrup/"), which "ghcr.io/stirrup/*" would match because the
+	// "ghcr.io/rxbynerd/"), which "ghcr.io/rxbynerd/*" would match because the
 	// glob "*" accepts the empty string. Reject it here with a clear message
 	// rather than handing a malformed reference to the engine to fail on.
 	if strings.HasSuffix(ref, "/") {
@@ -51,11 +51,11 @@ func checkImageAllowed(image string, allowlist []string) error {
 // normaliseImageRef expands a Docker image reference to its fully-qualified
 // "host/repository" form with the tag and digest removed, mirroring the
 // reference-resolution rules the engine applies:
-//   - "ubuntu"                 -> "docker.io/library/ubuntu"
-//   - "ubuntu:26.04"           -> "docker.io/library/ubuntu"
-//   - "myorg/app:tag"          -> "docker.io/myorg/app"
-//   - "ghcr.io/stirrup/base"   -> "ghcr.io/stirrup/base"
-//   - "host:5000/team/img@sha" -> "host:5000/team/img"
+//   - "ubuntu"                  -> "docker.io/library/ubuntu"
+//   - "ubuntu:26.04"            -> "docker.io/library/ubuntu"
+//   - "myorg/app:tag"           -> "docker.io/myorg/app"
+//   - "ghcr.io/rxbynerd/base"   -> "ghcr.io/rxbynerd/base"
+//   - "host:5000/team/img@sha"  -> "host:5000/team/img"
 //
 // A registry host is recognised by a "." or ":" in the first path segment, or
 // the literal "localhost"; otherwise the reference is treated as a Docker Hub

--- a/harness/internal/executor/container_test.go
+++ b/harness/internal/executor/container_test.go
@@ -1110,7 +1110,7 @@ func TestContainerExecutor_HardeningProfile(t *testing.T) {
 }
 
 // TestContainerExecutor_RegistryAllowlist_Default verifies the built-in
-// allowlist: a Docker Hub official image (library/*) and a ghcr.io/stirrup
+// allowlist: a Docker Hub official image (library/*) and a ghcr.io/rxbynerd
 // image construct, while a third-party reference is rejected before any
 // container is created.
 func TestContainerExecutor_RegistryAllowlist_Default(t *testing.T) {
@@ -1136,7 +1136,10 @@ func TestContainerExecutor_RegistryAllowlist_Default(t *testing.T) {
 	allowed := []string{
 		"ubuntu:26.04",
 		"docker.io/library/alpine",
-		"ghcr.io/stirrup/base:latest",
+		"ghcr.io/rxbynerd/base:latest",
+		// The documented quick-start sandbox image (docs/executors/k8s.md,
+		// README.md) must construct under the default allowlist.
+		"ghcr.io/rxbynerd/stirrup-sandbox:latest",
 		// The Docker Hub pull aliases must fold to docker.io and match the
 		// default docker.io/library/* pattern, or operators hit a false deny.
 		"index.docker.io/library/ubuntu",
@@ -1156,7 +1159,14 @@ func TestContainerExecutor_RegistryAllowlist_Default(t *testing.T) {
 	}
 
 	createCalled = false
-	denied := []string{"evil.example.com/malware:latest", "docker.io/someuser/app", "ghcr.io/attacker/img"}
+	denied := []string{
+		"evil.example.com/malware:latest",
+		"docker.io/someuser/app",
+		"ghcr.io/attacker/img",
+		// ghcr.io/stirrup is not a namespace the project publishes under;
+		// confirms the default was not left admitting a dead org.
+		"ghcr.io/stirrup/base",
+	}
 	for _, img := range denied {
 		_, err := NewContainerExecutorWithContext(context.Background(), ContainerExecutorConfig{
 			Image:      img,

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1024,16 +1024,17 @@ type ExecutorConfig struct {
 	// RegistryAllowlist constrains which container image references the
 	// container executor may run. Each entry is a path.Match glob over the
 	// normalised reference (registry host + repository path, tag/digest
-	// stripped) — e.g. "ghcr.io/stirrup/*" or "docker.io/library/*". An empty
-	// list lets the executor fall back to its built-in default (the project's
-	// own ghcr.io/stirrup images plus Docker Hub official "library/*"
-	// images). A reference matching no pattern is rejected before any
-	// container is created. Only meaningful for executor.type == "container".
+	// stripped) — e.g. "ghcr.io/rxbynerd/*" or "docker.io/library/*". An
+	// empty list lets the executor fall back to its built-in default (the
+	// project's own ghcr.io/rxbynerd images plus Docker Hub official
+	// "library/*" images). A reference matching no pattern is rejected
+	// before any container is created. Only meaningful for
+	// executor.type == "container".
 	//
 	// Globbing follows path.Match semantics: "*" matches within a single path
-	// segment and does NOT cross "/". So "ghcr.io/stirrup/*" matches
-	// "ghcr.io/stirrup/base" but not "ghcr.io/stirrup/team/base"; allow the
-	// deeper namespace with an explicit "ghcr.io/stirrup/*/*" entry.
+	// segment and does NOT cross "/". So "ghcr.io/rxbynerd/*" matches
+	// "ghcr.io/rxbynerd/base" but not "ghcr.io/rxbynerd/team/base"; allow the
+	// deeper namespace with an explicit "ghcr.io/rxbynerd/*/*" entry.
 	RegistryAllowlist []string `json:"registryAllowlist,omitempty"`
 
 	// WorkspaceExportTo, when set, instructs the harness to tarball the


### PR DESCRIPTION
## Summary

- The container executor's default `RegistryAllowlist` pointed at `ghcr.io/stirrup/*`, a GHCR org the project does not publish under (images ship as `ghcr.io/rxbynerd/*`). This surfaced during the v0.1 sandbox-image work (#480): the documented quick-start image `ghcr.io/rxbynerd/stirrup-sandbox:latest` fails `NewContainerExecutorWithContext` / the `--dry-run` preflight (`ProbeContainerEngine`) under the default allowlist, since it doesn't match `ghcr.io/stirrup/*` or `docker.io/library/*`.
- Fixes the default to `ghcr.io/rxbynerd/*` (keeping `docker.io/library/*`) — same trust intent, corrected namespace. No behavioral change beyond which namespace is trusted by default.

## Where the default lives / what enforces it

- Default value: `defaultRegistryAllowlist` in `harness/internal/executor/container_registry.go`.
- Enforcement: `checkImageAllowed`, called from two places, **both in the container executor only**:
  - `NewContainerExecutorWithContext` (real construction, `harness/internal/executor/container.go:174`)
  - `ProbeContainerEngine` (the `--dry-run` preflight image-presence check, `harness/internal/executor/container.go:116`)
- **The `k8s` and `k8s-sandbox` executors do not consult `RegistryAllowlist` at all.** `buildExecutor` (`harness/internal/core/factory.go`) only threads `RegistryAllowlist` into `ContainerExecutorConfig` for `case "container"`; the `case "k8s", "k8s-sandbox"` branch never reads it. Confirmed further by `types.validateExecutorRegistryAllowlist` (`types/runconfig.go`), which *rejects* a non-empty `registryAllowlist` when `executor.type` isn't `"container"` — so it's not just unused for k8s, it's actively invalid to set there. The k8s Pod image is scheduled by the cluster; stirrup applies no allowlist gate on that path today (a separate, unscoped gap — not touched here).

## The GAR decision

Per instruction, did **not** add Google Artifact Registry hosts to the default. Added an operator note in `docs/security.md` (the only place `registryAllowlist` is actually documented — it doesn't appear in `docs/configuration.md` or `docs/executors/k8s.md`, so those were left alone rather than adding a misleading mention of a mechanism that doesn't gate the k8s image path) explaining that GAR hosts (`*.pkg.dev`, including GAR remote/standard repos) are not in the default and must be added explicitly to `executor.registryAllowlist` for **container-executor** deployments pulling from GAR.

## examples/

No file under `examples/` on `main` carries a `registryAllowlist` workaround line (checked via grep for `registryAllowlist` and `ghcr.io/stirrup`) — nothing to touch. PR #480's `full.json` change referenced in the task lives on an unmerged branch and was not touched.

## Test plan

- [x] `just build`
- [x] `just test` (full `harness`/`types`/`eval` suite)
- [x] `just lint` (golangci-lint v2, 0 issues)
- [x] `TestContainerExecutor_RegistryAllowlist_Default` updated: asserts `ghcr.io/rxbynerd/stirrup-sandbox:latest` (the documented image) and `ghcr.io/rxbynerd/base:latest` are admitted by default, and that `ghcr.io/stirrup/base` (the old, nonexistent namespace) is now rejected alongside the existing arbitrary-registry cases.
- [x] `TestContainerExecutor_RegistryAllowlist_Override`, `TestNormaliseImageRef`, `TestCheckImageAllowed_RejectsEmptyRepo`, and the `types` glob-validation tests (`TestValidateRunConfig_RegistryAllowlist*`) all still pass unmodified — they test glob syntax / override behavior, not the specific default value.

Note: `go.work.sum` picks up unrelated drift under `just build`/`just test` in this environment (pre-existing, reproducible on a clean checkout of `origin/main`); intentionally left out of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ
