### PR TITLE
prompt: model-conditional system prompts via text/template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ stirrup/
       credential/            # Cross-cloud credential federation
       provider/              # ProviderAdapter: Anthropic, Bedrock, OpenAI-compatible, OpenAI Responses, Gemini (Vertex AI)
       router/                # ModelRouter: static, per-mode, dynamic
-      prompt/                # PromptBuilder: per-mode templates, composed fragments, overrides
+      prompt/                # PromptBuilder: per-mode text/template prompts (model tiers, #492), composed fragments, operator templates, overrides
       context/               # ContextStrategy: sliding window, summarise, offload-to-file
       tool/                  # ToolRegistry + built-in tools, including spawn_agent
       tool/toolname/         # Per-provider tool-name normalization + collision detection (#223)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ Quick map for "I need to change X" lookups:
 | Want to change… | Look in… |
 |---|---|
 | Provider behaviour or wire format | `harness/internal/provider/<name>.go` |
+| System prompt content or model tiers (the `.md` files are Go text/templates) | `harness/internal/prompt/systemprompts/*.md`, `harness/internal/prompt/modeltier.go` (operator doc: `docs/configuration.md#system-prompt-templating`) |
 | Tool definition or schema | `harness/internal/tool/builtins/<name>.go` |
 | Edit fallback logic | `harness/internal/edit/multi.go` |
 | Lifecycle hooks (pre/post-run exec, #461) | `harness/internal/hook/` (Runner/Noop/ExecRunner), loop wiring in `harness/internal/core/loop.go` (operator doc: `docs/configuration.md#lifecycle-hooks`) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,6 +281,7 @@ reference.
 |---|---|---|
 | `--provider` | `anthropic` | One of `anthropic`, `bedrock`, `openai-compatible`, `openai-responses`, `gemini`. |
 | `--model` | `claude-sonnet-4-6` | Model id for the static / per-mode router. |
+| `--prompt-model` | (none) | Model identity the system prompt templates render against, without changing the wire model. Combine with `--model` to compare a prompt tuned for one model against another. Empty derives the prompt model from the effective model. JSON path: `promptBuilder.promptModel`. See [System prompt templating](#system-prompt-templating). |
 | `--api-key-ref` | `secret://ANTHROPIC_API_KEY` | A `secret://` reference. API keys never live in `RunConfig`. Ignored when `--provider=gemini` (Vertex uses GCP IAM). |
 | `--base-url` | (none) | Provider base URL. Required for Azure / gateway scenarios. |
 | `--api-key-header` | (none) | Header name. Empty = `Authorization: Bearer`; set to `api-key` for Azure key auth. |
@@ -611,6 +612,132 @@ The read-only modes differ from each other only in prompt template:
 `planning` for "describe and reason before acting" first-touch use,
 `review` for change-review tasks, `research` for investigation across
 a codebase or the web, and `toil` for structured-briefing workflows.
+
+## System prompt templating
+
+The shipped per-mode system prompts are Go
+[`text/template`](https://pkg.go.dev/text/template) documents rendered
+per run against a *prompt model* — a model identity that selects which
+guidance the prompt carries. Frontier-generation models degrade under
+prescriptive process scaffolding and receive lean behavioural
+additions; open-weight models receive exactly that scaffolding. A
+model matching neither set renders the unconditional base prompt, so
+an unrecognised or brand-new model always gets a functional prompt
+(fall-through is structural, not configured).
+
+### Prompt model resolution
+
+The prompt model resolves in order:
+
+1. `promptBuilder.promptModel` (`--prompt-model`) when set — the
+   explicit override for prompt/model comparison runs;
+2. otherwise the model the router serves for this run's mode: the
+   `modeModels[mode]` entry for a per-mode router, else
+   `modelRouter.model`;
+3. otherwise the harness default model.
+
+Dynamic routers may switch models between turns, but the prompt is
+rendered once per run against the router's default model: re-rendering
+per turn would invalidate provider prompt caches and change agent
+guidance mid-run.
+
+The resolved prompt model and its tier are recorded on the run's root
+OTel span as `prompt.model` and `prompt.tier` (always on — these are
+config metadata, not content), so comparison runs remain attributable
+from traces alone.
+
+### Tiers
+
+Tier membership is a pair of glob tables in
+`harness/internal/prompt/modeltier.go` — adding a new model to a tier
+is a one-line change there. Globs use `path.Match` with the same
+semantics as the provider-quirks registry (`*` does not cross `/`;
+gateway-prefixed IDs are matched by `*/`-prefixed variants).
+
+| Tier | Members (initial) | Guidance shape |
+|---|---|---|
+| `frontier` | `claude-fable-5*`, `claude-mythos-5*`, `claude-sonnet-5*`, `claude-opus-4-8*`, `gpt-5.5*`, `gpt-5.6*` | Lean behavioural additions: act when ready, scope discipline, evidence-grounded progress claims, outcome-first summaries. |
+| `open-weight` | `gemma*`, `glm-*`, `deepseek*`, `qwen*` | Explicit process scaffolding: read/edit/test loop, invoke-don't-describe, restated output formats and stopping conditions. |
+| `default` | everything else | Base prompt only — byte-identical to the pre-templating prompts. |
+
+Inspect any rendering offline (no provider call, no credentials):
+
+```sh
+stirrup prompt render --mode execution --prompt-model claude-fable-5
+stirrup prompt render --mode execution --prompt-model gemma-4 --template ./tuned.tmpl
+```
+
+The rendered preamble prints to stdout; the resolved tier prints to
+stderr. Structural sections the harness appends at run time (working
+directory, turn budget, workspace tree, git status, dynamic context)
+are omitted because they depend on a live workspace.
+
+### Operator templates and the override
+
+Three prompt-content surfaces exist, in precedence order:
+
+1. **`systemPromptOverride`** — a raw string used verbatim as the
+   preamble. Never template-parsed, so content containing `{{` (for
+   example a prompt compiled by an external prompt-management system)
+   passes through untouched.
+2. **`promptBuilder.template`** — an operator-supplied Go
+   text/template replacing the shipped mode prompt. It renders against
+   the same data surface as the shipped prompts, so model-conditional
+   content and `--prompt-model` comparison keep working for tuned
+   prompts. Syntax is checked by `ValidateRunConfig`; the template is
+   additionally trial-rendered at component construction so execution
+   errors fail before the run starts.
+3. **Shipped mode templates** — the default.
+
+In both 1 and 2 the structural sections (workspace path, turn budget,
+workspace tree, git status, dynamic context with `untrusted_context`
+wrapping) are still appended.
+
+Combining `systemPromptOverride` with either `promptBuilder.template`
+or `promptBuilder.promptModel` is rejected by validation rather than
+resolved by precedence: the override bypasses template rendering, and
+in an eval sweep the silent no-op would masquerade as a valid
+prompt/model comparison.
+
+Templates render against this data surface (methods are called
+without arguments):
+
+| Expression | Value |
+|---|---|
+| `.Model` | The resolved prompt model string. |
+| `.Mode` | The run mode. |
+| `.Tier` | `"frontier"`, `"open-weight"`, or `"default"`. |
+| `.ModelIs "glob" ...` | `true` when the prompt model matches any `path.Match` glob (a malformed glob is a non-match). |
+
+Template rendering is pure string work: the data surface exposes no
+filesystem, environment, or network reach.
+
+### Control-plane prompt management (Langfuse)
+
+An upstream control plane that manages prompts in an external system
+such as [Langfuse prompt management](https://langfuse.com/docs/prompt-management/get-started)
+has two integration paths:
+
+- **Compiled prompt → `systemPromptOverride`.** Fetch the prompt by
+  name/label, compile its `{{variable}}` placeholders with the
+  Langfuse SDK, and ship the resulting string. Per-model tuning
+  happens control-plane-side (e.g. one Langfuse label per model
+  family). Because the override is never template-parsed, leftover
+  mustache syntax cannot be misinterpreted — but an *uncompiled*
+  prompt pasted into `promptBuilder.template` fails validation
+  loudly, which is the intended guard against confusing the two
+  surfaces.
+- **Go template → `promptBuilder.template`.** Store a Go
+  text/template in the external system and ship it verbatim. The
+  harness renders it per run with the model-conditional surface
+  above, so one stored prompt can serve every model tier and
+  `--prompt-model` comparisons still work.
+
+Stirrup's OTel emitter stays vendor-neutral either way: prompt
+name/version linkage attributes specific to Langfuse are not emitted.
+Use `prompt.model` / `prompt.tier` (and `gen_ai.system_instructions`
+under `--otel-capture-content`) to correlate runs with prompt
+versions.
 
 ## Toolset profiles
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -442,6 +442,7 @@ tree gains a `run_config.redacted.json` per task. See
 | `--concurrency`  | `1`              | Number of tasks executed in parallel. Workers preserve suite order in `result.json`. Values larger than the task count cap at `len(tasks)`. Concurrent invocations talking to the same provider hit rate limits faster — pick a value that respects your provider account's per-minute caps. |
 | `--dry-run`      | `false`          | Validate the suite (and, when present, the merged per-task RunConfig via `ValidateRunConfig`) and emit a synthetic result. |
 | `--model`        | empty            | Model to run every task with, forwarded to each harness invocation as `--model`. Overrides the harness default and any model pinned by the suite's `run_config` block. CI uses this to pin the per-push gate to a cheap model and the release sweep to stronger ones. |
+| `--prompt-model` | empty            | Prompt model to render system prompts with, forwarded to each harness invocation as `--prompt-model`. The wire model is unchanged. See [Comparing prompts across models](#comparing-prompts-across-models). |
 
 Exit code is `0` regardless of pass rate — use `compare` to gate CI.
 
@@ -648,6 +649,27 @@ cell red without holding the release.
    the committed baseline. PRs that introduce regressions fail.
 4. When a behaviour change is intentional, regenerate the baseline
    and commit it as part of the PR.
+
+### Comparing prompts across models
+
+The shipped system prompts are templated per model
+([configuration.md — System prompt templating](configuration.md#system-prompt-templating)),
+so two runs with different `--model` values no longer share prompt
+content. `--prompt-model` restores a controlled comparison by pinning
+the prompt while varying the model (or vice versa):
+
+```sh
+# A/B: does the new model do better with its own prompt or the
+# claude-fable-5 prompt it was not tuned for?
+stirrup-eval run --suite eval/suites/dogfood-seed.hcl --model claude-fable-6
+stirrup-eval run --suite eval/suites/dogfood-seed.hcl --model claude-fable-6 --prompt-model claude-fable-5
+```
+
+Baselines are keyed on `(suiteId, taskId)` outcomes only, so prompt
+templating does not change baseline identity; regenerate a baseline
+only when task outcomes legitimately change. The resolved prompt model
+and tier are recorded on each run's root OTel span (`prompt.model`,
+`prompt.tier`) for after-the-fact attribution.
 
 ### Continuous quality monitoring
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -110,6 +110,15 @@ The most security-relevant invariants:
 - **Path-only fields** (workspace, trace, policy file, semgrep
   config) are validated for traversal and absolute-path constraints
   appropriate to their use.
+- **Prompt templates** (`promptBuilder.template`) are syntax-checked
+  at validation and trial-rendered at component construction. The
+  template data surface is plain strings and pure matching methods —
+  no filesystem, environment, or network reach — so an
+  operator-supplied template is string interpolation only.
+  `systemPromptOverride` is never template-parsed. Combining the
+  override with `promptBuilder.template` or
+  `promptBuilder.promptModel` is rejected rather than resolved by
+  precedence.
 
 ## HTTP client hardening
 

--- a/eval/cmd/eval/main.go
+++ b/eval/cmd/eval/main.go
@@ -128,6 +128,7 @@ func cmdRun(args []string) {
 	junitPath := fs.String("junit", "", "Write JUnit XML to this path after result.json (default: disabled)")
 	acceptQuarantine := fs.Bool("accept-quarantine", false, "Permit execution of suites whose QuarantineFlags is non-empty. Without this flag, mined-from-production suites that carry classified content are refused. See #115.")
 	model := fs.String("model", "", "Model to run every task with (forwarded to each harness invocation as --model). Overrides the harness default and any model pinned by the suite's run_config block. Empty (the default) preserves existing behaviour.")
+	promptModel := fs.String("prompt-model", "", "Prompt model to render system prompts with (forwarded to each harness invocation as --prompt-model). The wire model is unchanged; combine with --model to compare a prompt tuned for one model against another. Empty (the default) derives the prompt model from the effective model.")
 	// Anthropic Workload Identity Federation flags. The runner forwards
 	// these verbatim to every `stirrup harness` invocation so the
 	// eval-gate CI job can authenticate via WIF instead of a static
@@ -178,6 +179,7 @@ func cmdRun(args []string) {
 		Concurrency: *concurrency,
 		DryRun:      *dryRun,
 		Model:       *model,
+		PromptModel: *promptModel,
 		AnthropicWIF: runner.AnthropicWIFConfig{
 			FederationRuleID:  *anthropicFederationRuleID,
 			OrganizationID:    *anthropicOrganizationID,

--- a/eval/runner/runner.go
+++ b/eval/runner/runner.go
@@ -57,6 +57,13 @@ type RunConfig struct {
 	// models at release) without editing suite files.
 	Model string
 
+	// PromptModel, when non-empty, is forwarded to every harness
+	// invocation as --prompt-model (#492). It pins the model identity
+	// the system prompt templates render against without changing the
+	// wire model, so a sweep can compare e.g. the "claude-fable-5
+	// prompt" on a newer model against that model's native prompt.
+	PromptModel string
+
 	// AnthropicWIF, when populated, instructs the runner to forward
 	// Anthropic Workload Identity Federation flags to every harness
 	// invocation. The four identifiers are non-secret per Anthropic's
@@ -474,6 +481,12 @@ func runTask(ctx context.Context, task types.EvalTask, cfg RunConfig, suiteArtif
 	// the operator-override semantic this field promises.
 	if cfg.Model != "" {
 		args = append(args, "--model", cfg.Model)
+	}
+
+	// Forward the prompt-model override with the same unconditional,
+	// Changed()-backed semantics as --model above.
+	if cfg.PromptModel != "" {
+		args = append(args, "--prompt-model", cfg.PromptModel)
 	}
 
 	cmd := exec.CommandContext(ctx, cfg.HarnessPath, args...)

--- a/eval/runner/runner_test.go
+++ b/eval/runner/runner_test.go
@@ -1187,3 +1187,124 @@ fi
 		t.Errorf("captured argv unexpectedly contains --model:\n%s", string(data))
 	}
 }
+
+// TestRunSuite_ForwardsPromptModelFlag pins that RunConfig.PromptModel
+// reaches the harness argv as --prompt-model (#492). Prompt/model
+// comparison sweeps rely on this; a silent drop would leave every run
+// rendering its native prompt while reporting a comparison.
+func TestRunSuite_ForwardsPromptModelFlag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake harness assumes POSIX sh")
+	}
+	harnessDir := t.TempDir()
+	harnessPath := filepath.Join(harnessDir, "fake-harness")
+	argvCapture := filepath.Join(harnessDir, "argv.txt")
+
+	script := fmt.Sprintf(`#!/bin/sh
+for a in "$@"; do printf '%%s\n' "$a"; done > %q
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$TRACE" ]; then
+  echo '{"id":"run-1","turns":1,"cost":0.01,"outcome":"success"}' > "$TRACE"
+fi
+`, argvCapture)
+	if err := os.WriteFile(harnessPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	suite := types.EvalSuite{
+		ID: "prompt-model-suite",
+		Tasks: []types.EvalTask{
+			{
+				ID:     "prompt-model-task",
+				Prompt: "noop",
+				Judge: types.EvalJudge{
+					Type:  "file-exists",
+					Paths: []string{"unused-by-prompt-model-test.txt"},
+				},
+			},
+		},
+	}
+
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harnessPath,
+		Model:       "claude-fable-6",
+		PromptModel: "claude-fable-5",
+	})
+	if err != nil {
+		t.Fatalf("RunSuite returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(argvCapture)
+	if err != nil {
+		t.Fatalf("reading captured argv: %v", err)
+	}
+	captured := string(data)
+	for _, frag := range []string{"--model", "claude-fable-6", "--prompt-model", "claude-fable-5"} {
+		if !strings.Contains(captured, frag+"\n") {
+			t.Errorf("captured argv missing %q\nfull capture:\n%s", frag, captured)
+		}
+	}
+}
+
+// An empty RunConfig.PromptModel must not emit --prompt-model at all,
+// mirroring TestRunSuite_NoModelFlagWhenUnset.
+func TestRunSuite_NoPromptModelFlagWhenUnset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake harness assumes POSIX sh")
+	}
+	harnessDir := t.TempDir()
+	harnessPath := filepath.Join(harnessDir, "fake-harness")
+	argvCapture := filepath.Join(harnessDir, "argv.txt")
+
+	script := fmt.Sprintf(`#!/bin/sh
+for a in "$@"; do printf '%%s\n' "$a"; done > %q
+TRACE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trace) TRACE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$TRACE" ]; then
+  echo '{"id":"run-1","turns":1,"cost":0.01,"outcome":"success"}' > "$TRACE"
+fi
+`, argvCapture)
+	if err := os.WriteFile(harnessPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	suite := types.EvalSuite{
+		ID: "no-prompt-model-suite",
+		Tasks: []types.EvalTask{
+			{
+				ID:     "no-prompt-model-task",
+				Prompt: "noop",
+				Judge: types.EvalJudge{
+					Type:  "file-exists",
+					Paths: []string{"unused-by-prompt-model-test.txt"},
+				},
+			},
+		},
+	}
+
+	_, err := RunSuite(context.Background(), suite, RunConfig{
+		HarnessPath: harnessPath,
+	})
+	if err != nil {
+		t.Fatalf("RunSuite returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(argvCapture)
+	if err != nil {
+		t.Fatalf("reading captured argv: %v", err)
+	}
+	if strings.Contains(string(data), "--prompt-model\n") {
+		t.Errorf("captured argv unexpectedly contains --prompt-model:\n%s", string(data))
+	}
+}

--- a/eval/spec/runconfig.go
+++ b/eval/spec/runconfig.go
@@ -135,8 +135,9 @@ type modelRouterSpec struct {
 }
 
 type promptBuilderSpec struct {
-	Type     string `hcl:"type"`
-	Template string `hcl:"template,optional"`
+	Type        string `hcl:"type"`
+	Template    string `hcl:"template,optional"`
+	PromptModel string `hcl:"prompt_model,optional"`
 }
 
 type contextStrategySpec struct {
@@ -501,7 +502,7 @@ func modelRouterSpecToType(s *modelRouterSpec) types.ModelRouterConfig {
 }
 
 func promptBuilderSpecToType(s *promptBuilderSpec) types.PromptBuilderConfig {
-	return types.PromptBuilderConfig{Type: s.Type, Template: s.Template}
+	return types.PromptBuilderConfig{Type: s.Type, Template: s.Template, PromptModel: s.PromptModel}
 }
 
 func contextStrategySpecToType(s *contextStrategySpec) types.ContextStrategyConfig {

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -564,6 +564,10 @@ type RunConfig struct {
 	// Optional. When set, used as the complete system prompt preamble,
 	// bypassing prompt_builder mode selection. Workspace path, turn budget,
 	// and dynamic_context sections are still appended by the harness.
+	// The value is used verbatim and never template-parsed, so prompts
+	// compiled by an external prompt-management system (e.g. Langfuse)
+	// pass through untouched. Mutually exclusive with
+	// prompt_builder.template and prompt_builder.prompt_model.
 	SystemPromptOverride string `protobuf:"bytes,23,opt,name=system_prompt_override,json=systemPromptOverride,proto3" json:"system_prompt_override,omitempty"`
 	// Optional. Human-readable label attached to the run for reporting.
 	// Surfaces in structured logs (sessionName), JSONL traces (config.sessionName),
@@ -2867,11 +2871,23 @@ type PromptBuilderConfig struct {
 	// Valid values:
 	//
 	//	"default"  — built-in per-mode templates (default).
-	//	"composed" — combines the default template with a custom suffix.
+	//	"composed" — fragment-based assembly of the same sections.
 	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
-	// For "composed": the custom template text appended to the default
-	// per-mode system prompt.
-	Template      string `protobuf:"bytes,2,opt,name=template,proto3" json:"template,omitempty"`
+	// Optional. An operator-supplied Go text/template that replaces the
+	// shipped mode prompt as the system prompt preamble. Structural
+	// sections (workspace path, turn budget, workspace tree, git status,
+	// dynamic context) are still appended. Renders against the same data
+	// surface as the shipped prompts (.Model, .Mode, .Tier, .ModelIs), so
+	// model-conditional content and prompt_model keep working for tuned
+	// prompts. Syntax-checked at config validation. Mutually exclusive
+	// with system_prompt_override.
+	Template string `protobuf:"bytes,2,opt,name=template,proto3" json:"template,omitempty"`
+	// Optional. Overrides the model identity the system prompt templates
+	// render against, without changing which model is called on the wire.
+	// Enables prompt/model comparison runs (e.g. the "claude-fable-5
+	// prompt" against a newer model). Empty derives the prompt model from
+	// the model router. Mutually exclusive with system_prompt_override.
+	PromptModel   string `protobuf:"bytes,3,opt,name=prompt_model,json=promptModel,proto3" json:"prompt_model,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2916,6 +2932,13 @@ func (x *PromptBuilderConfig) GetType() string {
 func (x *PromptBuilderConfig) GetTemplate() string {
 	if x != nil {
 		return x.Template
+	}
+	return ""
+}
+
+func (x *PromptBuilderConfig) GetPromptModel() string {
+	if x != nil {
+		return x.PromptModel
 	}
 	return ""
 }
@@ -4210,10 +4233,11 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\x12cheap_stop_reasons\x18\v \x03(\tR\x10cheapStopReasons\x1a=\n" +
 	"\x0fModeModelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"E\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"h\n" +
 	"\x13PromptBuilderConfig\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1a\n" +
-	"\btemplate\x18\x02 \x01(\tR\btemplate\"J\n" +
+	"\btemplate\x18\x02 \x01(\tR\btemplate\x12!\n" +
+	"\fprompt_model\x18\x03 \x01(\tR\vpromptModel\"J\n" +
 	"\x15ContextStrategyConfig\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1d\n" +
 	"\n" +

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -128,9 +128,15 @@ type harnessCLIOptions struct {
 	// Closed set, validated by ValidateRunConfig. Empty by default, which
 	// is the identity presentation: a bare invocation presents tools under
 	// their internal names exactly as before.
-	ToolsProfile  string
-	Model         string
-	Workspace     string
+	ToolsProfile string
+	Model        string
+
+	// PromptModel pins the model identity the system prompt templates
+	// render against (promptBuilder.promptModel, issue #492) without
+	// changing the wire model. Empty derives it from Model.
+	PromptModel string
+
+	Workspace string
 	MaxTurns      int
 	Timeout       int
 	TracePath     string
@@ -421,7 +427,7 @@ func buildHarnessRunConfigCore(opts harnessCLIOptions) (*types.RunConfig, error)
 			Provider: opts.ProviderType,
 			Model:    opts.Model,
 		},
-		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default", PromptModel: opts.PromptModel},
 		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window", MaxTokens: 200000},
 		Executor: types.ExecutorConfig{
 			Type:              executorType,
@@ -954,6 +960,9 @@ func applyOverrides(cmd *cobra.Command, cfg *types.RunConfig, args []string) err
 		// on the router (per-mode/dynamic) — for static routers this is
 		// where the active model lives.
 		cfg.ModelRouter.Model, _ = f.GetString("model")
+	}
+	if changed("prompt-model") {
+		cfg.PromptBuilder.PromptModel, _ = f.GetString("prompt-model")
 	}
 	if changed("api-key-ref") {
 		cfg.Provider.APIKeyRef, _ = f.GetString("api-key-ref")

--- a/harness/cmd/stirrup/cmd/harness.go
+++ b/harness/cmd/stirrup/cmd/harness.go
@@ -136,7 +136,7 @@ type harnessCLIOptions struct {
 	// changing the wire model. Empty derives it from Model.
 	PromptModel string
 
-	Workspace string
+	Workspace     string
 	MaxTurns      int
 	Timeout       int
 	TracePath     string

--- a/harness/cmd/stirrup/cmd/harness_test.go
+++ b/harness/cmd/stirrup/cmd/harness_test.go
@@ -2103,6 +2103,40 @@ func TestApplyOverrides_FollowupGraceZeroClears(t *testing.T) {
 // override path must rely on flags.Changed() instead, or every run
 // that omits the flag silently rewrites a file-provided non-zero
 // value to greedy decoding.
+// --prompt-model must follow the Changed() discipline: a config file's
+// promptBuilder.promptModel survives when the flag is unset, and an
+// explicit flag overrides it (#492).
+func TestApplyOverrides_PromptModelChangedGated(t *testing.T) {
+	t.Run("unset leaves file value alone", func(t *testing.T) {
+		cmd := newTestHarnessCommand()
+		cfg := baseFileConfig()
+		cfg.PromptBuilder.PromptModel = "claude-fable-5"
+
+		if err := applyOverrides(cmd, cfg, nil); err != nil {
+			t.Fatalf("applyOverrides: %v", err)
+		}
+		if cfg.PromptBuilder.PromptModel != "claude-fable-5" {
+			t.Errorf("unset --prompt-model must preserve file value, got %q", cfg.PromptBuilder.PromptModel)
+		}
+	})
+
+	t.Run("explicit flag overrides file value", func(t *testing.T) {
+		cmd := newTestHarnessCommand()
+		cfg := baseFileConfig()
+		cfg.PromptBuilder.PromptModel = "claude-fable-5"
+
+		if err := cmd.Flags().Set("prompt-model", "claude-fable-6"); err != nil {
+			t.Fatalf("set prompt-model: %v", err)
+		}
+		if err := applyOverrides(cmd, cfg, nil); err != nil {
+			t.Fatalf("applyOverrides: %v", err)
+		}
+		if cfg.PromptBuilder.PromptModel != "claude-fable-6" {
+			t.Errorf("--prompt-model override failed, got %q", cfg.PromptBuilder.PromptModel)
+		}
+	})
+}
+
 func TestApplyOverrides_TemperatureChangedDisambiguatesZero(t *testing.T) {
 	t.Run("unset leaves file value alone", func(t *testing.T) {
 		cmd := newTestHarnessCommand()

--- a/harness/cmd/stirrup/cmd/promptrender.go
+++ b/harness/cmd/stirrup/cmd/promptrender.go
@@ -95,7 +95,9 @@ func runPromptRenderWithIO(cmd *cobra.Command, stdout, stderr io.Writer) error {
 		}
 	}
 
-	fmt.Fprintf(stderr, "prompt model: %q, tier: %s\n", promptModel, prompt.TierFor(promptModel))
-	fmt.Fprintln(stdout, rendered)
+	_, _ = fmt.Fprintf(stderr, "prompt model: %q, tier: %s\n", promptModel, prompt.TierFor(promptModel))
+	if _, err := fmt.Fprintln(stdout, rendered); err != nil {
+		return fmt.Errorf("write rendered prompt: %w", err)
+	}
 	return nil
 }

--- a/harness/cmd/stirrup/cmd/promptrender.go
+++ b/harness/cmd/stirrup/cmd/promptrender.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+)
+
+// promptCmd is the root of the `stirrup prompt …` subcommand family.
+// The subcommands inspect prompt-builder output without booting the
+// agentic loop or contacting a provider.
+var promptCmd = &cobra.Command{
+	Use:   "prompt",
+	Short: "Inspect system prompt rendering",
+	Long: `Inspect system prompt rendering without running a turn.
+
+Subcommands:
+  render  Render a mode's system prompt template for a model and print
+          the result. Side-effect-free; needs no API key.`,
+}
+
+// promptRenderCmd renders the shipped mode prompt templates (#492)
+// offline so prompt content can be iterated on and diffed across
+// models without a provider call or credentials.
+var promptRenderCmd = &cobra.Command{
+	Use:   "render",
+	Short: "Render a mode's system prompt template for a model",
+	Long: `Render the system prompt preamble for the supplied (--mode,
+--prompt-model) pair and print it to stdout. Only the templated
+preamble is rendered: the structural sections the harness appends at
+run time (working directory, turn budget, workspace tree, git status,
+dynamic context) depend on a live workspace and are omitted.
+
+By default the shipped, embedded mode template is rendered. Passing
+--template <path> renders an operator template file instead — the same
+content promptBuilder.template accepts — so tuned prompts can be
+previewed against models before deployment.
+
+The resolved tier is printed to stderr so a shell capturing stdout
+still gets only prompt text. A model matching no tier table renders
+the base prompt ("default" tier); this is the documented fall-through
+for unrecognised models, not an error.`,
+	Args: cobra.NoArgs,
+	RunE: runPromptRender,
+}
+
+func init() {
+	rootCmd.AddCommand(promptCmd)
+	promptCmd.AddCommand(promptRenderCmd)
+
+	f := promptRenderCmd.Flags()
+	f.StringP("mode", "m", "planning", "Run mode whose prompt to render: execution, planning, review, research, toil.")
+	f.String("prompt-model", "", "Model identity to render the template against (same semantics as the harness --prompt-model flag). Empty renders the base prompt only.")
+	f.String("template", "", "Path to an operator Go text/template file to render instead of the shipped mode template (the same content promptBuilder.template accepts).")
+}
+
+func runPromptRender(cmd *cobra.Command, _ []string) error {
+	return runPromptRenderWithIO(cmd, cmd.OutOrStdout(), cmd.ErrOrStderr())
+}
+
+// runPromptRenderWithIO is the testable seam for runPromptRender: it
+// accepts explicit stdout and stderr so tests can assert the prompt
+// text and tier report separately through the real cobra wiring.
+func runPromptRenderWithIO(cmd *cobra.Command, stdout, stderr io.Writer) error {
+	f := cmd.Flags()
+	mode, _ := f.GetString("mode")
+	promptModel, _ := f.GetString("prompt-model")
+	templatePath, _ := f.GetString("template")
+
+	data := prompt.TemplateData{Model: promptModel, Mode: mode}
+
+	var rendered string
+	if templatePath != "" {
+		raw, err := os.ReadFile(templatePath)
+		if err != nil {
+			return fmt.Errorf("read template file: %w", err)
+		}
+		builder, err := prompt.NewTemplatePromptBuilder(string(raw), data)
+		if err != nil {
+			return err
+		}
+		rendered, err = builder.Build(cmd.Context(), prompt.PromptContext{Mode: mode, Model: promptModel})
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		rendered, err = prompt.RenderModePrompt(mode, prompt.PromptContext{Mode: mode, Model: promptModel})
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(stderr, "prompt model: %q, tier: %s\n", promptModel, prompt.TierFor(promptModel))
+	fmt.Fprintln(stdout, rendered)
+	return nil
+}

--- a/harness/cmd/stirrup/cmd/promptrender_test.go
+++ b/harness/cmd/stirrup/cmd/promptrender_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rxbynerd/stirrup/harness/internal/prompt"
+)
+
+func newTestPromptRenderCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "render", Args: cobra.NoArgs, RunE: runPromptRender}
+	f := cmd.Flags()
+	f.StringP("mode", "m", "planning", "")
+	f.String("prompt-model", "", "")
+	f.String("template", "", "")
+	return cmd
+}
+
+func TestPromptRender_ShippedTemplate(t *testing.T) {
+	cmd := newTestPromptRenderCommand()
+	if err := cmd.Flags().Set("mode", "execution"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("prompt-model", "claude-fable-5"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := runPromptRenderWithIO(cmd, &stdout, &stderr); err != nil {
+		t.Fatalf("runPromptRenderWithIO: %v", err)
+	}
+
+	want, err := prompt.RenderModePrompt("execution", prompt.PromptContext{Mode: "execution", Model: "claude-fable-5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != want {
+		t.Errorf("stdout differs from RenderModePrompt output:\n%s", got)
+	}
+	if !strings.Contains(stderr.String(), "tier: frontier") {
+		t.Errorf("stderr should report the tier, got: %q", stderr.String())
+	}
+}
+
+func TestPromptRender_UnknownModeFails(t *testing.T) {
+	cmd := newTestPromptRenderCommand()
+	if err := cmd.Flags().Set("mode", "no-such-mode"); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := runPromptRenderWithIO(cmd, &stdout, &stderr); err == nil {
+		t.Fatal("expected error for unknown mode")
+	}
+}
+
+func TestPromptRender_OperatorTemplateFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tuned.tmpl")
+	content := `Tuned preamble.{{if eq .Tier "open-weight"}} Follow the loop.{{end}}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestPromptRenderCommand()
+	for k, v := range map[string]string{"mode": "execution", "prompt-model": "gemma-4", "template": path} {
+		if err := cmd.Flags().Set(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := runPromptRenderWithIO(cmd, &stdout, &stderr); err != nil {
+		t.Fatalf("runPromptRenderWithIO: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Tuned preamble. Follow the loop.") {
+		t.Errorf("operator template not rendered with tier branch: %q", got)
+	}
+	if !strings.Contains(stderr.String(), "tier: open-weight") {
+		t.Errorf("stderr should report the tier, got: %q", stderr.String())
+	}
+}
+
+func TestPromptRender_BadTemplateFileFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broken.tmpl")
+	if err := os.WriteFile(path, []byte("{{criticlevel}}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newTestPromptRenderCommand()
+	if err := cmd.Flags().Set("template", path); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := runPromptRenderWithIO(cmd, &stdout, &stderr); err == nil {
+		t.Fatal("expected error for mustache-style placeholder in template file")
+	}
+}

--- a/harness/cmd/stirrup/cmd/runconfigbuilder.go
+++ b/harness/cmd/stirrup/cmd/runconfigbuilder.go
@@ -416,6 +416,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 	mode, _ := f.GetString("mode")
 	sessionName, _ := f.GetString("name")
 	model, _ := f.GetString("model")
+	promptModel, _ := f.GetString("prompt-model")
 	providerType, _ := f.GetString("provider")
 	apiKeyRef, _ := f.GetString("api-key-ref")
 	baseURL, _ := f.GetString("base-url")
@@ -563,6 +564,7 @@ func buildFlagOnlyRunConfig(cmd *cobra.Command, args []string) (*types.RunConfig
 		AzureClientID:                azureClientID,
 		AzureScope:                   azureScope,
 		Model:                        model,
+		PromptModel:                  promptModel,
 		Workspace:                    workspace,
 		MaxTurns:                     maxTurns,
 		Timeout:                      timeout,

--- a/harness/cmd/stirrup/cmd/runconfigflags.go
+++ b/harness/cmd/stirrup/cmd/runconfigflags.go
@@ -23,6 +23,7 @@ func addRunConfigFlags(cmd *cobra.Command) {
 	f.String("config", "", "Path to a JSON RunConfig file (mirrors proto/harness/v1/harness.proto). Use \"-\" to read from stdin. Explicit flags still override individual fields; unset flags do not.")
 	f.StringP("mode", "m", "planning", "Run mode: execution, planning, review, research, toil. Default is the read-only `planning` mode (no edits, no shell, deny-side-effects policy); pass `--mode execution` for editable runs with shell access.")
 	f.String("model", "claude-sonnet-4-6", "Model to use (sets ModelRouter.Model; for dynamic/per-mode routers in --config files this only sets the default-model field, not the cheap/expensive override)")
+	f.String("prompt-model", "", "Render the shipped system prompt templates as if for this model (sets promptBuilder.promptModel). The model called on the wire is unchanged — combine with --model to compare a prompt tuned for one model against another. Empty derives the prompt model from --model.")
 	f.String("provider", "anthropic", "Provider type: anthropic, bedrock, gemini (Vertex AI), openai-compatible (Chat Completions), openai-responses (Responses API). The two OpenAI variants speak different wire formats and must be selected explicitly.")
 	f.String("api-key-ref", "secret://ANTHROPIC_API_KEY", "Secret reference for API key")
 	f.String("base-url", "", "API base URL for openai-compatible / openai-responses providers (e.g. https://<resource>.openai.azure.com/openai/v1)")

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -96,7 +96,10 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	rtr := buildRouter(config.ModelRouter, config.Provider.Type)
 
 	// 2. Prompt builder.
-	pb := buildPromptBuilder(config.PromptBuilder, config.SystemPromptOverride)
+	pb, err := buildPromptBuilder(config)
+	if err != nil {
+		return nil, fmt.Errorf("build prompt builder: %w", err)
+	}
 
 	// 3. Executor (built early because context strategy may need it).
 	// Thread the security logger into the container executor so the
@@ -781,7 +784,7 @@ func buildRouter(cfg types.ModelRouterConfig, defaultProvider string) router.Mod
 		if defaultProvider == "" {
 			defaultProvider = "anthropic"
 		}
-		return router.NewStaticRouter(defaultProvider, "claude-sonnet-4-6")
+		return router.NewStaticRouter(defaultProvider, types.DefaultModel)
 	}
 }
 
@@ -798,7 +801,7 @@ func buildPerModeRouter(cfg types.ModelRouterConfig, fallbackProvider string) *r
 	}
 	defaultModel := cfg.Model
 	if defaultModel == "" {
-		defaultModel = "claude-sonnet-4-6"
+		defaultModel = types.DefaultModel
 	}
 	defaultSel := router.ModelSelection{Provider: defaultProvider, Model: defaultModel}
 
@@ -827,7 +830,7 @@ func buildDynamicRouter(cfg types.ModelRouterConfig, fallbackProvider string) *r
 	}
 	defaultModel := cfg.Model
 	if defaultModel == "" {
-		defaultModel = "claude-sonnet-4-6"
+		defaultModel = types.DefaultModel
 	}
 
 	cheapProvider := cfg.CheapProvider
@@ -845,7 +848,7 @@ func buildDynamicRouter(cfg types.ModelRouterConfig, fallbackProvider string) *r
 	}
 	expensiveModel := cfg.ExpensiveModel
 	if expensiveModel == "" {
-		expensiveModel = "claude-sonnet-4-6"
+		expensiveModel = types.DefaultModel
 	}
 
 	turnThreshold := cfg.ExpensiveTurnThreshold
@@ -873,19 +876,33 @@ func buildDynamicRouter(cfg types.ModelRouterConfig, fallbackProvider string) *r
 	})
 }
 
-func buildPromptBuilder(cfg types.PromptBuilderConfig, systemPromptOverride string) prompt.PromptBuilder {
-	if systemPromptOverride != "" {
-		return prompt.NewOverridePromptBuilder(systemPromptOverride)
+// buildPromptBuilder selects the prompt preamble source. Precedence:
+// systemPromptOverride (raw, never template-parsed), then an operator
+// template (promptBuilder.template), then the embedded mode templates.
+// ValidateRunConfig rejects the override combined with either template
+// field, so the precedence never silently discards operator input. The
+// operator template is trial-rendered against the run's resolved prompt
+// model and mode — the exact render the loop will perform — so template
+// execution errors fail at construction.
+func buildPromptBuilder(config *types.RunConfig) (prompt.PromptBuilder, error) {
+	if config.SystemPromptOverride != "" {
+		return prompt.NewOverridePromptBuilder(config.SystemPromptOverride), nil
 	}
-	switch cfg.Type {
+	if tmpl := config.PromptBuilder.Template; tmpl != "" {
+		return prompt.NewTemplatePromptBuilder(tmpl, prompt.TemplateData{
+			Model: config.EffectivePromptModel(),
+			Mode:  config.Mode,
+		})
+	}
+	switch config.PromptBuilder.Type {
 	case "composed":
 		return prompt.NewComposedPromptBuilder(
 			prompt.WithFragments(prompt.DefaultComposedFragments()...),
-		)
+		), nil
 	case "default", "":
-		return prompt.NewDefaultPromptBuilder()
+		return prompt.NewDefaultPromptBuilder(), nil
 	default:
-		return prompt.NewDefaultPromptBuilder()
+		return prompt.NewDefaultPromptBuilder(), nil
 	}
 }
 

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -224,38 +224,89 @@ func TestBuildDynamicRouter_CustomThresholds(t *testing.T) {
 
 // --- buildPromptBuilder ---
 
+func mustBuildPromptBuilder(t *testing.T, config *types.RunConfig) prompt.PromptBuilder {
+	t.Helper()
+	pb, err := buildPromptBuilder(config)
+	if err != nil {
+		t.Fatalf("buildPromptBuilder: %v", err)
+	}
+	return pb
+}
+
 func TestBuildPromptBuilder_Default(t *testing.T) {
-	pb := buildPromptBuilder(types.PromptBuilderConfig{Type: "default"}, "")
+	pb := mustBuildPromptBuilder(t, &types.RunConfig{PromptBuilder: types.PromptBuilderConfig{Type: "default"}})
 	if _, ok := pb.(*prompt.DefaultPromptBuilder); !ok {
 		t.Fatalf("expected DefaultPromptBuilder, got %T", pb)
 	}
 }
 
 func TestBuildPromptBuilder_Empty(t *testing.T) {
-	pb := buildPromptBuilder(types.PromptBuilderConfig{}, "")
+	pb := mustBuildPromptBuilder(t, &types.RunConfig{})
 	if _, ok := pb.(*prompt.DefaultPromptBuilder); !ok {
 		t.Fatalf("expected DefaultPromptBuilder for empty type, got %T", pb)
 	}
 }
 
 func TestBuildPromptBuilder_Composed(t *testing.T) {
-	pb := buildPromptBuilder(types.PromptBuilderConfig{Type: "composed"}, "")
+	pb := mustBuildPromptBuilder(t, &types.RunConfig{PromptBuilder: types.PromptBuilderConfig{Type: "composed"}})
 	if _, ok := pb.(*prompt.ComposedPromptBuilder); !ok {
 		t.Fatalf("expected ComposedPromptBuilder, got %T", pb)
 	}
 }
 
 func TestBuildPromptBuilder_UnknownFallsBackToDefault(t *testing.T) {
-	pb := buildPromptBuilder(types.PromptBuilderConfig{Type: "nonexistent"}, "")
+	pb := mustBuildPromptBuilder(t, &types.RunConfig{PromptBuilder: types.PromptBuilderConfig{Type: "nonexistent"}})
 	if _, ok := pb.(*prompt.DefaultPromptBuilder); !ok {
 		t.Fatalf("expected DefaultPromptBuilder for unknown type, got %T", pb)
 	}
 }
 
 func TestBuildPromptBuilder_SystemPromptOverride(t *testing.T) {
-	pb := buildPromptBuilder(types.PromptBuilderConfig{Type: "default"}, "Custom system prompt")
+	pb := mustBuildPromptBuilder(t, &types.RunConfig{
+		PromptBuilder:        types.PromptBuilderConfig{Type: "default"},
+		SystemPromptOverride: "Custom system prompt",
+	})
 	if _, ok := pb.(*prompt.ComposedPromptBuilder); !ok {
 		t.Fatalf("expected ComposedPromptBuilder for override, got %T", pb)
+	}
+}
+
+func TestBuildPromptBuilder_OperatorTemplate(t *testing.T) {
+	pb := mustBuildPromptBuilder(t, &types.RunConfig{
+		Mode:          "execution",
+		PromptBuilder: types.PromptBuilderConfig{Template: `Tuned.{{if eq .Tier "frontier"}} Act when ready.{{end}}`},
+	})
+	if _, ok := pb.(*prompt.ComposedPromptBuilder); !ok {
+		t.Fatalf("expected ComposedPromptBuilder for operator template, got %T", pb)
+	}
+}
+
+// A template that parses but fails at execution (unknown field) must be
+// caught by the trial render at construction, not at run start.
+func TestBuildPromptBuilder_OperatorTemplateExecErrorFailsFast(t *testing.T) {
+	_, err := buildPromptBuilder(&types.RunConfig{
+		Mode:          "execution",
+		PromptBuilder: types.PromptBuilderConfig{Template: "hello {{.NoSuchField}}"},
+	})
+	if err == nil {
+		t.Fatal("expected error from trial render")
+	}
+}
+
+// The override wins over an operator template. ValidateRunConfig rejects
+// the combination, but the factory's precedence must still be safe if a
+// caller skips validation.
+func TestBuildPromptBuilder_OverrideWinsOverTemplate(t *testing.T) {
+	pb := mustBuildPromptBuilder(t, &types.RunConfig{
+		SystemPromptOverride: "Raw override with {{not a template}}",
+		PromptBuilder:        types.PromptBuilderConfig{Template: "Tuned."},
+	})
+	got, err := pb.Build(t.Context(), prompt.PromptContext{Mode: "execution"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, "Raw override with {{not a template}}") {
+		t.Fatalf("override not used verbatim: %q", got)
 	}
 }
 

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -222,10 +222,12 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	}
 	l.observeSensitive(runCtx, config, "dynamic_context", 0, sortedContextValues(dynamicContext))
 
+	promptModel := config.EffectivePromptModel()
 	systemPrompt, err := l.Prompt.Build(runCtx, prompt.PromptContext{
 		Mode:           config.Mode,
 		Workspace:      config.Executor.Workspace,
 		MaxTurns:       config.MaxTurns,
+		Model:          promptModel,
 		DynamicContext: dynamicContext,
 	})
 	if err != nil {
@@ -240,6 +242,14 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 	// owns the scrub-and-gate logic, so this is unconditional.
 	if recorder, ok := l.Trace.(trace.SystemInstructionsRecorder); ok {
 		recorder.RecordSystemInstructions(systemPrompt)
+	}
+
+	// Record which model identity the prompt rendered against and the
+	// guidance tier it selected (#492). Unlike system instructions this
+	// is config metadata, not content, so the emitter records it
+	// regardless of content capture.
+	if recorder, ok := l.Trace.(trace.PromptResolutionRecorder); ok {
+		recorder.RecordPromptResolution(promptModel, prompt.TierFor(promptModel))
 	}
 
 	// Pre-run lifecycle hooks (issue #461): operator-authored setup

--- a/harness/internal/core/loop_test.go
+++ b/harness/internal/core/loop_test.go
@@ -233,6 +233,42 @@ func TestLoop_SanitizesDynamicContextBeforePromptBuildAndEmitsEvents(t *testing.
 	}
 }
 
+// The loop must thread the resolved prompt model into PromptContext so
+// the mode templates render against it (#492): the promptModel override
+// when set, otherwise the router's model.
+func TestLoop_ThreadsPromptModelIntoPromptContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		promptModel string
+		want        string
+	}{
+		{name: "router model by default", promptModel: "", want: "claude-sonnet-4-6"},
+		{name: "promptModel override wins", promptModel: "claude-fable-5", want: "claude-fable-5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prov := &mockProvider{
+				events: []types.StreamEvent{
+					{Type: "text_delta", Text: "Done"},
+					{Type: "message_complete", StopReason: "end_turn"},
+				},
+			}
+			loop := buildTestLoop(prov)
+			capturingPrompt := &capturingPromptBuilder{}
+			loop.Prompt = capturingPrompt
+			config := buildTestConfig()
+			config.PromptBuilder.PromptModel = tt.promptModel
+
+			if _, err := loop.Run(context.Background(), config); err != nil {
+				t.Fatalf("Run() error: %v", err)
+			}
+			if got := capturingPrompt.last.Model; got != tt.want {
+				t.Fatalf("PromptContext.Model = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoop_ToolUseAndContinue(t *testing.T) {
 	// First call: model requests a tool call.
 	// Second call: model provides final text.

--- a/harness/internal/prompt/composed.go
+++ b/harness/internal/prompt/composed.go
@@ -100,6 +100,20 @@ func (f *modeFragment) Render(_ context.Context, pc PromptContext) (string, erro
 	return "", fmt.Errorf("no text for mode %q and no default", pc.Mode)
 }
 
+// modeTemplateFragment renders the embedded mode prompt template for the
+// current mode against the prompt model (see RenderModePrompt).
+type modeTemplateFragment struct{}
+
+// ModeTemplateFragment returns a fragment that renders the embedded,
+// model-conditional system prompt template for the current mode.
+func ModeTemplateFragment() PromptFragment {
+	return &modeTemplateFragment{}
+}
+
+func (f *modeTemplateFragment) Render(_ context.Context, pc PromptContext) (string, error) {
+	return RenderModePrompt(pc.Mode, pc)
+}
+
 // dynamicContextFragment wraps the PromptContext's DynamicContext entries in
 // <untrusted_context> tags, matching the security convention used by
 // DefaultPromptBuilder.
@@ -235,7 +249,7 @@ func (f *gitStatusFragment) Render(ctx context.Context, pc PromptContext) (strin
 // DefaultPromptBuilder but with composable pieces.
 func DefaultComposedFragments() []PromptFragment {
 	return []PromptFragment{
-		ModeFragment(ModePrompts()),
+		ModeTemplateFragment(),
 		WorkspacePathFragment(),
 		TurnBudgetFragment(),
 		WorkspaceTreeFragment(),

--- a/harness/internal/prompt/default.go
+++ b/harness/internal/prompt/default.go
@@ -20,13 +20,13 @@ func NewDefaultPromptBuilder() *DefaultPromptBuilder {
 
 // Build constructs the system prompt for the given context.
 func (b *DefaultPromptBuilder) Build(_ context.Context, pc PromptContext) (string, error) {
-	tmpl, ok := ModePrompts()[pc.Mode]
-	if !ok {
-		return "", fmt.Errorf("unknown mode: %q", pc.Mode)
+	preamble, err := RenderModePrompt(pc.Mode, pc)
+	if err != nil {
+		return "", err
 	}
 
 	var sb strings.Builder
-	sb.WriteString(tmpl)
+	sb.WriteString(preamble)
 
 	if pc.Workspace != "" {
 		fmt.Fprintf(&sb, "\n\nWorking directory: %s", pc.Workspace)

--- a/harness/internal/prompt/modeltier.go
+++ b/harness/internal/prompt/modeltier.go
@@ -1,0 +1,96 @@
+package prompt
+
+import "path"
+
+// Prompt tiers group models by how much prompting they need. Frontier
+// models degrade under over-prescriptive prompts and get lean additions;
+// open-weight models benefit from explicit process scaffolding; everything
+// else renders the base prompt only, so an unrecognised model is always
+// safe (issue #492's fall-through requirement).
+const (
+	TierFrontier   = "frontier"
+	TierOpenWeight = "open-weight"
+	TierDefault    = "default"
+)
+
+// Tier membership is defined here and nowhere else: adding a new model to
+// a tier is a one-line change to one of these tables. Globs use path.Match
+// with the same semantics as the provider quirks registry — "*" does not
+// cross "/", so gateway-prefixed IDs (e.g. "openrouter/gemma-4") need the
+// "*/" variants that withPrefixedVariants adds.
+var (
+	frontierModelGlobs = withPrefixedVariants(
+		"claude-fable-5*",
+		"claude-mythos-5*",
+		"claude-sonnet-5*",
+		"claude-opus-4-8*",
+		"gpt-5.5*",
+		"gpt-5.6*",
+	)
+
+	openWeightModelGlobs = withPrefixedVariants(
+		"gemma*",
+		"glm-*",
+		"deepseek*",
+		"qwen*",
+	)
+)
+
+func withPrefixedVariants(globs ...string) []string {
+	out := make([]string, 0, len(globs)*2)
+	for _, g := range globs {
+		out = append(out, g, "*/"+g)
+	}
+	return out
+}
+
+// TemplateData is the data surface system prompt templates render against.
+// Both the shipped mode prompts and operator-supplied templates
+// (promptBuilder.template) see the same surface. Matching is exposed as
+// methods rather than a FuncMap so templates parse once and render
+// concurrently, and so a bare text/template.Parse in ValidateRunConfig is
+// a faithful syntax check.
+type TemplateData struct {
+	// Model is the resolved prompt model (see PromptContext.Model).
+	Model string
+	// Mode is the run mode ("execution", "planning", ...).
+	Mode string
+}
+
+// ModelIs reports whether the prompt model matches any of the given
+// path.Match globs. A malformed glob counts as a non-match rather than an
+// error so a typo in one branch cannot take down prompt rendering.
+func (d TemplateData) ModelIs(globs ...string) bool {
+	return modelMatchesAny(d.Model, globs)
+}
+
+// Tier returns the prompt tier for the model: TierFrontier,
+// TierOpenWeight, or TierDefault when the model matches neither table.
+func (d TemplateData) Tier() string {
+	return TierFor(d.Model)
+}
+
+// TierFor resolves a model identity to its prompt tier. Exported for the
+// trace emitter, which records the tier alongside the prompt model.
+func TierFor(model string) string {
+	switch {
+	case modelMatchesAny(model, frontierModelGlobs):
+		return TierFrontier
+	case modelMatchesAny(model, openWeightModelGlobs):
+		return TierOpenWeight
+	default:
+		return TierDefault
+	}
+}
+
+func modelMatchesAny(model string, globs []string) bool {
+	if model == "" {
+		return false
+	}
+	for _, g := range globs {
+		if ok, err := path.Match(g, model); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}

--- a/harness/internal/prompt/modeltier_test.go
+++ b/harness/internal/prompt/modeltier_test.go
@@ -1,0 +1,119 @@
+package prompt
+
+import (
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestTierFor(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{"claude-fable-5", TierFrontier},
+		{"claude-fable-5-20260115", TierFrontier},
+		{"claude-mythos-5", TierFrontier},
+		{"claude-sonnet-5", TierFrontier},
+		{"claude-opus-4-8", TierFrontier},
+		{"gpt-5.5", TierFrontier},
+		{"gpt-5.6-turbo", TierFrontier},
+		{"openrouter/claude-fable-5", TierFrontier},
+		{"gemma-4-27b", TierOpenWeight},
+		{"gemma3", TierOpenWeight},
+		{"glm-5.2", TierOpenWeight},
+		{"deepseek-v4", TierOpenWeight},
+		{"qwen3-coder", TierOpenWeight},
+		{"org/gemma-4", TierOpenWeight},
+		{"deepseek/deepseek-v4", TierOpenWeight},
+		{"claude-sonnet-4-6", TierDefault},
+		{"claude-haiku-4-5-20251001", TierDefault},
+		{"gpt-4o", TierDefault},
+		{"some-brand-new-model", TierDefault},
+		{"", TierDefault},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := TierFor(tt.model); got != tt.want {
+				t.Errorf("TierFor(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTemplateData_ModelIs(t *testing.T) {
+	d := TemplateData{Model: "claude-fable-5-20260115"}
+	if !d.ModelIs("claude-fable-5*") {
+		t.Error("expected match for claude-fable-5*")
+	}
+	if !d.ModelIs("gpt-5.6*", "claude-fable-5*") {
+		t.Error("expected multi-glob OR to match on the second glob")
+	}
+	if d.ModelIs("gpt-5.6*") {
+		t.Error("expected no match for gpt-5.6*")
+	}
+	// path.Match does not cross "/": a bare glob must not match a
+	// gateway-prefixed ID.
+	prefixed := TemplateData{Model: "openrouter/claude-fable-5"}
+	if prefixed.ModelIs("claude-fable-5*") {
+		t.Error("bare glob must not cross the / boundary")
+	}
+	if !prefixed.ModelIs("*/claude-fable-5*") {
+		t.Error("expected */ variant to match the prefixed ID")
+	}
+	// A malformed glob is a non-match, not an error.
+	if d.ModelIs("[unclosed") {
+		t.Error("malformed glob must not match")
+	}
+	// Empty model never matches.
+	empty := TemplateData{Model: ""}
+	if empty.ModelIs("*") {
+		t.Error("empty model must not match any glob")
+	}
+}
+
+// The tier tables must stay disjoint: a model matching both would get
+// whichever tier TierFor checks first, hiding a classification bug.
+func TestTierGlobs_DisjointAndWellFormed(t *testing.T) {
+	samples := []string{
+		"claude-fable-5", "claude-mythos-5", "claude-sonnet-5",
+		"claude-opus-4-8", "gpt-5.5", "gpt-5.6",
+		"gemma-4", "glm-5.2", "deepseek-v4", "qwen3",
+		"openrouter/claude-fable-5", "org/gemma-4",
+	}
+	for _, tables := range [][]string{frontierModelGlobs, openWeightModelGlobs} {
+		for _, g := range tables {
+			if _, err := path.Match(g, "probe"); err != nil {
+				t.Errorf("glob %q does not compile: %v", g, err)
+			}
+		}
+	}
+	for _, m := range samples {
+		inFrontier := modelMatchesAny(m, frontierModelGlobs)
+		inOpenWeight := modelMatchesAny(m, openWeightModelGlobs)
+		if inFrontier && inOpenWeight {
+			t.Errorf("model %q matches both tier tables", m)
+		}
+	}
+}
+
+// Every tier table entry has a "*/"-prefixed sibling so gateway-routed
+// model IDs classify the same as their bare forms.
+func TestTierGlobs_PrefixedVariantsPresent(t *testing.T) {
+	for _, table := range [][]string{frontierModelGlobs, openWeightModelGlobs} {
+		bare := make(map[string]bool)
+		prefixed := make(map[string]bool)
+		for _, g := range table {
+			if rest, ok := strings.CutPrefix(g, "*/"); ok {
+				prefixed[rest] = true
+			} else {
+				bare[g] = true
+			}
+		}
+		for g := range bare {
+			if !prefixed[g] {
+				t.Errorf("glob %q has no */ variant", g)
+			}
+		}
+	}
+}

--- a/harness/internal/prompt/modes.go
+++ b/harness/internal/prompt/modes.go
@@ -2,9 +2,11 @@ package prompt
 
 import (
 	"embed"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
+	"text/template"
 )
 
 //go:embed systemprompts/*.md
@@ -50,4 +52,46 @@ func ModePrompts() map[string]string {
 		}
 	})
 	return modePromptsMap
+}
+
+var (
+	modeTemplatesOnce sync.Once
+	modeTemplatesMap  map[string]*template.Template
+)
+
+// modeTemplates parses each embedded mode prompt as a Go text/template.
+// Like ModePrompts, it panics on failure: an embedded prompt that does
+// not parse is a build-time packaging error (typically a stray "{{" from
+// a prompt edit) that the parse-all test in modes_test.go catches before
+// it can ship.
+func modeTemplates() map[string]*template.Template {
+	modeTemplatesOnce.Do(func() {
+		prompts := ModePrompts()
+		modeTemplatesMap = make(map[string]*template.Template, len(prompts))
+		for mode, text := range prompts {
+			tmpl, err := template.New(mode).Parse(text)
+			if err != nil {
+				panic("prompt: embedded system prompt " + mode + ".md does not parse as a text/template: " + err.Error())
+			}
+			modeTemplatesMap[mode] = tmpl
+		}
+	})
+	return modeTemplatesMap
+}
+
+// RenderModePrompt renders the embedded system prompt template for the
+// given mode against the prompt model carried in pc (see TemplateData for
+// the surface templates can use). A model matching neither tier table
+// renders the base prompt text only, so unrecognised models always get a
+// functional prompt.
+func RenderModePrompt(mode string, pc PromptContext) (string, error) {
+	tmpl, ok := modeTemplates()[mode]
+	if !ok {
+		return "", fmt.Errorf("unknown mode: %q", mode)
+	}
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, TemplateData{Model: pc.Model, Mode: mode}); err != nil {
+		return "", fmt.Errorf("render mode prompt %q: %w", mode, err)
+	}
+	return strings.TrimSpace(sb.String()), nil
 }

--- a/harness/internal/prompt/operator_template.go
+++ b/harness/internal/prompt/operator_template.go
@@ -1,0 +1,52 @@
+package prompt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// NewTemplatePromptBuilder returns a ComposedPromptBuilder whose preamble
+// is an operator-supplied Go text/template (promptBuilder.template),
+// replacing the shipped mode prompt. The template renders against the
+// same TemplateData surface as the shipped prompts, so model-conditional
+// content and the promptModel override keep working for tuned prompts.
+// The structural fragments (workspace path, turn budget, workspace tree,
+// git status, and dynamic context with untrusted_context wrapping) are
+// still appended, matching NewOverridePromptBuilder.
+//
+// The template is parsed and trial-rendered against trial — the run's
+// resolved prompt model and mode — so execution-time errors (an unknown
+// field, a misspelled method) surface at component construction instead
+// of at run start. Rendering is pure string work: TemplateData exposes no
+// filesystem, environment, or network reach.
+func NewTemplatePromptBuilder(text string, trial TemplateData) (*ComposedPromptBuilder, error) {
+	tmpl, err := template.New("promptBuilder.template").Parse(text)
+	if err != nil {
+		return nil, fmt.Errorf("parse promptBuilder.template: %w", err)
+	}
+	if err := tmpl.Execute(&strings.Builder{}, trial); err != nil {
+		return nil, fmt.Errorf("render promptBuilder.template for model %q, mode %q: %w", trial.Model, trial.Mode, err)
+	}
+	return NewComposedPromptBuilder(WithFragments(
+		&operatorTemplateFragment{tmpl: tmpl},
+		WorkspacePathFragment(),
+		TurnBudgetFragment(),
+		WorkspaceTreeFragment(),
+		GitStatusFragment(),
+		DynamicContextFragment(),
+	)), nil
+}
+
+type operatorTemplateFragment struct {
+	tmpl *template.Template
+}
+
+func (f *operatorTemplateFragment) Render(_ context.Context, pc PromptContext) (string, error) {
+	var sb strings.Builder
+	if err := f.tmpl.Execute(&sb, TemplateData{Model: pc.Model, Mode: pc.Mode}); err != nil {
+		return "", fmt.Errorf("render promptBuilder.template: %w", err)
+	}
+	return strings.TrimSpace(sb.String()), nil
+}

--- a/harness/internal/prompt/operator_template_test.go
+++ b/harness/internal/prompt/operator_template_test.go
@@ -1,0 +1,98 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+func trialData() TemplateData {
+	return TemplateData{Model: "claude-fable-5", Mode: "execution"}
+}
+
+func TestNewTemplatePromptBuilder_RendersModelConditionals(t *testing.T) {
+	b, err := NewTemplatePromptBuilder(
+		`You are a tuned agent.{{if eq .Tier "frontier"}} Act when ready.{{end}}{{if .ModelIs "gemma*"}} Follow the loop.{{end}}`,
+		trialData(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := b.Build(t.Context(), PromptContext{Mode: "execution", Model: "claude-fable-5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "You are a tuned agent. Act when ready.") {
+		t.Errorf("frontier branch not rendered: %q", got)
+	}
+	if strings.Contains(got, "Follow the loop.") {
+		t.Errorf("open-weight branch rendered for a frontier model: %q", got)
+	}
+
+	got, err = b.Build(t.Context(), PromptContext{Mode: "execution", Model: "gemma-4"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "Follow the loop.") {
+		t.Errorf("ModelIs branch not rendered for gemma-4: %q", got)
+	}
+}
+
+// The operator template replaces the mode prompt but keeps the structural
+// fragments, matching NewOverridePromptBuilder's contract.
+func TestNewTemplatePromptBuilder_KeepsStructuralFragments(t *testing.T) {
+	b, err := NewTemplatePromptBuilder("Tuned preamble.", trialData())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := b.Build(t.Context(), PromptContext{
+		Mode:           "execution",
+		Model:          "claude-fable-5",
+		Workspace:      t.TempDir(),
+		MaxTurns:       7,
+		DynamicContext: map[string]string{"ticket": "fix the bug"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, "Tuned preamble.") {
+		t.Errorf("preamble missing: %q", got)
+	}
+	execBase := ModePrompts()["execution"]
+	if strings.Contains(got, execBase) {
+		t.Error("mode prompt should be replaced, not appended")
+	}
+	for _, want := range []string{"Working directory:", "Turn budget: 7", "<untrusted_context"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("structural fragment %q missing from output", want)
+		}
+	}
+}
+
+func TestNewTemplatePromptBuilder_ParseError(t *testing.T) {
+	_, err := NewTemplatePromptBuilder("broken {{if .Tier}} unclosed", trialData())
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+// Mustache-style placeholders from an uncompiled external prompt (e.g.
+// Langfuse "{{var}}") must fail at construction, not at run start.
+func TestNewTemplatePromptBuilder_LangfusePlaceholderFails(t *testing.T) {
+	_, err := NewTemplatePromptBuilder("You are an {{criticlevel}} movie critic", trialData())
+	if err == nil {
+		t.Fatal("expected error for mustache-style placeholder")
+	}
+}
+
+// Execution errors (a field TemplateData does not have) surface from the
+// trial render at construction.
+func TestNewTemplatePromptBuilder_TrialRenderCatchesExecError(t *testing.T) {
+	_, err := NewTemplatePromptBuilder("hello {{.NoSuchField}}", trialData())
+	if err == nil {
+		t.Fatal("expected trial-render error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "claude-fable-5") {
+		t.Errorf("expected error to name the trial model, got: %v", err)
+	}
+}

--- a/harness/internal/prompt/prompt.go
+++ b/harness/internal/prompt/prompt.go
@@ -6,9 +6,14 @@ import "context"
 
 // PromptContext provides the information a prompt builder needs.
 type PromptContext struct {
-	Mode           string
-	Workspace      string
-	MaxTurns       int
+	Mode      string
+	Workspace string
+	MaxTurns  int
+	// Model is the resolved prompt model (RunConfig.EffectivePromptModel):
+	// the model identity the system prompt templates render against. It may
+	// differ from the wire model when promptBuilder.promptModel is set for
+	// a prompt/model comparison run.
+	Model          string
 	DynamicContext map[string]string
 }
 

--- a/harness/internal/prompt/render_test.go
+++ b/harness/internal/prompt/render_test.go
@@ -1,0 +1,86 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+// Representative model IDs, one per tier plus the boundary cases.
+var renderMatrixModels = []string{
+	"claude-fable-5-20260115", // frontier
+	"gpt-5.6",                 // frontier
+	"gemma-4-27b",             // open-weight
+	"glm-5.2",                 // open-weight
+	"org/gemma-4",             // open-weight, gateway-prefixed
+	"some-brand-new-model",    // unknown → default tier
+	"",                        // unset → default tier
+}
+
+// Every embedded mode prompt must parse as a template and render for
+// every tier. The base prompt text must always be the prefix of the
+// rendered output: tier blocks are additive, appended after the base, so
+// a model matching neither tier table gets exactly the base prompt
+// (issue #492's fall-through requirement).
+func TestRenderModePrompt_Matrix(t *testing.T) {
+	for mode, base := range ModePrompts() {
+		for _, model := range renderMatrixModels {
+			name := mode + "/" + model
+			if model == "" {
+				name = mode + "/(empty)"
+			}
+			t.Run(name, func(t *testing.T) {
+				got, err := RenderModePrompt(mode, PromptContext{Mode: mode, Model: model})
+				if err != nil {
+					t.Fatalf("RenderModePrompt(%q) error: %v", mode, err)
+				}
+				if !strings.HasPrefix(got, base) {
+					t.Errorf("rendered prompt for model %q does not start with the base prompt text", model)
+				}
+			})
+		}
+	}
+}
+
+// A model outside both tier tables renders the base prompt byte-identical
+// to the raw embedded text — the regression test for fall-through.
+func TestRenderModePrompt_UnknownModelRendersBaseExactly(t *testing.T) {
+	for mode, base := range ModePrompts() {
+		for _, model := range []string{"some-brand-new-model", ""} {
+			got, err := RenderModePrompt(mode, PromptContext{Mode: mode, Model: model})
+			if err != nil {
+				t.Fatalf("RenderModePrompt(%q) error: %v", mode, err)
+			}
+			if got != base {
+				t.Errorf("mode %q, model %q: rendered prompt differs from base text\ngot:\n%s\nwant:\n%s", mode, model, got, base)
+			}
+		}
+	}
+}
+
+func TestRenderModePrompt_UnknownMode(t *testing.T) {
+	_, err := RenderModePrompt("no-such-mode", PromptContext{Mode: "no-such-mode"})
+	if err == nil {
+		t.Fatal("expected error for unknown mode")
+	}
+	if !strings.Contains(err.Error(), "no-such-mode") {
+		t.Errorf("expected error to name the mode, got: %v", err)
+	}
+}
+
+// DefaultPromptBuilder and the composed ModeTemplateFragment must agree
+// with RenderModePrompt so the "default" and "composed" builder types
+// produce the same preamble.
+func TestModeTemplateFragment_MatchesRenderModePrompt(t *testing.T) {
+	pc := PromptContext{Mode: "execution", Model: "claude-fable-5"}
+	want, err := RenderModePrompt("execution", pc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ModeTemplateFragment().Render(t.Context(), pc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("fragment output differs from RenderModePrompt")
+	}
+}

--- a/harness/internal/prompt/render_test.go
+++ b/harness/internal/prompt/render_test.go
@@ -16,44 +16,95 @@ var renderMatrixModels = []string{
 	"",                        // unset → default tier
 }
 
-// Every embedded mode prompt must parse as a template and render for
-// every tier. The base prompt text must always be the prefix of the
-// rendered output: tier blocks are additive, appended after the base, so
-// a model matching neither tier table gets exactly the base prompt
-// (issue #492's fall-through requirement).
+// executionBasePrompt pins the execution mode's fall-through text to the
+// exact prompt shipped before #492 introduced templating. If this test
+// fails, either the base text was edited (update the constant alongside
+// a deliberate prompt change) or tier content leaked into the default
+// tier (a fall-through regression).
+const executionBasePrompt = `You are a coding agent with full read/write access to the workspace.
+Read relevant files before making changes. Apply edits, run tests, and iterate until all tests pass and the task is complete.
+If the task is ambiguous, make the minimal reasonable interpretation rather than asking.
+You can read files, write files, search the codebase, and run shell commands.`
+
+func renderMode(t *testing.T, mode, model string) string {
+	t.Helper()
+	got, err := RenderModePrompt(mode, PromptContext{Mode: mode, Model: model})
+	if err != nil {
+		t.Fatalf("RenderModePrompt(%q, model %q) error: %v", mode, model, err)
+	}
+	return got
+}
+
+// Every embedded mode prompt must parse and render cleanly for every
+// tier: no leftover template syntax, and the default-tier text is always
+// a prefix of the output because tier blocks are additive (issue #492's
+// fall-through requirement, held structurally).
 func TestRenderModePrompt_Matrix(t *testing.T) {
-	for mode, base := range ModePrompts() {
+	for mode := range ModePrompts() {
+		base := renderMode(t, mode, "")
+		if base == "" {
+			t.Fatalf("mode %q: empty base render", mode)
+		}
 		for _, model := range renderMatrixModels {
 			name := mode + "/" + model
 			if model == "" {
 				name = mode + "/(empty)"
 			}
 			t.Run(name, func(t *testing.T) {
-				got, err := RenderModePrompt(mode, PromptContext{Mode: mode, Model: model})
-				if err != nil {
-					t.Fatalf("RenderModePrompt(%q) error: %v", mode, err)
+				got := renderMode(t, mode, model)
+				if strings.Contains(got, "{{") || strings.Contains(got, "}}") {
+					t.Errorf("rendered prompt contains unrendered template syntax:\n%s", got)
 				}
 				if !strings.HasPrefix(got, base) {
-					t.Errorf("rendered prompt for model %q does not start with the base prompt text", model)
+					t.Errorf("rendered prompt for model %q does not start with the default-tier text", model)
 				}
 			})
 		}
 	}
 }
 
-// A model outside both tier tables renders the base prompt byte-identical
-// to the raw embedded text — the regression test for fall-through.
-func TestRenderModePrompt_UnknownModelRendersBaseExactly(t *testing.T) {
-	for mode, base := range ModePrompts() {
-		for _, model := range []string{"some-brand-new-model", ""} {
-			got, err := RenderModePrompt(mode, PromptContext{Mode: mode, Model: model})
-			if err != nil {
-				t.Fatalf("RenderModePrompt(%q) error: %v", mode, err)
-			}
-			if got != base {
-				t.Errorf("mode %q, model %q: rendered prompt differs from base text\ngot:\n%s\nwant:\n%s", mode, model, got, base)
+// A model outside both tier tables renders exactly the default-tier
+// text, and for the execution mode that text is byte-identical to the
+// pre-templating prompt.
+func TestRenderModePrompt_UnknownModelFallsThrough(t *testing.T) {
+	for mode := range ModePrompts() {
+		base := renderMode(t, mode, "")
+		for _, model := range []string{"some-brand-new-model", "claude-haiku-4-5-20251001"} {
+			if got := renderMode(t, mode, model); got != base {
+				t.Errorf("mode %q, model %q: rendered prompt differs from the default-tier text\ngot:\n%s\nwant:\n%s", mode, model, got, base)
 			}
 		}
+	}
+	if got := renderMode(t, "execution", "some-brand-new-model"); got != executionBasePrompt {
+		t.Errorf("execution fall-through drifted from the pinned pre-#492 prompt\ngot:\n%s", got)
+	}
+}
+
+// Each tier's block must actually render for its models and stay out of
+// the other tier's output.
+func TestRenderModePrompt_TierBlocksRender(t *testing.T) {
+	for mode := range ModePrompts() {
+		base := renderMode(t, mode, "")
+		frontier := renderMode(t, mode, "claude-fable-5")
+		openWeight := renderMode(t, mode, "gemma-4")
+
+		if frontier == base {
+			t.Errorf("mode %q: frontier render is identical to base — frontier block missing", mode)
+		}
+		if openWeight == base {
+			t.Errorf("mode %q: open-weight render is identical to base — open-weight block missing", mode)
+		}
+		if frontier == openWeight {
+			t.Errorf("mode %q: frontier and open-weight renders are identical", mode)
+		}
+	}
+
+	// Spot-check one distinctive phrase per tier on the execution mode.
+	if got := renderMode(t, "execution", "claude-fable-5"); !strings.Contains(got, "When you have enough information to act, act.") {
+		t.Errorf("execution frontier block missing its guidance:\n%s", got)
+	}
+	if got := renderMode(t, "execution", "glm-5.2"); !strings.Contains(got, "Never describe an edit or command in prose") {
+		t.Errorf("execution open-weight block missing its guidance:\n%s", got)
 	}
 }
 

--- a/harness/internal/prompt/systemprompts/execution.md
+++ b/harness/internal/prompt/systemprompts/execution.md
@@ -1,4 +1,20 @@
+{{- /* Go text/template rendered per model; tier tables live in harness/internal/prompt/modeltier.go. Tier blocks are additive and appended after this base text so unmatched models render exactly the base prompt. */ -}}
 You are a coding agent with full read/write access to the workspace.
 Read relevant files before making changes. Apply edits, run tests, and iterate until all tests pass and the task is complete.
 If the task is ambiguous, make the minimal reasonable interpretation rather than asking.
 You can read files, write files, search the codebase, and run shell commands.
+{{- if eq .Tier "frontier"}}
+
+When you have enough information to act, act. Do not re-derive established facts or survey options you will not pursue.
+Don't add features, refactor, or introduce abstractions beyond what the task requires. Do the simplest thing that works well.
+Before reporting progress, audit each claim against a tool result from this session. If tests fail, say so with the output; if a step was skipped, say that. Report outcomes faithfully.
+Do not end your turn on a promise of work you have not done. If your last paragraph is a plan or an intention, do that work now with tool calls.
+Lead with the outcome when you finish: one sentence on what happened, then supporting detail.
+{{- end}}
+{{- if eq .Tier "open-weight"}}
+
+Work in a strict loop: read the relevant files first, then apply one edit, then run the tests, then read the failures and fix them. Repeat until the tests pass.
+Always invoke tools to act. Never describe an edit or command in prose instead of making the tool call that performs it.
+Make one tool call at a time and check its result before deciding the next step.
+Stop only when the task is complete and verified by a passing test run, or when you cannot proceed without information you do not have. State which of the two applies.
+{{- end}}

--- a/harness/internal/prompt/systemprompts/planning.md
+++ b/harness/internal/prompt/systemprompts/planning.md
@@ -1,5 +1,18 @@
+{{- /* Go text/template rendered per model; tier tables live in harness/internal/prompt/modeltier.go. Tier blocks are additive and appended after this base text so unmatched models render exactly the base prompt. */ -}}
 You are a planning agent with read-only access to the workspace.
 Analyze the codebase and produce a step-by-step implementation plan.
 Structure your output as a numbered list of concrete steps, each referencing the specific files and functions affected.
 Include a risk or edge-case note for any non-obvious steps.
 You can read files and search the codebase. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine existing or in-progress changes when planning around them; they return bounded, structured output without modifying the workspace. Do not modify any files.
+{{- if eq .Tier "frontier"}}
+
+Verify every file and function you cite by reading it in this session; do not plan against symbols you have not seen.
+Where a choice exists, give one recommendation with a one-line rationale, not a survey of alternatives.
+Be selective: include the steps and risks that change what the implementer would do, and leave out the rest.
+{{- end}}
+{{- if eq .Tier "open-weight"}}
+
+Follow this process: first list the files relevant to the task, then read each one, then write the plan.
+Every step must name at least one file path. If a step names a function, quote its exact signature from the file.
+End your reply with the numbered plan and nothing after it.
+{{- end}}

--- a/harness/internal/prompt/systemprompts/research.md
+++ b/harness/internal/prompt/systemprompts/research.md
@@ -1,4 +1,16 @@
+{{- /* Go text/template rendered per model; tier tables live in harness/internal/prompt/modeltier.go. Tier blocks are additive and appended after this base text so unmatched models render exactly the base prompt. */ -}}
 You are a research agent with read-only access to the workspace.
 Explore the codebase, read relevant documentation, and synthesize your findings into a clear summary.
 Cite specific file paths and line numbers when referencing code. Conclude with actionable recommendations.
 You can read files, search the codebase, and fetch URLs. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine the change history or working-tree state when it informs the research; they return bounded, structured output without modifying the workspace. Do not modify any files.
+{{- if eq .Tier "frontier"}}
+
+Lead with the answer: open your summary with the finding the question was really after, then the supporting evidence.
+Cite only files you read in this session. Be selective — drop details that do not change what the reader would do next.
+{{- end}}
+{{- if eq .Tier "open-weight"}}
+
+Follow this process: first search for the relevant files, then read each one, then write the summary from what you read.
+Every claim in the summary must carry a file path citation from this session. Do not cite from memory.
+End your reply with the summary followed by the recommendations, and nothing after it.
+{{- end}}

--- a/harness/internal/prompt/systemprompts/review.md
+++ b/harness/internal/prompt/systemprompts/review.md
@@ -1,4 +1,16 @@
+{{- /* Go text/template rendered per model; tier tables live in harness/internal/prompt/modeltier.go. Tier blocks are additive and appended after this base text so unmatched models render exactly the base prompt. */ -}}
 You are a code review agent with read-only access to the workspace.
 Review the provided changes for: correctness, edge cases, security issues, style violations, and missed test coverage.
 Structure your output with a brief summary, then a list of findings categorized by severity (critical / major / minor / nit).
 You can read files and search the codebase. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine the change set under review; they return bounded, structured output without modifying the workspace. Do not modify any files.
+{{- if eq .Tier "frontier"}}
+
+Ground every finding in code you read in this session, citing the file and line. For a correctness finding, state the concrete input or state that triggers the failure.
+Assign severity decisively. Do not pad the list: a finding that would not change what the author does next is not worth reporting.
+{{- end}}
+{{- if eq .Tier "open-weight"}}
+
+Follow this process: first run git_changed_files, then git_diff for each changed file, then read the surrounding code before judging it.
+Report only problems you can point to in the diff or the surrounding code. Do not invent findings to fill severity categories; an empty category is a valid result.
+End your reply with the summary followed by the categorized findings list, and nothing after it.
+{{- end}}

--- a/harness/internal/prompt/systemprompts/toil.md
+++ b/harness/internal/prompt/systemprompts/toil.md
@@ -1,3 +1,15 @@
+{{- /* Go text/template rendered per model; tier tables live in harness/internal/prompt/modeltier.go. Tier blocks are additive and appended after this base text so unmatched models render exactly the base prompt. */ -}}
 You are a monitoring agent with read-only access to the workspace.
 Check for the specified trigger condition. If triggered, prepare a concise briefing for the engineer describing what you found and the recommended action.
 You can read files, search the codebase, and fetch URLs. Use the git inspection tools — git_status, git_changed_files, git_diff, and git_show — to examine recent changes when the trigger condition concerns the working tree; they return bounded, structured output without modifying the workspace. Do not modify any files.
+{{- if eq .Tier "frontier"}}
+
+Deliver a decisive verdict: the condition either triggered or it did not. Do not hedge between the two.
+Ground the verdict in evidence you observed in this session, and include that evidence in the briefing.
+{{- end}}
+{{- if eq .Tier "open-weight"}}
+
+Follow this process: first read the trigger condition carefully, then gather the evidence that bears on it, then decide.
+Start your reply with exactly one of "TRIGGERED:" or "NOT TRIGGERED:" followed by the one-sentence reason.
+If triggered, follow with the briefing: what you found, where you found it, and the recommended action.
+{{- end}}

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -69,6 +69,15 @@ const (
 	genAIToolCallIDKey        = "gen_ai.tool.call.id"
 	genAIToolCallArgumentsKey = "gen_ai.tool.call.arguments"
 	genAIToolCallResultKey    = "gen_ai.tool.call.result"
+
+	// Prompt-resolution attributes (#492), stirrup-specific (no GenAI
+	// counterpart). prompt.model is the model identity the system prompt
+	// templates rendered against — it differs from gen_ai.request.model
+	// when promptBuilder.promptModel pins a different prompt for a
+	// comparison run. prompt.tier is the guidance tier that identity
+	// selected ("frontier", "open-weight", or "default").
+	promptModelKey = "prompt.model"
+	promptTierKey  = "prompt.tier"
 )
 
 // genAIProviderName maps stirrup provider type strings to the OTel GenAI
@@ -174,6 +183,7 @@ type OTelTraceEmitter struct {
 var (
 	_ TraceEmitter               = (*OTelTraceEmitter)(nil)
 	_ SystemInstructionsRecorder = (*OTelTraceEmitter)(nil)
+	_ PromptResolutionRecorder   = (*OTelTraceEmitter)(nil)
 	_ FinalAssistantTextRecorder = (*OTelTraceEmitter)(nil)
 )
 
@@ -711,6 +721,23 @@ func (e *OTelTraceEmitter) RecordSystemInstructions(system string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.systemInstructionsJSON = genAISystemInstructionsJSON(security.Scrub(system))
+}
+
+// RecordPromptResolution sets the resolved prompt model and tier on the
+// root span (#492). Always-on, unlike RecordSystemInstructions: the
+// values are config metadata, not message content, and a prompt/model
+// comparison run (promptBuilder.promptModel differing from the wire
+// model) must be attributable from its trace alone.
+func (e *OTelTraceEmitter) RecordPromptResolution(model, tier string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.rootSpan == nil || !e.rootSpan.SpanContext().IsValid() {
+		return
+	}
+	e.rootSpan.SetAttributes(
+		attribute.String(promptModelKey, model),
+		attribute.String(promptTierKey, tier),
+	)
 }
 
 // RecordFinalAssistantText stores the run's final assistant text so the

--- a/harness/internal/trace/otel_test.go
+++ b/harness/internal/trace/otel_test.go
@@ -748,3 +748,26 @@ func TestOTelTraceEmitter_ErrorStatus(t *testing.T) {
 		}
 	})
 }
+
+// RecordPromptResolution is config metadata, not content: the attributes
+// must land on the root span even with content capture off (the test
+// emitter's default), so a prompt/model comparison run is attributable
+// from any trace.
+func TestOTelTraceEmitter_RecordPromptResolution(t *testing.T) {
+	emitter, exporter := newTestOTelEmitter()
+	emitter.Start("run-prompt-res", nil)
+	emitter.RecordPromptResolution("claude-fable-5", "frontier")
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	root := findSpanByName(t, exporter.GetSpans(), "run")
+	assertAttribute(t, root, promptModelKey, "claude-fable-5")
+	assertAttribute(t, root, promptTierKey, "frontier")
+}
+
+// Calling the recorder before Start (no root span yet) must be a no-op,
+// not a panic.
+func TestOTelTraceEmitter_RecordPromptResolutionBeforeStart(t *testing.T) {
+	emitter, _ := newTestOTelEmitter()
+	emitter.RecordPromptResolution("claude-fable-5", "frontier")
+}

--- a/harness/internal/trace/trace.go
+++ b/harness/internal/trace/trace.go
@@ -56,6 +56,19 @@ type SystemInstructionsRecorder interface {
 	RecordSystemInstructions(system string)
 }
 
+// PromptResolutionRecorder is an optional capability a TraceEmitter can
+// implement to receive the resolved prompt model and tier (#492): which
+// model identity the system prompt templates rendered against, and which
+// guidance tier that selected. The loop forwards both via a type
+// assertion after PromptBuilder.Build succeeds, mirroring
+// SystemInstructionsRecorder. Unlike system instructions this is config
+// metadata, not message content, so recording is not gated on content
+// capture — a prompt/model comparison run must be attributable from its
+// trace alone.
+type PromptResolutionRecorder interface {
+	RecordPromptResolution(model, tier string)
+}
+
 // HookRecorder is an optional capability a TraceEmitter can implement to
 // receive lifecycle hook results (issue #461) as they complete. The
 // agentic loop forwards each types.HookExecution via a type assertion

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -120,8 +120,9 @@ func runConfigFromProto(pc *pb.RunConfig) types.RunConfig {
 	}
 	if pc.PromptBuilder != nil {
 		rc.PromptBuilder = types.PromptBuilderConfig{
-			Type:     pc.PromptBuilder.Type,
-			Template: pc.PromptBuilder.Template,
+			Type:        pc.PromptBuilder.Type,
+			Template:    pc.PromptBuilder.Template,
+			PromptModel: pc.PromptBuilder.PromptModel,
 		}
 	}
 	if pc.ContextStrategy != nil {

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -27,6 +27,32 @@ func TestRunConfigFromProto_SessionNamePropagates(t *testing.T) {
 	}
 }
 
+// TestRunConfigFromProto_PromptBuilderFieldsPreserved covers the prompt
+// templating surface (#492): a control plane that tunes prompts via
+// prompt_builder.template or pins a prompt model for comparison runs
+// must not have either silently dropped on the job path.
+func TestRunConfigFromProto_PromptBuilderFieldsPreserved(t *testing.T) {
+	pc := &pb.RunConfig{
+		PromptBuilder: &pb.PromptBuilderConfig{
+			Type:        "composed",
+			Template:    `Custom agent.{{if eq .Tier "frontier"}} Act when ready.{{end}}`,
+			PromptModel: "claude-fable-5",
+		},
+	}
+
+	rc := runConfigFromProto(pc)
+
+	if rc.PromptBuilder.Type != "composed" {
+		t.Errorf("PromptBuilder.Type not propagated: got %q", rc.PromptBuilder.Type)
+	}
+	if rc.PromptBuilder.Template != pc.PromptBuilder.Template {
+		t.Errorf("PromptBuilder.Template not propagated: got %q", rc.PromptBuilder.Template)
+	}
+	if rc.PromptBuilder.PromptModel != "claude-fable-5" {
+		t.Errorf("PromptBuilder.PromptModel not propagated: got %q", rc.PromptBuilder.PromptModel)
+	}
+}
+
 // TestRuleOfTwoProto_EmptyMessageDoesNotDisableEnforcement guards the
 // proto3 wire default for RuleOfTwoConfig.enforce. The field is declared
 // `optional bool` so an unset value is wire-distinguishable from an

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -364,6 +364,10 @@ message RunConfig {
   // Optional. When set, used as the complete system prompt preamble,
   // bypassing prompt_builder mode selection. Workspace path, turn budget,
   // and dynamic_context sections are still appended by the harness.
+  // The value is used verbatim and never template-parsed, so prompts
+  // compiled by an external prompt-management system (e.g. Langfuse)
+  // pass through untouched. Mutually exclusive with
+  // prompt_builder.template and prompt_builder.prompt_model.
   string system_prompt_override = 23;
 
   // Optional. Human-readable label attached to the run for reporting.
@@ -1218,12 +1222,25 @@ message PromptBuilderConfig {
   // Optional. The prompt builder implementation.
   // Valid values:
   //   "default"  — built-in per-mode templates (default).
-  //   "composed" — combines the default template with a custom suffix.
+  //   "composed" — fragment-based assembly of the same sections.
   string type = 1;
 
-  // For "composed": the custom template text appended to the default
-  // per-mode system prompt.
+  // Optional. An operator-supplied Go text/template that replaces the
+  // shipped mode prompt as the system prompt preamble. Structural
+  // sections (workspace path, turn budget, workspace tree, git status,
+  // dynamic context) are still appended. Renders against the same data
+  // surface as the shipped prompts (.Model, .Mode, .Tier, .ModelIs), so
+  // model-conditional content and prompt_model keep working for tuned
+  // prompts. Syntax-checked at config validation. Mutually exclusive
+  // with system_prompt_override.
   string template = 2;
+
+  // Optional. Overrides the model identity the system prompt templates
+  // render against, without changing which model is called on the wire.
+  // Enables prompt/model comparison runs (e.g. the "claude-fable-5
+  // prompt" against a newer model). Empty derives the prompt model from
+  // the model router. Mutually exclusive with system_prompt_override.
+  string prompt_model = 3;
 }
 
 // ContextStrategyConfig selects how message history is managed as the

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"text/template"
 	"unicode"
 	"unicode/utf8"
 )
@@ -165,6 +166,12 @@ type RunConfig struct {
 	// SystemPromptOverride, when set, is used as the complete system prompt
 	// preamble, bypassing prompt_builder mode selection. Workspace path,
 	// turn budget, and dynamic_context sections are still appended.
+	//
+	// The value is used verbatim and is never template-parsed, so prompts
+	// compiled by an external prompt-management system (e.g. Langfuse)
+	// pass through untouched even when they contain "{{" sequences.
+	// Mutually exclusive with promptBuilder.template and
+	// promptBuilder.promptModel — see ValidateRunConfig.
 	SystemPromptOverride string `json:"systemPromptOverride,omitempty"`
 
 	// RuleOfTwo carries the operator override for the "Agents Rule of
@@ -343,6 +350,48 @@ func (rc *RunConfig) EffectiveToolDispatchMaxParallel() int {
 		return DefaultToolDispatchMaxParallel
 	}
 	return rc.ToolDispatch.MaxParallel
+}
+
+// DefaultModel is the model the harness falls back to when neither the
+// config nor the CLI names one. The model-router factory and the CLI
+// --model flag default must agree with this value.
+const DefaultModel = "claude-sonnet-4-6"
+
+// EffectivePromptModel returns the model identity the system prompt
+// templates render against. Resolution order:
+//
+//  1. promptBuilder.promptModel — the explicit override for
+//     prompt/model comparison runs;
+//  2. the model that will actually serve this run's turns: for a
+//     per-mode router, the model part of modeModels[mode] (values are
+//     "provider/model"; a value without a slash is a bare model name),
+//     otherwise modelRouter.model;
+//  3. DefaultModel, mirroring the router factory's fallback so the
+//     rendered tier matches the model used on the wire.
+//
+// Dynamic routers may switch models between turns, but the prompt is
+// rendered once per run against the router's default model: re-rendering
+// per turn would invalidate provider prompt caches and change agent
+// guidance mid-run.
+func (rc *RunConfig) EffectivePromptModel() string {
+	if rc == nil {
+		return DefaultModel
+	}
+	if m := rc.PromptBuilder.PromptModel; m != "" {
+		return m
+	}
+	if rc.ModelRouter.Type == "per-mode" {
+		if spec, ok := rc.ModelRouter.ModeModels[rc.Mode]; ok && spec != "" {
+			if _, model, found := strings.Cut(spec, "/"); found {
+				return model
+			}
+			return spec
+		}
+	}
+	if rc.ModelRouter.Model != "" {
+		return rc.ModelRouter.Model
+	}
+	return DefaultModel
 }
 
 // RuleOfTwoConfig configures the Rule-of-Two structural invariant. The
@@ -965,8 +1014,29 @@ type ModelRouterConfig struct {
 
 // PromptBuilderConfig selects the prompt builder implementation.
 type PromptBuilderConfig struct {
-	Type     string `json:"type"`               // "default" | "custom"
-	Template string `json:"template,omitempty"` // for custom
+	Type string `json:"type"` // "default" | "composed"
+
+	// Template, when set, is an operator-supplied Go text/template that
+	// replaces the shipped mode prompt as the system prompt preamble.
+	// Structural fragments (workspace path, turn budget, workspace tree,
+	// git status, dynamic context) are still appended. The template
+	// renders against the same data surface as the shipped mode prompts
+	// (.Model, .Mode, .Tier, .ModelIs), so model-conditional content and
+	// the promptModel override keep working for tuned prompts. Syntax is
+	// checked in ValidateRunConfig; execution failures abort the run at
+	// component construction. Mutually exclusive with
+	// systemPromptOverride.
+	Template string `json:"template,omitempty"`
+
+	// PromptModel, when set, overrides the model identity used to render
+	// the system prompt templates without changing which model is called
+	// on the wire. This enables prompt/model comparisons: e.g. running
+	// the "claude-fable-5 prompt" against a newer model to isolate
+	// prompt-content effects from model effects. Empty (the default)
+	// derives the prompt model from the model router — see
+	// EffectivePromptModel. Mutually exclusive with systemPromptOverride,
+	// which bypasses template rendering entirely.
+	PromptModel string `json:"promptModel,omitempty"`
 }
 
 // ContextStrategyConfig selects the context strategy implementation.
@@ -2102,6 +2172,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateRequiredType("provider", config.Provider.Type, validProviderTypes, &errs)
 	validateOptionalType("modelRouter", config.ModelRouter.Type, validModelRouterTypes, &errs)
 	validateOptionalType("promptBuilder", config.PromptBuilder.Type, validPromptBuilderTypes, &errs)
+	validatePromptBuilderConfig(config, &errs)
 	validateOptionalType("contextStrategy", config.ContextStrategy.Type, validContextStrategyTypes, &errs)
 	validateContextStrategyBudget(config.ContextStrategy, &errs)
 	validateOptionalType("executor", config.Executor.Type, validExecutorTypes, &errs)
@@ -2237,6 +2308,35 @@ func validateOptionalType(name, value string, valid map[string]bool, errs *[]str
 	}
 	if !valid[value] {
 		*errs = append(*errs, fmt.Sprintf("unsupported %s type %q", name, value))
+	}
+}
+
+// validatePromptBuilderConfig enforces the mutual exclusions between the
+// three prompt-content surfaces and syntax-checks operator templates.
+//
+// systemPromptOverride bypasses template rendering entirely, so combining
+// it with promptBuilder.template or promptBuilder.promptModel would
+// silently discard the latter — in an eval sweep that silent no-op would
+// masquerade as a valid prompt/model comparison, so both combinations are
+// rejected loudly instead of resolved by precedence.
+//
+// The template syntax check uses a bare text/template.Parse: the shipped
+// data surface is plain struct fields and methods, so no FuncMap is
+// needed, and a prompt containing external-system placeholders (e.g. an
+// uncompiled Langfuse "{{var}}") fails here rather than at run start.
+func validatePromptBuilderConfig(config *RunConfig, errs *[]string) {
+	if config.SystemPromptOverride != "" {
+		if config.PromptBuilder.Template != "" {
+			*errs = append(*errs, "systemPromptOverride and promptBuilder.template are mutually exclusive: the override would silently discard the template")
+		}
+		if config.PromptBuilder.PromptModel != "" {
+			*errs = append(*errs, "systemPromptOverride and promptBuilder.promptModel are mutually exclusive: the override bypasses template rendering, so the prompt model would have no effect")
+		}
+	}
+	if tmpl := config.PromptBuilder.Template; tmpl != "" {
+		if _, err := template.New("promptBuilder.template").Parse(tmpl); err != nil {
+			*errs = append(*errs, fmt.Sprintf("promptBuilder.template does not parse as a Go text/template: %v", err))
+		}
 	}
 }
 

--- a/types/runconfig_prompt_test.go
+++ b/types/runconfig_prompt_test.go
@@ -1,0 +1,180 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEffectivePromptModel(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*RunConfig)
+		want   string
+	}{
+		{
+			name:   "empty config falls back to DefaultModel",
+			mutate: func(c *RunConfig) {},
+			want:   DefaultModel,
+		},
+		{
+			name: "static router model",
+			mutate: func(c *RunConfig) {
+				c.ModelRouter = ModelRouterConfig{Type: "static", Model: "claude-fable-5"}
+			},
+			want: "claude-fable-5",
+		},
+		{
+			name: "promptModel override wins over router model",
+			mutate: func(c *RunConfig) {
+				c.ModelRouter = ModelRouterConfig{Type: "static", Model: "claude-fable-6"}
+				c.PromptBuilder.PromptModel = "claude-fable-5"
+			},
+			want: "claude-fable-5",
+		},
+		{
+			name: "per-mode router uses the mode's model, provider stripped",
+			mutate: func(c *RunConfig) {
+				c.Mode = "execution"
+				c.ModelRouter = ModelRouterConfig{
+					Type:       "per-mode",
+					Model:      "claude-sonnet-5",
+					ModeModels: map[string]string{"execution": "openai/gpt-5.6"},
+				}
+			},
+			want: "gpt-5.6",
+		},
+		{
+			name: "per-mode router bare model value",
+			mutate: func(c *RunConfig) {
+				c.Mode = "execution"
+				c.ModelRouter = ModelRouterConfig{
+					Type:       "per-mode",
+					Model:      "claude-sonnet-5",
+					ModeModels: map[string]string{"execution": "gpt-5.6"},
+				}
+			},
+			want: "gpt-5.6",
+		},
+		{
+			name: "per-mode router without an entry for the mode uses the default model",
+			mutate: func(c *RunConfig) {
+				c.Mode = "execution"
+				c.ModelRouter = ModelRouterConfig{
+					Type:       "per-mode",
+					Model:      "claude-sonnet-5",
+					ModeModels: map[string]string{"planning": "openai/gpt-5.6"},
+				}
+			},
+			want: "claude-sonnet-5",
+		},
+		{
+			name: "dynamic router uses the default model, not cheap or expensive",
+			mutate: func(c *RunConfig) {
+				c.ModelRouter = ModelRouterConfig{
+					Type:           "dynamic",
+					Model:          "claude-sonnet-5",
+					CheapModel:     "claude-haiku-4-5",
+					ExpensiveModel: "claude-fable-5",
+				}
+			},
+			want: "claude-sonnet-5",
+		},
+		{
+			name: "promptModel override wins over per-mode entry",
+			mutate: func(c *RunConfig) {
+				c.Mode = "execution"
+				c.ModelRouter = ModelRouterConfig{
+					Type:       "per-mode",
+					ModeModels: map[string]string{"execution": "openai/gpt-5.6"},
+				}
+				c.PromptBuilder.PromptModel = "claude-fable-5"
+			},
+			want: "claude-fable-5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validConfig()
+			tt.mutate(c)
+			if got := c.EffectivePromptModel(); got != tt.want {
+				t.Errorf("EffectivePromptModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectivePromptModel_NilReceiver(t *testing.T) {
+	var c *RunConfig
+	if got := c.EffectivePromptModel(); got != DefaultModel {
+		t.Errorf("EffectivePromptModel() on nil = %q, want %q", got, DefaultModel)
+	}
+}
+
+func TestValidateRunConfig_PromptModelWithSystemPromptOverride(t *testing.T) {
+	c := validConfig()
+	c.SystemPromptOverride = "You are a helpful agent."
+	c.PromptBuilder.PromptModel = "claude-fable-5"
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for promptModel combined with systemPromptOverride")
+	}
+	if !strings.Contains(err.Error(), "promptBuilder.promptModel") {
+		t.Errorf("expected error to mention promptBuilder.promptModel, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_TemplateWithSystemPromptOverride(t *testing.T) {
+	c := validConfig()
+	c.SystemPromptOverride = "You are a helpful agent."
+	c.PromptBuilder.Template = "You are an agent for {{.Model}}."
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for template combined with systemPromptOverride")
+	}
+	if !strings.Contains(err.Error(), "promptBuilder.template") {
+		t.Errorf("expected error to mention promptBuilder.template, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_TemplateSyntaxError(t *testing.T) {
+	c := validConfig()
+	c.PromptBuilder.Template = "broken {{if .Tier}} unclosed"
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for unparseable template")
+	}
+	if !strings.Contains(err.Error(), "text/template") {
+		t.Errorf("expected error to mention text/template, got: %v", err)
+	}
+}
+
+// An uncompiled prompt from an external prompt-management system uses
+// "{{var}}" placeholders, which Go's template parser rejects as an
+// undefined function. Validation must catch this before run start.
+func TestValidateRunConfig_TemplateLangfusePlaceholder(t *testing.T) {
+	c := validConfig()
+	c.PromptBuilder.Template = "You are an {{criticlevel}} movie critic"
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected error for mustache-style placeholder in template")
+	}
+	if !strings.Contains(err.Error(), "promptBuilder.template") {
+		t.Errorf("expected error to mention promptBuilder.template, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_ValidTemplateAccepted(t *testing.T) {
+	c := validConfig()
+	c.PromptBuilder.Template = `You are a coding agent.{{if eq .Tier "frontier"}} Act when ready.{{end}}`
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("expected valid template to be accepted, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_PromptModelAloneAccepted(t *testing.T) {
+	c := validConfig()
+	c.PromptBuilder.PromptModel = "claude-fable-5"
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("expected promptModel without override to be accepted, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #492.

## What

The shipped per-mode system prompts become Go `text/template` documents rendered per run against a **prompt model** — the model identity that selects which guidance the prompt carries:

- **Tiers.** `frontier` models (`claude-fable-5*`, `claude-mythos-5*`, `claude-sonnet-5*`, `claude-opus-4-8*`, `gpt-5.5*`, `gpt-5.6*`) get lean behavioural additions; `open-weight` models (`gemma*`, `glm-*`, `deepseek*`, `qwen*`) get explicit process scaffolding; everything else renders the base prompt **byte-identical to the pre-templating text** — fall-through is structural, and the execution base is pinned verbatim in `render_test.go`. Content is sourced from the published Fable 5 / GPT 5.6 prompting guidance (both report prescriptive scaffolding degrades frontier models; OpenAI cites 10–15% eval gains from leaner prompts). Tier membership is one glob table in `prompt/modeltier.go`, with quirks-registry `path.Match` semantics.
- **`promptBuilder.promptModel` / `--prompt-model`.** Renders the prompts as if for one model while calling another on the wire, so evals can isolate prompt-content effects from model effects ("Fable 5 prompt on Fable 6"). `stirrup-eval run --prompt-model` forwards it like `--model`; the suite HCL mirror gains `prompt_model`.
- **`promptBuilder.template` wired.** The long-dead field now accepts an operator Go text/template that replaces the mode prompt, keeps the structural fragments, renders against the same data surface (`.Model`, `.Mode`, `.Tier`, `.ModelIs`), and is trial-rendered at construction so exec errors fail before the run. ⚠️ This redefines the proto field-2 comment ("appended" → "replaces"); the field was never consumed, so no deployed behaviour changes.
- **`systemPromptOverride` stays raw** — never template-parsed, so Langfuse-compiled prompts containing `{{var}}` pass through. Combining the override with either new field is a validation error rather than silent precedence (a silent no-op would masquerade as a valid comparison in an eval sweep). Both control-plane integration paths are documented in `configuration.md#system-prompt-templating`.
- **Observability.** The resolved prompt model and tier land on the root OTel span as `prompt.model` / `prompt.tier`, always-on (config metadata, not content), so comparison runs are attributable from traces alone.
- **`stirrup prompt render --mode X --prompt-model Y [--template FILE]`** renders any combination offline — no provider, no key.

## Verification

- `just` (build + full test) green; `just lint` 0 issues; `just proto` output committed.
- Fall-through pinned: unknown/gate models render the exact pre-#492 prompt (`render_test.go`).
- `stirrup run-config --model gemma-4 --prompt-model claude-fable-5` emits `promptBuilder.promptModel`; override+promptModel rejected by `--validate`.
- Live run (Haiku 4.5 wire, Fable 5 prompt): success; JSONL trace records the override.
- `dogfood-seed` eval with the gate model: one task (`add-go-file-passing-test`) failed in two full-suite runs, but the rendered prompt for Haiku is byte-identical to main's, the same task passes 3/3 on **both** this branch's and main's binaries in isolation, and main's full suite passed — pre-existing model flake (Haiku occasionally creates the module at the workspace root instead of `module-root/`), not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJxqANds7Q31N8cq9RGkoU