### PR TITLE
executor: bound container API calls with explicit deadlines

### DIFF
--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -47,6 +47,22 @@ const (
 	hostGatewayHost = "host.docker.internal"
 )
 
+var (
+	// containerFileIOTimeout bounds a single ReadFile/WriteFile operation
+	// (archive transfer, plus WriteFile's mkdir -p). Mirrors
+	// k8sFileIOTimeout: file I/O has no caller-supplied timeout, and the
+	// Docker API client's transport has no blanket timeout of its own (see
+	// container_api.go), so without an explicit deadline here a wedged
+	// daemon would hang the calling goroutine indefinitely. A var (not
+	// const), like the timeouts in container_api.go, so tests can shrink
+	// it to exercise the timeout path quickly.
+	containerFileIOTimeout = 60 * time.Second
+	// containerMkdirTimeout bounds WriteFile's "mkdir -p" exec call
+	// specifically — snappier than the file-transfer budget above since it
+	// is a small, near-instant operation on a healthy daemon.
+	containerMkdirTimeout = 10 * time.Second
+)
+
 // ContainerExecutorConfig holds the configuration for creating a ContainerExecutor.
 type ContainerExecutorConfig struct {
 	Image      string
@@ -362,16 +378,22 @@ func (e *ContainerExecutor) ResolvePath(relativePath string) (string, error) {
 }
 
 // ReadFile reads a file from inside the container using the archive API.
-// The file must be within /workspace and no larger than 10 MB.
+// The file must be within /workspace and no larger than 10 MB. The whole
+// operation is bounded by containerFileIOTimeout (#S2): the archive
+// endpoints have no timeout of their own (see container_api.go), so a
+// wedged daemon would otherwise hang the calling goroutine indefinitely.
 func (e *ContainerExecutor) ReadFile(ctx context.Context, filePath string) (string, error) {
 	resolved, err := e.ResolvePath(filePath)
 	if err != nil {
 		return "", err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, containerFileIOTimeout)
+	defer cancel()
+
 	tarStream, err := e.api.getArchive(ctx, e.containerID, resolved)
 	if err != nil {
-		return "", fmt.Errorf("get archive: %w", err)
+		return "", classifyFileIOCtxErr(ctx, "get archive", err)
 	}
 	defer func() { _ = tarStream.Close() }()
 
@@ -381,7 +403,7 @@ func (e *ContainerExecutor) ReadFile(ctx context.Context, filePath string) (stri
 		return "", fmt.Errorf("file not found in archive: %s", filePath)
 	}
 	if err != nil {
-		return "", fmt.Errorf("read tar header: %w", err)
+		return "", classifyFileIOCtxErr(ctx, "read tar header", err)
 	}
 
 	if header.Typeflag == tar.TypeDir {
@@ -397,14 +419,30 @@ func (e *ContainerExecutor) ReadFile(ctx context.Context, filePath string) (stri
 
 	data, err := io.ReadAll(io.LimitReader(tr, maxFileSize+1))
 	if err != nil {
-		return "", fmt.Errorf("read file from tar: %w", err)
+		return "", classifyFileIOCtxErr(ctx, "read file from tar", err)
 	}
 	return string(data), nil
 }
 
-// WriteFile writes content to a file inside the container using the archive API.
-// Parent directories must already exist in the container, or the archive
-// extraction will create them. Content must not exceed 10 MB.
+// classifyFileIOCtxErr wraps a ReadFile/WriteFile failure through the
+// shared ErrTimeout sentinel when it happened because ctx's own
+// containerFileIOTimeout deadline elapsed (e.g. a wedged daemon mid-archive
+// transfer), rather than surfacing the raw transport/tar error — composing
+// with #489's classifyExecCtxErr instead of a bespoke error, so callers
+// matching on errors.Is(err, ErrTimeout) see this identically to an Exec
+// command timeout.
+func classifyFileIOCtxErr(ctx context.Context, verb string, err error) error {
+	if ctx.Err() != nil {
+		return classifyExecCtxErr(ctx, containerFileIOTimeout)
+	}
+	return fmt.Errorf("%s: %w", verb, err)
+}
+
+// WriteFile writes content to a file inside the container using the archive
+// API. Parent directories must already exist in the container, or the
+// archive extraction will create them. Content must not exceed 10 MB. The
+// whole operation (mkdir -p plus the archive upload) is bounded by
+// containerFileIOTimeout (#S2), for the same reason as ReadFile.
 func (e *ContainerExecutor) WriteFile(ctx context.Context, filePath string, content string) error {
 	if len(content) > maxFileSize {
 		if e.Security != nil {
@@ -418,10 +456,13 @@ func (e *ContainerExecutor) WriteFile(ctx context.Context, filePath string, cont
 		return err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, containerFileIOTimeout)
+	defer cancel()
+
 	// Ensure parent directory exists inside the container.
 	dir := path.Dir(resolved)
 	if dir != e.workspace {
-		_, mkdirErr := e.execInContainer(ctx, []string{"mkdir", "-p", dir}, e.workspace, 10*time.Second)
+		_, mkdirErr := e.execInContainer(ctx, []string{"mkdir", "-p", dir}, e.workspace, containerMkdirTimeout)
 		if mkdirErr != nil {
 			return fmt.Errorf("create parent directory: %w", mkdirErr)
 		}
@@ -449,7 +490,7 @@ func (e *ContainerExecutor) WriteFile(ctx context.Context, filePath string, cont
 
 	// Upload to the parent directory so the file is placed correctly.
 	if err := e.api.putArchive(ctx, e.containerID, dir, &buf); err != nil {
-		return fmt.Errorf("put archive: %w", err)
+		return classifyFileIOCtxErr(ctx, "put archive", err)
 	}
 	return nil
 }
@@ -548,21 +589,44 @@ func (e *ContainerExecutor) Capabilities() ExecutorCapabilities {
 }
 
 // execInContainer runs a command inside the container using the exec API.
-// It handles the full create → start → read output → inspect flow. On a
-// failure partway through — most commonly the ctx ending (deadline or
+// It handles the full create → start → read output → inspect flow, bounding
+// the whole sequence by timeout (a context.WithTimeout child of ctx). Every
+// call site already computed a timeout value, but the parameter used to be
+// named `_` and silently dropped — so WriteFile's mkdir and ListDirectory's
+// ls ran under whatever deadline ctx happened to carry (often none), and a
+// wedged daemon on those paths could hang the caller indefinitely (#S2).
+// Exec() itself was unaffected by that specific bug (it already wraps ctx
+// with the same timeout before calling in), but the internal wrap here is
+// applied unconditionally for uniformity and because it is what non-Exec
+// callers rely on.
+//
+// On a failure partway through — most commonly the ctx ending (deadline or
 // cancellation) while demuxDockerStream is blocked reading the exec
 // stream — the returned *ExecResult still carries whatever stdout/stderr
 // was captured before the failure, rather than nil; only a failure before
 // any output could exist (create/start exec) returns a nil result. Exec
-// relies on this to preserve partial output on timeout (#473).
-func (e *ContainerExecutor) execInContainer(ctx context.Context, cmd []string, workdir string, _ time.Duration) (*ExecResult, error) {
+// relies on this to preserve partial output on timeout (#473). A ctx-expiry
+// failure is classified via classifyExecCtxErr so callers matching on
+// errors.Is(err, ErrTimeout) — including WriteFile's mkdir and
+// ListDirectory's ls, which previously had no such classification at all —
+// see this identically to a top-level Exec timeout.
+func (e *ContainerExecutor) execInContainer(ctx context.Context, cmd []string, workdir string, timeout time.Duration) (*ExecResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	execID, err := e.api.createExec(ctx, e.containerID, cmd, workdir)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, classifyExecCtxErr(ctx, timeout)
+		}
 		return nil, fmt.Errorf("create exec: %w", err)
 	}
 
 	stream, err := e.api.startExec(ctx, execID)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, classifyExecCtxErr(ctx, timeout)
+		}
 		return nil, fmt.Errorf("start exec: %w", err)
 	}
 	defer func() { _ = stream.Close() }()
@@ -570,11 +634,17 @@ func (e *ContainerExecutor) execInContainer(ctx context.Context, cmd []string, w
 	stdout, stderr, err := demuxDockerStream(stream)
 	result := &ExecResult{Stdout: stdout, Stderr: stderr}
 	if err != nil {
+		if ctx.Err() != nil {
+			return result, classifyExecCtxErr(ctx, timeout)
+		}
 		return result, fmt.Errorf("read exec output: %w", err)
 	}
 
 	exitCode, err := e.api.inspectExec(ctx, execID)
 	if err != nil {
+		if ctx.Err() != nil {
+			return result, classifyExecCtxErr(ctx, timeout)
+		}
 		return result, fmt.Errorf("inspect exec: %w", err)
 	}
 	result.ExitCode = exitCode

--- a/harness/internal/executor/container_api.go
+++ b/harness/internal/executor/container_api.go
@@ -11,9 +11,34 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const apiVersion = "v1.47"
+
+var (
+	// containerDialTimeout bounds the initial Unix-socket connection. A var
+	// (not const) so tests can shrink it to exercise the timeout path
+	// without waiting out the real production window.
+	containerDialTimeout = 10 * time.Second
+	// containerResponseHeaderTimeout bounds only the wait for response
+	// headers, never the body — so it cannot kill a long-running exec
+	// output stream or a large archive transfer once headers have arrived
+	// (Docker sends both essentially immediately after accepting a
+	// request). It is the connection-level backstop that catches a daemon
+	// that accepts the connection but then never answers at all,
+	// independent of whether a per-call context deadline was set below.
+	containerResponseHeaderTimeout = 30 * time.Second
+	// containerControlPlaneTimeout bounds a single short Docker Engine API
+	// call — create/start/stop/remove/ping/exec-create/exec-inspect. It is
+	// deliberately NOT applied to startExec (exec output attach) or the
+	// archive endpoints (getArchive/putArchive): those are long-lived
+	// streaming calls bounded instead by the caller's own command/file-I/O
+	// deadline, so a legitimate slow-but-alive stream is never killed by
+	// this control-plane window. Mirrors k8sAPITimeout's role for the k8s
+	// executor's rest.Config.Timeout.
+	containerControlPlaneTimeout = 30 * time.Second
+)
 
 // containerAPIClient is a thin client for the Docker Engine API (also
 // compatible with Podman) that communicates over a Unix socket. It uses only
@@ -24,16 +49,43 @@ type containerAPIClient struct {
 }
 
 // newContainerAPIClient creates a client connected to the given Unix socket.
+//
+// The client deliberately has no blanket http.Client.Timeout: exec output
+// attach and archive (file) transfer are long-lived streaming reads that can
+// legitimately outlast any single short window, and a client-level Timeout
+// bounds the entire round trip including the body. Instead, every
+// control-plane method below applies its own context.WithTimeout, and
+// streaming calls are bounded by the caller's command/file-I/O deadline
+// (see container.go). The Transport's ResponseHeaderTimeout (and the
+// dialer's timeout) still give an explicit, connection-level bound — as the
+// project's HTTP-client invariant requires — for the case where a caller
+// forgets to supply one.
 func newContainerAPIClient(socketPath string) *containerAPIClient {
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			return (&net.Dialer{Timeout: containerDialTimeout}).DialContext(ctx, "unix", socketPath)
 		},
+		ResponseHeaderTimeout: containerResponseHeaderTimeout,
 	}
 	return &containerAPIClient{
 		client: &http.Client{Transport: transport},
 		host:   "unix://" + socketPath,
 	}
+}
+
+// classifyControlPlaneErr wraps a failed short Docker Engine API call
+// through the shared ErrTimeout sentinel when the failure happened because
+// ctx's own containerControlPlaneTimeout deadline elapsed — e.g. a daemon
+// that accepted the connection but never answered — rather than surfacing
+// the raw transport error. This composes with #489's classifyExecCtxErr
+// instead of inventing a parallel timeout-detection mechanism, so callers
+// matching on errors.Is(err, ErrTimeout) see this identically to a
+// command timeout.
+func classifyControlPlaneErr(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		return classifyExecCtxErr(ctx, containerControlPlaneTimeout)
+	}
+	return err
 }
 
 // detectSocket probes for a container runtime socket in priority order:
@@ -155,6 +207,9 @@ type containerCreateResponse struct {
 }
 
 func (c *containerAPIClient) createContainer(ctx context.Context, cfg containerCreateRequest) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	body, err := json.Marshal(cfg)
 	if err != nil {
 		return "", fmt.Errorf("marshal container config: %w", err)
@@ -168,7 +223,7 @@ func (c *containerAPIClient) createContainer(ctx context.Context, cfg containerC
 
 	resp, err := c.doRequest(req)
 	if err != nil {
-		return "", err
+		return "", classifyControlPlaneErr(ctx, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -185,13 +240,16 @@ func (c *containerAPIClient) createContainer(ctx context.Context, cfg containerC
 // unreachable or stopped daemon surfaces before the run commits to
 // creating a container.
 func (c *containerAPIClient) ping(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url("/_ping"), nil)
 	if err != nil {
 		return err
 	}
 	resp, err := c.doRequest(req)
 	if err != nil {
-		return err
+		return classifyControlPlaneErr(ctx, err)
 	}
 	_ = resp.Body.Close()
 	return nil
@@ -206,13 +264,16 @@ func (c *containerAPIClient) ping(ctx context.Context) error {
 // itself. The image reference is path-escaped because it may contain a
 // registry host, a tag, or an "@sha256:" digest with reserved bytes.
 func (c *containerAPIClient) imageExistsLocally(ctx context.Context, image string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url("/images/"+url.PathEscape(image)+"/json"), nil)
 	if err != nil {
 		return false, err
 	}
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return false, fmt.Errorf("docker API request GET /images/%q/json: %w", image, err)
+		return false, classifyControlPlaneErr(ctx, fmt.Errorf("docker API request GET /images/%q/json: %w", image, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 	switch {
@@ -231,19 +292,25 @@ func (c *containerAPIClient) imageExistsLocally(ctx context.Context, image strin
 }
 
 func (c *containerAPIClient) startContainer(ctx context.Context, id string) error {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(fmt.Sprintf("/containers/%s/start", id)), nil)
 	if err != nil {
 		return err
 	}
 	resp, err := c.doRequest(req)
 	if err != nil {
-		return err
+		return classifyControlPlaneErr(ctx, err)
 	}
 	_ = resp.Body.Close()
 	return nil
 }
 
 func (c *containerAPIClient) stopContainer(ctx context.Context, id string, timeout int) error {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	url := fmt.Sprintf("/containers/%s/stop?t=%d", id, timeout)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(url), nil)
 	if err != nil {
@@ -255,13 +322,16 @@ func (c *containerAPIClient) stopContainer(ctx context.Context, id string, timeo
 		if strings.Contains(err.Error(), "HTTP 304") {
 			return nil
 		}
-		return err
+		return classifyControlPlaneErr(ctx, err)
 	}
 	_ = resp.Body.Close()
 	return nil
 }
 
 func (c *containerAPIClient) removeContainer(ctx context.Context, id string, force bool) error {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	url := fmt.Sprintf("/containers/%s?force=%t", id, force)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.url(url), nil)
 	if err != nil {
@@ -269,7 +339,7 @@ func (c *containerAPIClient) removeContainer(ctx context.Context, id string, for
 	}
 	resp, err := c.doRequest(req)
 	if err != nil {
-		return err
+		return classifyControlPlaneErr(ctx, err)
 	}
 	_ = resp.Body.Close()
 	return nil
@@ -288,7 +358,15 @@ type execCreateResponse struct {
 	ID string `json:"Id"`
 }
 
+// createExec is a short control-plane call — it registers the exec instance
+// but does not run it — so it gets containerControlPlaneTimeout rather than
+// the caller's (potentially much longer) command timeout. startExec is the
+// call that actually runs the command and streams output; that one is
+// bounded by the caller's timeout instead (see execInContainer).
 func (c *containerAPIClient) createExec(ctx context.Context, containerID string, cmd []string, workdir string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	body, err := json.Marshal(execCreateRequest{
 		AttachStdout: true,
 		AttachStderr: true,
@@ -309,7 +387,7 @@ func (c *containerAPIClient) createExec(ctx context.Context, containerID string,
 
 	resp, err := c.doRequest(req)
 	if err != nil {
-		return "", err
+		return "", classifyControlPlaneErr(ctx, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -320,8 +398,14 @@ func (c *containerAPIClient) createExec(ctx context.Context, containerID string,
 	return result.ID, nil
 }
 
-// startExec starts an exec instance and returns the multiplexed output stream.
-// The caller must close the returned ReadCloser.
+// startExec starts an exec instance and returns the multiplexed output
+// stream. The caller must close the returned ReadCloser. Unlike the other
+// methods in this file, startExec deliberately does NOT apply
+// containerControlPlaneTimeout: it is the call that actually runs the
+// command and streams its output, so bounding it to the short control-plane
+// window would kill a legitimate long-running command almost immediately.
+// It relies entirely on ctx, which the caller (execInContainer) has already
+// bound to the command's own timeout.
 func (c *containerAPIClient) startExec(ctx context.Context, execID string) (io.ReadCloser, error) {
 	body := `{"Detach":false,"Tty":false}`
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
@@ -344,7 +428,14 @@ type execInspectResponse struct {
 	Running  bool `json:"Running"`
 }
 
+// inspectExec is a short metadata read (fetch the exit code after the
+// command has already finished streaming), so it gets the control-plane
+// timeout rather than whatever budget remained on the command's own
+// deadline.
 func (c *containerAPIClient) inspectExec(ctx context.Context, execID string) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, containerControlPlaneTimeout)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		c.url(fmt.Sprintf("/exec/%s/json", execID)),
 		nil)
@@ -354,7 +445,7 @@ func (c *containerAPIClient) inspectExec(ctx context.Context, execID string) (in
 
 	resp, err := c.doRequest(req)
 	if err != nil {
-		return -1, err
+		return -1, classifyControlPlaneErr(ctx, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -367,7 +458,11 @@ func (c *containerAPIClient) inspectExec(ctx context.Context, execID string) (in
 
 // --- Archive (file transfer) ---
 
-// putArchive uploads a tar archive to a path inside the container.
+// putArchive uploads a tar archive to a path inside the container. Like
+// startExec, this is a long-lived streaming call (the archive body can be
+// up to maxFileSize) so it is bounded only by ctx — the caller
+// (ContainerExecutor.WriteFile) applies containerFileIOTimeout — not by
+// containerControlPlaneTimeout.
 func (c *containerAPIClient) putArchive(ctx context.Context, containerID, destPath string, tarReader io.Reader) error {
 	url := fmt.Sprintf("/containers/%s/archive?path=%s", containerID, url.QueryEscape(destPath))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(url), tarReader)
@@ -385,7 +480,8 @@ func (c *containerAPIClient) putArchive(ctx context.Context, containerID, destPa
 }
 
 // getArchive downloads a tar archive of a path from inside the container.
-// The caller must close the returned ReadCloser.
+// The caller must close the returned ReadCloser. Bounded by ctx only, same
+// rationale as putArchive.
 func (c *containerAPIClient) getArchive(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error) {
 	url := fmt.Sprintf("/containers/%s/archive?path=%s", containerID, url.QueryEscape(srcPath))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(url), nil)

--- a/harness/internal/executor/container_test.go
+++ b/harness/internal/executor/container_test.go
@@ -620,6 +620,189 @@ func TestContainerExecutor_Exec_CancelledContext_NotErrTimeout(t *testing.T) {
 	}
 }
 
+// --- S2: Docker API client / file-I/O timeout tests ---
+//
+// These exercise the fix for "execInContainer ignores its timeout
+// parameter" and "the Docker Engine API client has no explicit timeout": a
+// wedged daemon (accepts the connection, never responds) must not hang the
+// executor forever, on any call class, while a slow-but-legitimate
+// streaming exec must not be killed by a blanket short timeout. Each test
+// temporarily shrinks the relevant package-level timeout var so the
+// scenario completes in well under a second instead of the real 10-60s
+// production window.
+
+// withShortTimeout sets *knob to short for the duration of the test and
+// restores the original value via t.Cleanup, so package-level timeout vars
+// shared across the executor package tests are never left mutated for
+// unrelated tests.
+func withShortTimeout(t *testing.T, knob *time.Duration, short time.Duration) {
+	t.Helper()
+	orig := *knob
+	*knob = short
+	t.Cleanup(func() { *knob = orig })
+}
+
+// TestContainerAPIClient_ControlPlaneCall_BoundedWithoutCallerDeadline is
+// the S2 regression for control-plane calls (create/start/stop/ping/
+// exec-create/exec-inspect): a fake daemon that accepts the connection but
+// never responds must not hang the call forever even when the caller
+// supplies no context deadline of its own (context.Background()) — the
+// per-call containerControlPlaneTimeout must still bound it — and the
+// resulting error must classify via errors.Is(err, ErrTimeout), composing
+// with #489's sentinel rather than surfacing a bespoke "context deadline
+// exceeded" string.
+func TestContainerAPIClient_ControlPlaneCall_BoundedWithoutCallerDeadline(t *testing.T) {
+	withShortTimeout(t, &containerControlPlaneTimeout, 150*time.Millisecond)
+
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, r *http.Request) {
+			// Never write a response. The handler blocks on the server's
+			// request context, which is cancelled once our client gives up
+			// on its own deadline and the connection closes — so
+			// mockEngineServer's Close() doesn't hang waiting for this
+			// handler to return.
+			<-r.Context().Done()
+		},
+	})
+	defer cleanup()
+
+	client := newContainerAPIClient(sock)
+
+	start := time.Now()
+	err := client.ping(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a daemon that never responds")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("err = %v, want errors.Is(err, ErrTimeout)", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("ping took %v with no caller-supplied deadline, want bounded by containerControlPlaneTimeout (~150ms)", elapsed)
+	}
+}
+
+// TestContainerAPIClient_ConnectionLevelHang_BoundedByResponseHeaderTimeout
+// proves the connection-level backstop independently of any per-call
+// context deadline: even if containerControlPlaneTimeout were much larger
+// than the time the daemon takes to (never) respond, the Transport's
+// ResponseHeaderTimeout still bounds the wait for headers. This is the
+// "half-open TCP / wedged daemon" case called out in the task — it is a
+// pure connection-level bound, so (unlike the context-deadline path above)
+// it is not required to classify via ErrTimeout.
+func TestContainerAPIClient_ConnectionLevelHang_BoundedByResponseHeaderTimeout(t *testing.T) {
+	withShortTimeout(t, &containerResponseHeaderTimeout, 150*time.Millisecond)
+	// Deliberately much larger than the header timeout above, so the
+	// ctx-deadline path this test is NOT exercising cannot be the thing
+	// that saves us.
+	withShortTimeout(t, &containerControlPlaneTimeout, 10*time.Second)
+
+	sock, cleanup := mockEngineServer(t, map[string]http.HandlerFunc{
+		"GET /_ping": func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		},
+	})
+	defer cleanup()
+
+	client := newContainerAPIClient(sock)
+
+	start := time.Now()
+	err := client.ping(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a daemon that never responds")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("ping took %v, want bounded by containerResponseHeaderTimeout (~150ms) despite a 10s control-plane ctx budget", elapsed)
+	}
+}
+
+// TestContainerExecutor_WriteFile_MkdirTimeout is the S2 regression for the
+// specific bug: execInContainer's timeout parameter was named `_` and
+// silently dropped, so WriteFile's "mkdir -p" call — which passes its own
+// 10s budget — actually ran under whatever deadline the caller's ctx
+// happened to carry (often none). With no caller deadline
+// (context.Background()) and a wedged daemon, this used to hang forever;
+// now containerMkdirTimeout (shrunk here for test speed) bounds it and the
+// error classifies via ErrTimeout.
+func TestContainerExecutor_WriteFile_MkdirTimeout(t *testing.T) {
+	withShortTimeout(t, &containerMkdirTimeout, 150*time.Millisecond)
+
+	exec, cleanup := newMockContainerExecutor(t, map[string]http.HandlerFunc{
+		"POST /containers/*/exec": func(w http.ResponseWriter, r *http.Request) {
+			// mkdir -p's exec-create call itself succeeds fast; only the
+			// stream never responds, matching a daemon wedged mid-command.
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execCreateResponse{ID: "mkdir-exec-hang"})
+		},
+		"POST /exec/*/start": func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		},
+	})
+	defer cleanup()
+
+	start := time.Now()
+	// No deadline at all on the caller's ctx — this is the exact gap S2
+	// closes: previously only execInContainer's ignored parameter stood
+	// between this call and an indefinite hang.
+	err := exec.WriteFile(context.Background(), "sub/dir/test.txt", "file content")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a daemon wedged mid-mkdir")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("err = %v, want errors.Is(err, ErrTimeout)", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("WriteFile took %v with no caller-supplied deadline, want bounded by containerMkdirTimeout (~150ms)", elapsed)
+	}
+}
+
+// TestContainerExecutor_Exec_SlowStreamNotKilledByControlPlaneTimeout
+// verifies the call-class distinction: a legitimate command whose output
+// trickles in past the (shrunk) control-plane window, but well within its
+// own configured command timeout, must complete successfully rather than
+// being killed by a blanket short timeout leaking into the streaming path.
+func TestContainerExecutor_Exec_SlowStreamNotKilledByControlPlaneTimeout(t *testing.T) {
+	withShortTimeout(t, &containerControlPlaneTimeout, 100*time.Millisecond)
+
+	exec, cleanup := newMockContainerExecutor(t, map[string]http.HandlerFunc{
+		"POST /containers/*/exec": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execCreateResponse{ID: "exec-slow-stream"})
+		},
+		"POST /exec/*/start": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.docker.raw-stream")
+			writeDockerFrame(w, 1, []byte("part1\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			// Sleep past containerControlPlaneTimeout (100ms) but well
+			// within the command's own 2s timeout. startExec deliberately
+			// does not apply the control-plane window (see
+			// container_api.go), so this trickle must survive.
+			time.Sleep(300 * time.Millisecond)
+			writeDockerFrame(w, 1, []byte("part2\n"))
+		},
+		"GET /exec/*/json": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execInspectResponse{ExitCode: 0})
+		},
+	})
+	defer cleanup()
+
+	result, err := exec.Exec(context.Background(), "slow but legitimate command", 2*time.Second)
+	if err != nil {
+		t.Fatalf("Exec: %v, want the slow-but-legitimate stream to complete without error", err)
+	}
+	if !strings.Contains(result.Stdout, "part1") || !strings.Contains(result.Stdout, "part2") {
+		t.Errorf("stdout = %q, want both part1 and part2 (stream must survive the control-plane window elapsing mid-read)", result.Stdout)
+	}
+}
+
 func TestContainerExecutor_ListDirectory(t *testing.T) {
 	exec, cleanup := newMockContainerExecutor(t, map[string]http.HandlerFunc{
 		"POST /containers/*/exec": func(w http.ResponseWriter, r *http.Request) {

--- a/harness/internal/executor/executor.go
+++ b/harness/internal/executor/executor.go
@@ -18,6 +18,15 @@ import (
 // harness/internal/hook/runner.go) match on this sentinel instead of the
 // error's formatted text, so a wording change in one executor can't
 // silently break TimedOut classification downstream (#468).
+//
+// The container executor also routes its Docker Engine API deadlines
+// through this sentinel (#S2): the short control-plane calls
+// (create/start/stop/exec-create/exec-inspect) and the file I/O paths
+// (ReadFile/WriteFile) have no caller-supplied timeout of their own, so
+// they apply an internal one and classify a resulting ctx expiry the same
+// way, rather than inventing a second, parallel timeout-detection
+// mechanism — see container_api.go's classifyControlPlaneErr and
+// container.go's classifyFileIOCtxErr.
 var ErrTimeout = errors.New("command timed out")
 
 // classifyExecCtxErr builds the error an Executor's Exec method returns once


### PR DESCRIPTION
## Summary

Fixes v0.1 executor review item S2 (untracked, no GitHub issue): `execInContainer` ignored its timeout parameter, and the hand-rolled Docker Engine REST API client had no `http.Client` timeout at all — a wedged Docker daemon could hang `read_file`/`write_file`/`run_command` indefinitely, violating the project's explicit-timeout invariant.

**Stacked on #489** (`fix/executor-timeout-sentinel`, not yet merged) — this branch is based on `origin/fix/executor-timeout-sentinel` and must be retargeted to `main` once #489 merges.

## Timeout scheme (mirrors the k8s executor's `k8sAPITimeout`/`k8sFileIOTimeout` split)

- **Short control-plane calls** (create/start/stop/remove/ping/exec-create/exec-inspect) get `containerControlPlaneTimeout` (30s), applied per-call via `context.WithTimeout`.
- **Long-lived streaming calls** (`startExec`'s output attach, `getArchive`/`putArchive`'s archive bodies) are deliberately *excluded* from that window — they rely on the caller's own command timeout (`Exec`) or file-I/O timeout (`ReadFile`/`WriteFile`) instead, so a legitimate slow command or large file transfer is never killed early.
- **Transport-level backstop**: an explicit Unix-socket dial timeout and `ResponseHeaderTimeout` bound connection-level hangs (wedged daemon, half-open TCP) independent of whether a caller happens to supply a context deadline. No blanket `http.Client.Timeout` — that would bound the streaming body too and kill legitimate long-running output.
- **File I/O**: `ReadFile`/`WriteFile` get `containerFileIOTimeout` (60s, mirrors `k8sFileIOTimeout`); `WriteFile`'s `mkdir -p` keeps its own tighter `containerMkdirTimeout` (10s) nested inside that.
- `execInContainer`'s timeout parameter (previously named `_` and silently dropped) is now applied via `context.WithTimeout` — this is what actually fixes `WriteFile`'s mkdir call and `ListDirectory`'s `ls` call, which previously ran unbounded except for whatever deadline the caller's `ctx` happened to already carry (usually none). `Exec()` itself was not affected by that specific bug (it already wrapped `ctx` with the same timeout before calling in), but the internal wrap is now applied uniformly.

## Composition with #489's `ErrTimeout` sentinel

All new deadline errors classify through the existing `classifyExecCtxErr` sentinel mechanism rather than a parallel one:
- `container_api.go`: new `classifyControlPlaneErr(ctx, err)` — wraps a failed control-plane call via `classifyExecCtxErr` when `ctx.Err() != nil`.
- `container.go`: new `classifyFileIOCtxErr(ctx, verb, err)` — same idea for `ReadFile`/`WriteFile`.
- `execInContainer` now classifies its own ctx-expiry failures the same way, so `WriteFile`'s mkdir and `ListDirectory`'s `ls` — which previously had no classification at all — see `errors.Is(err, ErrTimeout)` identically to a top-level `Exec` timeout.

The Transport's `ResponseHeaderTimeout` backstop is a pure connection-level bound and intentionally does **not** attempt sentinel classification (there's no context deadline to inspect when it fires) — it only guarantees the call returns rather than hangs.

## Tests

Added to `harness/internal/executor/container_test.go` (reusing the existing `mockEngineServer` fake-daemon pattern already used throughout the file):

- `TestContainerAPIClient_ControlPlaneCall_BoundedWithoutCallerDeadline` — fake daemon accepts the connection but never responds (`<-r.Context().Done()`); `ping(context.Background())` (no caller deadline) returns on `containerControlPlaneTimeout` and classifies via `errors.Is(err, ErrTimeout)`.
- `TestContainerAPIClient_ConnectionLevelHang_BoundedByResponseHeaderTimeout` — same hanging daemon, but with the control-plane ctx timeout deliberately set much larger than `containerResponseHeaderTimeout`, proving the Transport-level backstop alone still bounds the call.
- `TestContainerExecutor_WriteFile_MkdirTimeout` — the direct S2 regression: `WriteFile` with `context.Background()` against a daemon that hangs mid-`mkdir` now returns bounded and classified, where before the fix this call had no bound at all.
- `TestContainerExecutor_Exec_SlowStreamNotKilledByControlPlaneTimeout` — a command whose output trickles in past the (shrunk) control-plane window but within its own command timeout completes successfully; proves the streaming/control-plane call-class split.

All new tests shrink the relevant package-level timeout `var`s (via a `withShortTimeout` test helper with `t.Cleanup` restore) so the suite runs in well under a second instead of the real 10-60s production windows.

**Pre-fix verification**: stashed the source fixes (`container.go`, `container_api.go`, `executor.go`), keeping the new tests. `go build` doesn't compile `_test.go` files, but `go vet ./internal/executor/...` confirmed the new tests fail to even *compile* pre-fix (`undefined: containerControlPlaneTimeout` etc.) — the timeout knobs the tests exercise didn't exist before this change. Restored via `git stash pop` and reran the full suite green.

### Test plan
- [x] `just build`
- [x] `just test` (full suite, all packages green)
- [x] `just lint` (0 issues)
- [x] `go test ./internal/executor/... -race -run TestContainer -v` (race-clean)
- [x] Stash round-trip confirms new tests are new/tied to the fix (compile-fail pre-fix, pass post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lje66DDPppHJugw8ggZGiJ
