### PR TITLE
tool, core, executor: capture run_command output in a run-scoped store with paged reads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -668,7 +668,10 @@ Full reference: [`eval.md`](eval.md).
 | `MaxTokenBudget` | unset | 50 M |
 | `MaxCostBudget` | unset | $100 |
 | File read/write size | 10 MB | — |
-| Command output | 1 MB | — |
+| `Executor.Exec` output (hooks/verifiers/git helpers) | 1 MB | — |
+| `run_command` inline model output | 32 KiB combined | configurable |
+| `run_command` capture per stream | 50 MiB | 256 MiB |
+| `run_command` capture per run | 500 MiB | 2 GiB |
 | Command timeout (`run_command` tool) | 30 s | 5 min |
 | `Executor.Exec` hard cap (`local`/`container`/`k8s`/`k8s-sandbox`) | 30 s | 30 min |
 | Web fetch response | 100 KB | — |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -550,6 +550,8 @@ configuration space — the common cases. Anything below requires
 | `traceEmitter` | `bucket` / `objectPrefix` / `credential` (the `gcs` emitter's routing — selectable via `--trace-emitter gcs` but configurable only by file). |
 | `provider` | Multi-provider routing via `providers{}` plus a `modelRouter` of type `dynamic` or `per-mode`. |
 | `tools.mcpServers` | Remote MCP server registration. |
+| `tools.commandOutput` | Full-stream command capture limits and model preview thresholds. |
+| `traceEmitter.archive` | Explicit local or GCS destination for compressed command-output sidecars. |
 
 The CLI flags for each of these set the *type* selection only.
 
@@ -663,6 +665,41 @@ either "called by internal name under the default profile" or "the name
 did not resolve to a known tool under a non-default profile". The active
 `tools.profile` is recorded in the trace's attached `RunConfig`, so the
 two cases are distinguishable by reading it alongside the record.
+
+## Command output capture
+
+`run_command` streams complete stdout and stderr into a run-scoped secure
+store. Output up to `tools.commandOutput.inlineMaxBytes` remains inline after
+secret scrubbing. Larger output returns scrubbed tails plus opaque
+`stirrup://command-output/...` references; the automatically registered,
+read-only `read_command_output` tool reads those references in 32 KiB pages
+(128 KiB maximum per call).
+
+```json
+{
+  "tools": {
+    "commandOutput": {
+      "inlineMaxBytes": 32768,
+      "previewBytesPerStream": 4096,
+      "maxBytesPerStream": 52428800,
+      "maxBytesPerRun": 524288000
+    }
+  },
+  "traceEmitter": {
+    "type": "jsonl",
+    "filePath": "run.jsonl",
+    "archive": {"type": "local", "filePath": "run.command-output.tar.gz"}
+  }
+}
+```
+
+The stream and run maxima are compliance boundaries, not truncation limits.
+Crossing one cancels the command and prevents a successful run outcome. Raw
+bytes are deleted after whole-stream redaction; archives contain scrubbed
+streams, while raw byte counts and SHA-256 hashes remain as integrity metadata.
+Without an explicit destination, JSONL and GCS derive an adjacent archive;
+other emitters retain a local archive and report its absolute path in
+`RunResult.commandOutputArchive`.
 
 ## Lifecycle hooks
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -671,9 +671,17 @@ two cases are distinguishable by reading it alongside the record.
 `run_command` streams complete stdout and stderr into a run-scoped secure
 store. Output up to `tools.commandOutput.inlineMaxBytes` remains inline after
 secret scrubbing. Larger output returns scrubbed tails plus opaque
-`stirrup://command-output/...` references; the automatically registered,
-read-only `read_command_output` tool reads those references in 32 KiB pages
+`stirrup://command-output/...` references; the read-only
+`read_command_output` tool reads those references in 32 KiB pages
 (128 KiB maximum per call).
+
+`read_command_output` is `run_command`'s companion: it registers
+automatically whenever `run_command` registers with capture enabled — a
+spilled reference without its reader would be unusable, and `tools.builtIn`
+allowlists written before capture existed keep working unchanged. Listing
+`read_command_output` in `tools.builtIn` is only needed for standalone
+replay runs; listing it while `enabled` is `false` is rejected as
+contradictory at validation.
 
 ```json
 {
@@ -716,6 +724,11 @@ after whole-stream redaction; an unclean shutdown (crash, SIGKILL) can leave
 raw spool files in the OS temp directory until it is cleared. Archives
 contain scrubbed streams only, while raw byte counts and SHA-256 hashes
 remain as integrity metadata.
+
+The `eval/suites/command-output-ab-{on,off}.hcl` pair measures the
+pipeline's context-saving claim: identical tasks with capture forced to
+spill versus disabled, compared via `stirrup-eval compare` (mean tokens at
+equal-or-better pass rate). See [`eval/suites/README.md`](../eval/suites/README.md).
 Without an explicit destination, JSONL and GCS derive an adjacent archive;
 other emitters retain a local archive and report its absolute path in
 `RunResult.commandOutputArchive`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -679,6 +679,8 @@ read-only `read_command_output` tool reads those references in 32 KiB pages
 {
   "tools": {
     "commandOutput": {
+      "enabled": true,
+      "failurePosture": "strict",
       "inlineMaxBytes": 32768,
       "previewBytesPerStream": 4096,
       "maxBytesPerStream": 52428800,
@@ -693,9 +695,22 @@ read-only `read_command_output` tool reads those references in 32 KiB pages
 }
 ```
 
-The stream and run maxima are compliance boundaries, not truncation limits.
-Crossing one cancels the command and prevents a successful run outcome. Raw
-bytes are deleted after whole-stream redaction; archives contain scrubbed
+Capture defaults to on; `"enabled": false` reverts `run_command` to the
+legacy bounded-inline behaviour, registers no `read_command_output` tool,
+and writes no archive — the lever for A/B comparison of the feature under
+`stirrup-eval`.
+
+The stream and run maxima are compliance boundaries, not truncation limits:
+crossing one always cancels the offending command. What happens next is the
+`failurePosture`. Under `"strict"` (the default) the store refuses further
+captures and an otherwise-successful run reports
+`command_output_capture_failed` (or `command_output_archive_failed` when the
+sidecar itself cannot be written or uploaded); a run that already failed for
+a primary reason keeps that outcome. Under `"bestEffort"` later commands
+keep capturing, the run outcome is never overridden, and the failure stays
+visible in the archive manifest and per-command trace records.
+
+Raw bytes are deleted after whole-stream redaction; archives contain scrubbed
 streams, while raw byte counts and SHA-256 hashes remain as integrity metadata.
 Without an explicit destination, JSONL and GCS derive an adjacent archive;
 other emitters retain a local archive and report its absolute path in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -710,8 +710,12 @@ a primary reason keeps that outcome. Under `"bestEffort"` later commands
 keep capturing, the run outcome is never overridden, and the failure stays
 visible in the archive manifest and per-command trace records.
 
-Raw bytes are deleted after whole-stream redaction; archives contain scrubbed
-streams, while raw byte counts and SHA-256 hashes remain as integrity metadata.
+Raw bytes are spooled to run-scoped files (0600, under a 0700 temporary
+directory) while a command streams and are deleted at command completion,
+after whole-stream redaction; an unclean shutdown (crash, SIGKILL) can leave
+raw spool files in the OS temp directory until it is cleared. Archives
+contain scrubbed streams only, while raw byte counts and SHA-256 hashes
+remain as integrity metadata.
 Without an explicit destination, JSONL and GCS derive an adjacent archive;
 other emitters retain a local archive and report its absolute path in
 `RunResult.commandOutputArchive`.

--- a/docs/trace-inspection.md
+++ b/docs/trace-inspection.md
@@ -20,12 +20,16 @@ a `kind` discriminator. A complete run produces:
 {"kind":"run_started","schemaVersion":"1","runId":"...","config":{...redacted...},"startedAt":"..."}
 {"kind":"turn_record","turn":1,"modelInput":{...},"modelOutput":[...],"toolCalls":[...]}
 {"kind":"tool_call_record","turn":1,"name":"read_file","input":{...},"output":"..."}
+{"kind":"command_output_record","commandOutput":{"archiveId":"...","toolUseId":"...","stdout":{"rawBytes":123,"scrubbedBytes":111,"rawSha256":"...","scrubbedSha256":"..."}}}
 {"kind":"turn_record","turn":2,"modelInput":{...},"modelOutput":[...]}
 {"kind":"run_finished","trace":{...RunTrace summary...},"completedAt":"..."}
 ```
 
 `turn_record` carries the full transcript the model saw and produced
-that turn, including raw tool inputs and outputs. `tool_call_record`
+that turn, including the exact scrubbed tool results shown to it.
+`command_output_record` links a `run_command` call to bounded stream hashes,
+sizes, references, and its compressed sidecar archive without embedding full
+sandbox output in JSONL. `tool_call_record`
 is emitted in addition so a live consumer sees each call as soon as
 it lands. `run_finished` carries the same `RunTrace` summary the
 legacy single-blob format used; `stirrup trace show / stats / grep`

--- a/eval/spec/runconfig.go
+++ b/eval/spec/runconfig.go
@@ -214,7 +214,20 @@ type traceEmitterSpec struct {
 }
 
 type toolsSpec struct {
-	BuiltIn []string `hcl:"built_in,optional"`
+	BuiltIn       []string           `hcl:"built_in,optional"`
+	CommandOutput *commandOutputSpec `hcl:"command_output,block"`
+}
+
+// commandOutputSpec mirrors types.CommandOutputConfig so suites can A/B the
+// capture pipeline (enabled = false vs a low inline_max_bytes that forces
+// spilling) without a full run_config_file.
+type commandOutputSpec struct {
+	Enabled               *bool  `hcl:"enabled,optional"`
+	FailurePosture        string `hcl:"failure_posture,optional"`
+	InlineMaxBytes        int64  `hcl:"inline_max_bytes,optional"`
+	PreviewBytesPerStream int64  `hcl:"preview_bytes_per_stream,optional"`
+	MaxBytesPerStream     int64  `hcl:"max_bytes_per_stream,optional"`
+	MaxBytesPerRun        int64  `hcl:"max_bytes_per_run,optional"`
 }
 
 type ruleOfTwoSpec struct {
@@ -361,6 +374,16 @@ func runConfigSpecToType(s *runConfigSpec) *types.RunConfig {
 	}
 	if s.Tools != nil {
 		out.Tools = types.ToolsConfig{BuiltIn: s.Tools.BuiltIn}
+		if co := s.Tools.CommandOutput; co != nil {
+			out.Tools.CommandOutput = types.CommandOutputConfig{
+				Enabled:               co.Enabled,
+				FailurePosture:        co.FailurePosture,
+				InlineMaxBytes:        co.InlineMaxBytes,
+				PreviewBytesPerStream: co.PreviewBytesPerStream,
+				MaxBytesPerStream:     co.MaxBytesPerStream,
+				MaxBytesPerRun:        co.MaxBytesPerRun,
+			}
+		}
 	}
 	if s.RuleOfTwo != nil {
 		out.RuleOfTwo = &types.RuleOfTwoConfig{Enforce: s.RuleOfTwo.Enforce}

--- a/eval/spec/runconfig_test.go
+++ b/eval/spec/runconfig_test.go
@@ -149,6 +149,66 @@ suite "s" {
 	}
 }
 
+func TestLoadSuiteHCL_ToolsCommandOutputBlock(t *testing.T) {
+	src := `
+suite "s" {
+  run_config {
+    mode = "execution"
+
+    provider {
+      type        = "anthropic"
+      api_key_ref = "secret://ANTHROPIC_KEY"
+    }
+
+    model_router {
+      type     = "static"
+      provider = "anthropic"
+      model    = "claude-haiku-4-5"
+    }
+
+    tools {
+      built_in = ["run_command", "read_file"]
+
+      command_output {
+        enabled          = false
+        failure_posture  = "bestEffort"
+        inline_max_bytes = 4096
+      }
+    }
+  }
+
+  task "t1" {
+    mode   = "execution"
+    prompt = "p"
+    judge {
+      type    = "test-command"
+      command = "true"
+    }
+  }
+}
+`
+	path := writeTemp(t, "runcfg-command-output.hcl", src)
+	got, err := LoadSuiteHCL(path)
+	if err != nil {
+		t.Fatalf("LoadSuiteHCL: %v", err)
+	}
+	if got.RunConfig == nil {
+		t.Fatal("RunConfig should be non-nil")
+	}
+	enabled := false
+	wantTools := types.ToolsConfig{
+		BuiltIn: []string{"run_command", "read_file"},
+		CommandOutput: types.CommandOutputConfig{
+			Enabled:        &enabled,
+			FailurePosture: "bestEffort",
+			InlineMaxBytes: 4096,
+		},
+	}
+	if !reflect.DeepEqual(got.RunConfig.Tools, wantTools) {
+		t.Fatalf("Tools mismatch\n got:  %#v\n want: %#v", got.RunConfig.Tools, wantTools)
+	}
+}
+
 // TestLoadSuiteHCL_RunConfigMutuallyExclusive asserts that setting both
 // `run_config_file` and `run_config` on the same suite is a parse error
 // that names the suite ID and both offending field names — operators

--- a/eval/suites/README.md
+++ b/eval/suites/README.md
@@ -25,6 +25,7 @@ For the suite schema and the per-task contract see
 
 | Suite | Source | Notes |
 |---|---|---|
+| `command-output-ab-{on,off}.hcl` | Hand-authored (PR #495) | A/B pair for the command-output capture pipeline: byte-identical tasks, differing only in `tools.command_output`. Run both arms, then `stirrup-eval compare -baseline <off>/result.json -current <on>/result.json` — the feature's context-saving claim holds iff the on arm lowers mean tokens at an equal-or-better pass rate. Opt-in, live-provider, no CI baseline. |
 | `dogfood-seed.hcl` | Hand-authored (#13) | Starter suite for the v0.1 eval-gate. Targets harness behaviours stirrup's maintainers actually rely on; judges are deterministic. Replace with the mined output once the dogfood recording loop is established. |
 | `guardrail.hcl` | Hand-authored (#43) | Red-team suite for the GuardRail component. Requires a vLLM endpoint with Granite Guardian loaded. |
 | `openai-responses-empty-tool-output.hcl` | Hand-authored | Regression pin for a provider edge case. |

--- a/eval/suites/command-output-ab-off.hcl
+++ b/eval/suites/command-output-ab-off.hcl
@@ -1,0 +1,112 @@
+// Command-output capture A/B suite — "off" arm (issue: PR #495).
+//
+// This suite and command-output-ab-on.hcl carry byte-identical tasks;
+// the only difference is the suite-level tools.command_output block.
+// This arm disables capture, reverting run_command to the legacy
+// inline path: the full command output lands in the model's context.
+// See command-output-ab-on.hcl for the full A/B recipe.
+
+suite "command-output-ab-off" {
+  description = "A/B arm with command-output capture disabled (legacy inline run_command). Pair with command-output-ab-on; identical tasks, differing only in tools.command_output."
+
+  run_config {
+    mode      = "execution"
+    max_turns = 20
+
+    provider {
+      type        = "anthropic"
+      api_key_ref = "secret://ANTHROPIC_API_KEY"
+    }
+
+    model_router {
+      type     = "static"
+      provider = "anthropic"
+      model    = "claude-haiku-4-5"
+    }
+
+    tools {
+      command_output {
+        enabled = false
+      }
+    }
+  }
+
+  task "needle-in-verbose-output" {
+    description = "A ~200 KB build log streams to stdout with a single ERROR line buried mid-stream, outside any spill preview. The agent must identify the failing test name. Measures whether targeted reads beat inlining the whole stream."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      The workspace contains a script called noisy.sh. Run `sh noisy.sh` and find the single ERROR line in its output. Write the name of the failing test (just the test name, e.g. test_something_123) to a file called answer.txt.
+    EOT
+
+    file "noisy.sh" {
+      content = <<-EOT
+        #!/bin/sh
+        i=1
+        while [ $i -le 3000 ]; do
+          echo "INFO 2026-07-12T00:00:00Z module-$i initialized in $${i}ms status=ok build=stable"
+          if [ $i -eq 2100 ]; then
+            echo "ERROR test_alpha_7731 failed: assertion mismatch (exit 3)"
+          fi
+          i=$((i+1))
+        done
+      EOT
+    }
+
+    judge {
+      type    = "file-contains"
+      path    = "answer.txt"
+      pattern = "test_alpha_7731"
+    }
+  }
+
+  task "two-needles-require-paging" {
+    description = "Two numeric tokens sit ~170 KB apart in one command's stdout — no single preview or page contains both. The agent must sum them, forcing either paged reads or full-stream ingestion."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      The workspace contains a script called emit.sh. Run `sh emit.sh`. Its output contains exactly one line starting with "TOKEN-A:" and exactly one line starting with "TOKEN-B:", each followed by an integer. Add the two integers together and write the sum (digits only) to a file called answer.txt.
+    EOT
+
+    file "emit.sh" {
+      content = <<-EOT
+        #!/bin/sh
+        i=1
+        while [ $i -le 3000 ]; do
+          echo "DEBUG 2026-07-12T00:00:00Z worker-$i heartbeat rss=$${i}kb queue=0 state=idle"
+          if [ $i -eq 200 ]; then
+            echo "TOKEN-A: 4217"
+          fi
+          if [ $i -eq 2600 ]; then
+            echo "TOKEN-B: 9038"
+          fi
+          i=$((i+1))
+        done
+      EOT
+    }
+
+    judge {
+      type    = "file-contains"
+      path    = "answer.txt"
+      pattern = "13255"
+    }
+  }
+
+  task "small-output-stays-simple" {
+    description = "Control task: a command with tiny output. Both arms should behave identically — guards against the capture pipeline regressing the common case."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      Run the shell command `echo ready-42`. Write the exact text it printed to a file called answer.txt.
+    EOT
+
+    judge {
+      type    = "file-contains"
+      path    = "answer.txt"
+      pattern = "ready-42"
+    }
+  }
+}

--- a/eval/suites/command-output-ab-on.hcl
+++ b/eval/suites/command-output-ab-on.hcl
@@ -1,0 +1,131 @@
+// Command-output capture A/B suite — "on" arm (issue: PR #495).
+//
+// This suite and command-output-ab-off.hcl carry byte-identical tasks;
+// the only difference is the suite-level tools.command_output block.
+// This arm enables capture with a deliberately low inline_max_bytes so
+// every noisy command spills: the model sees a bounded preview plus a
+// stirrup://command-output reference it can page through with
+// read_command_output. The off arm reverts run_command to the legacy
+// inline path, so the full stream lands in the model's context.
+//
+// Each task runs a command whose stdout is large (~200 KB) while the
+// answer needs only a targeted slice of it — the workload the capture
+// pipeline claims to improve. Judges are deterministic file checks.
+//
+// A/B recipe (compare token spend at equal-or-better pass rate):
+//   ANTHROPIC_API_KEY=... ./stirrup-eval run \
+//       --suite eval/suites/command-output-ab-off.hcl --output results/co-off
+//   ANTHROPIC_API_KEY=... ./stirrup-eval run \
+//       --suite eval/suites/command-output-ab-on.hcl --output results/co-on
+//   ./stirrup-eval compare -baseline results/co-off/result.json \
+//       -current results/co-on/result.json
+//
+// Opt-in, live-provider, no CI baseline. Pass --model to test other
+// models; it overrides the pinned model_router.
+
+suite "command-output-ab-on" {
+  description = "A/B arm with command-output capture enabled and a low spill threshold. Pair with command-output-ab-off; identical tasks, differing only in tools.command_output."
+
+  run_config {
+    mode      = "execution"
+    max_turns = 20
+
+    provider {
+      type        = "anthropic"
+      api_key_ref = "secret://ANTHROPIC_API_KEY"
+    }
+
+    model_router {
+      type     = "static"
+      provider = "anthropic"
+      model    = "claude-haiku-4-5"
+    }
+
+    tools {
+      command_output {
+        enabled                  = true
+        inline_max_bytes         = 4096
+        preview_bytes_per_stream = 2048
+      }
+    }
+  }
+
+  task "needle-in-verbose-output" {
+    description = "A ~200 KB build log streams to stdout with a single ERROR line buried mid-stream, outside any spill preview. The agent must identify the failing test name. Measures whether targeted reads beat inlining the whole stream."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      The workspace contains a script called noisy.sh. Run `sh noisy.sh` and find the single ERROR line in its output. Write the name of the failing test (just the test name, e.g. test_something_123) to a file called answer.txt.
+    EOT
+
+    file "noisy.sh" {
+      content = <<-EOT
+        #!/bin/sh
+        i=1
+        while [ $i -le 3000 ]; do
+          echo "INFO 2026-07-12T00:00:00Z module-$i initialized in $${i}ms status=ok build=stable"
+          if [ $i -eq 2100 ]; then
+            echo "ERROR test_alpha_7731 failed: assertion mismatch (exit 3)"
+          fi
+          i=$((i+1))
+        done
+      EOT
+    }
+
+    judge {
+      type    = "file-contains"
+      path    = "answer.txt"
+      pattern = "test_alpha_7731"
+    }
+  }
+
+  task "two-needles-require-paging" {
+    description = "Two numeric tokens sit ~170 KB apart in one command's stdout — no single preview or page contains both. The agent must sum them, forcing either paged reads or full-stream ingestion."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      The workspace contains a script called emit.sh. Run `sh emit.sh`. Its output contains exactly one line starting with "TOKEN-A:" and exactly one line starting with "TOKEN-B:", each followed by an integer. Add the two integers together and write the sum (digits only) to a file called answer.txt.
+    EOT
+
+    file "emit.sh" {
+      content = <<-EOT
+        #!/bin/sh
+        i=1
+        while [ $i -le 3000 ]; do
+          echo "DEBUG 2026-07-12T00:00:00Z worker-$i heartbeat rss=$${i}kb queue=0 state=idle"
+          if [ $i -eq 200 ]; then
+            echo "TOKEN-A: 4217"
+          fi
+          if [ $i -eq 2600 ]; then
+            echo "TOKEN-B: 9038"
+          fi
+          i=$((i+1))
+        done
+      EOT
+    }
+
+    judge {
+      type    = "file-contains"
+      path    = "answer.txt"
+      pattern = "13255"
+    }
+  }
+
+  task "small-output-stays-simple" {
+    description = "Control task: a command with tiny output. Both arms should behave identically — guards against the capture pipeline regressing the common case."
+    repo        = ""
+    ref         = ""
+    mode        = "execution"
+    prompt      = <<-EOT
+      Run the shell command `echo ready-42`. Write the exact text it printed to a file called answer.txt.
+    EOT
+
+    judge {
+      type    = "file-contains"
+      path    = "answer.txt"
+      pattern = "ready-42"
+    }
+  }
+}

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -109,6 +109,9 @@ func printRunSummary(runTrace *types.RunTrace) {
 		ran, failed := hookSummaryCounts(runTrace.HookResults)
 		fmt.Fprintf(os.Stderr, "Hooks: %d run, %d failed\n", ran, failed)
 	}
+	if runTrace.CommandOutputArchive != "" {
+		fmt.Fprintf(os.Stderr, "Command output archive: %s\n", runTrace.CommandOutputArchive)
+	}
 }
 
 // hookSummaryCounts reports how many lifecycle hooks (issue #461)
@@ -154,13 +157,14 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 		return types.RunResult{SchemaVersion: 1, Outcome: "internal-error"}
 	}
 	res := types.RunResult{
-		SchemaVersion:      1,
-		RunID:              rt.ID,
-		Outcome:            rt.Outcome,
-		Turns:              rt.Turns,
-		TokenUsage:         rt.TokenUsage,
-		DurationMs:         rt.CompletedAt.Sub(rt.StartedAt).Milliseconds(),
-		FinalAssistantText: rt.FinalAssistantText,
+		SchemaVersion:        1,
+		RunID:                rt.ID,
+		Outcome:              rt.Outcome,
+		Turns:                rt.Turns,
+		TokenUsage:           rt.TokenUsage,
+		DurationMs:           rt.CompletedAt.Sub(rt.StartedAt).Milliseconds(),
+		FinalAssistantText:   rt.FinalAssistantText,
+		CommandOutputArchive: rt.CommandOutputArchive,
 	}
 	if n := len(rt.VerificationResults); n > 0 {
 		last := rt.VerificationResults[n-1]
@@ -182,7 +186,8 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 // other documented value on types.RunTrace.Outcome — "error",
 // "tool_failures", "verification_failed", "verification_error",
 // "max_turns", "max_tokens", "budget_exceeded", "stalled",
-// "cancelled", "timeout", "setup_failed", "hook_failed" — means the
+// "cancelled", "timeout", "setup_failed", "hook_failed",
+// "command_output_capture_failed", "trace_archive_failed" — means the
 // run did not complete its task, whether via a hard failure, an
 // exhausted resource limit, or an interruption. docs/configuration.md
 // draws the same line ("a failed or cancelled run still exits

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -187,7 +187,7 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 // "tool_failures", "verification_failed", "verification_error",
 // "max_turns", "max_tokens", "budget_exceeded", "stalled",
 // "cancelled", "timeout", "setup_failed", "hook_failed",
-// "command_output_capture_failed", "trace_archive_failed" — means the
+// "command_output_capture_failed", "command_output_archive_failed" — means the
 // run did not complete its task, whether via a hard failure, an
 // exhausted resource limit, or an interruption. docs/configuration.md
 // draws the same line ("a failed or cancelled run still exits

--- a/harness/internal/commandoutput/gcs.go
+++ b/harness/internal/commandoutput/gcs.go
@@ -1,0 +1,56 @@
+package commandoutput
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/credential"
+	"github.com/rxbynerd/stirrup/harness/internal/gcs"
+)
+
+type GCSUploaderOptions struct {
+	Bucket          string
+	ObjectPrefix    string
+	Bearer          credential.BearerTokenFunc
+	HTTPClient      *http.Client
+	EndpointBaseURL string
+}
+
+type GCSUploader struct{ opts GCSUploaderOptions }
+
+func NewGCSUploader(opts GCSUploaderOptions) (*GCSUploader, error) {
+	if opts.Bucket == "" || opts.Bearer == nil {
+		return nil, fmt.Errorf("command output GCS uploader requires bucket and bearer token")
+	}
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = &http.Client{Timeout: 5 * time.Minute}
+	}
+	return &GCSUploader{opts: opts}, nil
+}
+
+func (u *GCSUploader) UploadCommandOutputArchive(ctx context.Context, localPath, archiveID string) (string, error) {
+	f, err := os.Open(localPath)
+	if err != nil {
+		return "", fmt.Errorf("open archive for upload: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat archive for upload: %w", err)
+	}
+	object := archiveID + ".command-output.tar.gz"
+	if u.opts.ObjectPrefix != "" {
+		object = strings.TrimSuffix(u.opts.ObjectPrefix, "/") + "/" + object
+	}
+	if err := gcs.UploadObject(ctx, u.opts.HTTPClient, gcs.UploadOptions{
+		Bucket: u.opts.Bucket, Object: object, BodyReader: f, BodySize: info.Size(), ContentType: "application/gzip",
+		Bearer: u.opts.Bearer, EndpointBaseURL: u.opts.EndpointBaseURL,
+	}); err != nil {
+		return "", err
+	}
+	return "gs://" + u.opts.Bucket + "/" + object, nil
+}

--- a/harness/internal/commandoutput/gcs_test.go
+++ b/harness/internal/commandoutput/gcs_test.go
@@ -50,3 +50,33 @@ func TestGCSUploaderStreamsArchiveBesideTracePrefix(t *testing.T) {
 		t.Fatalf("body=%q", got)
 	}
 }
+
+func TestGCSUploaderNormalisesUnslashedPrefix(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("name") != "traces/run-1.command-output.tar.gz" {
+			t.Errorf("name=%q", r.URL.Query().Get("name"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+	if err := os.WriteFile(path, []byte("bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// ValidateRunConfig deliberately does not rewrite the configured
+	// prefix; the uploader owns slash normalisation.
+	uploader, err := NewGCSUploader(GCSUploaderOptions{
+		Bucket: "bucket-name", ObjectPrefix: "traces", EndpointBaseURL: server.URL,
+		Bearer: func(context.Context) (string, error) { return "token", nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	uri, err := uploader.UploadCommandOutputArchive(context.Background(), path, "run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uri != "gs://bucket-name/traces/run-1.command-output.tar.gz" {
+		t.Fatalf("uri=%q", uri)
+	}
+}

--- a/harness/internal/commandoutput/gcs_test.go
+++ b/harness/internal/commandoutput/gcs_test.go
@@ -1,0 +1,52 @@
+package commandoutput
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGCSUploaderStreamsArchiveBesideTracePrefix(t *testing.T) {
+	var got []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Errorf("authorization=%q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Query().Get("name") != "traces/run-1.command-output.tar.gz" {
+			t.Errorf("name=%q", r.URL.Query().Get("name"))
+		}
+		var err error
+		got, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+	want := []byte("compressed archive bytes")
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	uploader, err := NewGCSUploader(GCSUploaderOptions{
+		Bucket: "bucket-name", ObjectPrefix: "traces/", EndpointBaseURL: server.URL,
+		Bearer: func(context.Context) (string, error) { return "token", nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	uri, err := uploader.UploadCommandOutputArchive(context.Background(), path, "run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uri != "gs://bucket-name/traces/run-1.command-output.tar.gz" {
+		t.Fatalf("uri=%q", uri)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("body=%q", got)
+	}
+}

--- a/harness/internal/commandoutput/store.go
+++ b/harness/internal/commandoutput/store.go
@@ -378,7 +378,16 @@ func (c *Capture) canonicalize(stream string, w *spoolWriter) (string, string, t
 		return "", "", meta, fmt.Errorf("%w: write canonical %s: %v", ErrCaptureIO, stream, err)
 	}
 	sum := sha256.Sum256([]byte(scrubbed))
-	ref := fmt.Sprintf("stirrup://command-output/%s/%s/%s", c.store.archiveID, memberID, stream)
+	// The model-visible reference must stay short: the loop's tool guard
+	// rejects inputs containing base64-like runs longer than 100
+	// characters (security.GuardToolCall's encoded_payload rule), and a
+	// reference embedding archiveID plus the base64url member ID tripped
+	// it — the model's first read_command_output call was denied. A
+	// truncated digest of the store-unique entry key keeps the reference
+	// opaque, collision-safe within the run, and far under the guard's
+	// threshold; the refs map carries the actual file mapping.
+	refID := sha256.Sum256([]byte(c.entry.record.RunID + "\x00" + c.entry.record.ToolUseID))
+	ref := fmt.Sprintf("stirrup://command-output/%s/%s", hex.EncodeToString(refID[:8]), stream)
 	meta.ScrubbedBytes = int64(len(scrubbed))
 	meta.ScrubbedSHA256 = hex.EncodeToString(sum[:])
 	meta.ArchiveMember = member

--- a/harness/internal/commandoutput/store.go
+++ b/harness/internal/commandoutput/store.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -51,26 +52,6 @@ type Options struct {
 	Config      types.CommandOutputConfig
 	ArchivePath string
 	Uploader    Uploader
-}
-
-// CallContext is attached by the loop before a model-facing command tool is
-// invoked. It lets the store correlate bytes with transcript identifiers.
-type CallContext struct {
-	RunID       string
-	ParentRunID string
-	Turn        int
-	ToolUseID   string
-}
-
-type callContextKey struct{}
-
-func WithCallContext(ctx context.Context, meta CallContext) context.Context {
-	return context.WithValue(ctx, callContextKey{}, meta)
-}
-
-func CallContextFrom(ctx context.Context) CallContext {
-	meta, _ := ctx.Value(callContextKey{}).(CallContext)
-	return meta
 }
 
 // Store is shared by a parent run and all subagents.
@@ -221,7 +202,7 @@ func (s *Store) Begin(ctx context.Context, cancel context.CancelCauseFunc) (*Cap
 		return nil, fmt.Errorf("command output store is failed: %w", err)
 	}
 	s.mu.Unlock()
-	meta := CallContextFrom(ctx)
+	meta := tool.CallContextFrom(ctx)
 	if meta.ToolUseID == "" {
 		meta.ToolUseID = fmt.Sprintf("command-%d", time.Now().UnixNano())
 	}
@@ -489,7 +470,7 @@ func (s *Store) Read(ref string, offset, limit int64) (ReadResult, error) {
 // member path: the store is shared across a parent run and its subagents, so
 // a bare tool-use ID can collide across conversations and silently overwrite
 // a ledger file.
-func (s *Store) RecordRead(reader CallContext, ref string, result ReadResult, modelVisible string) error {
+func (s *Store) RecordRead(reader tool.CallContext, ref string, result ReadResult, modelVisible string) error {
 	s.mu.Lock()
 	r, ok := s.refs[ref]
 	s.mu.Unlock()

--- a/harness/internal/commandoutput/store.go
+++ b/harness/internal/commandoutput/store.go
@@ -1,6 +1,13 @@
 // Package commandoutput owns complete, scrubbed run_command output capture.
-// Raw bytes exist only in run-scoped spool files and are deleted immediately
-// after whole-stream redaction; durable archives contain scrubbed bytes only.
+//
+// Raw (unscrubbed) bytes are spooled to run-scoped 0600 files under a 0700
+// temp directory while a command streams, and each spool is deleted when its
+// command completes and whole-stream redaction has produced the scrubbed
+// canonical copy. Durable archives contain scrubbed bytes only. The raw
+// spool's lifetime therefore depends on clean completion: a crash or SIGKILL
+// mid-command can leave raw spool files in the OS temp directory until it is
+// cleared (scrub-on-write, which would remove the raw-bytes-at-rest window
+// entirely, is tracked as a follow-up).
 package commandoutput
 
 import (

--- a/harness/internal/commandoutput/store.go
+++ b/harness/internal/commandoutput/store.go
@@ -264,7 +264,11 @@ func (w *spoolWriter) Write(p []byte) (int, error) {
 	if streamExceeded || runExceeded {
 		err := fmt.Errorf("%w: per-stream=%d/%d run=%d/%d", ErrCaptureLimit,
 			w.count+int64(len(p)), w.limit, w.store.totalRaw+int64(len(p)), w.store.config.MaxBytesPerRun)
-		if w.store.fatalErr == nil {
+		// A limit breach always cancels the offending command, but only
+		// the strict posture poisons the store: under bestEffort later
+		// commands keep capturing (run-total accounting still applies —
+		// once totalRaw is at the cap every subsequent write breaches).
+		if w.store.config.FailurePosture != types.CommandOutputPostureBestEffort && w.store.fatalErr == nil {
 			w.store.fatalErr = err
 		}
 		w.store.mu.Unlock()
@@ -309,6 +313,12 @@ func (w *spoolWriter) close() error {
 func (w *spoolWriter) sum() string { return hex.EncodeToString(w.hash.Sum(nil)) }
 
 func (s *Store) fail(err error) {
+	// Pure limit breaches are per-command failures under bestEffort;
+	// storage (IO) failures poison the store in both postures.
+	if s.config.FailurePosture == types.CommandOutputPostureBestEffort &&
+		errors.Is(err, ErrCaptureLimit) && !errors.Is(err, ErrCaptureIO) {
+		return
+	}
 	s.mu.Lock()
 	if s.fatalErr == nil {
 		s.fatalErr = err
@@ -525,12 +535,17 @@ func (s *Store) Finalize(ctx context.Context) (string, error) {
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].record.ToolUseID < entries[j].record.ToolUseID })
 	commands := make([]types.CommandOutputRecord, 0, len(entries))
+	allComplete := true
 	for _, e := range entries {
 		e.mu.Lock()
 		commands = append(commands, e.record)
+		allComplete = allComplete && e.record.CaptureComplete
 		e.mu.Unlock()
 	}
-	m := manifest{SchemaVersion: 1, ArchiveID: s.archiveID, CreatedAt: time.Now(), Complete: fatal == nil, Commands: commands}
+	// Complete requires every capture to have finished cleanly, not just
+	// the absence of a store-fatal error: under bestEffort a limit breach
+	// fails only its own command and must still be visible here.
+	m := manifest{SchemaVersion: 1, ArchiveID: s.archiveID, CreatedAt: time.Now(), Complete: fatal == nil && allComplete, Commands: commands}
 	if fatal != nil {
 		m.Failure = security.Scrub(fatal.Error())
 	}

--- a/harness/internal/commandoutput/store.go
+++ b/harness/internal/commandoutput/store.go
@@ -485,14 +485,18 @@ func (s *Store) Read(ref string, offset, limit int64) (ReadResult, error) {
 }
 
 // RecordRead adds the exact model-visible read result to the access ledger.
-func (s *Store) RecordRead(readerToolUseID, ref string, result ReadResult, modelVisible string) error {
+// The archive member is scoped by the reader's run ID, matching every other
+// member path: the store is shared across a parent run and its subagents, so
+// a bare tool-use ID can collide across conversations and silently overwrite
+// a ledger file.
+func (s *Store) RecordRead(reader CallContext, ref string, result ReadResult, modelVisible string) error {
 	s.mu.Lock()
 	r, ok := s.refs[ref]
 	s.mu.Unlock()
 	if !ok {
 		return fmt.Errorf("unknown command output reference")
 	}
-	member := filepath.ToSlash(filepath.Join("model-visible", encodedID(readerToolUseID), "chunk.txt"))
+	member := filepath.ToSlash(filepath.Join("model-visible", encodedID(reader.RunID+"-"+reader.ToolUseID), "chunk.txt"))
 	path := filepath.Join(s.root, filepath.FromSlash(member))
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		wrapped := fmt.Errorf("%w: write read ledger directory: %v", ErrCaptureIO, err)
@@ -506,7 +510,7 @@ func (s *Store) RecordRead(readerToolUseID, ref string, result ReadResult, model
 	}
 	sum := sha256.Sum256([]byte(modelVisible))
 	read := types.CommandOutputReadRecord{
-		ToolUseID: readerToolUseID, Reference: ref, Offset: result.Offset,
+		ToolUseID: reader.ToolUseID, Reference: ref, Offset: result.Offset,
 		EndOffset: result.End, EOF: result.EOF, ResultSHA256: hex.EncodeToString(sum[:]),
 		ArchiveMember: member,
 	}

--- a/harness/internal/commandoutput/store.go
+++ b/harness/internal/commandoutput/store.go
@@ -1,0 +1,688 @@
+// Package commandoutput owns complete, scrubbed run_command output capture.
+// Raw bytes exist only in run-scoped spool files and are deleted immediately
+// after whole-stream redaction; durable archives contain scrubbed bytes only.
+package commandoutput
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+const (
+	ReadDefaultBytes int64 = 32 << 10
+	ReadMaxBytes     int64 = 128 << 10
+)
+
+var (
+	ErrCaptureLimit = errors.New("command output capture limit exceeded")
+	ErrCaptureIO    = errors.New("command output capture storage failed")
+)
+
+// Recorder receives bounded command metadata for the trace stream.
+type Recorder interface {
+	RecordCommandOutput(types.CommandOutputRecord)
+}
+
+// Uploader persists a completed archive and returns its durable URI.
+type Uploader interface {
+	UploadCommandOutputArchive(ctx context.Context, localPath, archiveID string) (string, error)
+}
+
+type Options struct {
+	RunID       string
+	Config      types.CommandOutputConfig
+	ArchivePath string
+	Uploader    Uploader
+}
+
+// CallContext is attached by the loop before a model-facing command tool is
+// invoked. It lets the store correlate bytes with transcript identifiers.
+type CallContext struct {
+	RunID       string
+	ParentRunID string
+	Turn        int
+	ToolUseID   string
+}
+
+type callContextKey struct{}
+
+func WithCallContext(ctx context.Context, meta CallContext) context.Context {
+	return context.WithValue(ctx, callContextKey{}, meta)
+}
+
+func CallContextFrom(ctx context.Context) CallContext {
+	meta, _ := ctx.Value(callContextKey{}).(CallContext)
+	return meta
+}
+
+// Store is shared by a parent run and all subagents.
+type Store struct {
+	mu          sync.Mutex
+	root        string
+	archivePath string
+	archiveID   string
+	config      types.CommandOutputConfig
+	uploader    Uploader
+	recorder    Recorder
+	totalRaw    int64
+	fatalErr    error
+	entries     map[string]*entry
+	refs        map[string]streamRef
+	finalized   bool
+	archiveURI  string
+}
+
+type entry struct {
+	mu           sync.Mutex
+	record       types.CommandOutputRecord
+	stdoutPath   string
+	stderrPath   string
+	initialPath  string
+	modelFiles   []string
+	recorderSent bool
+}
+
+type streamRef struct {
+	entry  *entry
+	stream string
+	path   string
+}
+
+type Capture struct {
+	store  *Store
+	entry  *entry
+	stdout *spoolWriter
+	stderr *spoolWriter
+}
+
+type spoolWriter struct {
+	store  *Store
+	file   *os.File
+	hash   hash.Hash
+	count  int64
+	limit  int64
+	cancel context.CancelCauseFunc
+	failed error
+	closed bool
+	mu     sync.Mutex
+}
+
+type Completion struct {
+	ExitCode  int
+	TimedOut  bool
+	Cancelled bool
+}
+
+type Captured struct {
+	Record types.CommandOutputRecord
+	Stdout string
+	Stderr string
+}
+
+type ReadResult struct {
+	Content types.CommandOutputStreamRecord
+	Bytes   []byte
+	Offset  int64
+	End     int64
+	EOF     bool
+	Stream  string
+}
+
+type manifest struct {
+	SchemaVersion int                         `json:"schemaVersion"`
+	ArchiveID     string                      `json:"archiveId"`
+	CreatedAt     time.Time                   `json:"createdAt"`
+	Complete      bool                        `json:"complete"`
+	Failure       string                      `json:"failure,omitempty"`
+	Commands      []types.CommandOutputRecord `json:"commands"`
+}
+
+func New(opts Options) (*Store, error) {
+	opts.Config = (types.ToolsConfig{CommandOutput: opts.Config}).EffectiveCommandOutput()
+	root, err := os.MkdirTemp("", "stirrup-command-output-")
+	if err != nil {
+		return nil, fmt.Errorf("create command output store: %w", err)
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("secure command output store: %w", err)
+	}
+	archiveID := safeID(opts.RunID)
+	if archiveID == "" {
+		archiveID = fmt.Sprintf("run-%d", time.Now().UnixNano())
+	}
+	archivePath := opts.ArchivePath
+	if archivePath == "" {
+		archivePath = filepath.Join(os.TempDir(), archiveID+".command-output.tar.gz")
+	}
+	absArchive, err := filepath.Abs(archivePath)
+	if err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("resolve command output archive path: %w", err)
+	}
+	return &Store{
+		root: root, archivePath: absArchive, archiveID: archiveID,
+		config: opts.Config, uploader: opts.Uploader,
+		entries: map[string]*entry{}, refs: map[string]streamRef{},
+	}, nil
+}
+
+func (s *Store) SetRecorder(recorder Recorder) {
+	s.mu.Lock()
+	s.recorder = recorder
+	s.mu.Unlock()
+}
+
+func (s *Store) FatalError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fatalErr
+}
+
+func (s *Store) Archive() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.archiveURI != "" {
+		return s.archiveURI
+	}
+	return s.archivePath
+}
+
+func (s *Store) HasEntries() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries) > 0
+}
+
+func (s *Store) Begin(ctx context.Context, cancel context.CancelCauseFunc) (*Capture, error) {
+	s.mu.Lock()
+	if s.fatalErr != nil {
+		err := s.fatalErr
+		s.mu.Unlock()
+		cancel(err)
+		return nil, fmt.Errorf("command output store is failed: %w", err)
+	}
+	s.mu.Unlock()
+	meta := CallContextFrom(ctx)
+	if meta.ToolUseID == "" {
+		meta.ToolUseID = fmt.Sprintf("command-%d", time.Now().UnixNano())
+	}
+	key := meta.RunID + "\x00" + meta.ToolUseID
+	dirName := encodedID(meta.RunID + "-" + meta.ToolUseID)
+	dir := filepath.Join(s.root, "commands", dirName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		s.fail(fmt.Errorf("%w: create command spool directory: %v", ErrCaptureIO, err))
+		return nil, s.FatalError()
+	}
+	stdout, err := newSpoolWriter(s, filepath.Join(dir, "stdout.raw"), s.config.MaxBytesPerStream, cancel)
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := newSpoolWriter(s, filepath.Join(dir, "stderr.raw"), s.config.MaxBytesPerStream, cancel)
+	if err != nil {
+		_ = stdout.close()
+		return nil, err
+	}
+	e := &entry{record: types.CommandOutputRecord{
+		ArchiveID: s.archiveID, RunID: meta.RunID, ParentRunID: meta.ParentRunID,
+		Turn: meta.Turn, ToolUseID: meta.ToolUseID, StartedAt: time.Now(),
+	}}
+	s.mu.Lock()
+	if _, exists := s.entries[key]; exists {
+		s.mu.Unlock()
+		_ = stdout.close()
+		_ = stderr.close()
+		return nil, fmt.Errorf("duplicate command output capture for tool use %q", meta.ToolUseID)
+	}
+	s.entries[key] = e
+	s.mu.Unlock()
+	return &Capture{store: s, entry: e, stdout: stdout, stderr: stderr}, nil
+}
+
+func newSpoolWriter(store *Store, path string, limit int64, cancel context.CancelCauseFunc) (*spoolWriter, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		wrapped := fmt.Errorf("%w: create spool: %v", ErrCaptureIO, err)
+		store.fail(wrapped)
+		cancel(wrapped)
+		return nil, wrapped
+	}
+	return &spoolWriter{store: store, file: f, hash: sha256.New(), limit: limit, cancel: cancel}, nil
+}
+
+func (w *spoolWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.failed != nil {
+		return 0, w.failed
+	}
+	if w.closed {
+		return 0, os.ErrClosed
+	}
+	w.store.mu.Lock()
+	streamExceeded := w.count+int64(len(p)) > w.limit
+	runExceeded := w.store.totalRaw+int64(len(p)) > w.store.config.MaxBytesPerRun
+	if streamExceeded || runExceeded {
+		err := fmt.Errorf("%w: per-stream=%d/%d run=%d/%d", ErrCaptureLimit,
+			w.count+int64(len(p)), w.limit, w.store.totalRaw+int64(len(p)), w.store.config.MaxBytesPerRun)
+		if w.store.fatalErr == nil {
+			w.store.fatalErr = err
+		}
+		w.store.mu.Unlock()
+		w.failed = err
+		w.cancel(err)
+		return 0, err
+	}
+	w.store.totalRaw += int64(len(p))
+	w.store.mu.Unlock()
+	n, err := w.file.Write(p)
+	if n > 0 {
+		_, _ = w.hash.Write(p[:n])
+		w.count += int64(n)
+	}
+	if err != nil || n != len(p) {
+		if err == nil {
+			err = io.ErrShortWrite
+		}
+		wrapped := fmt.Errorf("%w: write spool: %v", ErrCaptureIO, err)
+		w.failed = wrapped
+		w.store.fail(wrapped)
+		w.cancel(wrapped)
+		return n, wrapped
+	}
+	return n, nil
+}
+
+func (w *spoolWriter) close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return w.failed
+	}
+	w.closed = true
+	if err := w.file.Close(); err != nil && w.failed == nil {
+		w.failed = fmt.Errorf("%w: close spool: %v", ErrCaptureIO, err)
+		w.store.fail(w.failed)
+	}
+	return w.failed
+}
+
+func (w *spoolWriter) sum() string { return hex.EncodeToString(w.hash.Sum(nil)) }
+
+func (s *Store) fail(err error) {
+	s.mu.Lock()
+	if s.fatalErr == nil {
+		s.fatalErr = err
+	}
+	s.mu.Unlock()
+}
+
+func (c *Capture) Stdout() io.Writer { return c.stdout }
+func (c *Capture) Stderr() io.Writer { return c.stderr }
+
+func (c *Capture) Complete(status Completion) (Captured, error) {
+	stdoutClose := c.stdout.close()
+	stderrClose := c.stderr.close()
+	record := &c.entry.record
+	record.CompletedAt = time.Now()
+	record.ExitCode = status.ExitCode
+	record.TimedOut = status.TimedOut
+	record.Cancelled = status.Cancelled
+
+	stdout, stdoutPath, stdoutMeta, stdoutErr := c.canonicalize("stdout", c.stdout)
+	stderr, stderrPath, stderrMeta, stderrErr := c.canonicalize("stderr", c.stderr)
+	record.Stdout, record.Stderr = stdoutMeta, stderrMeta
+	c.entry.stdoutPath, c.entry.stderrPath = stdoutPath, stderrPath
+
+	err := errors.Join(stdoutClose, stderrClose, stdoutErr, stderrErr)
+	record.CaptureComplete = err == nil
+	if err != nil {
+		record.CaptureError = security.Scrub(err.Error())
+		c.store.fail(err)
+	}
+	return Captured{Record: *record, Stdout: stdout, Stderr: stderr}, err
+}
+
+func (c *Capture) canonicalize(stream string, w *spoolWriter) (string, string, types.CommandOutputStreamRecord, error) {
+	rawPath := w.file.Name()
+	meta := types.CommandOutputStreamRecord{RawBytes: w.count, RawSHA256: w.sum()}
+	defer func() { _ = os.Remove(rawPath) }()
+	raw, err := os.ReadFile(rawPath)
+	if err != nil {
+		return "", "", meta, fmt.Errorf("%w: read complete %s spool: %v", ErrCaptureIO, stream, err)
+	}
+	scrubbed, stats := security.ScrubWithStats(string(raw))
+	memberID := encodedID(c.entry.record.RunID + "-" + c.entry.record.ToolUseID)
+	member := filepath.ToSlash(filepath.Join("commands", memberID, stream+".txt"))
+	path := filepath.Join(c.store.root, filepath.FromSlash(member))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", "", meta, fmt.Errorf("%w: create canonical directory: %v", ErrCaptureIO, err)
+	}
+	if err := os.WriteFile(path, []byte(scrubbed), 0o600); err != nil {
+		return "", "", meta, fmt.Errorf("%w: write canonical %s: %v", ErrCaptureIO, stream, err)
+	}
+	sum := sha256.Sum256([]byte(scrubbed))
+	ref := fmt.Sprintf("stirrup://command-output/%s/%s/%s", c.store.archiveID, memberID, stream)
+	meta.ScrubbedBytes = int64(len(scrubbed))
+	meta.ScrubbedSHA256 = hex.EncodeToString(sum[:])
+	meta.ArchiveMember = member
+	meta.Reference = ref
+	meta.RedactionCount = stats.Count
+	meta.RedactionPatterns = append([]string(nil), stats.Patterns...)
+	c.store.mu.Lock()
+	c.store.refs[ref] = streamRef{entry: c.entry, stream: stream, path: path}
+	c.store.mu.Unlock()
+	modelContent := scrubbed
+	retain := c.store.config.InlineMaxBytes
+	if c.store.config.PreviewBytesPerStream > retain {
+		retain = c.store.config.PreviewBytesPerStream
+	}
+	if int64(len(modelContent)) > retain {
+		// Copy the tail so the small preview does not retain the complete
+		// scrubbed stream's backing allocation after canonicalization.
+		modelContent = string(append([]byte(nil), modelContent[len(modelContent)-int(retain):]...))
+	}
+	return modelContent, path, meta, nil
+}
+
+// RecordInitial persists the exact scrubbed result exposed to the model and
+// emits the now-complete metadata record to the configured trace recorder.
+func (s *Store) RecordInitial(record *types.CommandOutputRecord, result string) error {
+	key := record.RunID + "\x00" + record.ToolUseID
+	s.mu.Lock()
+	e := s.entries[key]
+	recorder := s.recorder
+	s.mu.Unlock()
+	if e == nil {
+		return fmt.Errorf("command output record not found for %q", record.ToolUseID)
+	}
+	memberID := encodedID(record.RunID + "-" + record.ToolUseID)
+	member := filepath.ToSlash(filepath.Join("model-visible", memberID, "initial-result.txt"))
+	path := filepath.Join(s.root, filepath.FromSlash(member))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		wrapped := fmt.Errorf("%w: write initial result directory: %v", ErrCaptureIO, err)
+		s.fail(wrapped)
+		return wrapped
+	}
+	if err := os.WriteFile(path, []byte(result), 0o600); err != nil {
+		wrapped := fmt.Errorf("%w: write initial result: %v", ErrCaptureIO, err)
+		s.fail(wrapped)
+		return wrapped
+	}
+	sum := sha256.Sum256([]byte(result))
+	e.mu.Lock()
+	e.initialPath = path
+	e.record.InitialResultSHA256 = hex.EncodeToString(sum[:])
+	e.record.InitialResultMember = member
+	*record = e.record
+	copyRecord := e.record
+	e.recorderSent = true
+	e.mu.Unlock()
+	if recorder != nil {
+		recorder.RecordCommandOutput(copyRecord)
+	}
+	return nil
+}
+
+func (s *Store) Read(ref string, offset, limit int64) (ReadResult, error) {
+	if offset < 0 {
+		return ReadResult{}, fmt.Errorf("offset must not be negative")
+	}
+	if limit <= 0 {
+		limit = ReadDefaultBytes
+	}
+	if limit > ReadMaxBytes {
+		limit = ReadMaxBytes
+	}
+	s.mu.Lock()
+	r, ok := s.refs[ref]
+	s.mu.Unlock()
+	if !ok {
+		return ReadResult{}, fmt.Errorf("unknown command output reference")
+	}
+	var meta types.CommandOutputStreamRecord
+	r.entry.mu.Lock()
+	if r.stream == "stdout" {
+		meta = r.entry.record.Stdout
+	} else {
+		meta = r.entry.record.Stderr
+	}
+	r.entry.mu.Unlock()
+	if offset > meta.ScrubbedBytes {
+		return ReadResult{}, fmt.Errorf("offset %d exceeds stream size %d", offset, meta.ScrubbedBytes)
+	}
+	f, err := os.Open(r.path)
+	if err != nil {
+		return ReadResult{}, fmt.Errorf("open command output: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	buf := make([]byte, limit)
+	n, err := f.ReadAt(buf, offset)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return ReadResult{}, fmt.Errorf("read command output: %w", err)
+	}
+	buf = buf[:n]
+	end := offset + int64(n)
+	return ReadResult{Content: meta, Bytes: buf, Offset: offset, End: end, EOF: end >= meta.ScrubbedBytes, Stream: r.stream}, nil
+}
+
+// RecordRead adds the exact model-visible read result to the access ledger.
+func (s *Store) RecordRead(readerToolUseID, ref string, result ReadResult, modelVisible string) error {
+	s.mu.Lock()
+	r, ok := s.refs[ref]
+	s.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("unknown command output reference")
+	}
+	member := filepath.ToSlash(filepath.Join("model-visible", encodedID(readerToolUseID), "chunk.txt"))
+	path := filepath.Join(s.root, filepath.FromSlash(member))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		wrapped := fmt.Errorf("%w: write read ledger directory: %v", ErrCaptureIO, err)
+		s.fail(wrapped)
+		return wrapped
+	}
+	if err := os.WriteFile(path, []byte(modelVisible), 0o600); err != nil {
+		wrapped := fmt.Errorf("%w: write read ledger: %v", ErrCaptureIO, err)
+		s.fail(wrapped)
+		return wrapped
+	}
+	sum := sha256.Sum256([]byte(modelVisible))
+	read := types.CommandOutputReadRecord{
+		ToolUseID: readerToolUseID, Reference: ref, Offset: result.Offset,
+		EndOffset: result.End, EOF: result.EOF, ResultSHA256: hex.EncodeToString(sum[:]),
+		ArchiveMember: member,
+	}
+	r.entry.mu.Lock()
+	r.entry.record.Reads = append(r.entry.record.Reads, read)
+	r.entry.modelFiles = append(r.entry.modelFiles, path)
+	r.entry.mu.Unlock()
+	return nil
+}
+
+func (s *Store) Finalize(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	if s.finalized {
+		archive := s.archiveURI
+		if archive == "" {
+			archive = s.archivePath
+		}
+		s.mu.Unlock()
+		return archive, nil
+	}
+	s.finalized = true
+	entries := make([]*entry, 0, len(s.entries))
+	for _, e := range s.entries {
+		entries = append(entries, e)
+	}
+	fatal := s.fatalErr
+	s.mu.Unlock()
+	if len(entries) == 0 {
+		_ = os.RemoveAll(s.root)
+		return "", nil
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].record.ToolUseID < entries[j].record.ToolUseID })
+	commands := make([]types.CommandOutputRecord, 0, len(entries))
+	for _, e := range entries {
+		e.mu.Lock()
+		commands = append(commands, e.record)
+		e.mu.Unlock()
+	}
+	m := manifest{SchemaVersion: 1, ArchiveID: s.archiveID, CreatedAt: time.Now(), Complete: fatal == nil, Commands: commands}
+	if fatal != nil {
+		m.Failure = security.Scrub(fatal.Error())
+	}
+	if err := s.writeArchive(m, entries); err != nil {
+		s.fail(fmt.Errorf("archive finalization: %w", err))
+		m.Complete = false
+		m.Failure = security.Scrub(err.Error())
+		_ = s.writeFailureArchive(m)
+		return s.archivePath, err
+	}
+	archive := s.archivePath
+	if s.uploader != nil {
+		uri, err := s.uploader.UploadCommandOutputArchive(ctx, s.archivePath, s.archiveID)
+		if err != nil {
+			s.fail(fmt.Errorf("archive upload: %w", err))
+			m.Complete = false
+			m.Failure = security.Scrub(err.Error())
+			_ = s.writeArchive(m, entries)
+			return s.archivePath, err
+		}
+		archive = uri
+		s.mu.Lock()
+		s.archiveURI = uri
+		s.mu.Unlock()
+		_ = os.Remove(s.archivePath)
+	}
+	_ = os.RemoveAll(s.root)
+	return archive, nil
+}
+
+// Close removes unfinished spool state. Finalized archives are outside root
+// and are never removed by Close.
+func (s *Store) Close() error { return os.RemoveAll(s.root) }
+
+func (s *Store) writeArchive(m manifest, entries []*entry) error {
+	if err := os.MkdirAll(filepath.Dir(s.archivePath), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.archivePath), ".command-output-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	gz := gzip.NewWriter(tmp)
+	tw := tar.NewWriter(gz)
+	manifestBytes, err := json.MarshalIndent(m, "", "  ")
+	if err == nil {
+		err = writeTarBytes(tw, "manifest.json", manifestBytes)
+	}
+	if err == nil {
+		for _, e := range entries {
+			e.mu.Lock()
+			files := []struct{ name, path string }{
+				{e.record.Stdout.ArchiveMember, e.stdoutPath}, {e.record.Stderr.ArchiveMember, e.stderrPath},
+				{e.record.InitialResultMember, e.initialPath},
+			}
+			for i, read := range e.record.Reads {
+				if i < len(e.modelFiles) {
+					files = append(files, struct{ name, path string }{read.ArchiveMember, e.modelFiles[i]})
+				}
+			}
+			e.mu.Unlock()
+			for _, f := range files {
+				if f.name == "" || f.path == "" {
+					continue
+				}
+				if err = writeTarFile(tw, f.name, f.path); err != nil {
+					break
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+	}
+	if closeErr := tw.Close(); err == nil {
+		err = closeErr
+	}
+	if closeErr := gz.Close(); err == nil {
+		err = closeErr
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, s.archivePath); err != nil {
+		return err
+	}
+	return os.Chmod(s.archivePath, 0o600)
+}
+
+func (s *Store) writeFailureArchive(m manifest) error { return s.writeArchive(m, nil) }
+
+func writeTarBytes(tw *tar.Writer, name string, data []byte) error {
+	h := &tar.Header{Name: filepath.ToSlash(name), Mode: 0o600, Size: int64(len(data)), ModTime: time.Now()}
+	if err := tw.WriteHeader(h); err != nil {
+		return err
+	}
+	_, err := tw.Write(data)
+	return err
+}
+
+func writeTarFile(tw *tar.Writer, name, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	h := &tar.Header{Name: filepath.ToSlash(name), Mode: 0o600, Size: info.Size(), ModTime: time.Now()}
+	if err := tw.WriteHeader(h); err != nil {
+		return err
+	}
+	_, err = io.Copy(tw, f)
+	return err
+}
+
+func encodedID(value string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(value))
+}
+
+func safeID(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+		}
+	}
+	return strings.Trim(b.String(), ".")
+}

--- a/harness/internal/commandoutput/store_test.go
+++ b/harness/internal/commandoutput/store_test.go
@@ -1,0 +1,279 @@
+package commandoutput
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+type failingUploader struct{}
+
+func (failingUploader) UploadCommandOutputArchive(context.Context, string, string) (string, error) {
+	return "", errors.New("upload unavailable")
+}
+
+func testConfig() types.CommandOutputConfig {
+	return types.CommandOutputConfig{InlineMaxBytes: 32 << 10, PreviewBytesPerStream: 4 << 10, MaxBytesPerStream: 1 << 20, MaxBytesPerRun: 2 << 20}
+}
+
+func TestStoreWholeStreamScrubArchiveAndLedger(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "output.tar.gz")
+	store, err := New(Options{RunID: "run-1", Config: testConfig(), ArchivePath: archive})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	info, err := os.Stat(store.root)
+	if err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("store mode=%v err=%v", info.Mode().Perm(), err)
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "run-1", Turn: 2, ToolUseID: "tool-1"}), cancel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Stdout().Write([]byte("before sk-ant-")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Stdout().Write([]byte("abcdefghijklmnop after")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Stderr().Write([]byte("stderr-data")); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := capture.Complete(Completion{ExitCode: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(captured.Stdout, "sk-ant-") || !strings.Contains(captured.Stdout, "[REDACTED]") {
+		t.Fatalf("stdout not scrubbed: %q", captured.Stdout)
+	}
+	raw := []byte("before sk-ant-abcdefghijklmnop after")
+	rawSum := sha256.Sum256(raw)
+	if captured.Record.Stdout.RawSHA256 != hex.EncodeToString(rawSum[:]) {
+		t.Fatalf("raw hash=%s", captured.Record.Stdout.RawSHA256)
+	}
+	if captured.Record.Stdout.RedactionCount != 1 {
+		t.Fatalf("redactions=%d", captured.Record.Stdout.RedactionCount)
+	}
+	rawFiles, err := filepath.Glob(filepath.Join(store.root, "commands", "*", "*.raw"))
+	if err != nil || len(rawFiles) != 0 {
+		t.Fatalf("raw spools remain: %v err=%v", rawFiles, err)
+	}
+
+	if err := store.RecordInitial(&captured.Record, "model-visible initial"); err != nil {
+		t.Fatal(err)
+	}
+	read, err := store.Read(captured.Record.Stdout.Reference, 7, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordRead("reader-1", captured.Record.Stdout.Reference, read, "model-visible chunk"); err != nil {
+		t.Fatal(err)
+	}
+	location, err := store.Finalize(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if location != archive {
+		t.Fatalf("location=%q", location)
+	}
+	archiveInfo, err := os.Stat(archive)
+	if err != nil || archiveInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("archive mode=%v err=%v", archiveInfo.Mode().Perm(), err)
+	}
+
+	members := readArchive(t, archive)
+	if got := string(members[captured.Record.Stdout.ArchiveMember]); got != captured.Stdout {
+		t.Fatalf("archived stdout=%q", got)
+	}
+	if got := string(members[captured.Record.Stderr.ArchiveMember]); got != "stderr-data" {
+		t.Fatalf("archived stderr=%q", got)
+	}
+	if got := string(members[captured.Record.InitialResultMember]); got != "model-visible initial" {
+		t.Fatalf("initial=%q", got)
+	}
+	var gotManifest manifest
+	if err := json.Unmarshal(members["manifest.json"], &gotManifest); err != nil {
+		t.Fatal(err)
+	}
+	if !gotManifest.Complete || len(gotManifest.Commands) != 1 || len(gotManifest.Commands[0].Reads) != 1 {
+		t.Fatalf("manifest=%+v", gotManifest)
+	}
+	if gotManifest.Commands[0].Reads[0].Offset != 7 || gotManifest.Commands[0].Reads[0].EndOffset != 19 {
+		t.Fatalf("ledger=%+v", gotManifest.Commands[0].Reads[0])
+	}
+	if strings.Contains(string(members["manifest.json"]), "sk-ant-") {
+		t.Fatal("secret leaked into manifest")
+	}
+}
+
+func TestStoreLimitFailureIsStickyAndCancels(t *testing.T) {
+	cfg := testConfig()
+	cfg.MaxBytesPerStream = 4
+	cfg.MaxBytesPerRun = 8
+	store, err := New(Options{RunID: "run-limit", Config: cfg, ArchivePath: filepath.Join(t.TempDir(), "limit.tar.gz")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "run-limit", ToolUseID: "tool-limit"}), cancel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Stdout().Write([]byte("12345")); err == nil {
+		t.Fatal("expected limit error")
+	}
+	if context.Cause(ctx) == nil || !strings.Contains(context.Cause(ctx).Error(), "capture limit") {
+		t.Fatalf("cause=%v", context.Cause(ctx))
+	}
+	if store.FatalError() == nil {
+		t.Fatal("failure not sticky")
+	}
+	captured, err := capture.Complete(Completion{Cancelled: true, ExitCode: -1})
+	if err == nil || captured.Record.CaptureComplete {
+		t.Fatalf("err=%v record=%+v", err, captured.Record)
+	}
+	if _, err := store.Finalize(context.Background()); err != nil {
+		t.Fatalf("failure manifest archive: %v", err)
+	}
+}
+
+func TestStoreLargeStreamArchiveReconstructsWithoutRetainingFullModelCopy(t *testing.T) {
+	cfg := testConfig()
+	cfg.InlineMaxBytes = 32
+	cfg.PreviewBytesPerStream = 8
+	archive := filepath.Join(t.TempDir(), "large.tar.gz")
+	store, err := New(Options{RunID: "large", Config: cfg, ArchivePath: archive})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "large", ToolUseID: "tool"}), cancel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Repeat("abcdef", 20_000)
+	if _, err := io.WriteString(capture.Stdout(), want); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := capture.Complete(Completion{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(captured.Stdout) > int(cfg.InlineMaxBytes) {
+		t.Fatalf("model copy retained %d bytes", len(captured.Stdout))
+	}
+	if err := store.RecordInitial(&captured.Record, "preview"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Finalize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	members := readArchive(t, archive)
+	if got := string(members[captured.Record.Stdout.ArchiveMember]); got != want {
+		t.Fatalf("archive reconstruction mismatch: got %d bytes want %d", len(got), len(want))
+	}
+}
+
+func TestStoreDiskAndUploadFailuresFailClosed(t *testing.T) {
+	t.Run("spool write", func(t *testing.T) {
+		store, err := New(Options{RunID: "disk", Config: testConfig(), ArchivePath: filepath.Join(t.TempDir(), "disk.tar.gz")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = store.Close() }()
+		ctx, cancel := context.WithCancelCause(context.Background())
+		capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "disk", ToolUseID: "tool"}), cancel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := capture.stdout.file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := capture.Stdout().Write([]byte("x")); err == nil {
+			t.Fatal("expected closed-file write failure")
+		}
+		if store.FatalError() == nil || context.Cause(ctx) == nil {
+			t.Fatalf("fatal=%v cause=%v", store.FatalError(), context.Cause(ctx))
+		}
+	})
+
+	t.Run("upload", func(t *testing.T) {
+		archive := filepath.Join(t.TempDir(), "upload.tar.gz")
+		store, err := New(Options{RunID: "upload", Config: testConfig(), ArchivePath: archive, Uploader: failingUploader{}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = store.Close() }()
+		ctx, cancel := context.WithCancelCause(context.Background())
+		capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "upload", ToolUseID: "tool"}), cancel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = capture.Stdout().Write([]byte("ok"))
+		captured, err := capture.Complete(Completion{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.RecordInitial(&captured.Record, "ok"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Finalize(context.Background()); err == nil {
+			t.Fatal("expected upload failure")
+		}
+		members := readArchive(t, archive)
+		var got manifest
+		if err := json.Unmarshal(members["manifest.json"], &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.Complete || !strings.Contains(got.Failure, "upload unavailable") {
+			t.Fatalf("manifest=%+v", got)
+		}
+	})
+}
+
+func readArchive(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	out := map[string][]byte{}
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[h.Name] = data
+	}
+	return out
+}

--- a/harness/internal/commandoutput/store_test.go
+++ b/harness/internal/commandoutput/store_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -118,6 +119,35 @@ func TestStoreWholeStreamScrubArchiveAndLedger(t *testing.T) {
 	}
 	if strings.Contains(string(members["manifest.json"]), "sk-ant-") {
 		t.Fatal("secret leaked into manifest")
+	}
+}
+
+// TestStoreReferencePassesToolGuard pins the model-visible reference format
+// against the loop's tool guard: a reference embedding the base64url member
+// ID formed a >100-character base64-like run and tripped the encoded_payload
+// rule, so the model's first read_command_output call was denied.
+func TestStoreReferencePassesToolGuard(t *testing.T) {
+	store, err := New(Options{RunID: "run-1783849881112083000", Config: testConfig(), ArchivePath: filepath.Join(t.TempDir(), "ref.tar.gz")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run-1783849881112083000", ToolUseID: "toolu_01ErmGRT7vjR545VQFnHNFAx"}), cancel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Stdout().Write([]byte("output")); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := capture.Complete(Completion{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := captured.Record.Stdout.Reference
+	input, _ := json.Marshal(map[string]any{"ref": ref, "offset": 0, "limit": 32768})
+	if findings := security.GuardToolCall("read_command_output", false, input); len(findings) != 0 {
+		t.Fatalf("reference %q must pass the tool guard, got findings %+v", ref, findings)
 	}
 }
 

--- a/harness/internal/commandoutput/store_test.go
+++ b/harness/internal/commandoutput/store_test.go
@@ -206,6 +206,69 @@ func TestStoreLimitFailureIsStickyAndCancels(t *testing.T) {
 	}
 }
 
+func TestStoreBestEffortLimitBreachIsPerCommand(t *testing.T) {
+	cfg := testConfig()
+	cfg.FailurePosture = types.CommandOutputPostureBestEffort
+	cfg.MaxBytesPerStream = 4
+	cfg.MaxBytesPerRun = 16
+	archive := filepath.Join(t.TempDir(), "besteffort.tar.gz")
+	store, err := New(Options{RunID: "run-be", Config: cfg, ArchivePath: archive})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run-be", ToolUseID: "cmd-1"}), cancel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Stdout().Write([]byte("12345")); err == nil {
+		t.Fatal("expected limit error")
+	}
+	if context.Cause(ctx) == nil {
+		t.Fatal("breaching command must still be cancelled")
+	}
+	if captured, err := capture.Complete(Completion{Cancelled: true, ExitCode: -1}); err == nil || captured.Record.CaptureComplete {
+		t.Fatalf("err=%v record=%+v", err, captured.Record)
+	}
+	if store.FatalError() != nil {
+		t.Fatalf("bestEffort limit breach must not poison the store: %v", store.FatalError())
+	}
+
+	ctx2, cancel2 := context.WithCancelCause(context.Background())
+	capture2, err := store.Begin(tool.WithCallContext(ctx2, tool.CallContext{RunID: "run-be", ToolUseID: "cmd-2"}), cancel2)
+	if err != nil {
+		t.Fatalf("next command must keep capturing under bestEffort: %v", err)
+	}
+	if _, err := capture2.Stdout().Write([]byte("ok")); err != nil {
+		t.Fatal(err)
+	}
+	captured2, err := capture2.Complete(Completion{})
+	if err != nil || !captured2.Record.CaptureComplete {
+		t.Fatalf("err=%v record=%+v", err, captured2.Record)
+	}
+	if err := store.RecordInitial(&captured2.Record, "ok"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Finalize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	members := readArchive(t, archive)
+	var got manifest
+	if err := json.Unmarshal(members["manifest.json"], &got); err != nil {
+		t.Fatal(err)
+	}
+	// The breached capture must stay visible even though the store never
+	// went fatal.
+	if got.Complete {
+		t.Fatalf("manifest must not claim completeness with a breached capture: %+v", got)
+	}
+	if len(got.Commands) != 2 {
+		t.Fatalf("commands=%d", len(got.Commands))
+	}
+}
+
 func TestStoreLargeStreamArchiveReconstructsWithoutRetainingFullModelCopy(t *testing.T) {
 	cfg := testConfig()
 	cfg.InlineMaxBytes = 32

--- a/harness/internal/commandoutput/store_test.go
+++ b/harness/internal/commandoutput/store_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -40,7 +41,7 @@ func TestStoreWholeStreamScrubArchiveAndLedger(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancelCause(context.Background())
-	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "run-1", Turn: 2, ToolUseID: "tool-1"}), cancel)
+	capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run-1", Turn: 2, ToolUseID: "tool-1"}), cancel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +81,7 @@ func TestStoreWholeStreamScrubArchiveAndLedger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RecordRead(CallContext{RunID: "run-1", ToolUseID: "reader-1"}, captured.Record.Stdout.Reference, read, "model-visible chunk"); err != nil {
+	if err := store.RecordRead(tool.CallContext{RunID: "run-1", ToolUseID: "reader-1"}, captured.Record.Stdout.Reference, read, "model-visible chunk"); err != nil {
 		t.Fatal(err)
 	}
 	location, err := store.Finalize(context.Background())
@@ -128,7 +129,7 @@ func TestStoreRecordReadScopesLedgerMembersByRunID(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 	ctx, cancel := context.WithCancelCause(context.Background())
-	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "parent", ToolUseID: "cmd-1"}), cancel)
+	capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "parent", ToolUseID: "cmd-1"}), cancel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,10 +151,10 @@ func TestStoreRecordReadScopesLedgerMembersByRunID(t *testing.T) {
 	// A parent run and a subagent share the store; providers can reuse short
 	// tool-use IDs across the two conversations, so identical tool-use IDs
 	// under different run IDs must produce distinct ledger members.
-	if err := store.RecordRead(CallContext{RunID: "parent", ToolUseID: "call_1"}, ref, read, "parent chunk"); err != nil {
+	if err := store.RecordRead(tool.CallContext{RunID: "parent", ToolUseID: "call_1"}, ref, read, "parent chunk"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RecordRead(CallContext{RunID: "subagent", ToolUseID: "call_1"}, ref, read, "subagent chunk"); err != nil {
+	if err := store.RecordRead(tool.CallContext{RunID: "subagent", ToolUseID: "call_1"}, ref, read, "subagent chunk"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := store.Finalize(context.Background()); err != nil {
@@ -183,7 +184,7 @@ func TestStoreLimitFailureIsStickyAndCancels(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 	ctx, cancel := context.WithCancelCause(context.Background())
-	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "run-limit", ToolUseID: "tool-limit"}), cancel)
+	capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run-limit", ToolUseID: "tool-limit"}), cancel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +217,7 @@ func TestStoreLargeStreamArchiveReconstructsWithoutRetainingFullModelCopy(t *tes
 	}
 	defer func() { _ = store.Close() }()
 	ctx, cancel := context.WithCancelCause(context.Background())
-	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "large", ToolUseID: "tool"}), cancel)
+	capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "large", ToolUseID: "tool"}), cancel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +252,7 @@ func TestStoreDiskAndUploadFailuresFailClosed(t *testing.T) {
 		}
 		defer func() { _ = store.Close() }()
 		ctx, cancel := context.WithCancelCause(context.Background())
-		capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "disk", ToolUseID: "tool"}), cancel)
+		capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "disk", ToolUseID: "tool"}), cancel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -274,7 +275,7 @@ func TestStoreDiskAndUploadFailuresFailClosed(t *testing.T) {
 		}
 		defer func() { _ = store.Close() }()
 		ctx, cancel := context.WithCancelCause(context.Background())
-		capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "upload", ToolUseID: "tool"}), cancel)
+		capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "upload", ToolUseID: "tool"}), cancel)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/harness/internal/commandoutput/store_test.go
+++ b/harness/internal/commandoutput/store_test.go
@@ -80,7 +80,7 @@ func TestStoreWholeStreamScrubArchiveAndLedger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RecordRead("reader-1", captured.Record.Stdout.Reference, read, "model-visible chunk"); err != nil {
+	if err := store.RecordRead(CallContext{RunID: "run-1", ToolUseID: "reader-1"}, captured.Record.Stdout.Reference, read, "model-visible chunk"); err != nil {
 		t.Fatal(err)
 	}
 	location, err := store.Finalize(context.Background())
@@ -117,6 +117,59 @@ func TestStoreWholeStreamScrubArchiveAndLedger(t *testing.T) {
 	}
 	if strings.Contains(string(members["manifest.json"]), "sk-ant-") {
 		t.Fatal("secret leaked into manifest")
+	}
+}
+
+func TestStoreRecordReadScopesLedgerMembersByRunID(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "ledger.tar.gz")
+	store, err := New(Options{RunID: "parent", Config: testConfig(), ArchivePath: archive})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	capture, err := store.Begin(WithCallContext(ctx, CallContext{RunID: "parent", ToolUseID: "cmd-1"}), cancel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Stdout().Write([]byte("shared output")); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := capture.Complete(Completion{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordInitial(&captured.Record, "initial"); err != nil {
+		t.Fatal(err)
+	}
+	read, err := store.Read(captured.Record.Stdout.Reference, 0, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := captured.Record.Stdout.Reference
+	// A parent run and a subagent share the store; providers can reuse short
+	// tool-use IDs across the two conversations, so identical tool-use IDs
+	// under different run IDs must produce distinct ledger members.
+	if err := store.RecordRead(CallContext{RunID: "parent", ToolUseID: "call_1"}, ref, read, "parent chunk"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordRead(CallContext{RunID: "subagent", ToolUseID: "call_1"}, ref, read, "subagent chunk"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Finalize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	members := readArchive(t, archive)
+	var got manifest
+	if err := json.Unmarshal(members["manifest.json"], &got); err != nil {
+		t.Fatal(err)
+	}
+	reads := got.Commands[0].Reads
+	if len(reads) != 2 || reads[0].ArchiveMember == reads[1].ArchiveMember {
+		t.Fatalf("reads=%+v", reads)
+	}
+	if string(members[reads[0].ArchiveMember]) != "parent chunk" || string(members[reads[1].ArchiveMember]) != "subagent chunk" {
+		t.Fatalf("ledger contents: %q / %q", members[reads[0].ArchiveMember], members[reads[1].ArchiveMember])
 	}
 }
 

--- a/harness/internal/core/command_output_finalize_test.go
+++ b/harness/internal/core/command_output_finalize_test.go
@@ -117,7 +117,7 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 		emitter := tracepkg.NewJSONLTraceEmitter(&bytes.Buffer{})
 		emitter.Start("run", &types.RunConfig{})
 		loop := &AgenticLoop{CommandOutput: store, OwnsCommandOutput: true, Trace: emitter, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
-		if got := loop.finalizeCommandOutput(context.Background(), "success"); got != "trace_archive_failed" {
+		if got := loop.finalizeCommandOutput(context.Background(), "success"); got != "command_output_archive_failed" {
 			t.Fatalf("outcome=%q", got)
 		}
 	})

--- a/harness/internal/core/command_output_finalize_test.go
+++ b/harness/internal/core/command_output_finalize_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	tracepkg "github.com/rxbynerd/stirrup/harness/internal/trace"
 	"github.com/rxbynerd/stirrup/types"
 )
@@ -22,7 +23,7 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 			t.Fatal(err)
 		}
 		ctx, cancel := context.WithCancelCause(context.Background())
-		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -46,7 +47,7 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 			t.Fatal(err)
 		}
 		ctx, cancel := context.WithCancelCause(context.Background())
-		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +75,7 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 			t.Fatal(err)
 		}
 		ctx, cancel := context.WithCancelCause(context.Background())
-		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -102,7 +103,7 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 			t.Fatal(err)
 		}
 		ctx, cancel := context.WithCancelCause(context.Background())
-		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/harness/internal/core/command_output_finalize_test.go
+++ b/harness/internal/core/command_output_finalize_test.go
@@ -92,6 +92,37 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 		}
 	})
 
+	t.Run("bestEffort never claims the outcome", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := types.CommandOutputConfig{FailurePosture: types.CommandOutputPostureBestEffort, InlineMaxBytes: 10, PreviewBytesPerStream: 2, MaxBytesPerStream: 10, MaxBytesPerRun: 20}
+		store, err := commandoutput.New(commandoutput.Options{RunID: "run", Config: cfg, ArchivePath: filepath.Join(parent, "archive.tar.gz")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = capture.Stdout().Write([]byte("ok"))
+		captured, err := capture.Complete(commandoutput.Completion{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.RecordInitial(&captured.Record, "ok"); err != nil {
+			t.Fatal(err)
+		}
+		emitter := tracepkg.NewJSONLTraceEmitter(&bytes.Buffer{})
+		emitter.Start("run", &types.RunConfig{})
+		loop := &AgenticLoop{CommandOutput: store, OwnsCommandOutput: true, CommandOutputBestEffort: true, Trace: emitter, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		if got := loop.finalizeCommandOutput(context.Background(), "success"); got != "success" {
+			t.Fatalf("outcome=%q, want archive failure ignored under bestEffort", got)
+		}
+	})
+
 	t.Run("archive failure", func(t *testing.T) {
 		parent := filepath.Join(t.TempDir(), "not-a-directory")
 		if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {

--- a/harness/internal/core/command_output_finalize_test.go
+++ b/harness/internal/core/command_output_finalize_test.go
@@ -1,0 +1,72 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
+	tracepkg "github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
+	t.Run("capture failure", func(t *testing.T) {
+		cfg := types.CommandOutputConfig{InlineMaxBytes: 1, PreviewBytesPerStream: 1, MaxBytesPerStream: 1, MaxBytesPerRun: 2}
+		store, err := commandoutput.New(commandoutput.Options{RunID: "run", Config: cfg, ArchivePath: filepath.Join(t.TempDir(), "archive.tar.gz")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = capture.Stdout().Write([]byte("too large"))
+		captured, _ := capture.Complete(commandoutput.Completion{Cancelled: true})
+		if err := store.RecordInitial(&captured.Record, "failed"); err != nil {
+			t.Fatal(err)
+		}
+		emitter := tracepkg.NewJSONLTraceEmitter(&bytes.Buffer{})
+		emitter.Start("run", &types.RunConfig{})
+		loop := &AgenticLoop{CommandOutput: store, OwnsCommandOutput: true, Trace: emitter, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		if got := loop.finalizeCommandOutput(context.Background(), "success"); got != "command_output_capture_failed" {
+			t.Fatalf("outcome=%q", got)
+		}
+	})
+
+	t.Run("archive failure", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := types.CommandOutputConfig{InlineMaxBytes: 10, PreviewBytesPerStream: 2, MaxBytesPerStream: 10, MaxBytesPerRun: 20}
+		store, err := commandoutput.New(commandoutput.Options{RunID: "run", Config: cfg, ArchivePath: filepath.Join(parent, "archive.tar.gz")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = capture.Stdout().Write([]byte("ok"))
+		captured, err := capture.Complete(commandoutput.Completion{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.RecordInitial(&captured.Record, "ok"); err != nil {
+			t.Fatal(err)
+		}
+		emitter := tracepkg.NewJSONLTraceEmitter(&bytes.Buffer{})
+		emitter.Start("run", &types.RunConfig{})
+		loop := &AgenticLoop{CommandOutput: store, OwnsCommandOutput: true, Trace: emitter, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		if got := loop.finalizeCommandOutput(context.Background(), "success"); got != "trace_archive_failed" {
+			t.Fatalf("outcome=%q", got)
+		}
+	})
+}

--- a/harness/internal/core/command_output_finalize_test.go
+++ b/harness/internal/core/command_output_finalize_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	tracepkg "github.com/rxbynerd/stirrup/harness/internal/trace"
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -153,4 +155,83 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 			t.Fatalf("outcome=%q", got)
 		}
 	})
+}
+
+// TestFinishWithOutcomeFinalizesCommandOutput covers the early-exit path
+// (setup_failed and friends): finalization must run, and a poisoned store
+// must not mask the primary failure outcome.
+func TestFinishWithOutcomeFinalizesCommandOutput(t *testing.T) {
+	cfg := types.CommandOutputConfig{InlineMaxBytes: 1, PreviewBytesPerStream: 1, MaxBytesPerStream: 1, MaxBytesPerRun: 2}
+	archive := filepath.Join(t.TempDir(), "archive.tar.gz")
+	store, err := commandoutput.New(commandoutput.Options{RunID: "run", Config: cfg, ArchivePath: archive})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	capture, err := store.Begin(tool.WithCallContext(ctx, tool.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = capture.Stdout().Write([]byte("too large"))
+	captured, _ := capture.Complete(commandoutput.Completion{Cancelled: true})
+	if err := store.RecordInitial(&captured.Record, "failed"); err != nil {
+		t.Fatal(err)
+	}
+
+	emitter := tracepkg.NewJSONLTraceEmitter(&bytes.Buffer{})
+	emitter.Start("run", &types.RunConfig{})
+	loop := &AgenticLoop{
+		CommandOutput:     store,
+		OwnsCommandOutput: true,
+		Trace:             emitter,
+		Transport:         transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{}),
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	runTrace, _ := loop.finishWithOutcome(context.Background(), "setup_failed", errors.New("preRun hook failed"))
+	if runTrace == nil || runTrace.Outcome != "setup_failed" {
+		t.Fatalf("trace=%+v, want the primary setup_failed outcome preserved", runTrace)
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Fatalf("early-exit path must still write the failure archive: %v", err)
+	}
+}
+
+// TestBuildCommandOutputStore_ArchivePathDerivation pins the documented
+// defaults: a JSONL trace derives an adjacent archive, an explicit local
+// archive config wins, and other emitters fall back to a temp location.
+func TestBuildCommandOutputStore_ArchivePathDerivation(t *testing.T) {
+	dir := t.TempDir()
+
+	jsonlCfg := &types.RunConfig{RunID: "derive", TraceEmitter: types.TraceEmitterConfig{Type: "jsonl", FilePath: filepath.Join(dir, "run.jsonl")}}
+	store, err := buildCommandOutputStore(context.Background(), jsonlCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	if got, want := store.Archive(), filepath.Join(dir, "run.jsonl.command-output.tar.gz"); got != want {
+		t.Fatalf("jsonl-adjacent archive: got %q want %q", got, want)
+	}
+
+	explicit := &types.RunConfig{RunID: "derive-explicit", TraceEmitter: types.TraceEmitterConfig{
+		Type: "jsonl", FilePath: filepath.Join(dir, "run.jsonl"),
+		Archive: &types.TraceArchiveConfig{Type: "local", FilePath: filepath.Join(dir, "custom.tar.gz")},
+	}}
+	store2, err := buildCommandOutputStore(context.Background(), explicit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store2.Close() }()
+	if got, want := store2.Archive(), filepath.Join(dir, "custom.tar.gz"); got != want {
+		t.Fatalf("explicit local archive: got %q want %q", got, want)
+	}
+
+	otel := &types.RunConfig{RunID: "derive-otel", TraceEmitter: types.TraceEmitterConfig{Type: "otel"}}
+	store3, err := buildCommandOutputStore(context.Background(), otel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store3.Close() }()
+	if got := store3.Archive(); got == "" || filepath.Dir(got) == dir {
+		t.Fatalf("otel emitter should fall back to a temp archive, got %q", got)
+	}
 }

--- a/harness/internal/core/command_output_finalize_test.go
+++ b/harness/internal/core/command_output_finalize_test.go
@@ -39,6 +39,58 @@ func TestFinalizeCommandOutputFailClosedOutcomes(t *testing.T) {
 		}
 	})
 
+	t.Run("capture failure never masks a primary failure outcome", func(t *testing.T) {
+		cfg := types.CommandOutputConfig{InlineMaxBytes: 1, PreviewBytesPerStream: 1, MaxBytesPerStream: 1, MaxBytesPerRun: 2}
+		store, err := commandoutput.New(commandoutput.Options{RunID: "run", Config: cfg, ArchivePath: filepath.Join(t.TempDir(), "archive.tar.gz")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = capture.Stdout().Write([]byte("too large"))
+		captured, _ := capture.Complete(commandoutput.Completion{Cancelled: true})
+		if err := store.RecordInitial(&captured.Record, "failed"); err != nil {
+			t.Fatal(err)
+		}
+		emitter := tracepkg.NewJSONLTraceEmitter(&bytes.Buffer{})
+		emitter.Start("run", &types.RunConfig{})
+		loop := &AgenticLoop{CommandOutput: store, OwnsCommandOutput: true, Trace: emitter, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		if got := loop.finalizeCommandOutput(context.Background(), "timeout"); got != "timeout" {
+			t.Fatalf("outcome=%q, want the primary timeout preserved", got)
+		}
+	})
+
+	t.Run("capture failure outranks archive failure", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := types.CommandOutputConfig{InlineMaxBytes: 1, PreviewBytesPerStream: 1, MaxBytesPerStream: 1, MaxBytesPerRun: 2}
+		store, err := commandoutput.New(commandoutput.Options{RunID: "run", Config: cfg, ArchivePath: filepath.Join(parent, "archive.tar.gz")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		capture, err := store.Begin(commandoutput.WithCallContext(ctx, commandoutput.CallContext{RunID: "run", ToolUseID: "tool"}), cancel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = capture.Stdout().Write([]byte("too large"))
+		captured, _ := capture.Complete(commandoutput.Completion{Cancelled: true})
+		if err := store.RecordInitial(&captured.Record, "failed"); err != nil {
+			t.Fatal(err)
+		}
+		emitter := tracepkg.NewJSONLTraceEmitter(&bytes.Buffer{})
+		emitter.Start("run", &types.RunConfig{})
+		loop := &AgenticLoop{CommandOutput: store, OwnsCommandOutput: true, Trace: emitter, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		if got := loop.finalizeCommandOutput(context.Background(), "success"); got != "command_output_capture_failed" {
+			t.Fatalf("outcome=%q, want capture failure to outrank archive failure", got)
+		}
+	})
+
 	t.Run("archive failure", func(t *testing.T) {
 		parent := filepath.Join(t.TempDir(), "not-a-directory")
 		if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -13,10 +13,10 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
-	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -137,9 +137,9 @@ func (l *AgenticLoop) planAndDispatch(
 			),
 		)
 		toolSpanCtx := oteltrace.ContextWithSpan(ctx, toolSpan)
-		callMeta := commandoutput.CallContextFrom(ctx)
+		callMeta := tool.CallContextFrom(ctx)
 		callMeta.ToolUseID = call.ID
-		toolSpanCtx = commandoutput.WithCallContext(toolSpanCtx, callMeta)
+		toolSpanCtx = tool.WithCallContext(toolSpanCtx, callMeta)
 		plan[i] = pendingCall{
 			call:      call,
 			span:      toolSpan,

--- a/harness/internal/core/dispatch.go
+++ b/harness/internal/core/dispatch.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
@@ -136,6 +137,9 @@ func (l *AgenticLoop) planAndDispatch(
 			),
 		)
 		toolSpanCtx := oteltrace.ContextWithSpan(ctx, toolSpan)
+		callMeta := commandoutput.CallContextFrom(ctx)
+		callMeta.ToolUseID = call.ID
+		toolSpanCtx = commandoutput.WithCallContext(toolSpanCtx, callMeta)
 		plan[i] = pendingCall{
 			call:      call,
 			span:      toolSpan,
@@ -373,6 +377,7 @@ func (l *AgenticLoop) planAndDispatch(
 			Success:      p.success,
 			Structured:   structuredForRecord,
 			Kind:         p.structured.kind,
+			IsError:      !p.success,
 		}
 
 		if err := l.Transport.Emit(types.HarnessEvent{

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -594,6 +594,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	if commandOutputStore != nil {
 		loop.CommandOutput = commandOutputStore
 		loop.OwnsCommandOutput = true
+		loop.CommandOutputBestEffort = config.Tools.EffectiveCommandOutput().FailurePosture == types.CommandOutputPostureBestEffort
 	}
 
 	// Register spawn_agent after loop construction. The tool needs a

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -14,6 +14,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
@@ -111,6 +112,13 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		ownedClosers = append(ownedClosers, closer)
 	}
 
+	commandOutputStore, err := buildCommandOutputStore(ctx, config)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("build command output store: %w", err)
+	}
+	ownedClosers = append(ownedClosers, commandOutputStore)
+
 	// 4. Tool registry.
 	// The base edit strategy is constructed first, then optionally wrapped
 	// with a CodeScanner pass when one is configured. ValidateRunConfig
@@ -124,7 +132,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		cleanup()
 		return nil, fmt.Errorf("build code scanner: %w", err)
 	}
-	registry := buildToolRegistry(exec, es, config.Tools)
+	registry := buildToolRegistry(exec, es, config.Tools, commandOutputStore)
 
 	// resourceOpts captures the run-scoped OTel Resource attributes
 	// (deployment.environment, service.namespace, harness.run.mode) shared by
@@ -257,6 +265,9 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	providers := components.providers
 	pp := components.permissionPolicy
 	te := components.traceEmitter
+	if recorder, ok := te.(trace.CommandOutputRecorder); ok {
+		commandOutputStore.SetRecorder(recorder)
+	}
 	if closer, ok := te.(io.Closer); ok {
 		ownedClosers = append(ownedClosers, closer)
 	}
@@ -552,29 +563,31 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	escalation := buildEscalationPolicy(config.EffectiveToolChoiceEscalationMaxRetries(), prov)
 
 	loop := &AgenticLoop{
-		Provider:     prov,
-		Providers:    providers,
-		Router:       rtr,
-		Prompt:       pb,
-		Context:      cs,
-		Tools:        registry,
-		Executor:     exec,
-		Edit:         es,
-		Verifier:     v,
-		Permissions:  pp,
-		Git:          gs,
-		GuardRail:    gr,
-		RuleOfTwo:    rot,
-		Escalation:   escalation,
-		Hooks:        hooksRunner,
-		Transport:    tp,
-		Trace:        te,
-		Tracer:       tracer,
-		Metrics:      metrics,
-		Security:     secLogger,
-		Logger:       logger,
-		emitReady:    emitReady,
-		ownedClosers: ownedClosers,
+		Provider:          prov,
+		Providers:         providers,
+		Router:            rtr,
+		Prompt:            pb,
+		Context:           cs,
+		Tools:             registry,
+		Executor:          exec,
+		Edit:              es,
+		Verifier:          v,
+		Permissions:       pp,
+		Git:               gs,
+		GuardRail:         gr,
+		RuleOfTwo:         rot,
+		Escalation:        escalation,
+		Hooks:             hooksRunner,
+		Transport:         tp,
+		Trace:             te,
+		Tracer:            tracer,
+		Metrics:           metrics,
+		Security:          secLogger,
+		Logger:            logger,
+		CommandOutput:     commandOutputStore,
+		OwnsCommandOutput: true,
+		emitReady:         emitReady,
+		ownedClosers:      ownedClosers,
 	}
 
 	// Register spawn_agent after loop construction. The tool needs a
@@ -998,8 +1011,12 @@ func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets securi
 	}
 }
 
-func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.ToolsConfig) *tool.Registry {
+func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.ToolsConfig, stores ...*commandoutput.Store) *tool.Registry {
 	registry := tool.NewRegistry()
+	var outputStore *commandoutput.Store
+	if len(stores) > 0 {
+		outputStore = stores[0]
+	}
 	caps := exec.Capabilities()
 	if toolEnabled(cfg.BuiltIn, "read_file") && caps.CanRead {
 		registry.Register(builtins.ReadFileTool(exec))
@@ -1043,7 +1060,12 @@ func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.T
 		registry.Register(builtins.GitShowTool(exec))
 	}
 	if toolEnabled(cfg.BuiltIn, "run_command") && caps.CanExec {
-		registry.Register(builtins.RunCommandTool(exec))
+		registry.Register(builtins.RunCommandToolWithStore(exec, outputStore, cfg.EffectiveCommandOutput()))
+		if outputStore != nil {
+			registry.Register(builtins.ReadCommandOutputTool(outputStore, exec))
+		}
+	} else if toolEnabled(cfg.BuiltIn, "read_command_output") && outputStore != nil {
+		registry.Register(builtins.ReadCommandOutputTool(outputStore, exec))
 	}
 	if toolEnabled(cfg.BuiltIn, "web_fetch") {
 		registry.Register(builtins.WebFetchTool())
@@ -1052,6 +1074,48 @@ func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.T
 		registry.Register(editStrategyTool(es, exec))
 	}
 	return registry
+}
+
+func buildCommandOutputStore(ctx context.Context, config *types.RunConfig) (*commandoutput.Store, error) {
+	archivePath := ""
+	var uploader commandoutput.Uploader
+	archiveCfg := config.TraceEmitter.Archive
+	if archiveCfg != nil && archiveCfg.Type == "local" {
+		archivePath = archiveCfg.FilePath
+	} else if archiveCfg == nil && (config.TraceEmitter.Type == "jsonl" || config.TraceEmitter.Type == "") && config.TraceEmitter.FilePath != "" {
+		archivePath = config.TraceEmitter.FilePath + ".command-output.tar.gz"
+	}
+
+	if (archiveCfg != nil && archiveCfg.Type == "gcs") || (archiveCfg == nil && config.TraceEmitter.Type == "gcs") {
+		bucket := config.TraceEmitter.Bucket
+		prefix := config.TraceEmitter.ObjectPrefix
+		credentialCfg := config.TraceEmitter.Credential
+		if archiveCfg != nil {
+			bucket = archiveCfg.Bucket
+			prefix = archiveCfg.ObjectPrefix
+			credentialCfg = archiveCfg.Credential
+		}
+		source, err := buildGCSTraceCredentialSource(credentialCfg)
+		if err != nil {
+			return nil, err
+		}
+		resolved, err := source.Resolve(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolve archive credential: %w", err)
+		}
+		if resolved == nil || resolved.BearerToken == nil {
+			return nil, fmt.Errorf("archive credential produced no bearer token")
+		}
+		uploader, err = commandoutput.NewGCSUploader(commandoutput.GCSUploaderOptions{
+			Bucket: bucket, ObjectPrefix: prefix, Bearer: resolved.BearerToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return commandoutput.New(commandoutput.Options{
+		RunID: config.RunID, Config: config.Tools.EffectiveCommandOutput(), ArchivePath: archivePath, Uploader: uploader,
+	})
 }
 
 func toolEnabled(enabled []string, name string) bool {

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -117,7 +117,9 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		cleanup()
 		return nil, fmt.Errorf("build command output store: %w", err)
 	}
-	ownedClosers = append(ownedClosers, commandOutputStore)
+	if commandOutputStore != nil {
+		ownedClosers = append(ownedClosers, commandOutputStore)
+	}
 
 	// 4. Tool registry.
 	// The base edit strategy is constructed first, then optionally wrapped
@@ -265,7 +267,7 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	providers := components.providers
 	pp := components.permissionPolicy
 	te := components.traceEmitter
-	if recorder, ok := te.(trace.CommandOutputRecorder); ok {
+	if recorder, ok := te.(trace.CommandOutputRecorder); ok && commandOutputStore != nil {
 		commandOutputStore.SetRecorder(recorder)
 	}
 	if closer, ok := te.(io.Closer); ok {
@@ -563,31 +565,35 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 	escalation := buildEscalationPolicy(config.EffectiveToolChoiceEscalationMaxRetries(), prov)
 
 	loop := &AgenticLoop{
-		Provider:          prov,
-		Providers:         providers,
-		Router:            rtr,
-		Prompt:            pb,
-		Context:           cs,
-		Tools:             registry,
-		Executor:          exec,
-		Edit:              es,
-		Verifier:          v,
-		Permissions:       pp,
-		Git:               gs,
-		GuardRail:         gr,
-		RuleOfTwo:         rot,
-		Escalation:        escalation,
-		Hooks:             hooksRunner,
-		Transport:         tp,
-		Trace:             te,
-		Tracer:            tracer,
-		Metrics:           metrics,
-		Security:          secLogger,
-		Logger:            logger,
-		CommandOutput:     commandOutputStore,
-		OwnsCommandOutput: true,
-		emitReady:         emitReady,
-		ownedClosers:      ownedClosers,
+		Provider:     prov,
+		Providers:    providers,
+		Router:       rtr,
+		Prompt:       pb,
+		Context:      cs,
+		Tools:        registry,
+		Executor:     exec,
+		Edit:         es,
+		Verifier:     v,
+		Permissions:  pp,
+		Git:          gs,
+		GuardRail:    gr,
+		RuleOfTwo:    rot,
+		Escalation:   escalation,
+		Hooks:        hooksRunner,
+		Transport:    tp,
+		Trace:        te,
+		Tracer:       tracer,
+		Metrics:      metrics,
+		Security:     secLogger,
+		Logger:       logger,
+		emitReady:    emitReady,
+		ownedClosers: ownedClosers,
+	}
+	// Assigned only for a live store: a nil *commandoutput.Store stored in
+	// the CommandOutputFinalizer interface would defeat the loop's nil check.
+	if commandOutputStore != nil {
+		loop.CommandOutput = commandOutputStore
+		loop.OwnsCommandOutput = true
 	}
 
 	// Register spawn_agent after loop construction. The tool needs a
@@ -1011,12 +1017,8 @@ func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets securi
 	}
 }
 
-func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.ToolsConfig, stores ...*commandoutput.Store) *tool.Registry {
+func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.ToolsConfig, outputStore *commandoutput.Store) *tool.Registry {
 	registry := tool.NewRegistry()
-	var outputStore *commandoutput.Store
-	if len(stores) > 0 {
-		outputStore = stores[0]
-	}
 	caps := exec.Capabilities()
 	if toolEnabled(cfg.BuiltIn, "read_file") && caps.CanRead {
 		registry.Register(builtins.ReadFileTool(exec))
@@ -1059,6 +1061,14 @@ func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.T
 	if toolEnabled(cfg.BuiltIn, "git_show") && caps.CanRead {
 		registry.Register(builtins.GitShowTool(exec))
 	}
+	// read_command_output is run_command's companion: it registers
+	// automatically whenever run_command registers with a live capture
+	// store — a spilled reference without its reader is incoherent, and
+	// operator configs written before capture existed list run_command in
+	// explicit builtIn allowlists that would otherwise silently strand
+	// refs. Listing it in builtIn is only needed for the standalone
+	// (replay) case; ValidateRunConfig rejects listing it with capture
+	// disabled.
 	if toolEnabled(cfg.BuiltIn, "run_command") && caps.CanExec {
 		registry.Register(builtins.RunCommandToolWithStore(exec, outputStore, cfg.EffectiveCommandOutput()))
 		if outputStore != nil {
@@ -1076,7 +1086,19 @@ func buildToolRegistry(exec executor.Executor, es edit.EditStrategy, cfg types.T
 	return registry
 }
 
+var _ CommandOutputFinalizer = (*commandoutput.Store)(nil)
+
+// buildCommandOutputStore returns nil when capture is disabled or no
+// registered tool could feed the store — read-only modes exclude
+// run_command, and skipping construction also skips resolving GCS archive
+// credentials those runs would never use.
 func buildCommandOutputStore(ctx context.Context, config *types.RunConfig) (*commandoutput.Store, error) {
+	if !config.Tools.CommandOutputCaptureEnabled() {
+		return nil, nil
+	}
+	if !toolEnabled(config.Tools.BuiltIn, "run_command") && !toolEnabled(config.Tools.BuiltIn, "read_command_output") {
+		return nil, nil
+	}
 	archivePath := ""
 	var uploader commandoutput.Uploader
 	archiveCfg := config.TraceEmitter.Archive

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
@@ -710,7 +711,7 @@ func TestBuildPermissionPolicy_AllowAll(t *testing.T) {
 func TestBuildPermissionPolicy_DenySideEffects(t *testing.T) {
 	registry := buildToolRegistry(&registryExecutor{
 		caps: executor.ExecutorCapabilities{CanRead: true, CanWrite: true, CanExec: true},
-	}, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	}, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 	pp := buildPermissionPolicyForTest(t, types.PermissionPolicyConfig{Type: "deny-side-effects"}, registry, nil)
 	if _, ok := pp.(*permission.DenySideEffects); !ok {
 		t.Fatalf("expected DenySideEffects, got %T", pp)
@@ -720,7 +721,7 @@ func TestBuildPermissionPolicy_DenySideEffects(t *testing.T) {
 func TestBuildPermissionPolicy_AskUpstream(t *testing.T) {
 	registry := buildToolRegistry(&registryExecutor{
 		caps: executor.ExecutorCapabilities{CanRead: true},
-	}, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	}, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
 	pp := buildPermissionPolicyForTest(t, types.PermissionPolicyConfig{Type: "ask-upstream", Timeout: 60}, registry, tp)
 	if _, ok := pp.(*permission.AskUpstreamPolicy); !ok {
@@ -737,7 +738,7 @@ func TestBuildPermissionPolicy_AskUpstream(t *testing.T) {
 func TestBuildPermissionPolicy_UnknownTypeReturnsError(t *testing.T) {
 	registry := buildToolRegistry(&registryExecutor{
 		caps: executor.ExecutorCapabilities{CanRead: true},
-	}, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	}, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 	rc := &types.RunConfig{
 		PermissionPolicy: types.PermissionPolicyConfig{Type: "bogus"},
 	}
@@ -761,7 +762,7 @@ func TestBuildPermissionPolicy_PolicyEngine(t *testing.T) {
 	}
 	registry := buildToolRegistry(&registryExecutor{
 		caps: executor.ExecutorCapabilities{CanRead: true, CanWrite: true, CanExec: true},
-	}, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	}, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 	rc := &types.RunConfig{
 		RunID: "test-run",
 		Mode:  "execution",
@@ -792,7 +793,7 @@ func TestBuildPermissionPolicy_PolicyEngineFallbackIsBuilt(t *testing.T) {
 	}
 	registry := buildToolRegistry(&registryExecutor{
 		caps: executor.ExecutorCapabilities{CanRead: true, CanWrite: true, CanExec: true},
-	}, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	}, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 	tp := transport.NewStdioTransport(&bytes.Buffer{}, &bytes.Buffer{})
 	rc := &types.RunConfig{
 		RunID: "test-run",
@@ -855,7 +856,7 @@ func TestBuildPermissionPolicy_PolicyEngineFileReadOnce(t *testing.T) {
 
 	registry := buildToolRegistry(&registryExecutor{
 		caps: executor.ExecutorCapabilities{CanRead: true, CanWrite: true, CanExec: true},
-	}, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	}, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 	rc := &types.RunConfig{
 		RunID: "test-run",
 		Mode:  "execution",
@@ -1342,7 +1343,7 @@ func TestEditToolEnabled_NoMatch(t *testing.T) {
 
 func TestMutatingToolSet(t *testing.T) {
 	exec, _ := executor.NewLocalExecutor(t.TempDir())
-	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 
 	mutating := mutatingToolSet(registry)
 
@@ -1367,7 +1368,7 @@ func TestMutatingToolSet(t *testing.T) {
 
 func TestApprovalRequiredToolSet(t *testing.T) {
 	exec, _ := executor.NewLocalExecutor(t.TempDir())
-	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 
 	approval := approvalRequiredToolSet(registry)
 
@@ -1414,7 +1415,7 @@ func TestBuildToolRegistry_DefaultReadOnlyIncludesGitTools(t *testing.T) {
 	}
 	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{
 		BuiltIn: types.DefaultReadOnlyBuiltInTools(),
-	})
+	}, nil)
 
 	registered := make(map[string]bool)
 	for _, def := range registry.List() {
@@ -1466,7 +1467,7 @@ func TestBuildToolRegistry_GitStatusExecutes(t *testing.T) {
 	}
 	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{
 		BuiltIn: types.DefaultReadOnlyBuiltInTools(),
-	})
+	}, nil)
 
 	gitStatus := registry.Resolve("git_status")
 	if gitStatus == nil {
@@ -3354,5 +3355,73 @@ func TestBuildLoopWithTransport_OpenAIResponsesAdapterHasLogger(t *testing.T) {
 	}
 	if adapter.Logger == nil {
 		t.Error("OpenAIResponsesAdapter.Logger is nil; factory should inject the ScrubHandler-backed logger so the quirks debug log and tool-choice downgrade warn keep run/trace correlation and scrubbing")
+	}
+}
+
+func TestBuildToolRegistry_CommandOutputCompanion(t *testing.T) {
+	store, err := commandoutput.New(commandoutput.Options{RunID: "registry-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	execAll := &registryExecutor{caps: executor.ExecutorCapabilities{CanRead: true, CanWrite: true, CanExec: true}}
+
+	cases := []struct {
+		name       string
+		builtIn    []string
+		store      *commandoutput.Store
+		wantRun    bool
+		wantReader bool
+	}{
+		{"default tools with store", nil, store, true, true},
+		{"default tools without store", nil, nil, true, false},
+		{"explicit run_command allowlist gains the companion reader", []string{"run_command"}, store, true, true},
+		{"standalone reader for replay", []string{"read_command_output"}, store, false, true},
+		{"reader listed without a store registers nothing", []string{"read_command_output"}, nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := buildToolRegistry(execAll, edit.NewWholeFileStrategy(), types.ToolsConfig{BuiltIn: tc.builtIn}, tc.store)
+			if got := registry.Resolve("run_command") != nil; got != tc.wantRun {
+				t.Errorf("run_command registered=%t, want %t", got, tc.wantRun)
+			}
+			if got := registry.Resolve("read_command_output") != nil; got != tc.wantReader {
+				t.Errorf("read_command_output registered=%t, want %t", got, tc.wantReader)
+			}
+		})
+	}
+}
+
+func TestBuildCommandOutputStore_Gating(t *testing.T) {
+	disabled := false
+	cases := []struct {
+		name    string
+		mutate  func(*types.RunConfig)
+		wantNil bool
+	}{
+		{"default builds a store", func(*types.RunConfig) {}, false},
+		{"enabled=false skips construction", func(c *types.RunConfig) { c.Tools.CommandOutput.Enabled = &disabled }, true},
+		{"tool list without command tools skips construction", func(c *types.RunConfig) {
+			c.Tools.BuiltIn = []string{"read_file", "grep_files"}
+		}, true},
+		{"explicit run_command builds a store", func(c *types.RunConfig) {
+			c.Tools.BuiltIn = []string{"run_command"}
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &types.RunConfig{RunID: "gating-test"}
+			tc.mutate(cfg)
+			store, err := buildCommandOutputStore(context.Background(), cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if store != nil {
+				defer func() { _ = store.Close() }()
+			}
+			if gotNil := store == nil; gotNil != tc.wantNil {
+				t.Fatalf("store nil=%t, want %t", gotNil, tc.wantNil)
+			}
+		})
 	}
 }

--- a/harness/internal/core/integration_test.go
+++ b/harness/internal/core/integration_test.go
@@ -171,7 +171,7 @@ func TestBuildToolRegistry_RespectsExecutorCapabilities(t *testing.T) {
 		},
 	}
 
-	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{})
+	registry := buildToolRegistry(exec, edit.NewWholeFileStrategy(), types.ToolsConfig{}, nil)
 
 	if registry.Resolve("read_file") == nil {
 		t.Fatal("expected read_file to be registered")

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -1941,12 +1941,17 @@ func (l *AgenticLoop) finishWithOutcome(ctx context.Context, outcome string, err
 	return runTrace, err
 }
 
+// commandOutputFinalizeBudget bounds end-of-run archive finalization: the
+// GCS uploader's HTTP client allows 5 minutes per attempt
+// (commandoutput/gcs.go), plus headroom for writing the tar.gz locally.
+const commandOutputFinalizeBudget = 6 * time.Minute
+
 func (l *AgenticLoop) finalizeCommandOutput(ctx context.Context, outcome string) string {
 	if l.CommandOutput == nil || !l.OwnsCommandOutput {
 		return outcome
 	}
 	captureFailed := l.CommandOutput.FatalError() != nil
-	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 6*time.Minute)
+	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), commandOutputFinalizeBudget)
 	defer cancel()
 	archive, err := l.CommandOutput.Finalize(finalizeCtx)
 	if archive != "" {
@@ -1956,6 +1961,12 @@ func (l *AgenticLoop) finalizeCommandOutput(ctx context.Context, outcome string)
 	}
 	if err != nil {
 		l.Logger.Error("command output archive finalization failed", "error", err, "archive", archive)
+	}
+	// Under the bestEffort posture failures are recorded (manifest,
+	// per-command records, the log line above) but never claim the run's
+	// outcome.
+	if l.CommandOutputBestEffort {
+		return outcome
 	}
 	// Like hook_failed, capture and archive failures only claim the outcome
 	// of an otherwise-successful run — the primary failure cause stays

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -1945,9 +1945,7 @@ func (l *AgenticLoop) finalizeCommandOutput(ctx context.Context, outcome string)
 	if l.CommandOutput == nil || !l.OwnsCommandOutput {
 		return outcome
 	}
-	if l.CommandOutput.FatalError() != nil {
-		outcome = "command_output_capture_failed"
-	}
+	captureFailed := l.CommandOutput.FatalError() != nil
 	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 6*time.Minute)
 	defer cancel()
 	archive, err := l.CommandOutput.Finalize(finalizeCtx)
@@ -1958,6 +1956,18 @@ func (l *AgenticLoop) finalizeCommandOutput(ctx context.Context, outcome string)
 	}
 	if err != nil {
 		l.Logger.Error("command output archive finalization failed", "error", err, "archive", archive)
+	}
+	// Like hook_failed, capture and archive failures only claim the outcome
+	// of an otherwise-successful run — the primary failure cause stays
+	// authoritative. Capture failure outranks archive failure: the former
+	// lost command output, the latter only its durable copy.
+	if outcome != "success" {
+		return outcome
+	}
+	if captureFailed {
+		return "command_output_capture_failed"
+	}
+	if err != nil {
 		return "trace_archive_failed"
 	}
 	return outcome

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -12,13 +12,13 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
-	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/prompt"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/harness/internal/trace"
 	"github.com/rxbynerd/stirrup/harness/internal/verifier"
 	"github.com/rxbynerd/stirrup/types"
@@ -1181,7 +1181,7 @@ func (l *AgenticLoop) runInnerLoop(
 		// The router's provider/model selection is forwarded so per-call
 		// failure metrics (stirrup.harness.tool_failures) can be attributed
 		// back to the model that emitted the offending tool_use block.
-		dispatchCtx := commandoutput.WithCallContext(ctx, commandoutput.CallContext{
+		dispatchCtx := tool.WithCallContext(ctx, tool.CallContext{
 			RunID: config.RunID, ParentRunID: l.ParentRunID, Turn: turn + 1,
 		})
 		toolResults, toolRecords, stallOutcome := l.planAndDispatch(dispatchCtx, config, toolCalls, stall, selection.Provider, selection.Model)

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -1968,7 +1968,7 @@ func (l *AgenticLoop) finalizeCommandOutput(ctx context.Context, outcome string)
 		return "command_output_capture_failed"
 	}
 	if err != nil {
-		return "trace_archive_failed"
+		return "command_output_archive_failed"
 	}
 	return outcome
 }

--- a/harness/internal/core/loop.go
+++ b/harness/internal/core/loop.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/guard"
 	"github.com/rxbynerd/stirrup/harness/internal/observability"
@@ -478,6 +479,8 @@ func (l *AgenticLoop) Run(ctx context.Context, config *types.RunConfig) (*types.
 			outcome = "hook_failed"
 		}
 	}
+
+	outcome = l.finalizeCommandOutput(ctx, outcome)
 
 	l.Logger.Info("run finished", "outcome", outcome)
 
@@ -1178,7 +1181,10 @@ func (l *AgenticLoop) runInnerLoop(
 		// The router's provider/model selection is forwarded so per-call
 		// failure metrics (stirrup.harness.tool_failures) can be attributed
 		// back to the model that emitted the offending tool_use block.
-		toolResults, toolRecords, stallOutcome := l.planAndDispatch(ctx, config, toolCalls, stall, selection.Provider, selection.Model)
+		dispatchCtx := commandoutput.WithCallContext(ctx, commandoutput.CallContext{
+			RunID: config.RunID, ParentRunID: l.ParentRunID, Turn: turn + 1,
+		})
+		toolResults, toolRecords, stallOutcome := l.planAndDispatch(dispatchCtx, config, toolCalls, stall, selection.Provider, selection.Model)
 		turnRecord.ToolCalls = toolRecords
 		l.Trace.RecordTurnRecord(turnRecord)
 		messages = appendToolResults(messages, toolResults)
@@ -1904,6 +1910,7 @@ func (l *AgenticLoop) finishWithError(ctx context.Context, err error) (*types.Ru
 // "setup_failed" (or a ctx-cause outcome if the run's own wall-clock
 // timeout/cancel raced the hook failure) instead of the generic "error".
 func (l *AgenticLoop) finishWithOutcome(ctx context.Context, outcome string, err error) (*types.RunTrace, error) {
+	outcome = l.finalizeCommandOutput(ctx, outcome)
 	if emitErr := l.Transport.Emit(types.HarnessEvent{
 		Type:    "error",
 		Message: err.Error(),
@@ -1932,4 +1939,26 @@ func (l *AgenticLoop) finishWithOutcome(ctx context.Context, outcome string, err
 		l.Logger.Warn("trace finish failed", "error", traceErr)
 	}
 	return runTrace, err
+}
+
+func (l *AgenticLoop) finalizeCommandOutput(ctx context.Context, outcome string) string {
+	if l.CommandOutput == nil || !l.OwnsCommandOutput {
+		return outcome
+	}
+	if l.CommandOutput.FatalError() != nil {
+		outcome = "command_output_capture_failed"
+	}
+	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 6*time.Minute)
+	defer cancel()
+	archive, err := l.CommandOutput.Finalize(finalizeCtx)
+	if archive != "" {
+		if recorder, ok := l.Trace.(trace.CommandOutputArchiveRecorder); ok {
+			recorder.RecordCommandOutputArchive(archive)
+		}
+	}
+	if err != nil {
+		l.Logger.Error("command output archive finalization failed", "error", err, "archive", archive)
+		return "trace_archive_failed"
+	}
+	return outcome
 }

--- a/harness/internal/core/subagent.go
+++ b/harness/internal/core/subagent.go
@@ -160,13 +160,16 @@ func SpawnSubAgent(ctx context.Context, parent *AgenticLoop, parentConfig *types
 		// Hooks are parent-run-only (#461): a sub-agent never runs
 		// lifecycle hooks, regardless of what the parent's RunConfig
 		// configured.
-		Hooks:     hook.NewNoop(),
-		Transport: captureTp,
-		Trace:     childTrace,
-		Tracer:    tracer,
-		Metrics:   parent.Metrics,
-		Logger:    parent.Logger,
-		Security:  parent.Security,
+		Hooks:             hook.NewNoop(),
+		Transport:         captureTp,
+		Trace:             childTrace,
+		Tracer:            tracer,
+		Metrics:           parent.Metrics,
+		Logger:            parent.Logger,
+		Security:          parent.Security,
+		CommandOutput:     parent.CommandOutput,
+		OwnsCommandOutput: false,
+		ParentRunID:       parentConfig.RunID,
 		// Inherit the parent's GuardRail so spawned sub-agents are
 		// not a silent escape hatch around the configured guards.
 		// Without this, an indirect-injection payload could route

--- a/harness/internal/core/tooluse_replay_test.go
+++ b/harness/internal/core/tooluse_replay_test.go
@@ -101,7 +101,7 @@ func runToolUseScenario(t *testing.T, sc toolUseScenario) (string, *types.RunTra
 		es = edit.NewWholeFileStrategy()
 	}
 
-	registry := buildToolRegistry(exec, es, types.ToolsConfig{})
+	registry := buildToolRegistry(exec, es, types.ToolsConfig{}, nil)
 	for _, et := range sc.extraTools {
 		registry.Register(et)
 	}

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -140,7 +140,11 @@ type AgenticLoop struct {
 	// with OwnsCommandOutput=false; only the owning loop finalizes.
 	CommandOutput     CommandOutputFinalizer
 	OwnsCommandOutput bool
-	ParentRunID       string
+	// CommandOutputBestEffort mirrors the resolved
+	// tools.commandOutput.failurePosture: false (the zero value) is the
+	// strict default, matching EffectiveCommandOutput.
+	CommandOutputBestEffort bool
+	ParentRunID             string
 	// MetricAttrs is a set of attributes prepended to every metric
 	// observation emitted from this loop. Empty for top-level runs;
 	// SpawnSubAgent populates it on child loops with subagent=true and

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
@@ -115,14 +116,17 @@ type AgenticLoop struct {
 	// (CLAUDE.md invariant). Nil-safe: a hand-assembled loop (tests,
 	// embedders) that leaves it unset sees the pre-remediation
 	// behaviour (postRun bounded only by its own budget).
-	Shutdown     context.Context
-	Transport    transport.Transport
-	Trace        trace.TraceEmitter
-	Tracer       oteltrace.Tracer         // OTel tracer for loop-level spans (noop when not using OTel)
-	TraceContext context.Context          // context carrying the root span for child span parenting
-	Metrics      *observability.Metrics   // OTel metric instruments (noop when disabled)
-	Security     *security.SecurityLogger // optional, for structured security event logging
-	Logger       *slog.Logger             // structured logger with secret scrubbing
+	Shutdown          context.Context
+	Transport         transport.Transport
+	Trace             trace.TraceEmitter
+	Tracer            oteltrace.Tracer         // OTel tracer for loop-level spans (noop when not using OTel)
+	TraceContext      context.Context          // context carrying the root span for child span parenting
+	Metrics           *observability.Metrics   // OTel metric instruments (noop when disabled)
+	Security          *security.SecurityLogger // optional, for structured security event logging
+	Logger            *slog.Logger             // structured logger with secret scrubbing
+	CommandOutput     *commandoutput.Store
+	OwnsCommandOutput bool
+	ParentRunID       string
 	// MetricAttrs is a set of attributes prepended to every metric
 	// observation emitted from this loop. Empty for top-level runs;
 	// SpawnSubAgent populates it on child loops with subagent=true and
@@ -430,6 +434,9 @@ func (l *AgenticLoop) dispatchToolCallCategorized(ctx context.Context, call type
 		res, err := t.StructuredHandler(ctx, inputForCall)
 		if err != nil {
 			return "Tool error: " + err.Error(), false, observability.ToolFailureHandlerError, structuredOutput{}
+		}
+		if res.IsError {
+			return res.Text, false, observability.ToolFailureHandlerError, structuredOutput{payload: res.Structured, kind: res.Kind}
 		}
 		return res.Text, true, "", structuredOutput{payload: res.Structured, kind: res.Kind}
 	case t.Handler != nil:

--- a/harness/internal/core/types.go
+++ b/harness/internal/core/types.go
@@ -18,7 +18,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
-	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	contextpkg "github.com/rxbynerd/stirrup/harness/internal/context"
 	"github.com/rxbynerd/stirrup/harness/internal/edit"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
@@ -54,6 +53,16 @@ const maxAsyncToolResultBytes = 1 << 20 // 1MB
 // asyncResultTruncationSuffix is appended when content exceeds
 // maxAsyncToolResultBytes. The model and the trace see this marker.
 const asyncResultTruncationSuffix = "... [truncated by harness]"
+
+// CommandOutputFinalizer is the loop's complete usage surface of the
+// command output store (cf. batchModeAdapter): a sticky capture failure to
+// map into the run outcome, and end-of-run archive finalization. Keeping it
+// a loop-local interface preserves the loop-as-pure-interfaces invariant
+// (CLAUDE.md) while the factory wires the concrete store.
+type CommandOutputFinalizer interface {
+	FatalError() error
+	Finalize(ctx context.Context) (string, error)
+}
 
 // AgenticLoop drives the ReAct loop. All dependencies are injected as struct
 // fields — the loop has no imports from concrete implementations, no environment
@@ -116,15 +125,20 @@ type AgenticLoop struct {
 	// (CLAUDE.md invariant). Nil-safe: a hand-assembled loop (tests,
 	// embedders) that leaves it unset sees the pre-remediation
 	// behaviour (postRun bounded only by its own budget).
-	Shutdown          context.Context
-	Transport         transport.Transport
-	Trace             trace.TraceEmitter
-	Tracer            oteltrace.Tracer         // OTel tracer for loop-level spans (noop when not using OTel)
-	TraceContext      context.Context          // context carrying the root span for child span parenting
-	Metrics           *observability.Metrics   // OTel metric instruments (noop when disabled)
-	Security          *security.SecurityLogger // optional, for structured security event logging
-	Logger            *slog.Logger             // structured logger with secret scrubbing
-	CommandOutput     *commandoutput.Store
+	Shutdown     context.Context
+	Transport    transport.Transport
+	Trace        trace.TraceEmitter
+	Tracer       oteltrace.Tracer         // OTel tracer for loop-level spans (noop when not using OTel)
+	TraceContext context.Context          // context carrying the root span for child span parenting
+	Metrics      *observability.Metrics   // OTel metric instruments (noop when disabled)
+	Security     *security.SecurityLogger // optional, for structured security event logging
+	Logger       *slog.Logger             // structured logger with secret scrubbing
+	// CommandOutput is the loop's view of the run-scoped command output
+	// store; the factory injects the concrete *commandoutput.Store (or
+	// leaves this nil when capture is disabled) so the loop stays a pure
+	// function of its interfaces. Sub-agents share the parent's value
+	// with OwnsCommandOutput=false; only the owning loop finalizes.
+	CommandOutput     CommandOutputFinalizer
 	OwnsCommandOutput bool
 	ParentRunID       string
 	// MetricAttrs is a set of attributes prepended to every metric

--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -556,6 +556,28 @@ func (e *ContainerExecutor) Exec(ctx context.Context, command string, timeout ti
 	return e.truncateAndReport(command, result), nil
 }
 
+// ExecStream streams Docker multiplexed stdout/stderr directly to caller-owned
+// writers, bypassing the legacy 1 MiB Exec cap.
+func (e *ContainerExecutor) ExecStream(ctx context.Context, command string, timeout time.Duration, stdout, stderr io.Writer) (*ExecResult, error) {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	if timeout > maxTimeout {
+		timeout = maxTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := e.execInContainerStream(ctx, []string{"sh", "-c", command}, e.workspace, timeout, stdout, stderr)
+	if result == nil {
+		result = &ExecResult{}
+	}
+	if err != nil && ctx.Err() != nil {
+		result.ExitCode = -1
+		return result, classifyExecCtxErr(ctx, timeout)
+	}
+	return result, err
+}
+
 // truncateAndReport caps result's stdout/stderr at maxOutputSize and, when a
 // SecurityEventEmitter is wired, reports OutputTruncated using the
 // pre-truncation combined size. Shared by the success and timeout/cancel
@@ -650,6 +672,72 @@ func (e *ContainerExecutor) execInContainer(ctx context.Context, cmd []string, w
 	result.ExitCode = exitCode
 
 	return result, nil
+}
+
+func (e *ContainerExecutor) execInContainerStream(ctx context.Context, cmd []string, workdir string, timeout time.Duration, stdout, stderr io.Writer) (*ExecResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	execID, err := e.api.createExec(ctx, e.containerID, cmd, workdir)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, classifyExecCtxErr(ctx, timeout)
+		}
+		return nil, fmt.Errorf("create exec: %w", err)
+	}
+	stream, err := e.api.startExec(ctx, execID)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, classifyExecCtxErr(ctx, timeout)
+		}
+		return nil, fmt.Errorf("start exec: %w", err)
+	}
+	defer func() { _ = stream.Close() }()
+	result := &ExecResult{}
+	if err := demuxDockerStreamTo(stream, stdout, stderr); err != nil {
+		if ctx.Err() != nil {
+			return result, classifyExecCtxErr(ctx, timeout)
+		}
+		return result, fmt.Errorf("read exec output: %w", err)
+	}
+	exitCode, err := e.api.inspectExec(ctx, execID)
+	if err != nil {
+		if ctx.Err() != nil {
+			return result, classifyExecCtxErr(ctx, timeout)
+		}
+		return result, fmt.Errorf("inspect exec: %w", err)
+	}
+	result.ExitCode = exitCode
+	return result, nil
+}
+
+func demuxDockerStreamTo(r io.Reader, stdout, stderr io.Writer) error {
+	header := make([]byte, 8)
+	for {
+		_, err := io.ReadFull(r, header)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read stream header: %w", err)
+		}
+		frameSize := binary.BigEndian.Uint32(header[4:8])
+		if frameSize == 0 {
+			continue
+		}
+		if frameSize > maxDockerFrameSize {
+			return fmt.Errorf("docker stream frame exceeds %d byte limit: %d", maxDockerFrameSize, frameSize)
+		}
+		var dst io.Writer = io.Discard
+		switch header[0] {
+		case 1:
+			dst = stdout
+		case 2:
+			dst = stderr
+		}
+		if _, err := io.CopyN(dst, r, int64(frameSize)); err != nil {
+			return fmt.Errorf("read stream frame: %w", err)
+		}
+	}
 }
 
 // demuxDockerStream reads the Docker multiplexed stream format.

--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -727,7 +727,7 @@ func demuxDockerStreamTo(r io.Reader, stdout, stderr io.Writer) error {
 		if frameSize > maxDockerFrameSize {
 			return fmt.Errorf("docker stream frame exceeds %d byte limit: %d", maxDockerFrameSize, frameSize)
 		}
-		var dst io.Writer = io.Discard
+		dst := io.Discard
 		switch header[0] {
 		case 1:
 			dst = stdout

--- a/harness/internal/executor/container_test.go
+++ b/harness/internal/executor/container_test.go
@@ -1679,3 +1679,85 @@ func (m *mockSecurityEmitter) OutputTruncated(_ string, _, _ int) {
 
 // Ensure that mockSecurityEmitter satisfies the interface.
 var _ SecurityEventEmitter = (*mockSecurityEmitter)(nil)
+
+// TestContainerExecutor_ExecStream verifies the streaming path demuxes
+// stdout and stderr frames into the caller's writers without the inline
+// 1 MiB cap, and carries the inspected exit code.
+func TestContainerExecutor_ExecStream(t *testing.T) {
+	big := strings.Repeat("B", maxOutputSize+1000)
+	exec, cleanup := newMockContainerExecutor(t, map[string]http.HandlerFunc{
+		"POST /containers/*/exec": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execCreateResponse{ID: "exec-stream"})
+		},
+		"POST /exec/*/start": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.docker.raw-stream")
+			writeDockerFrame(w, 1, []byte(big))
+			writeDockerFrame(w, 2, []byte("warning\n"))
+		},
+		"GET /exec/*/json": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execInspectResponse{ExitCode: 3})
+		},
+	})
+	defer cleanup()
+
+	var stdout, stderr bytes.Buffer
+	result, err := exec.ExecStream(context.Background(), "make noise", 10*time.Second, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("ExecStream: %v", err)
+	}
+	if result.ExitCode != 3 {
+		t.Errorf("exit code: got %d, want 3", result.ExitCode)
+	}
+	if stdout.Len() != len(big) {
+		t.Errorf("stdout bytes: got %d, want %d (stream path must not cap)", stdout.Len(), len(big))
+	}
+	if stderr.String() != "warning\n" {
+		t.Errorf("stderr: got %q", stderr.String())
+	}
+}
+
+// failAfterWriter accepts n bytes then fails every subsequent write,
+// mimicking a command-output spool writer that hit its capture limit.
+type failAfterWriter struct {
+	remaining int
+	err       error
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	if len(p) <= w.remaining {
+		w.remaining -= len(p)
+		return len(p), nil
+	}
+	return 0, w.err
+}
+
+// TestContainerExecutor_ExecStream_WriterErrorAborts verifies a caller
+// writer failure (e.g. the spool's capture limit) surfaces as an error
+// instead of being swallowed.
+func TestContainerExecutor_ExecStream_WriterErrorAborts(t *testing.T) {
+	exec, cleanup := newMockContainerExecutor(t, map[string]http.HandlerFunc{
+		"POST /containers/*/exec": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execCreateResponse{ID: "exec-abort"})
+		},
+		"POST /exec/*/start": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.docker.raw-stream")
+			writeDockerFrame(w, 1, []byte(strings.Repeat("C", 4096)))
+			writeDockerFrame(w, 1, []byte(strings.Repeat("C", 4096)))
+		},
+		"GET /exec/*/json": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(execInspectResponse{ExitCode: 0})
+		},
+	})
+	defer cleanup()
+
+	limitErr := errors.New("capture limit exceeded")
+	var stderr bytes.Buffer
+	_, err := exec.ExecStream(context.Background(), "make noise", 10*time.Second, &failAfterWriter{remaining: 4096, err: limitErr}, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "capture limit exceeded") {
+		t.Fatalf("expected writer failure to surface, got %v", err)
+	}
+}

--- a/harness/internal/executor/executor.go
+++ b/harness/internal/executor/executor.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -75,4 +76,12 @@ type Executor interface {
 	Exec(ctx context.Context, command string, timeout time.Duration) (*ExecResult, error)
 	ResolvePath(relativePath string) (string, error)
 	Capabilities() ExecutorCapabilities
+}
+
+// StreamingExecutor is the optional full-output execution capability used by
+// run_command. Exec remains bounded for hooks, verifiers, git helpers, and
+// legacy callers; production executors implement this interface to stream
+// stdout/stderr directly into the harness-owned compliance store.
+type StreamingExecutor interface {
+	ExecStream(ctx context.Context, command string, timeout time.Duration, stdout, stderr io.Writer) (*ExecResult, error)
 }

--- a/harness/internal/executor/k8s_execcore.go
+++ b/harness/internal/executor/k8s_execcore.go
@@ -312,6 +312,32 @@ func (e *podExecCore) Exec(ctx context.Context, command string, timeout time.Dur
 	}, nil
 }
 
+// ExecStream streams pod exec output directly to caller-owned writers without
+// the historical 10 MiB buffers used by Exec.
+func (e *podExecCore) ExecStream(ctx context.Context, command string, timeout time.Duration, stdout, stderr io.Writer) (*ExecResult, error) {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	if timeout > maxTimeout {
+		timeout = maxTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	err := e.streamExec(ctx, []string{"/bin/sh", "-c", command}, nil, stdout, stderr)
+	if ctx.Err() != nil {
+		return &ExecResult{ExitCode: -1}, classifyExecCtxErr(ctx, timeout)
+	}
+	exitCode := 0
+	if err != nil {
+		code, ok := extractExitCode(err)
+		if !ok {
+			return &ExecResult{}, fmt.Errorf("exec: %w", err)
+		}
+		exitCode = code
+	}
+	return &ExecResult{ExitCode: exitCode}, nil
+}
+
 // streamExec builds and runs a pods/exec request against the agent
 // container, wiring the supplied stdin/stdout/stderr streams. It is the
 // single SPDY/remotecommand chokepoint shared by Exec and the tar-based

--- a/harness/internal/executor/local.go
+++ b/harness/internal/executor/local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -214,6 +215,26 @@ func (e *LocalExecutor) ListDirectory(ctx context.Context, path string) ([]strin
 // A zero timeout uses the default (30s). Output is truncated at 1 MB.
 // The process is killed if the context or timeout expires.
 func (e *LocalExecutor) Exec(ctx context.Context, command string, timeout time.Duration) (*ExecResult, error) {
+	stdout := newCappedWriter(maxOutputSize)
+	stderr := newCappedWriter(maxOutputSize)
+	result, err := e.ExecStream(ctx, command, timeout, stdout, stderr)
+	if result == nil {
+		result = &ExecResult{}
+	}
+	result.Stdout = stdout.result()
+	result.Stderr = stderr.result()
+	if e.Security != nil {
+		combinedSize := stdout.seen() + stderr.seen()
+		if combinedSize > maxOutputSize {
+			e.Security.OutputTruncated(command, combinedSize, maxOutputSize)
+		}
+	}
+	return result, err
+}
+
+// ExecStream executes without applying the legacy output cap. Callers own the
+// writers and are responsible for bounding storage.
+func (e *LocalExecutor) ExecStream(ctx context.Context, command string, timeout time.Duration, stdout, stderr io.Writer) (*ExecResult, error) {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
@@ -241,31 +262,12 @@ func (e *LocalExecutor) Exec(ctx context.Context, command string, timeout time.D
 	// returns promptly regardless of what an orphaned grandchild does.
 	cmd.WaitDelay = shortCommandKillGrace
 
-	// Stream into capped writers so peak memory is bounded to ~maxOutputSize
-	// per stream rather than buffering all output. This mirrors
-	// ContainerExecutor.demuxDockerStream's drain-on-cap behaviour: bytes past
-	// the cap are accepted (so the process never blocks on a full pipe) but not
-	// retained. Each writer still counts every byte it sees, so the true
-	// pre-truncation size and trigger condition reported to OutputTruncated
-	// match the container path byte-for-byte.
-	stdout := newCappedWriter(maxOutputSize)
-	stderr := newCappedWriter(maxOutputSize)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
 	err := cmd.Run()
 
-	result := &ExecResult{
-		Stdout: stdout.result(),
-		Stderr: stderr.result(),
-	}
-
-	if e.Security != nil {
-		combinedSize := stdout.seen() + stderr.seen()
-		if combinedSize > maxOutputSize {
-			e.Security.OutputTruncated(command, combinedSize, maxOutputSize)
-		}
-	}
+	result := &ExecResult{}
 
 	if err != nil {
 		// Check context cancellation first — a killed process also produces

--- a/harness/internal/executor/local_test.go
+++ b/harness/internal/executor/local_test.go
@@ -408,6 +408,24 @@ func TestExec_OutputStreamingBounded(t *testing.T) {
 	}
 }
 
+func TestExecStream_PreservesOutputBeyondLegacyCap(t *testing.T) {
+	exec, _ := newTestExecutor(t)
+	var stdout, stderr strings.Builder
+	result, err := exec.ExecStream(context.Background(), "yes x | head -c 2097152", 10*time.Second, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code=%d", result.ExitCode)
+	}
+	if stdout.Len() != 2*1024*1024 {
+		t.Fatalf("stdout bytes=%d want %d", stdout.Len(), 2*1024*1024)
+	}
+	if strings.Contains(stdout.String(), truncatedSuffix) {
+		t.Fatal("streaming output was legacy-truncated")
+	}
+}
+
 // TestExec_OutputTruncated_CombinedAcrossStreams locks in the trigger
 // alignment: stdout and stderr each under the 1 MB cap but together over it
 // must fire OutputTruncated, matching the container path's combined-size

--- a/harness/internal/executor/replay.go
+++ b/harness/internal/executor/replay.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -40,6 +41,9 @@ func NewReplayExecutor(workspace string, turns []types.TurnRecord) *ReplayExecut
 		for _, tc := range turn.ToolCalls {
 			key := recordingKey(tc.Name, tc.Input)
 			recordings[key] = tc
+			if tc.InternalName != "" && tc.InternalName != tc.Name {
+				recordings[recordingKey(tc.InternalName, tc.Input)] = tc
+			}
 		}
 	}
 	return &ReplayExecutor{
@@ -122,6 +126,25 @@ func (re *ReplayExecutor) Exec(_ context.Context, command string, _ time.Duratio
 		ExitCode: exitCode,
 		Stdout:   stdout,
 	}, nil
+}
+
+func (re *ReplayExecutor) ExecStream(ctx context.Context, command string, timeout time.Duration, stdout, stderr io.Writer) (*ExecResult, error) {
+	result, err := re.Exec(ctx, command, timeout)
+	if result != nil {
+		if _, writeErr := io.WriteString(stdout, result.Stdout); writeErr != nil {
+			return result, writeErr
+		}
+		if _, writeErr := io.WriteString(stderr, result.Stderr); writeErr != nil {
+			return result, writeErr
+		}
+	}
+	return result, err
+}
+
+// ReplayToolCall returns the exact recorded model-visible result for tool
+// replay, including structured payload and error state.
+func (re *ReplayExecutor) ReplayToolCall(name string, input json.RawMessage) (types.ToolCallRecord, bool) {
+	return re.lookup(name, input)
 }
 
 // ResolvePath returns the path joined with the workspace root.

--- a/harness/internal/gcs/upload.go
+++ b/harness/internal/gcs/upload.go
@@ -45,6 +45,12 @@ type UploadOptions struct {
 	// not retain a reference after returning.
 	Body []byte
 
+	// BodyReader streams an object without materialising it in memory. When
+	// non-nil it takes precedence over Body and BodySize must contain the
+	// exact byte length so the request can set Content-Length.
+	BodyReader io.Reader
+	BodySize   int64
+
 	// ContentType is the Content-Type header sent with the upload.
 	// Defaults to application/octet-stream when empty.
 	ContentType string
@@ -108,13 +114,22 @@ func UploadObject(ctx context.Context, client *http.Client, opts UploadOptions) 
 		urlPathEscape(opts.Object),
 	)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(opts.Body))
+	var body io.Reader = bytes.NewReader(opts.Body)
+	contentLength := int64(len(opts.Body))
+	if opts.BodyReader != nil {
+		if opts.BodySize < 0 {
+			return fmt.Errorf("gcs: body size must not be negative")
+		}
+		body = opts.BodyReader
+		contentLength = opts.BodySize
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", contentType)
-	req.ContentLength = int64(len(opts.Body))
+	req.ContentLength = contentLength
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -376,7 +376,14 @@ func anthropicToolResultContent(b types.ContentBlock, cap quirks.StructuredToolR
 	// pre-#231 shape for empty-content results (which omitted the content key
 	// entirely). When Content is empty, fall through to the nil-return below
 	// regardless of the structured payload.
-	if cap.Supported && cap.ContentBlockArray && len(b.Structured) > 0 && b.Content != "" {
+	//
+	// When the structured envelope is byte-identical to the canonical text
+	// (read_command_output renders its JSON payload as both), the array form
+	// would put the same bytes on the wire twice — for a 128 KiB page that
+	// doubles a full turn's cost and can push a run over the model's context
+	// limit. Identical payloads collapse to the single string form below.
+	if cap.Supported && cap.ContentBlockArray && len(b.Structured) > 0 && b.Content != "" &&
+		string(b.Structured) != b.Content {
 		parts := []anthropicToolResultPart{
 			{Type: "text", Text: b.Content},
 			{Type: "text", Text: string(b.Structured)},

--- a/harness/internal/provider/structuredresult_test.go
+++ b/harness/internal/provider/structuredresult_test.go
@@ -165,6 +165,28 @@ func TestAnthropicToolResultContent_EmptyContentCapabilityOn(t *testing.T) {
 	}
 }
 
+// TestAnthropicToolResultContent_IdenticalStructuredCollapses pins that a
+// tool result whose structured envelope is byte-identical to its canonical
+// text (read_command_output renders its JSON payload as both) is sent once
+// as the plain string form: the array form would put the same bytes on the
+// wire twice, doubling a large page's token cost.
+func TestAnthropicToolResultContent_IdenticalStructuredCollapses(t *testing.T) {
+	cap := quirks.StructuredToolResultCapability{Supported: true, ContentBlockArray: true}
+	payload := `{"reference":"stirrup://command-output/abc/stdout","content":"chunk bytes"}`
+	block := types.ContentBlock{
+		Type:       "tool_result",
+		ToolUseID:  "call_1",
+		Content:    payload,
+		Structured: json.RawMessage(payload),
+		Kind:       "command_output_chunk",
+	}
+	got := anthropicToolResultContent(block, cap)
+	want, _ := json.Marshal(payload)
+	if !bytes.Equal(got, want) {
+		t.Errorf("identical structured+text must collapse to the single string form\n got:  %s\n want: %s", got, want)
+	}
+}
+
 // TestGeminiStructuredToolResult_CapabilityOn pins that the Gemini builder
 // embeds the structured envelope under functionResponse.response.structured
 // (with kind) alongside the canonical content when the capability accepts it.

--- a/harness/internal/tool/builtins/command_output_test.go
+++ b/harness/internal/tool/builtins/command_output_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/harness/internal/tool"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -25,7 +26,7 @@ func TestRunCommandInlineBoundaryAndSpillRead(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 	run := RunCommandToolWithStore(exec, store, cfg)
-	ctx := commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run", Turn: 1, ToolUseID: "inline"})
+	ctx := tool.WithCallContext(context.Background(), tool.CallContext{RunID: "run", Turn: 1, ToolUseID: "inline"})
 	inline, err := run.StructuredHandler(ctx, json.RawMessage(`{"command":"printf 12345"}`))
 	if err != nil {
 		t.Fatal(err)
@@ -34,7 +35,7 @@ func TestRunCommandInlineBoundaryAndSpillRead(t *testing.T) {
 		t.Fatalf("inline=%q", inline.Text)
 	}
 
-	ctx = commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run", Turn: 2, ToolUseID: "spill"})
+	ctx = tool.WithCallContext(context.Background(), tool.CallContext{RunID: "run", Turn: 2, ToolUseID: "spill"})
 	spilled, err := run.StructuredHandler(ctx, json.RawMessage(`{"command":"printf 123456; printf abcdef >&2"}`))
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +52,7 @@ func TestRunCommandInlineBoundaryAndSpillRead(t *testing.T) {
 	}
 
 	reader := ReadCommandOutputTool(store, exec)
-	readCtx := commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run", Turn: 3, ToolUseID: "reader"})
+	readCtx := tool.WithCallContext(context.Background(), tool.CallContext{RunID: "run", Turn: 3, ToolUseID: "reader"})
 	input, _ := json.Marshal(map[string]any{"ref": result.StdoutRef, "offset": 1, "limit": 3})
 	chunk, err := reader.StructuredHandler(readCtx, input)
 	if err != nil {
@@ -80,7 +81,7 @@ func TestRunCommandTimeoutReturnsCapturedErrorResult(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 	run := RunCommandToolWithStore(exec, store, cfg)
-	ctx := commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run-timeout", ToolUseID: "timeout"})
+	ctx := tool.WithCallContext(context.Background(), tool.CallContext{RunID: "run-timeout", ToolUseID: "timeout"})
 	input := json.RawMessage([]byte("{\"command\":\"printf partial; sleep 5\",\"timeout\":1}"))
 	result, err := run.StructuredHandler(ctx, input)
 	if err != nil {

--- a/harness/internal/tool/builtins/command_output_test.go
+++ b/harness/internal/tool/builtins/command_output_test.go
@@ -1,0 +1,127 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
+	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func TestRunCommandInlineBoundaryAndSpillRead(t *testing.T) {
+	exec, err := executor.NewLocalExecutor(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := types.CommandOutputConfig{InlineMaxBytes: 5, PreviewBytesPerStream: 3, MaxBytesPerStream: 1 << 20, MaxBytesPerRun: 2 << 20}
+	store, err := commandoutput.New(commandoutput.Options{RunID: "run", Config: cfg, ArchivePath: filepath.Join(t.TempDir(), "archive.tar.gz")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	run := RunCommandToolWithStore(exec, store, cfg)
+	ctx := commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run", Turn: 1, ToolUseID: "inline"})
+	inline, err := run.StructuredHandler(ctx, json.RawMessage(`{"command":"printf 12345"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inline.Text != "12345" {
+		t.Fatalf("inline=%q", inline.Text)
+	}
+
+	ctx = commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run", Turn: 2, ToolUseID: "spill"})
+	spilled, err := run.StructuredHandler(ctx, json.RawMessage(`{"command":"printf 123456; printf abcdef >&2"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(spilled.Text, "command output spilled") || !strings.Contains(spilled.Text, "stirrup://command-output/") {
+		t.Fatalf("spill=%q", spilled.Text)
+	}
+	var result commandResult
+	if err := json.Unmarshal(spilled.Structured, &result); err != nil {
+		t.Fatal(err)
+	}
+	if !result.Spilled || result.Stdout != "456" || result.Stderr != "def" {
+		t.Fatalf("structured=%+v", result)
+	}
+
+	reader := ReadCommandOutputTool(store, exec)
+	readCtx := commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run", Turn: 3, ToolUseID: "reader"})
+	input, _ := json.Marshal(map[string]any{"ref": result.StdoutRef, "offset": 1, "limit": 3})
+	chunk, err := reader.StructuredHandler(readCtx, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(chunk.Text, `"content":"234"`) {
+		t.Fatalf("chunk=%s", chunk.Text)
+	}
+	if _, err := store.Finalize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(store.Archive()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunCommandTimeoutReturnsCapturedErrorResult(t *testing.T) {
+	exec, err := executor.NewLocalExecutor(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := types.CommandOutputConfig{InlineMaxBytes: 32 << 10, PreviewBytesPerStream: 1024, MaxBytesPerStream: 1 << 20, MaxBytesPerRun: 2 << 20}
+	store, err := commandoutput.New(commandoutput.Options{RunID: "run-timeout", Config: cfg, ArchivePath: filepath.Join(t.TempDir(), "archive.tar.gz")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	run := RunCommandToolWithStore(exec, store, cfg)
+	ctx := commandoutput.WithCallContext(context.Background(), commandoutput.CallContext{RunID: "run-timeout", ToolUseID: "timeout"})
+	input := json.RawMessage([]byte("{\"command\":\"printf partial; sleep 5\",\"timeout\":1}"))
+	result, err := run.StructuredHandler(ctx, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError || !strings.Contains(result.Text, "partial") {
+		t.Fatalf("result=%+v", result)
+	}
+	var structured commandResult
+	if err := json.Unmarshal(result.Structured, &structured); err != nil {
+		t.Fatal(err)
+	}
+	if !structured.TimedOut || !structured.CaptureComplete {
+		t.Fatalf("structured=%+v", structured)
+	}
+}
+
+func TestCommandOutputReplayUsesRecordedModelVisibleResultsVerbatim(t *testing.T) {
+	runInput := json.RawMessage([]byte("{\"command\":\"big-output\",\"timeout\":30}"))
+	readInput := json.RawMessage([]byte("{\"ref\":\"stirrup://command-output/a/b/stdout\",\"offset\":0}"))
+	replay := executor.NewReplayExecutor(t.TempDir(), []types.TurnRecord{{ToolCalls: []types.ToolCallRecord{
+		{Name: "run_command", Input: runInput, Output: "recorded initial preview", Success: true, Kind: kindCommandResult, Structured: json.RawMessage([]byte("{\"spilled\":true}"))},
+		{Name: "read_command_output", Input: readInput, Output: "recorded read chunk", Success: true, Kind: kindCommandOutputChunk},
+	}}})
+	store, err := commandoutput.New(commandoutput.Options{RunID: "replay", Config: types.CommandOutputConfig{}, ArchivePath: filepath.Join(t.TempDir(), "unused.tar.gz")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	runResult, err := RunCommandToolWithStore(replay, store, types.CommandOutputConfig{}).StructuredHandler(context.Background(), runInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runResult.Text != "recorded initial preview" {
+		t.Fatalf("run replay=%q", runResult.Text)
+	}
+	readResult, err := ReadCommandOutputTool(store, replay).StructuredHandler(context.Background(), readInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readResult.Text != "recorded read chunk" {
+		t.Fatalf("read replay=%q", readResult.Text)
+	}
+}

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -3,12 +3,16 @@ package builtins
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/commandoutput"
 	"github.com/rxbynerd/stirrup/harness/internal/executor"
+	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
+	"github.com/rxbynerd/stirrup/types"
 )
 
 // runCommandSchema is the JSON Schema for the run_command tool input.
@@ -30,6 +34,14 @@ var runCommandSchema = json.RawMessage(`{
 
 // RunCommandTool returns a tool that executes a shell command in the workspace.
 func RunCommandTool(exec executor.Executor) *tool.Tool {
+	return RunCommandToolWithStore(exec, nil, types.CommandOutputConfig{})
+}
+
+// RunCommandToolWithStore returns the compliance-capturing run_command tool.
+// A nil store preserves the legacy bounded path for embedders and unit-test
+// executors that do not expose streaming execution.
+func RunCommandToolWithStore(exec executor.Executor, store *commandoutput.Store, cfg types.CommandOutputConfig) *tool.Tool {
+	cfg = (types.ToolsConfig{CommandOutput: cfg}).EffectiveCommandOutput()
 	return &tool.Tool{
 		Name: "run_command",
 		Description: "Execute a shell command in the workspace directory. Returns stdout, then a 'STDERR:' block when stderr is non-empty, then '[exit code: N]' when the command exited non-zero. " +
@@ -43,6 +55,13 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
 		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
+			if replay, ok := exec.(interface {
+				ReplayToolCall(string, json.RawMessage) (types.ToolCallRecord, bool)
+			}); ok {
+				if rec, found := replay.ReplayToolCall("run_command", input); found {
+					return tool.StructuredResult{Text: rec.Output, Structured: rec.Structured, Kind: rec.Kind, IsError: rec.IsError || !rec.Success}, nil
+				}
+			}
 			var params struct {
 				Command string `json:"command"`
 				Timeout *int   `json:"timeout"`
@@ -66,29 +85,166 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 			}
 			timeout := time.Duration(timeoutSeconds) * time.Second
 
-			result, err := exec.Exec(ctx, params.Command, timeout)
+			if store == nil {
+				result, err := exec.Exec(ctx, params.Command, timeout)
+				if err != nil {
+					return tool.StructuredResult{}, err
+				}
+				stdout, stderr := security.Scrub(result.Stdout), security.Scrub(result.Stderr)
+				structured, marshalErr := json.Marshal(commandResult{Stdout: stdout, Stderr: stderr, ExitCode: result.ExitCode, TimedOut: false, TimeoutSeconds: timeoutSeconds})
+				if marshalErr != nil {
+					return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
+				}
+				return tool.StructuredResult{Text: formatRunCommand(stdout, stderr, result.ExitCode), Structured: structured, Kind: kindCommandResult}, nil
+			}
+
+			streaming, ok := exec.(executor.StreamingExecutor)
+			if !ok {
+				return tool.StructuredResult{}, fmt.Errorf("executor does not support compliant command output streaming")
+			}
+			execCtx, cancel := context.WithCancelCause(ctx)
+			defer cancel(nil)
+			capture, err := store.Begin(ctx, cancel)
 			if err != nil {
 				return tool.StructuredResult{}, err
 			}
+			result, execErr := streaming.ExecStream(execCtx, params.Command, timeout, capture.Stdout(), capture.Stderr())
+			if result == nil {
+				result = &executor.ExecResult{ExitCode: -1}
+			}
+			timedOut := errors.Is(execErr, executor.ErrTimeout)
+			cause := context.Cause(execCtx)
+			cancelled := execErr != nil && !timedOut && execCtx.Err() != nil &&
+				!errors.Is(cause, commandoutput.ErrCaptureLimit) && !errors.Is(cause, commandoutput.ErrCaptureIO)
+			captured, captureErr := capture.Complete(commandoutput.Completion{ExitCode: result.ExitCode, TimedOut: timedOut, Cancelled: cancelled})
+			isError := execErr != nil || captureErr != nil
+			text, spilled := formatCapturedCommand(captured, cfg, timeoutSeconds)
+			if execErr != nil && !timedOut && cause != nil && !cancelled {
+				text += "\n[capture/command error: " + security.Scrub(execErr.Error()) + "]"
+			}
+			if err := store.RecordInitial(&captured.Record, text); err != nil {
+				return tool.StructuredResult{}, fmt.Errorf("record command model result: %w", err)
+			}
 
 			structured, marshalErr := json.Marshal(commandResult{
-				Stdout:   result.Stdout,
-				Stderr:   result.Stderr,
-				ExitCode: result.ExitCode,
-				// A timeout surfaces as the err above, so a result reaching
-				// here always completed within the bound.
-				TimedOut:       false,
+				Stdout:         previewForStructured(captured.Stdout, cfg, spilled),
+				Stderr:         previewForStructured(captured.Stderr, cfg, spilled),
+				ExitCode:       result.ExitCode,
+				TimedOut:       timedOut,
 				TimeoutSeconds: timeoutSeconds,
+				Spilled:        spilled, CaptureComplete: captured.Record.CaptureComplete,
+				ArchiveID: captured.Record.ArchiveID,
+				StdoutRef: captured.Record.Stdout.Reference, StderrRef: captured.Record.Stderr.Reference,
+				StdoutRawBytes: captured.Record.Stdout.RawBytes, StderrRawBytes: captured.Record.Stderr.RawBytes,
+				StdoutScrubbedBytes: captured.Record.Stdout.ScrubbedBytes, StderrScrubbedBytes: captured.Record.Stderr.ScrubbedBytes,
+				StdoutSHA256: captured.Record.Stdout.ScrubbedSHA256, StderrSHA256: captured.Record.Stderr.ScrubbedSHA256,
 			})
 			if marshalErr != nil {
 				return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
 			}
 
 			return tool.StructuredResult{
-				Text:       formatRunCommand(result.Stdout, result.Stderr, result.ExitCode),
+				Text:       text,
 				Structured: structured,
 				Kind:       kindCommandResult,
+				IsError:    isError,
 			}, nil
+		},
+	}
+}
+
+func formatCapturedCommand(c commandoutput.Captured, cfg types.CommandOutputConfig, timeoutSeconds int) (string, bool) {
+	combined := c.Record.Stdout.ScrubbedBytes + c.Record.Stderr.ScrubbedBytes
+	if combined <= cfg.InlineMaxBytes && c.Record.CaptureComplete {
+		return formatRunCommand(c.Stdout, c.Stderr, c.Record.ExitCode), false
+	}
+	var out strings.Builder
+	out.WriteString("[command output spilled to compliance archive]\n")
+	fmt.Fprintf(&out, "exit_code=%d timed_out=%t timeout_seconds=%d capture_complete=%t archive_id=%s\n",
+		c.Record.ExitCode, c.Record.TimedOut, timeoutSeconds, c.Record.CaptureComplete, c.Record.ArchiveID)
+	writeStreamPreview(&out, "stdout", c.Stdout, c.Record.Stdout, cfg.PreviewBytesPerStream)
+	writeStreamPreview(&out, "stderr", c.Stderr, c.Record.Stderr, cfg.PreviewBytesPerStream)
+	if c.Record.CaptureError != "" {
+		out.WriteString("capture_error=" + c.Record.CaptureError + "\n")
+	}
+	return strings.TrimSuffix(out.String(), "\n"), true
+}
+
+func writeStreamPreview(out *strings.Builder, name, content string, meta types.CommandOutputStreamRecord, preview int64) {
+	fmt.Fprintf(out, "%s raw_bytes=%d scrubbed_bytes=%d raw_sha256=%s scrubbed_sha256=%s\n", name, meta.RawBytes, meta.ScrubbedBytes, meta.RawSHA256, meta.ScrubbedSHA256)
+	fmt.Fprintf(out, "%s_ref=%s\n", name, meta.Reference)
+	tail := content
+	if int64(len(tail)) > preview {
+		tail = tail[len(tail)-int(preview):]
+	}
+	fmt.Fprintf(out, "%s_tail:\n%s\n", name, tail)
+}
+
+func previewForStructured(content string, cfg types.CommandOutputConfig, spilled bool) string {
+	if !spilled {
+		return content
+	}
+	if int64(len(content)) <= cfg.PreviewBytesPerStream {
+		return content
+	}
+	return content[len(content)-int(cfg.PreviewBytesPerStream):]
+}
+
+var readCommandOutputSchema = json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "ref":{"type":"string","pattern":"^stirrup://command-output/"},
+    "offset":{"type":"integer","minimum":0},
+    "limit":{"type":"integer","minimum":1,"maximum":131072}
+  },
+  "required":["ref"],
+  "additionalProperties":false
+}`)
+
+// ReadCommandOutputTool returns a read-only, approval-free paginator over
+// scrubbed command streams.
+func ReadCommandOutputTool(store *commandoutput.Store, execs ...executor.Executor) *tool.Tool {
+	return &tool.Tool{
+		Name:        "read_command_output",
+		Description: "Read a scrubbed byte range from an opaque stirrup://command-output reference returned by run_command. Defaults to 32 KiB and permits at most 128 KiB per call.",
+		InputSchema: readCommandOutputSchema,
+		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
+			if len(execs) > 0 {
+				if replay, ok := execs[0].(interface {
+					ReplayToolCall(string, json.RawMessage) (types.ToolCallRecord, bool)
+				}); ok {
+					if rec, found := replay.ReplayToolCall("read_command_output", input); found {
+						return tool.StructuredResult{Text: rec.Output, Structured: rec.Structured, Kind: rec.Kind, IsError: rec.IsError || !rec.Success}, nil
+					}
+				}
+			}
+			var params struct {
+				Ref    string `json:"ref"`
+				Offset int64  `json:"offset"`
+				Limit  int64  `json:"limit"`
+			}
+			if err := json.Unmarshal(input, &params); err != nil {
+				return tool.StructuredResult{}, fmt.Errorf("parse input: %w", err)
+			}
+			read, err := store.Read(params.Ref, params.Offset, params.Limit)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			payload := commandOutputChunkResult{Reference: params.Ref, Stream: read.Stream, Offset: read.Offset, EndOffset: read.End, EOF: read.EOF, Content: string(read.Bytes), RawBytes: read.Content.RawBytes, RawSHA256: read.Content.RawSHA256, ScrubbedBytes: read.Content.ScrubbedBytes, ScrubbedSHA256: read.Content.ScrubbedSHA256, RedactionCount: read.Content.RedactionCount}
+			structured, err := json.Marshal(payload)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			textBytes, err := json.Marshal(payload)
+			if err != nil {
+				return tool.StructuredResult{}, err
+			}
+			text := string(textBytes)
+			meta := commandoutput.CallContextFrom(ctx)
+			if err := store.RecordRead(meta.ToolUseID, params.Ref, read, text); err != nil {
+				return tool.StructuredResult{}, fmt.Errorf("record command output read: %w", err)
+			}
+			return tool.StructuredResult{Text: text, Structured: structured, Kind: kindCommandOutputChunk}, nil
 		},
 	}
 }

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -203,19 +203,17 @@ var readCommandOutputSchema = json.RawMessage(`{
 
 // ReadCommandOutputTool returns a read-only, approval-free paginator over
 // scrubbed command streams.
-func ReadCommandOutputTool(store *commandoutput.Store, execs ...executor.Executor) *tool.Tool {
+func ReadCommandOutputTool(store *commandoutput.Store, exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
 		Name:        "read_command_output",
 		Description: "Read a scrubbed byte range from an opaque stirrup://command-output reference returned by run_command. Defaults to 32 KiB and permits at most 128 KiB per call.",
 		InputSchema: readCommandOutputSchema,
 		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
-			if len(execs) > 0 {
-				if replay, ok := execs[0].(interface {
-					ReplayToolCall(string, json.RawMessage) (types.ToolCallRecord, bool)
-				}); ok {
-					if rec, found := replay.ReplayToolCall("read_command_output", input); found {
-						return tool.StructuredResult{Text: rec.Output, Structured: rec.Structured, Kind: rec.Kind, IsError: rec.IsError || !rec.Success}, nil
-					}
+			if replay, ok := exec.(interface {
+				ReplayToolCall(string, json.RawMessage) (types.ToolCallRecord, bool)
+			}); ok {
+				if rec, found := replay.ReplayToolCall("read_command_output", input); found {
+					return tool.StructuredResult{Text: rec.Output, Structured: rec.Structured, Kind: rec.Kind, IsError: rec.IsError || !rec.Success}, nil
 				}
 			}
 			var params struct {

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -55,12 +55,8 @@ func RunCommandToolWithStore(exec executor.Executor, store *commandoutput.Store,
 		WorkspaceMutating: true,
 		RequiresApproval:  true,
 		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
-			if replay, ok := exec.(interface {
-				ReplayToolCall(string, json.RawMessage) (types.ToolCallRecord, bool)
-			}); ok {
-				if rec, found := replay.ReplayToolCall("run_command", input); found {
-					return tool.StructuredResult{Text: rec.Output, Structured: rec.Structured, Kind: rec.Kind, IsError: rec.IsError || !rec.Success}, nil
-				}
+			if res, found := replayResult(exec, "run_command", input); found {
+				return res, nil
 			}
 			var params struct {
 				Command string `json:"command"`
@@ -190,31 +186,47 @@ func previewForStructured(content string, cfg types.CommandOutputConfig, spilled
 	return content[len(content)-int(cfg.PreviewBytesPerStream):]
 }
 
-var readCommandOutputSchema = json.RawMessage(`{
+var readCommandOutputSchema = json.RawMessage(fmt.Sprintf(`{
   "type":"object",
   "properties":{
     "ref":{"type":"string","pattern":"^stirrup://command-output/"},
     "offset":{"type":"integer","minimum":0},
-    "limit":{"type":"integer","minimum":1,"maximum":131072}
+    "limit":{"type":"integer","minimum":1,"maximum":%d}
   },
   "required":["ref"],
   "additionalProperties":false
-}`)
+}`, commandoutput.ReadMaxBytes))
+
+// replayResult short-circuits a tool handler to the exact recorded
+// model-visible result when the executor is a replay executor. Both
+// run_command and read_command_output use it so replayed runs stay
+// byte-identical to the recording.
+func replayResult(exec executor.Executor, name string, input json.RawMessage) (tool.StructuredResult, bool) {
+	replay, ok := exec.(interface {
+		ReplayToolCall(string, json.RawMessage) (types.ToolCallRecord, bool)
+	})
+	if !ok {
+		return tool.StructuredResult{}, false
+	}
+	rec, found := replay.ReplayToolCall(name, input)
+	if !found {
+		return tool.StructuredResult{}, false
+	}
+	return tool.StructuredResult{Text: rec.Output, Structured: rec.Structured, Kind: rec.Kind, IsError: rec.IsError || !rec.Success}, true
+}
 
 // ReadCommandOutputTool returns a read-only, approval-free paginator over
 // scrubbed command streams.
 func ReadCommandOutputTool(store *commandoutput.Store, exec executor.Executor) *tool.Tool {
 	return &tool.Tool{
-		Name:        "read_command_output",
-		Description: "Read a scrubbed byte range from an opaque stirrup://command-output reference returned by run_command. Defaults to 32 KiB and permits at most 128 KiB per call.",
+		Name: "read_command_output",
+		Description: fmt.Sprintf(
+			"Read a scrubbed byte range from an opaque stirrup://command-output reference returned by run_command. Defaults to %d KiB and permits at most %d KiB per call.",
+			commandoutput.ReadDefaultBytes>>10, commandoutput.ReadMaxBytes>>10),
 		InputSchema: readCommandOutputSchema,
 		StructuredHandler: func(ctx context.Context, input json.RawMessage) (tool.StructuredResult, error) {
-			if replay, ok := exec.(interface {
-				ReplayToolCall(string, json.RawMessage) (types.ToolCallRecord, bool)
-			}); ok {
-				if rec, found := replay.ReplayToolCall("read_command_output", input); found {
-					return tool.StructuredResult{Text: rec.Output, Structured: rec.Structured, Kind: rec.Kind, IsError: rec.IsError || !rec.Success}, nil
-				}
+			if res, found := replayResult(exec, "read_command_output", input); found {
+				return res, nil
 			}
 			var params struct {
 				Ref    string `json:"ref"`
@@ -233,11 +245,7 @@ func ReadCommandOutputTool(store *commandoutput.Store, exec executor.Executor) *
 			if err != nil {
 				return tool.StructuredResult{}, err
 			}
-			textBytes, err := json.Marshal(payload)
-			if err != nil {
-				return tool.StructuredResult{}, err
-			}
-			text := string(textBytes)
+			text := string(structured)
 			meta := tool.CallContextFrom(ctx)
 			if err := store.RecordRead(meta, params.Ref, read, text); err != nil {
 				return tool.StructuredResult{}, fmt.Errorf("record command output read: %w", err)

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -241,7 +241,7 @@ func ReadCommandOutputTool(store *commandoutput.Store, execs ...executor.Executo
 			}
 			text := string(textBytes)
 			meta := commandoutput.CallContextFrom(ctx)
-			if err := store.RecordRead(meta.ToolUseID, params.Ref, read, text); err != nil {
+			if err := store.RecordRead(meta, params.Ref, read, text); err != nil {
 				return tool.StructuredResult{}, fmt.Errorf("record command output read: %w", err)
 			}
 			return tool.StructuredResult{Text: text, Structured: structured, Kind: kindCommandOutputChunk}, nil

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -240,7 +240,7 @@ func ReadCommandOutputTool(store *commandoutput.Store, execs ...executor.Executo
 				return tool.StructuredResult{}, err
 			}
 			text := string(textBytes)
-			meta := commandoutput.CallContextFrom(ctx)
+			meta := tool.CallContextFrom(ctx)
 			if err := store.RecordRead(meta, params.Ref, read, text); err != nil {
 				return tool.StructuredResult{}, fmt.Errorf("record command output read: %w", err)
 			}

--- a/harness/internal/tool/builtins/structured.go
+++ b/harness/internal/tool/builtins/structured.go
@@ -13,14 +13,15 @@ package builtins
 // stable values rather than JSON-sniffing the payload, which would violate the
 // typed-not-`any` rule. Each StructuredHandler returns the matching kind.
 const (
-	kindCommandResult   = "command_result"
-	kindSearchResult    = "search_result"
-	kindFindResult      = "find_result"
-	kindFileExcerpt     = "file_excerpt"
-	kindGitStatus       = "git_status"
-	kindGitChangedFiles = "git_changed_files"
-	kindGitDiff         = "git_diff"
-	kindGitShow         = "git_show"
+	kindCommandResult      = "command_result"
+	kindSearchResult       = "search_result"
+	kindFindResult         = "find_result"
+	kindFileExcerpt        = "file_excerpt"
+	kindGitStatus          = "git_status"
+	kindGitChangedFiles    = "git_changed_files"
+	kindGitDiff            = "git_diff"
+	kindGitShow            = "git_show"
+	kindCommandOutputChunk = "command_output_chunk"
 )
 
 // commandResult is the structured payload for run_command. timedOut reports
@@ -31,11 +32,36 @@ const (
 // executor that returns partial output on timeout can populate it without a
 // schema change.
 type commandResult struct {
-	Stdout         string `json:"stdout"`
-	Stderr         string `json:"stderr"`
-	ExitCode       int    `json:"exit_code"`
-	TimedOut       bool   `json:"timed_out"`
-	TimeoutSeconds int    `json:"timeout_seconds"`
+	Stdout              string `json:"stdout"`
+	Stderr              string `json:"stderr"`
+	ExitCode            int    `json:"exit_code"`
+	TimedOut            bool   `json:"timed_out"`
+	TimeoutSeconds      int    `json:"timeout_seconds"`
+	Spilled             bool   `json:"spilled,omitempty"`
+	CaptureComplete     bool   `json:"capture_complete"`
+	ArchiveID           string `json:"archive_id,omitempty"`
+	StdoutRef           string `json:"stdout_ref,omitempty"`
+	StderrRef           string `json:"stderr_ref,omitempty"`
+	StdoutRawBytes      int64  `json:"stdout_raw_bytes,omitempty"`
+	StderrRawBytes      int64  `json:"stderr_raw_bytes,omitempty"`
+	StdoutScrubbedBytes int64  `json:"stdout_scrubbed_bytes,omitempty"`
+	StderrScrubbedBytes int64  `json:"stderr_scrubbed_bytes,omitempty"`
+	StdoutSHA256        string `json:"stdout_sha256,omitempty"`
+	StderrSHA256        string `json:"stderr_sha256,omitempty"`
+}
+
+type commandOutputChunkResult struct {
+	Reference      string `json:"ref"`
+	Stream         string `json:"stream"`
+	Offset         int64  `json:"offset"`
+	EndOffset      int64  `json:"end_offset"`
+	EOF            bool   `json:"eof"`
+	Content        string `json:"content"`
+	RawBytes       int64  `json:"raw_bytes"`
+	RawSHA256      string `json:"raw_sha256"`
+	ScrubbedBytes  int64  `json:"scrubbed_bytes"`
+	ScrubbedSHA256 string `json:"scrubbed_sha256"`
+	RedactionCount int    `json:"redaction_count,omitempty"`
 }
 
 // searchMatch is a single hit from grep_files. Column is 1-indexed and present

--- a/harness/internal/tool/callcontext.go
+++ b/harness/internal/tool/callcontext.go
@@ -1,0 +1,29 @@
+package tool
+
+import "context"
+
+// CallContext identifies the run, turn, and tool_use block a tool invocation
+// belongs to. The loop attaches it to the dispatch context before invoking a
+// handler so components that persist per-call artefacts (e.g. the command
+// output store) can correlate bytes with transcript identifiers without
+// depending on loop internals.
+type CallContext struct {
+	RunID       string
+	ParentRunID string
+	Turn        int
+	ToolUseID   string
+}
+
+type callContextKey struct{}
+
+// WithCallContext returns a context carrying meta.
+func WithCallContext(ctx context.Context, meta CallContext) context.Context {
+	return context.WithValue(ctx, callContextKey{}, meta)
+}
+
+// CallContextFrom extracts the CallContext attached by the loop; the zero
+// value when none is attached.
+func CallContextFrom(ctx context.Context) CallContext {
+	meta, _ := ctx.Value(callContextKey{}).(CallContext)
+	return meta
+}

--- a/harness/internal/tool/tool.go
+++ b/harness/internal/tool/tool.go
@@ -43,6 +43,10 @@ type StructuredResult struct {
 	Text       string
 	Structured json.RawMessage
 	Kind       string
+	// IsError lets a handler return useful structured/partial output while
+	// still marking the model-facing tool result as failed (for example a
+	// timed-out command with captured stdout/stderr).
+	IsError bool
 }
 
 // Tool represents a single tool that the model can invoke.

--- a/harness/internal/trace/command_output_test.go
+++ b/harness/internal/trace/command_output_test.go
@@ -1,0 +1,48 @@
+package trace
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+	typestrace "github.com/rxbynerd/stirrup/types/trace"
+)
+
+func TestJSONLCommandOutputRecordAndArchiveLink(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := NewJSONLTraceEmitter(&buf)
+	emitter.Start("run-1", &types.RunConfig{})
+	record := types.CommandOutputRecord{
+		ArchiveID: "archive-1", RunID: "run-1", Turn: 1, ToolUseID: "tool-1", CaptureComplete: true,
+		Stdout: types.CommandOutputStreamRecord{RawBytes: 99, ScrubbedBytes: 80, RawSHA256: "raw", ScrubbedSHA256: "scrubbed", ArchiveMember: "commands/tool-1/stdout.txt"},
+	}
+	emitter.RecordCommandOutput(record)
+	emitter.RecordCommandOutputArchive("/tmp/run-1.command-output.tar.gz")
+	if _, err := emitter.Finish(context.Background(), "success"); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("lines=%d\n%s", len(lines), buf.String())
+	}
+	var event Event
+	if err := json.Unmarshal([]byte(lines[1]), &event); err != nil {
+		t.Fatal(err)
+	}
+	if event.Kind != EventKindCommandOutputRecord || event.CommandOutput == nil || event.CommandOutput.Stdout.RawBytes != 99 {
+		t.Fatalf("event=%+v", event)
+	}
+	if strings.Contains(lines[1], "stdout.txt content") {
+		t.Fatal("trace embedded command stream content")
+	}
+	recording, err := typestrace.NewReader(strings.NewReader(buf.String())).ReadRecording()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recording.CommandOutputs) != 1 || recording.FinalOutcome.CommandOutputArchive == "" {
+		t.Fatalf("recording=%+v", recording)
+	}
+}

--- a/harness/internal/trace/events.go
+++ b/harness/internal/trace/events.go
@@ -58,7 +58,8 @@ const (
 	// to the accumulated ToolCalls inside the embedded RunTrace at
 	// run_finished, so a live consumer sees each hook as soon as it
 	// lands (mirrors tool_call_record).
-	EventKindHookRecord EventKind = "hook_record"
+	EventKindHookRecord          EventKind = "hook_record"
+	EventKindCommandOutputRecord EventKind = "command_output_record"
 )
 
 // CurrentSchemaVersion is the streaming-trace schema version emitted in
@@ -89,7 +90,8 @@ type Event struct {
 	ToolCall    *types.ToolCallRecord  `json:"toolCall,omitempty"`
 
 	// Hook payload — populated for hook_record events.
-	Hook *types.HookExecution `json:"hook,omitempty"`
+	Hook          *types.HookExecution       `json:"hook,omitempty"`
+	CommandOutput *types.CommandOutputRecord `json:"commandOutput,omitempty"`
 
 	// Trace summary — populated for run_finished events. Embedding the
 	// full RunTrace here keeps the backward-compat reader's job trivial:

--- a/harness/internal/trace/gcs.go
+++ b/harness/internal/trace/gcs.go
@@ -62,17 +62,20 @@ type GCSTraceEmitter struct {
 	httpClient      *http.Client
 	endpointBaseURL string // override for tests
 
-	mu                 sync.Mutex
-	runID              string
-	config             *types.RunConfig
-	startedAt          time.Time
-	turns              []types.TurnTrace
-	toolCalls          []types.ToolCallTrace
-	permissionDenials  int
-	finalAssistantText string
+	mu                   sync.Mutex
+	runID                string
+	config               *types.RunConfig
+	startedAt            time.Time
+	turns                []types.TurnTrace
+	toolCalls            []types.ToolCallTrace
+	permissionDenials    int
+	finalAssistantText   string
+	commandOutputArchive string
 }
 
 var _ FinalAssistantTextRecorder = (*GCSTraceEmitter)(nil)
+var _ CommandOutputRecorder = (*GCSTraceEmitter)(nil)
+var _ CommandOutputArchiveRecorder = (*GCSTraceEmitter)(nil)
 
 // GCSTraceEmitterOptions configures a GCSTraceEmitter. Bucket is
 // required; ObjectPrefix is optional. CredentialSource is the resolved
@@ -149,6 +152,7 @@ func (e *GCSTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.toolCalls = nil
 	e.permissionDenials = 0
 	e.finalAssistantText = ""
+	e.commandOutputArchive = ""
 }
 
 // RecordTurn appends a turn trace.
@@ -188,6 +192,14 @@ func (e *GCSTraceEmitter) RecordFinalAssistantText(text string) {
 	e.finalAssistantText = text
 }
 
+func (e *GCSTraceEmitter) RecordCommandOutput(_ types.CommandOutputRecord) {}
+
+func (e *GCSTraceEmitter) RecordCommandOutputArchive(location string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.commandOutputArchive = location
+}
+
 // Finish builds the final RunTrace, marshals it as a single JSONL
 // line, and PUTs the bytes to gs://{bucket}/{objectPrefix}/{runID}.jsonl.
 // A run with zero turns still produces a single valid JSON line —
@@ -210,6 +222,7 @@ func (e *GCSTraceEmitter) Finish(ctx context.Context, outcome string) (*types.Ru
 	toolCalls := append([]types.ToolCallTrace(nil), e.toolCalls...)
 	permissionDenials := e.permissionDenials
 	finalAssistantText := e.finalAssistantText
+	commandOutputArchive := e.commandOutputArchive
 	e.mu.Unlock()
 
 	now := time.Now()
@@ -231,16 +244,17 @@ func (e *GCSTraceEmitter) Finish(ctx context.Context, outcome string) (*types.Ru
 	}
 
 	trace := &types.RunTrace{
-		ID:                 runID,
-		Config:             redactedConfig,
-		StartedAt:          startedAt,
-		CompletedAt:        now,
-		Turns:              len(turns),
-		TokenUsage:         totalTokens,
-		ToolCalls:          summaries,
-		PermissionDenials:  permissionDenials,
-		Outcome:            outcome,
-		FinalAssistantText: finalAssistantText,
+		ID:                   runID,
+		Config:               redactedConfig,
+		StartedAt:            startedAt,
+		CompletedAt:          now,
+		Turns:                len(turns),
+		TokenUsage:           totalTokens,
+		ToolCalls:            summaries,
+		PermissionDenials:    permissionDenials,
+		Outcome:              outcome,
+		FinalAssistantText:   finalAssistantText,
+		CommandOutputArchive: commandOutputArchive,
 	}
 
 	data, err := json.Marshal(trace)

--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -42,14 +42,17 @@ type JSONLTraceEmitter struct {
 	// canonical RunTrace (token totals, tool call summaries, outcome)
 	// for the in-process caller (harness factory, eval runner) that
 	// reads it directly without re-parsing the file.
-	turns              []types.TurnTrace
-	toolCalls          []types.ToolCallTrace
-	permissionDenials  int
-	hookResults        []types.HookExecution
-	finalAssistantText string
+	turns                []types.TurnTrace
+	toolCalls            []types.ToolCallTrace
+	permissionDenials    int
+	hookResults          []types.HookExecution
+	finalAssistantText   string
+	commandOutputArchive string
 }
 
 var _ FinalAssistantTextRecorder = (*JSONLTraceEmitter)(nil)
+var _ CommandOutputRecorder = (*JSONLTraceEmitter)(nil)
+var _ CommandOutputArchiveRecorder = (*JSONLTraceEmitter)(nil)
 
 // NewJSONLTraceEmitter creates a streaming trace emitter that writes to w.
 // If w implements io.Closer, Close on the emitter closes it.
@@ -97,6 +100,7 @@ func (e *JSONLTraceEmitter) Start(runID string, config *types.RunConfig) {
 	e.permissionDenials = 0
 	e.hookResults = nil
 	e.finalAssistantText = ""
+	e.commandOutputArchive = ""
 
 	startedAt := e.startedAt
 	var redacted types.RunConfig
@@ -230,6 +234,19 @@ func (e *JSONLTraceEmitter) RecordFinalAssistantText(text string) {
 	e.finalAssistantText = text
 }
 
+func (e *JSONLTraceEmitter) RecordCommandOutput(record types.CommandOutputRecord) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	copyRecord := record
+	_ = e.writeLineLocked(Event{Kind: EventKindCommandOutputRecord, CommandOutput: &copyRecord})
+}
+
+func (e *JSONLTraceEmitter) RecordCommandOutputArchive(location string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.commandOutputArchive = location
+}
+
 // Finish builds the canonical RunTrace summary, writes the
 // run_finished event, and returns the summary. A run with zero turns
 // still produces a valid run_finished line.
@@ -256,17 +273,18 @@ func (e *JSONLTraceEmitter) Finish(_ context.Context, outcome string) (*types.Ru
 	}
 
 	trace := &types.RunTrace{
-		ID:                 e.runID,
-		Config:             redactedConfig,
-		StartedAt:          e.startedAt,
-		CompletedAt:        now,
-		Turns:              len(e.turns),
-		TokenUsage:         totalTokens,
-		ToolCalls:          summaries,
-		PermissionDenials:  e.permissionDenials,
-		Outcome:            outcome,
-		FinalAssistantText: e.finalAssistantText,
-		HookResults:        e.hookResults,
+		ID:                   e.runID,
+		Config:               redactedConfig,
+		StartedAt:            e.startedAt,
+		CompletedAt:          now,
+		Turns:                len(e.turns),
+		TokenUsage:           totalTokens,
+		ToolCalls:            summaries,
+		PermissionDenials:    e.permissionDenials,
+		Outcome:              outcome,
+		FinalAssistantText:   e.finalAssistantText,
+		HookResults:          e.hookResults,
+		CommandOutputArchive: e.commandOutputArchive,
 	}
 
 	ev := Event{
@@ -326,18 +344,21 @@ func scrubTurnRecord(t types.TurnRecord) types.TurnRecord {
 	}
 	for i, tc := range t.ToolCalls {
 		out.ToolCalls[i] = types.ToolCallRecord{
-			ID:         tc.ID,
-			Name:       tc.Name,
-			Input:      scrubRawJSON(tc.Input),
-			Output:     security.Scrub(tc.Output),
-			DurationMs: tc.DurationMs,
-			Success:    tc.Success,
+			ID:           tc.ID,
+			Name:         tc.Name,
+			InternalName: tc.InternalName,
+			Input:        scrubRawJSON(tc.Input),
+			Output:       security.Scrub(tc.Output),
+			DurationMs:   tc.DurationMs,
+			Success:      tc.Success,
 			// The structured payload (issue #231) carries the same
 			// untrusted content as Output — a command transcript or file
 			// excerpt that can hold credentials — so it is scrubbed on the
 			// same footing. scrubRawJSON preserves a valid json.RawMessage
 			// shape on disk even when a secret straddles a JSON token.
 			Structured: scrubRawJSON(tc.Structured),
+			Kind:       tc.Kind,
+			IsError:    tc.IsError,
 		}
 	}
 	return out

--- a/harness/internal/trace/nested_jsonl.go
+++ b/harness/internal/trace/nested_jsonl.go
@@ -49,6 +49,7 @@ type NestedJSONLEmitter struct {
 }
 
 var _ FinalAssistantTextRecorder = (*NestedJSONLEmitter)(nil)
+var _ CommandOutputRecorder = (*NestedJSONLEmitter)(nil)
 
 // NewNestedJSONLEmitter returns an emitter that forwards Turn/ToolCall
 // events to parent, tagged with parentRunID and the child's runID set
@@ -157,6 +158,12 @@ func (e *NestedJSONLEmitter) RecordFinalAssistantText(text string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.finalAssistantText = text
+}
+
+func (e *NestedJSONLEmitter) RecordCommandOutput(record types.CommandOutputRecord) {
+	if parent, ok := e.parent.(CommandOutputRecorder); ok {
+		parent.RecordCommandOutput(record)
+	}
 }
 
 // Finish builds and returns the child's RunTrace. It does NOT call

--- a/harness/internal/trace/otel.go
+++ b/harness/internal/trace/otel.go
@@ -113,16 +113,17 @@ type OTelTraceEmitter struct {
 	// behaviour.
 	captureContent bool
 
-	mu                 sync.Mutex
-	runID              string
-	config             *types.RunConfig
-	startedAt          time.Time
-	rootSpan           oteltrace.Span
-	rootCtx            context.Context
-	turns              []types.TurnTrace
-	toolCalls          []types.ToolCallTrace
-	permissionDenials  int
-	finalAssistantText string
+	mu                   sync.Mutex
+	runID                string
+	config               *types.RunConfig
+	startedAt            time.Time
+	rootSpan             oteltrace.Span
+	rootCtx              context.Context
+	turns                []types.TurnTrace
+	toolCalls            []types.ToolCallTrace
+	permissionDenials    int
+	finalAssistantText   string
+	commandOutputArchive string
 
 	// systemInstructionsJSON is the run's system prompt, scrubbed and
 	// pre-serialised to the gen_ai.system_instructions attribute encoding
@@ -172,9 +173,11 @@ type OTelTraceEmitter struct {
 // SystemInstructionsRecorder assertion, so losing the method would be
 // a silent regression rather than a build break without this.
 var (
-	_ TraceEmitter               = (*OTelTraceEmitter)(nil)
-	_ SystemInstructionsRecorder = (*OTelTraceEmitter)(nil)
-	_ FinalAssistantTextRecorder = (*OTelTraceEmitter)(nil)
+	_ TraceEmitter                 = (*OTelTraceEmitter)(nil)
+	_ SystemInstructionsRecorder   = (*OTelTraceEmitter)(nil)
+	_ FinalAssistantTextRecorder   = (*OTelTraceEmitter)(nil)
+	_ CommandOutputRecorder        = (*OTelTraceEmitter)(nil)
+	_ CommandOutputArchiveRecorder = (*OTelTraceEmitter)(nil)
 )
 
 // pendingTurnKey pairs a buffered turn summary with its later
@@ -726,6 +729,41 @@ func (e *OTelTraceEmitter) RecordFinalAssistantText(text string) {
 	e.finalAssistantText = text
 }
 
+func (e *OTelTraceEmitter) RecordCommandOutput(record types.CommandOutputRecord) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.rootCtx == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("command_output.archive_id", record.ArchiveID),
+		attribute.String("command_output.tool_use_id", record.ToolUseID),
+		attribute.Bool("command_output.capture_complete", record.CaptureComplete),
+		attribute.Int64("command_output.stdout.raw_bytes", record.Stdout.RawBytes),
+		attribute.Int64("command_output.stdout.scrubbed_bytes", record.Stdout.ScrubbedBytes),
+		attribute.String("command_output.stdout.raw_sha256", record.Stdout.RawSHA256),
+		attribute.String("command_output.stdout.scrubbed_sha256", record.Stdout.ScrubbedSHA256),
+		attribute.Int64("command_output.stderr.raw_bytes", record.Stderr.RawBytes),
+		attribute.Int64("command_output.stderr.scrubbed_bytes", record.Stderr.ScrubbedBytes),
+		attribute.String("command_output.stderr.raw_sha256", record.Stderr.RawSHA256),
+		attribute.String("command_output.stderr.scrubbed_sha256", record.Stderr.ScrubbedSHA256),
+	}
+	_, span := e.tracer.Start(e.rootCtx, "command_output", oteltrace.WithAttributes(attrs...))
+	if !record.CaptureComplete {
+		span.SetStatus(codes.Error, "command output capture incomplete")
+	}
+	span.End()
+}
+
+func (e *OTelTraceEmitter) RecordCommandOutputArchive(location string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.commandOutputArchive = location
+	if e.rootSpan != nil {
+		e.rootSpan.SetAttributes(attribute.String("command_output.archive_uri", location))
+	}
+}
+
 // RecordToolCall creates a child span for a tool invocation.
 //
 // When content capture is on and the call carries a tool_use ID, the
@@ -920,16 +958,17 @@ func (e *OTelTraceEmitter) Finish(ctx context.Context, outcome string) (*types.R
 	}
 
 	trace := &types.RunTrace{
-		ID:                 e.runID,
-		Config:             redactedConfig,
-		StartedAt:          e.startedAt,
-		CompletedAt:        now,
-		Turns:              len(e.turns),
-		TokenUsage:         totalTokens,
-		ToolCalls:          summaries,
-		PermissionDenials:  e.permissionDenials,
-		Outcome:            outcome,
-		FinalAssistantText: e.finalAssistantText,
+		ID:                   e.runID,
+		Config:               redactedConfig,
+		StartedAt:            e.startedAt,
+		CompletedAt:          now,
+		Turns:                len(e.turns),
+		TokenUsage:           totalTokens,
+		ToolCalls:            summaries,
+		PermissionDenials:    e.permissionDenials,
+		Outcome:              outcome,
+		FinalAssistantText:   e.finalAssistantText,
+		CommandOutputArchive: e.commandOutputArchive,
 	}
 
 	return trace, nil

--- a/harness/internal/trace/trace.go
+++ b/harness/internal/trace/trace.go
@@ -83,3 +83,15 @@ type HookRecorder interface {
 type FinalAssistantTextRecorder interface {
 	RecordFinalAssistantText(text string)
 }
+
+// CommandOutputRecorder receives bounded metadata for complete command
+// captures. Full stream content remains in the sidecar archive.
+type CommandOutputRecorder interface {
+	RecordCommandOutput(types.CommandOutputRecord)
+}
+
+// CommandOutputArchiveRecorder attaches the finalized sidecar location to the
+// run summary and, for OTel, bounded root-span attributes.
+type CommandOutputArchiveRecorder interface {
+	RecordCommandOutputArchive(location string)
+}

--- a/types/quarantine.go
+++ b/types/quarantine.go
@@ -49,6 +49,14 @@ func ClassifyForQuarantine(recordings []RunRecording) []QuarantineFlag {
 // alone) exceeding limit bytes.
 func hasLargePayload(recordings []RunRecording, limit int) bool {
 	for _, rec := range recordings {
+		// Archive stream sizes are evaluated independently from transcript
+		// payload sizes: spilled sandbox output is intentionally absent from
+		// ToolCallRecord.Output, but remains relevant to quarantine policy.
+		for _, command := range rec.CommandOutputs {
+			if command.Stdout.ScrubbedBytes > int64(limit) || command.Stderr.ScrubbedBytes > int64(limit) {
+				return true
+			}
+		}
 		for _, turn := range rec.Turns {
 			turnSize := 0
 			for _, blk := range turn.ModelOutput {

--- a/types/quarantine_test.go
+++ b/types/quarantine_test.go
@@ -93,3 +93,15 @@ func TestClassifyForQuarantine_LargeTurnAggregate(t *testing.T) {
 		t.Errorf("aggregate-large flags = %v, want [%s]", flags, QuarantineLargePayload)
 	}
 }
+
+func TestClassifyForQuarantine_LargeArchivedCommandStream(t *testing.T) {
+	recordings := []RunRecording{{
+		RunID:          "r1",
+		Turns:          []TurnRecord{{ToolCalls: []ToolCallRecord{{Name: "run_command", Output: "small preview"}}}},
+		CommandOutputs: []CommandOutputRecord{{Stdout: CommandOutputStreamRecord{ScrubbedBytes: DefaultLargePayloadBytes + 1}}},
+	}}
+	flags := ClassifyForQuarantine(recordings)
+	if len(flags) != 1 || flags[0] != QuarantineLargePayload {
+		t.Fatalf("flags=%v", flags)
+	}
+}

--- a/types/result.go
+++ b/types/result.go
@@ -34,7 +34,7 @@ type RunResult struct {
 	// "stalled", "tool_failures", "timeout", "max_turns",
 	// "verification_failed", "verification_error", "budget_exceeded",
 	// "cancelled", "max_tokens", "command_output_capture_failed",
-	// "trace_archive_failed". The sentinel "internal-error" is
+	// "command_output_archive_failed". The sentinel "internal-error" is
 	// reserved for the case where the loop produced no RunTrace at all
 	// (e.g. a panic before the first turn); consumers should treat it
 	// as distinguishable from any RunTrace.Outcome value because no

--- a/types/result.go
+++ b/types/result.go
@@ -33,7 +33,8 @@ type RunResult struct {
 	// Outcome mirrors RunTrace.Outcome — e.g. "success", "error",
 	// "stalled", "tool_failures", "timeout", "max_turns",
 	// "verification_failed", "verification_error", "budget_exceeded",
-	// "cancelled", "max_tokens". The sentinel "internal-error" is
+	// "cancelled", "max_tokens", "command_output_capture_failed",
+	// "trace_archive_failed". The sentinel "internal-error" is
 	// reserved for the case where the loop produced no RunTrace at all
 	// (e.g. a panic before the first turn); consumers should treat it
 	// as distinguishable from any RunTrace.Outcome value because no
@@ -78,6 +79,10 @@ type RunResult struct {
 	// (without the full trace) can see that setup or teardown was not
 	// entirely clean.
 	HookFailures int `json:"hookFailures,omitempty"`
+
+	// CommandOutputArchive is the local path or durable URI of the compressed
+	// command-output compliance archive, when command output was captured.
+	CommandOutputArchive string `json:"commandOutputArchive,omitempty"`
 }
 
 // VerifierResult is the verifier outcome carried on RunResult. It

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -2344,9 +2344,6 @@ func validateTraceArchiveConfig(cfg *TraceArchiveConfig, errs *[]string) {
 				break
 			}
 		}
-		if cfg.ObjectPrefix != "" && !strings.HasSuffix(cfg.ObjectPrefix, "/") {
-			cfg.ObjectPrefix += "/"
-		}
 	case "":
 		*errs = append(*errs, "traceEmitter.archive.type is required")
 	default:

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1457,10 +1457,23 @@ type ToolsConfig struct {
 // limits: crossing one cancels the command and fails the run; output is never
 // silently truncated at these boundaries.
 type CommandOutputConfig struct {
+	// Enabled gates the capture pipeline as a whole. A pointer so unset is
+	// distinguishable from an explicit false (the RuleOfTwo.Enforce
+	// pattern): nil means enabled — capture is the default behaviour —
+	// while false reverts run_command to the legacy bounded-inline path,
+	// registers no read_command_output tool, and writes no archive.
+	Enabled *bool `json:"enabled,omitempty"`
+
 	InlineMaxBytes        int64 `json:"inlineMaxBytes,omitempty"`
 	PreviewBytesPerStream int64 `json:"previewBytesPerStream,omitempty"`
 	MaxBytesPerStream     int64 `json:"maxBytesPerStream,omitempty"`
 	MaxBytesPerRun        int64 `json:"maxBytesPerRun,omitempty"`
+}
+
+// CommandOutputCaptureEnabled reports whether run_command output capture is
+// active. Unset defaults to enabled.
+func (c ToolsConfig) CommandOutputCaptureEnabled() bool {
+	return c.CommandOutput.Enabled == nil || *c.CommandOutput.Enabled
 }
 
 const (
@@ -2186,7 +2199,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateBuiltInTools(config.Tools.BuiltIn, &errs)
 	validateMCPServers(config.Tools.MCPServers, &errs)
 	validateToolsProfile(config.Tools.Profile, &errs)
-	validateCommandOutputConfig(config.Tools.CommandOutput, &errs)
+	validateCommandOutputConfig(config.Tools, &errs)
 	validateTraceArchiveConfig(config.TraceEmitter.Archive, &errs)
 	validateCredentialConfig(config.Provider.Credential, "provider.credential", &errs)
 	if config.TraceEmitter.Archive != nil {
@@ -2289,7 +2302,8 @@ func ValidateRunConfig(config *RunConfig) error {
 	return nil
 }
 
-func validateCommandOutputConfig(cfg CommandOutputConfig, errs *[]string) {
+func validateCommandOutputConfig(tools ToolsConfig, errs *[]string) {
+	cfg := tools.CommandOutput
 	checks := []struct {
 		name  string
 		value int64
@@ -2308,12 +2322,20 @@ func validateCommandOutputConfig(cfg CommandOutputConfig, errs *[]string) {
 			*errs = append(*errs, fmt.Sprintf("%s exceeds maximum of %d", check.name, check.max))
 		}
 	}
-	effective := (ToolsConfig{CommandOutput: cfg}).EffectiveCommandOutput()
+	effective := tools.EffectiveCommandOutput()
 	if effective.PreviewBytesPerStream > effective.MaxBytesPerStream {
 		*errs = append(*errs, "tools.commandOutput.previewBytesPerStream must not exceed maxBytesPerStream")
 	}
 	if effective.MaxBytesPerRun < effective.MaxBytesPerStream {
 		*errs = append(*errs, "tools.commandOutput.maxBytesPerRun must be at least maxBytesPerStream")
+	}
+	if !tools.CommandOutputCaptureEnabled() {
+		for _, name := range tools.BuiltIn {
+			if name == "read_command_output" {
+				*errs = append(*errs, "tools.builtIn includes read_command_output but tools.commandOutput.enabled is false")
+				break
+			}
+		}
 	}
 }
 

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1368,6 +1368,23 @@ type TraceEmitterConfig struct {
 	// type=="otel"; rejected on the jsonl and gcs emitters like Protocol
 	// and Headers.
 	CaptureContent bool `json:"captureContent,omitempty"`
+
+	// Archive configures durable storage for command-output sidecars. When
+	// omitted, JSONL traces place the archive beside FilePath; GCS traces place
+	// it beside the trace object; all other configurations retain a local
+	// archive and expose its absolute path in RunResult.
+	Archive *TraceArchiveConfig `json:"archive,omitempty"`
+}
+
+// TraceArchiveConfig selects the destination for compressed command-output
+// sidecars. Type is "local" or "gcs". A local destination requires FilePath.
+// A GCS destination requires Bucket and may override ObjectPrefix/Credential.
+type TraceArchiveConfig struct {
+	Type         string            `json:"type"`
+	FilePath     string            `json:"filePath,omitempty"`
+	Bucket       string            `json:"bucket,omitempty"`
+	ObjectPrefix string            `json:"objectPrefix,omitempty"`
+	Credential   *CredentialConfig `json:"credential,omitempty"`
 }
 
 // ResultSinkConfig selects the result sink implementation. The
@@ -1430,6 +1447,49 @@ type ToolsConfig struct {
 	// identical to the pre-profile behaviour. Closed set, validated by
 	// ValidateRunConfig.
 	Profile string `json:"profile,omitempty"`
+
+	// CommandOutput controls compliant capture of run_command stdout/stderr.
+	// Zero values resolve to the documented defaults during validation.
+	CommandOutput CommandOutputConfig `json:"commandOutput,omitempty"`
+}
+
+// CommandOutputConfig bounds full command-output capture. These are audit
+// limits: crossing one cancels the command and fails the run; output is never
+// silently truncated at these boundaries.
+type CommandOutputConfig struct {
+	InlineMaxBytes        int64 `json:"inlineMaxBytes,omitempty"`
+	PreviewBytesPerStream int64 `json:"previewBytesPerStream,omitempty"`
+	MaxBytesPerStream     int64 `json:"maxBytesPerStream,omitempty"`
+	MaxBytesPerRun        int64 `json:"maxBytesPerRun,omitempty"`
+}
+
+const (
+	DefaultCommandOutputInlineMaxBytes        int64 = 32 << 10
+	DefaultCommandOutputPreviewBytesPerStream int64 = 4 << 10
+	DefaultCommandOutputMaxBytesPerStream     int64 = 50 << 20
+	DefaultCommandOutputMaxBytesPerRun        int64 = 500 << 20
+	MaxCommandOutputBytesPerStream            int64 = 256 << 20
+	MaxCommandOutputBytesPerRun               int64 = 2 << 30
+)
+
+// EffectiveCommandOutput returns command-output settings with zero values
+// replaced by defaults. ValidateRunConfig rejects negative and over-hard-cap
+// values before runtime construction.
+func (c ToolsConfig) EffectiveCommandOutput() CommandOutputConfig {
+	out := c.CommandOutput
+	if out.InlineMaxBytes == 0 {
+		out.InlineMaxBytes = DefaultCommandOutputInlineMaxBytes
+	}
+	if out.PreviewBytesPerStream == 0 {
+		out.PreviewBytesPerStream = DefaultCommandOutputPreviewBytesPerStream
+	}
+	if out.MaxBytesPerStream == 0 {
+		out.MaxBytesPerStream = DefaultCommandOutputMaxBytesPerStream
+	}
+	if out.MaxBytesPerRun == 0 {
+		out.MaxBytesPerRun = DefaultCommandOutputMaxBytesPerRun
+	}
+	return out
 }
 
 // MCPServerConfig describes a single MCP server connection.
@@ -1974,21 +2034,22 @@ const (
 )
 
 var validBuiltInToolNames = map[string]bool{
-	"read_file":         true,
-	"write_file":        true,
-	"search_replace":    true,
-	"apply_diff":        true,
-	"edit_file":         true,
-	"list_directory":    true,
-	"grep_files":        true,
-	"find_files":        true,
-	"run_command":       true,
-	"web_fetch":         true,
-	"spawn_agent":       true,
-	"git_status":        true,
-	"git_changed_files": true,
-	"git_diff":          true,
-	"git_show":          true,
+	"read_file":           true,
+	"write_file":          true,
+	"search_replace":      true,
+	"apply_diff":          true,
+	"edit_file":           true,
+	"list_directory":      true,
+	"grep_files":          true,
+	"find_files":          true,
+	"run_command":         true,
+	"read_command_output": true,
+	"web_fetch":           true,
+	"spawn_agent":         true,
+	"git_status":          true,
+	"git_changed_files":   true,
+	"git_diff":            true,
+	"git_show":            true,
 }
 
 // validRunModes is the closed set of values accepted on RunConfig.Mode.
@@ -2125,7 +2186,12 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateBuiltInTools(config.Tools.BuiltIn, &errs)
 	validateMCPServers(config.Tools.MCPServers, &errs)
 	validateToolsProfile(config.Tools.Profile, &errs)
+	validateCommandOutputConfig(config.Tools.CommandOutput, &errs)
+	validateTraceArchiveConfig(config.TraceEmitter.Archive, &errs)
 	validateCredentialConfig(config.Provider.Credential, "provider.credential", &errs)
+	if config.TraceEmitter.Archive != nil {
+		validateCredentialConfig(config.TraceEmitter.Archive.Credential, "traceEmitter.archive.credential", &errs)
+	}
 	for name, prov := range config.Providers {
 		validateCredentialConfig(prov.Credential, fmt.Sprintf("providers[%s].credential", name), &errs)
 	}
@@ -2221,6 +2287,71 @@ func ValidateRunConfig(config *RunConfig) error {
 		return fmt.Errorf("RunConfig validation failed: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+func validateCommandOutputConfig(cfg CommandOutputConfig, errs *[]string) {
+	checks := []struct {
+		name  string
+		value int64
+		max   int64
+	}{
+		{"tools.commandOutput.inlineMaxBytes", cfg.InlineMaxBytes, MaxCommandOutputBytesPerStream},
+		{"tools.commandOutput.previewBytesPerStream", cfg.PreviewBytesPerStream, MaxCommandOutputBytesPerStream},
+		{"tools.commandOutput.maxBytesPerStream", cfg.MaxBytesPerStream, MaxCommandOutputBytesPerStream},
+		{"tools.commandOutput.maxBytesPerRun", cfg.MaxBytesPerRun, MaxCommandOutputBytesPerRun},
+	}
+	for _, check := range checks {
+		if check.value < 0 {
+			*errs = append(*errs, check.name+" must not be negative")
+		}
+		if check.value > check.max {
+			*errs = append(*errs, fmt.Sprintf("%s exceeds maximum of %d", check.name, check.max))
+		}
+	}
+	effective := (ToolsConfig{CommandOutput: cfg}).EffectiveCommandOutput()
+	if effective.PreviewBytesPerStream > effective.MaxBytesPerStream {
+		*errs = append(*errs, "tools.commandOutput.previewBytesPerStream must not exceed maxBytesPerStream")
+	}
+	if effective.MaxBytesPerRun < effective.MaxBytesPerStream {
+		*errs = append(*errs, "tools.commandOutput.maxBytesPerRun must be at least maxBytesPerStream")
+	}
+}
+
+func validateTraceArchiveConfig(cfg *TraceArchiveConfig, errs *[]string) {
+	if cfg == nil {
+		return
+	}
+	switch cfg.Type {
+	case "local":
+		if cfg.FilePath == "" {
+			*errs = append(*errs, "traceEmitter.archive.filePath is required for local archives")
+		}
+		if cfg.Bucket != "" || cfg.ObjectPrefix != "" || cfg.Credential != nil {
+			*errs = append(*errs, "traceEmitter.archive GCS fields are only valid when type is gcs")
+		}
+	case "gcs":
+		if cfg.Bucket == "" {
+			*errs = append(*errs, "traceEmitter.archive.bucket is required for gcs archives")
+		} else if !gcsBucketNamePattern.MatchString(cfg.Bucket) {
+			*errs = append(*errs, fmt.Sprintf("traceEmitter.archive.bucket %q must match %s", cfg.Bucket, gcsBucketNamePattern.String()))
+		}
+		if cfg.FilePath != "" {
+			*errs = append(*errs, "traceEmitter.archive.filePath is only valid when type is local")
+		}
+		for _, seg := range strings.Split(strings.Trim(cfg.ObjectPrefix, "/"), "/") {
+			if seg == ".." {
+				*errs = append(*errs, "traceEmitter.archive.objectPrefix must not contain \"..\" path segments")
+				break
+			}
+		}
+		if cfg.ObjectPrefix != "" && !strings.HasSuffix(cfg.ObjectPrefix, "/") {
+			cfg.ObjectPrefix += "/"
+		}
+	case "":
+		*errs = append(*errs, "traceEmitter.archive.type is required")
+	default:
+		*errs = append(*errs, fmt.Sprintf("traceEmitter.archive.type %q is invalid (valid: local, gcs)", cfg.Type))
+	}
 }
 
 func validateRequiredType(name, value string, valid map[string]bool, errs *[]string) {

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1464,11 +1464,27 @@ type CommandOutputConfig struct {
 	// registers no read_command_output tool, and writes no archive.
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// FailurePosture selects how capture failures affect the run. "strict"
+	// (the default) treats the byte caps as compliance boundaries: a limit
+	// breach refuses further captures and an otherwise-successful run
+	// reports command_output_capture_failed / command_output_archive_failed.
+	// "bestEffort" still cancels the offending command at its cap — output
+	// is never silently truncated — but later commands keep capturing and
+	// the run outcome is never overridden; failures stay visible in the
+	// archive manifest and per-command records.
+	FailurePosture string `json:"failurePosture,omitempty"`
+
 	InlineMaxBytes        int64 `json:"inlineMaxBytes,omitempty"`
 	PreviewBytesPerStream int64 `json:"previewBytesPerStream,omitempty"`
 	MaxBytesPerStream     int64 `json:"maxBytesPerStream,omitempty"`
 	MaxBytesPerRun        int64 `json:"maxBytesPerRun,omitempty"`
 }
+
+// CommandOutput failure postures (CommandOutputConfig.FailurePosture).
+const (
+	CommandOutputPostureStrict     = "strict"
+	CommandOutputPostureBestEffort = "bestEffort"
+)
 
 // CommandOutputCaptureEnabled reports whether run_command output capture is
 // active. Unset defaults to enabled.
@@ -1501,6 +1517,9 @@ func (c ToolsConfig) EffectiveCommandOutput() CommandOutputConfig {
 	}
 	if out.MaxBytesPerRun == 0 {
 		out.MaxBytesPerRun = DefaultCommandOutputMaxBytesPerRun
+	}
+	if out.FailurePosture == "" {
+		out.FailurePosture = CommandOutputPostureStrict
 	}
 	return out
 }
@@ -2328,6 +2347,11 @@ func validateCommandOutputConfig(tools ToolsConfig, errs *[]string) {
 	}
 	if effective.MaxBytesPerRun < effective.MaxBytesPerStream {
 		*errs = append(*errs, "tools.commandOutput.maxBytesPerRun must be at least maxBytesPerStream")
+	}
+	switch cfg.FailurePosture {
+	case "", CommandOutputPostureStrict, CommandOutputPostureBestEffort:
+	default:
+		*errs = append(*errs, fmt.Sprintf("tools.commandOutput.failurePosture %q is invalid (valid: strict, bestEffort)", cfg.FailurePosture))
 	}
 	if !tools.CommandOutputCaptureEnabled() {
 		for _, name := range tools.BuiltIn {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5453,6 +5453,15 @@ func TestValidateRunConfig_TraceArchive(t *testing.T) {
 	if err := ValidateRunConfig(c); err == nil || !strings.Contains(err.Error(), "archive.bucket") {
 		t.Fatalf("expected bucket error, got %v", err)
 	}
+
+	c = validConfig()
+	c.TraceEmitter.Archive = &TraceArchiveConfig{Type: "gcs", Bucket: "stirrup-archives", ObjectPrefix: "runs"}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("valid gcs archive: %v", err)
+	}
+	if c.TraceEmitter.Archive.ObjectPrefix != "runs" {
+		t.Fatalf("validation mutated objectPrefix to %q; the uploader owns slash normalisation", c.TraceEmitter.Archive.ObjectPrefix)
+	}
 }
 
 func TestValidateRunConfig_TraceEmitterGCS_BucketRequired(t *testing.T) {

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5442,6 +5442,30 @@ func TestCommandOutputConfigDefaultsAndHardCaps(t *testing.T) {
 	}
 }
 
+func TestCommandOutputCaptureEnabled(t *testing.T) {
+	if !(ToolsConfig{}).CommandOutputCaptureEnabled() {
+		t.Fatal("unset enabled must default to capture on")
+	}
+	on, off := true, false
+	if !(ToolsConfig{CommandOutput: CommandOutputConfig{Enabled: &on}}).CommandOutputCaptureEnabled() {
+		t.Fatal("explicit true must enable capture")
+	}
+	if (ToolsConfig{CommandOutput: CommandOutputConfig{Enabled: &off}}).CommandOutputCaptureEnabled() {
+		t.Fatal("explicit false must disable capture")
+	}
+
+	c := validConfig()
+	c.Tools.BuiltIn = []string{"run_command", "read_command_output"}
+	c.Tools.CommandOutput.Enabled = &off
+	if err := ValidateRunConfig(c); err == nil || !strings.Contains(err.Error(), "read_command_output") {
+		t.Fatalf("expected contradiction error for reader without capture, got %v", err)
+	}
+	c.Tools.CommandOutput.Enabled = &on
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("reader with capture enabled should validate: %v", err)
+	}
+}
+
 func TestValidateRunConfig_TraceArchive(t *testing.T) {
 	c := validConfig()
 	c.TraceEmitter.Archive = &TraceArchiveConfig{Type: "local", FilePath: "/tmp/run.command-output.tar.gz"}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5430,6 +5430,31 @@ func TestValidateRunConfig_TraceEmitterGCS_Valid(t *testing.T) {
 	}
 }
 
+func TestCommandOutputConfigDefaultsAndHardCaps(t *testing.T) {
+	got := (ToolsConfig{}).EffectiveCommandOutput()
+	if got.InlineMaxBytes != 32<<10 || got.PreviewBytesPerStream != 4<<10 || got.MaxBytesPerStream != 50<<20 || got.MaxBytesPerRun != 500<<20 {
+		t.Fatalf("defaults=%+v", got)
+	}
+	c := validConfig()
+	c.Tools.CommandOutput.MaxBytesPerStream = MaxCommandOutputBytesPerStream + 1
+	if err := ValidateRunConfig(c); err == nil || !strings.Contains(err.Error(), "maxBytesPerStream") {
+		t.Fatalf("expected stream hard-cap error, got %v", err)
+	}
+}
+
+func TestValidateRunConfig_TraceArchive(t *testing.T) {
+	c := validConfig()
+	c.TraceEmitter.Archive = &TraceArchiveConfig{Type: "local", FilePath: "/tmp/run.command-output.tar.gz"}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("valid local archive: %v", err)
+	}
+	c = validConfig()
+	c.TraceEmitter.Archive = &TraceArchiveConfig{Type: "gcs"}
+	if err := ValidateRunConfig(c); err == nil || !strings.Contains(err.Error(), "archive.bucket") {
+		t.Fatalf("expected bucket error, got %v", err)
+	}
+}
+
 func TestValidateRunConfig_TraceEmitterGCS_BucketRequired(t *testing.T) {
 	c := validConfig()
 	c.TraceEmitter = TraceEmitterConfig{Type: "gcs"}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5466,6 +5466,24 @@ func TestCommandOutputCaptureEnabled(t *testing.T) {
 	}
 }
 
+func TestCommandOutputFailurePostureValidation(t *testing.T) {
+	if got := (ToolsConfig{}).EffectiveCommandOutput().FailurePosture; got != CommandOutputPostureStrict {
+		t.Fatalf("default posture=%q, want strict", got)
+	}
+	for _, valid := range []string{"", CommandOutputPostureStrict, CommandOutputPostureBestEffort} {
+		c := validConfig()
+		c.Tools.CommandOutput.FailurePosture = valid
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("posture %q should validate: %v", valid, err)
+		}
+	}
+	c := validConfig()
+	c.Tools.CommandOutput.FailurePosture = "lenient"
+	if err := ValidateRunConfig(c); err == nil || !strings.Contains(err.Error(), "failurePosture") {
+		t.Fatalf("expected closed-set error, got %v", err)
+	}
+}
+
 func TestValidateRunConfig_TraceArchive(t *testing.T) {
 	c := validConfig()
 	c.TraceEmitter.Archive = &TraceArchiveConfig{Type: "local", FilePath: "/tmp/run.command-output.tar.gz"}

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -38,6 +38,9 @@ type RunTrace struct {
 	// started (zero turns ran); hook_failed means a PostRun hook failed after
 	// an otherwise-successful run (it never overrides a non-success outcome —
 	// the primary failure cause stays authoritative).
+	// command_output_capture_failed and trace_archive_failed follow the same
+	// rule: they claim only an otherwise-successful run, and a capture
+	// failure outranks an archive failure when both occur.
 	Outcome string `json:"outcome"`
 	// FinalAssistantText is the loop's last non-empty assistant text,
 	// concatenated across the text blocks of the final response and carried

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -32,13 +32,13 @@ type RunTrace struct {
 	// Outcome is "success" | "error" | "max_turns" | "verification_failed" |
 	// "verification_error" | "budget_exceeded" | "stalled" | "tool_failures" |
 	// "cancelled" | "timeout" | "max_tokens" | "setup_failed" | "hook_failed" |
-	// "command_output_capture_failed" | "trace_archive_failed".
+	// "command_output_capture_failed" | "command_output_archive_failed".
 	// setup_failed and hook_failed (issue #461) report a fatal lifecycle-hook
 	// failure: setup_failed means a PreRun hook failed before the session
 	// started (zero turns ran); hook_failed means a PostRun hook failed after
 	// an otherwise-successful run (it never overrides a non-success outcome —
 	// the primary failure cause stays authoritative).
-	// command_output_capture_failed and trace_archive_failed follow the same
+	// command_output_capture_failed and command_output_archive_failed follow the same
 	// rule: they claim only an otherwise-successful run, and a capture
 	// failure outranks an archive failure when both occur.
 	Outcome string `json:"outcome"`

--- a/types/runtrace.go
+++ b/types/runtrace.go
@@ -31,7 +31,8 @@ type RunTrace struct {
 	VerificationResults []VerificationResult `json:"verificationResults"`
 	// Outcome is "success" | "error" | "max_turns" | "verification_failed" |
 	// "verification_error" | "budget_exceeded" | "stalled" | "tool_failures" |
-	// "cancelled" | "timeout" | "max_tokens" | "setup_failed" | "hook_failed".
+	// "cancelled" | "timeout" | "max_tokens" | "setup_failed" | "hook_failed" |
+	// "command_output_capture_failed" | "trace_archive_failed".
 	// setup_failed and hook_failed (issue #461) report a fatal lifecycle-hook
 	// failure: setup_failed means a PreRun hook failed before the session
 	// started (zero turns ran); hook_failed means a PostRun hook failed after
@@ -48,7 +49,56 @@ type RunTrace struct {
 	// when no hooks were configured. Populated by trace emitters that
 	// implement the optional trace.HookRecorder capability (today, the
 	// JSONL emitter).
-	HookResults []HookExecution `json:"hookResults,omitempty"`
+	HookResults          []HookExecution `json:"hookResults,omitempty"`
+	CommandOutputArchive string          `json:"commandOutputArchive,omitempty"`
+}
+
+// CommandOutputStreamRecord describes one complete command stream without
+// embedding its content in the trace.
+type CommandOutputStreamRecord struct {
+	RawBytes          int64    `json:"rawBytes"`
+	RawSHA256         string   `json:"rawSha256"`
+	ScrubbedBytes     int64    `json:"scrubbedBytes"`
+	ScrubbedSHA256    string   `json:"scrubbedSha256"`
+	ArchiveMember     string   `json:"archiveMember,omitempty"`
+	Reference         string   `json:"reference,omitempty"`
+	RedactionCount    int      `json:"redactionCount,omitempty"`
+	RedactionPatterns []string `json:"redactionPatterns,omitempty"`
+}
+
+// CommandOutputReadRecord identifies the exact scrubbed byte range returned
+// by a read_command_output call.
+type CommandOutputReadRecord struct {
+	ToolUseID     string `json:"toolUseId"`
+	Reference     string `json:"reference"`
+	Offset        int64  `json:"offset"`
+	EndOffset     int64  `json:"endOffset"`
+	EOF           bool   `json:"eof"`
+	ResultSHA256  string `json:"resultSha256"`
+	ArchiveMember string `json:"archiveMember,omitempty"`
+}
+
+// CommandOutputRecord is the bounded trace metadata for a run_command
+// capture. Full scrubbed bytes live only in the sidecar archive.
+type CommandOutputRecord struct {
+	ArchiveID                  string                    `json:"archiveId"`
+	RunID                      string                    `json:"runId"`
+	ParentRunID                string                    `json:"parentRunId,omitempty"`
+	Turn                       int                       `json:"turn,omitempty"`
+	ToolUseID                  string                    `json:"toolUseId"`
+	StartedAt                  time.Time                 `json:"startedAt"`
+	CompletedAt                time.Time                 `json:"completedAt"`
+	ExitCode                   int                       `json:"exitCode"`
+	TimedOut                   bool                      `json:"timedOut,omitempty"`
+	Cancelled                  bool                      `json:"cancelled,omitempty"`
+	CaptureComplete            bool                      `json:"captureComplete"`
+	CaptureError               string                    `json:"captureError,omitempty"`
+	Stdout                     CommandOutputStreamRecord `json:"stdout"`
+	Stderr                     CommandOutputStreamRecord `json:"stderr"`
+	InitialResultSHA256        string                    `json:"initialResultSha256,omitempty"`
+	InitialResultMember        string                    `json:"initialResultMember,omitempty"`
+	Reads                      []CommandOutputReadRecord `json:"reads,omitempty"`
+	LegacySingleRepresentation bool                      `json:"legacySingleRepresentation,omitempty"`
 }
 
 // HookExecution records the outcome of a single lifecycle hook (issue
@@ -267,14 +317,16 @@ type ToolCallRecord struct {
 	Success      bool            `json:"success"`
 	Structured   json.RawMessage `json:"structured,omitempty"`
 	Kind         string          `json:"kind,omitempty"`
+	IsError      bool            `json:"isError,omitempty"`
 }
 
 // RunRecording is a full recording of a run.
 type RunRecording struct {
-	RunID        string       `json:"runId"`
-	Config       RunConfig    `json:"config"`
-	Turns        []TurnRecord `json:"turns"`
-	FinalOutcome RunTrace     `json:"finalOutcome"`
+	RunID          string                `json:"runId"`
+	Config         RunConfig             `json:"config"`
+	Turns          []TurnRecord          `json:"turns"`
+	FinalOutcome   RunTrace              `json:"finalOutcome"`
+	CommandOutputs []CommandOutputRecord `json:"commandOutputs,omitempty"`
 }
 
 // BudgetCheck holds the result of a token budget check.

--- a/types/trace/command_output_reader_test.go
+++ b/types/trace/command_output_reader_test.go
@@ -1,0 +1,23 @@
+package trace
+
+import (
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+func TestSynthesizeLegacyCommandOutputs(t *testing.T) {
+	recording := &types.RunRecording{RunID: "run-1", Turns: []types.TurnRecord{{Turn: 1, ToolCalls: []types.ToolCallRecord{{ID: "tool-1", Name: "run_command", Output: "legacy output", Success: true}}}}}
+	synthesizeLegacyCommandOutputs(recording)
+	if len(recording.CommandOutputs) != 1 || !recording.CommandOutputs[0].LegacySingleRepresentation {
+		t.Fatalf("outputs=%+v", recording.CommandOutputs)
+	}
+	if recording.CommandOutputs[0].RunID != "run-1" || recording.CommandOutputs[0].Stdout.RawBytes != int64(len("legacy output")) {
+		t.Fatalf("record=%+v", recording.CommandOutputs[0])
+	}
+	recording.CommandOutputs = []types.CommandOutputRecord{{RunID: "run-1", ToolUseID: "tool-1", CaptureComplete: true}}
+	synthesizeLegacyCommandOutputs(recording)
+	if len(recording.CommandOutputs) != 1 {
+		t.Fatalf("native record duplicated: %+v", recording.CommandOutputs)
+	}
+}

--- a/types/trace/reader.go
+++ b/types/trace/reader.go
@@ -28,6 +28,8 @@ package trace
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -195,28 +197,30 @@ func (r *Reader) Next() (*types.RunTrace, error) {
 // here as untyped string constants so this package does not import the
 // harness internal trace package (which depends on types).
 const (
-	eventKindRunStarted     = "run_started"
-	eventKindTurnRecord     = "turn_record"
-	eventKindToolCallRecord = "tool_call_record"
-	eventKindRunFinished    = "run_finished"
+	eventKindRunStarted          = "run_started"
+	eventKindTurnRecord          = "turn_record"
+	eventKindToolCallRecord      = "tool_call_record"
+	eventKindRunFinished         = "run_finished"
+	eventKindCommandOutputRecord = "command_output_record"
 )
 
 // streamedEvent mirrors the on-wire shape of harness/internal/trace.Event
 // at the fields the reader cares about. Re-defining the shape locally
 // avoids an internal-package import while keeping the decoder lean.
 type streamedEvent struct {
-	Kind          string                 `json:"kind"`
-	SchemaVersion string                 `json:"schemaVersion,omitempty"`
-	RunID         string                 `json:"runId,omitempty"`
-	StartedAt     *time.Time             `json:"startedAt,omitempty"`
-	CompletedAt   *time.Time             `json:"completedAt,omitempty"`
-	Config        *types.RunConfig       `json:"config,omitempty"`
-	Turn          int                    `json:"turn,omitempty"`
-	ModelInput    *types.ModelInput      `json:"modelInput,omitempty"`
-	ModelOutput   []types.ContentBlock   `json:"modelOutput,omitempty"`
-	ToolCalls     []types.ToolCallRecord `json:"toolCalls,omitempty"`
-	ToolCall      *types.ToolCallRecord  `json:"toolCall,omitempty"`
-	Trace         *types.RunTrace        `json:"trace,omitempty"`
+	Kind          string                     `json:"kind"`
+	SchemaVersion string                     `json:"schemaVersion,omitempty"`
+	RunID         string                     `json:"runId,omitempty"`
+	StartedAt     *time.Time                 `json:"startedAt,omitempty"`
+	CompletedAt   *time.Time                 `json:"completedAt,omitempty"`
+	Config        *types.RunConfig           `json:"config,omitempty"`
+	Turn          int                        `json:"turn,omitempty"`
+	ModelInput    *types.ModelInput          `json:"modelInput,omitempty"`
+	ModelOutput   []types.ContentBlock       `json:"modelOutput,omitempty"`
+	ToolCalls     []types.ToolCallRecord     `json:"toolCalls,omitempty"`
+	ToolCall      *types.ToolCallRecord      `json:"toolCall,omitempty"`
+	Trace         *types.RunTrace            `json:"trace,omitempty"`
+	CommandOutput *types.CommandOutputRecord `json:"commandOutput,omitempty"`
 }
 
 // kindOnly is used to peek at the discriminator without decoding the
@@ -344,6 +348,10 @@ func (r *Reader) ReadRecording() (*types.RunRecording, error) {
 					recording.Config = ev.Trace.Config
 				}
 			}
+		case eventKindCommandOutputRecord:
+			if ev.CommandOutput != nil {
+				recording.CommandOutputs = append(recording.CommandOutputs, *ev.CommandOutput)
+			}
 		default:
 			// Unknown kind: skip. Forward compatibility — a future
 			// event kind added to the wire must not abort old
@@ -365,7 +373,41 @@ func (r *Reader) ReadRecording() (*types.RunRecording, error) {
 		}
 		return recording, fmt.Errorf("reading trace file: %w", err)
 	}
+	synthesizeLegacyCommandOutputs(recording)
 	return recording, nil
+}
+
+func synthesizeLegacyCommandOutputs(recording *types.RunRecording) {
+	if recording == nil {
+		return
+	}
+	seen := make(map[string]bool, len(recording.CommandOutputs))
+	for _, record := range recording.CommandOutputs {
+		seen[record.RunID+"\x00"+record.ToolUseID] = true
+	}
+	for _, turn := range recording.Turns {
+		for _, call := range turn.ToolCalls {
+			if call.Name != "run_command" && call.InternalName != "run_command" {
+				continue
+			}
+			runID := turn.RunID
+			if runID == "" {
+				runID = recording.RunID
+			}
+			key := runID + "\x00" + call.ID
+			if seen[key] {
+				continue
+			}
+			sum := sha256.Sum256([]byte(call.Output))
+			hash := hex.EncodeToString(sum[:])
+			stream := types.CommandOutputStreamRecord{RawBytes: int64(len(call.Output)), RawSHA256: hash, ScrubbedBytes: int64(len(call.Output)), ScrubbedSHA256: hash}
+			recording.CommandOutputs = append(recording.CommandOutputs, types.CommandOutputRecord{
+				RunID: runID, ParentRunID: turn.ParentRunID, Turn: turn.Turn, ToolUseID: call.ID,
+				CaptureComplete: true, Stdout: stream, InitialResultSHA256: hash, LegacySingleRepresentation: true,
+			})
+			seen[key] = true
+		}
+	}
 }
 
 // All drains the reader into a slice. The slice is empty when the


### PR DESCRIPTION
Captures complete `run_command` stdout/stderr in a run-scoped store so long command output no longer floods the model's context or silently loses its tail.

## What it does

- Output up to `tools.commandOutput.inlineMaxBytes` (32 KiB default) stays inline after secret scrubbing — the common case is unchanged.
- Larger output returns a scrubbed preview tail plus an opaque `stirrup://command-output/...` reference; the companion `read_command_output` tool pages through the full scrubbed stream (32 KiB default, 128 KiB max per call).
- Complete scrubbed streams, the initial model-visible result, and a read ledger are archived to a tar.gz sidecar (local, or GCS via `traceEmitter.archive`) with byte counts and SHA-256 hashes as integrity metadata.
- Executors gain a `StreamingExecutor` path (local, container, k8s, k8s-sandbox, replay); hooks/verifiers keep the legacy bounded `Exec`.
- Trace emitters record bounded `command_output_record` metadata (never content); the trace reader back-fills legacy traces.

## Configuration

- `tools.commandOutput.enabled` (*bool, nil→on): explicit `false` reverts to the legacy inline path — the A/B lever for eval.
- `tools.commandOutput.failurePosture` (`strict` default | `bestEffort`): byte caps always cancel the offending command (never silent truncation); strict additionally claims the outcome of an otherwise-successful run (`command_output_capture_failed` / `command_output_archive_failed`, never masking a primary failure), bestEffort records failures without touching the outcome.
- Byte knobs: `inlineMaxBytes`, `previewBytesPerStream`, `maxBytesPerStream` (50 MiB default / 256 MiB cap), `maxBytesPerRun` (500 MiB / 2 GiB).
- Exposed in eval HCL via `tools { command_output { ... } }`.

Operator docs: `docs/configuration.md` § *Command output capture*.

## A/B evidence (eval/suites/command-output-ab-{on,off}.hcl)

Byte-identical tasks (~250 KB stdout, answers need a targeted slice), Claude Haiku 4.5, single run per arm:

| Arm | Pass rate | Total input / output tokens | Notes |
|---|---|---|---|
| off (legacy inline) | 2/3 | 37,983 / 851 | `two-needles-require-paging` aborts the run: full stdout inlined into one request → `prompt is too long: 231810 tokens > 200000 maximum`. `needle` passed only because the model chose a grep-style pipe instead of inlining. |
| on (spill @ 4 KiB) | 3/3 | 469,563 / 1,462 | All tasks complete. Haiku pages greedily at the 128 KiB max, so cumulative input across turns is high — but every individual request stays inside the context window. |

Honest reading: at this output scale the pipeline's demonstrated benefit is **run survival** — the legacy path hard-fails whenever a command's output can't fit in one request, while capture turns that into a bounded preview plus pages. Raw token *savings* depend on the model reading selectively (targeted offsets or grep-first); a greedy pager spends more cumulative input than an inline arm that happens to fit. Single run per arm on a cheap model — treat as directional, re-run for anything load-bearing.

## Remediation history

The original draft (authored by GPT 5.6 Sol) shipped the mechanism always-on with several defects, fixed in the follow-up commits on this branch:

- **No off switch** → `enabled` flag + factory gating (read-only modes no longer resolve GCS archive credentials).
- **Loop invariant violation** — the loop held a concrete `*commandoutput.Store` → loop-local `CommandOutputFinalizer` interface; `CallContext` moved to the `tool` package; core no longer imports `commandoutput`.
- **Outcome masking** — capture/archive failures overrode `timeout`/`error` outcomes → hook_failed-style precedence (only claims otherwise-successful runs; capture outranks archive).
- **Guard collision (caught live in E2E)** — the reference format formed a >100-char base64-like run, tripping the loop's own `encoded_payload` tool guard on the model's first `read_command_output` call → short digest-based references, regression-pinned against `security.GuardToolCall`.
- **Read-ledger collision** — ledger members keyed by bare tool-use ID; parent+subagent share the store → run-scoped members.
- **Fail-closed-only posture** → `failurePosture` (user decision: strict default).
- `trace_archive_failed` → `command_output_archive_failed`; validator no longer mutates `archive.objectPrefix`; replay short-circuit deduplicated; read limits derived from constants; honest raw-spool lifetime docs; coverage for factory wiring, container `ExecStream`, and the early-exit finalize path.

## Follow-ups

- #496 — scrub-on-write so raw command bytes never persist (crash window + memory spikes)
- #497 — k8s `ExecStream` spill coverage in the cluster integration suite
- #498 — `traceEmitter.archive` in eval HCL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZhsmsysVZfkAscv31zE6X
