### PR TITLE
proto, transport: carry mcp trust fields over the grpc runconfig path

### DIFF
--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -3921,9 +3921,19 @@ type MCPServerConfig struct {
 	Uri string `protobuf:"bytes,2,opt,name=uri,proto3" json:"uri,omitempty"`
 	// Optional. Secret reference for server authentication
 	// (e.g. "secret://MCP_API_KEY"). Sent as a Bearer token.
-	ApiKeyRef     string `protobuf:"bytes,3,opt,name=api_key_ref,json=apiKeyRef,proto3" json:"api_key_ref,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ApiKeyRef string `protobuf:"bytes,3,opt,name=api_key_ref,json=apiKeyRef,proto3" json:"api_key_ref,omitempty"`
+	// Optional. Allowlist restricting which advertised tools the harness
+	// registers from this server, matched case-sensitively against the
+	// server-reported (unprefixed) tool name. Empty/unset registers every
+	// advertised tool (backward-compatible historical behaviour).
+	AllowedTools []string `protobuf:"bytes,4,rep,name=allowed_tools,json=allowedTools,proto3" json:"allowed_tools,omitempty"`
+	// Optional. Pins the set of hostnames this server's URI may resolve to.
+	// When non-empty, the URI host must appear in this list (exact,
+	// case-insensitive match) in addition to passing the SSRF guard.
+	// Empty/unset applies no host pinning.
+	AllowedMcpHosts []string `protobuf:"bytes,5,rep,name=allowed_mcp_hosts,json=allowedMcpHosts,proto3" json:"allowed_mcp_hosts,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *MCPServerConfig) Reset() {
@@ -3975,6 +3985,20 @@ func (x *MCPServerConfig) GetApiKeyRef() string {
 		return x.ApiKeyRef
 	}
 	return ""
+}
+
+func (x *MCPServerConfig) GetAllowedTools() []string {
+	if x != nil {
+		return x.AllowedTools
+	}
+	return nil
+}
+
+func (x *MCPServerConfig) GetAllowedMcpHosts() []string {
+	if x != nil {
+		return x.AllowedMcpHosts
+	}
+	return nil
 }
 
 var File_harness_v1_harness_proto protoreflect.FileDescriptor
@@ -4284,11 +4308,13 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\vToolsConfig\x12\x19\n" +
 	"\bbuilt_in\x18\x01 \x03(\tR\abuiltIn\x12D\n" +
 	"\vmcp_servers\x18\x02 \x03(\v2#.stirrup.harness.v1.MCPServerConfigR\n" +
-	"mcpServers\"W\n" +
+	"mcpServers\"\xa8\x01\n" +
 	"\x0fMCPServerConfig\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03uri\x18\x02 \x01(\tR\x03uri\x12\x1e\n" +
-	"\vapi_key_ref\x18\x03 \x01(\tR\tapiKeyRef2c\n" +
+	"\vapi_key_ref\x18\x03 \x01(\tR\tapiKeyRef\x12#\n" +
+	"\rallowed_tools\x18\x04 \x03(\tR\fallowedTools\x12*\n" +
+	"\x11allowed_mcp_hosts\x18\x05 \x03(\tR\x0fallowedMcpHosts2c\n" +
 	"\x0eHarnessService\x12Q\n" +
 	"\aRunTask\x12 .stirrup.harness.v1.HarnessEvent\x1a .stirrup.harness.v1.ControlEvent(\x010\x01B\xc6\x01\n" +
 	"\x16com.stirrup.harness.v1B\fHarnessProtoP\x01Z4github.com/rxbynerd/stirrup/gen/harness/v1;harnessv1\xa2\x02\x03SHX\xaa\x02\x12Stirrup.Harness.V1\xca\x02\x12Stirrup\\Harness\\V1\xe2\x02\x1eStirrup\\Harness\\V1\\GPBMetadata\xea\x02\x14Stirrup::Harness::V1b\x06proto3"

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -533,9 +533,11 @@ func toolsConfigFromProto(pc *pb.ToolsConfig) types.ToolsConfig {
 	}
 	for _, srv := range pc.McpServers {
 		tc.MCPServers = append(tc.MCPServers, types.MCPServerConfig{
-			Name:      srv.Name,
-			URI:       srv.Uri,
-			APIKeyRef: srv.ApiKeyRef,
+			Name:            srv.Name,
+			URI:             srv.Uri,
+			APIKeyRef:       srv.ApiKeyRef,
+			AllowedTools:    srv.AllowedTools,
+			AllowedMCPHosts: srv.AllowedMcpHosts,
 		})
 	}
 	return tc

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -1166,3 +1166,106 @@ func TestRunConfigFromProto_HooksNotAliased(t *testing.T) {
 			rc.Hooks.PreRun[0].Command, "original")
 	}
 }
+
+// TestRunConfigFromProto_MCPTrustFieldsPreserved guards the gRPC / K8s job
+// path for the MCP trust fields added in #393 (AllowedTools,
+// AllowedMCPHosts). Without an explicit translation, toolsConfigFromProto
+// silently drops both fields, so a gRPC-submitted RunConfig would register
+// every advertised tool from an MCP server and apply no host pinning
+// regardless of what the caller specified. Marshal/Unmarshal through the
+// actual wire format (not just an in-memory pointer copy) so a future
+// field-number collision or renumbering on MCPServerConfig (fields 4/5)
+// shows up here rather than only at runtime.
+func TestRunConfigFromProto_MCPTrustFieldsPreserved(t *testing.T) {
+	original := &pb.RunConfig{
+		Tools: &pb.ToolsConfig{
+			McpServers: []*pb.MCPServerConfig{
+				{
+					Name:            "search",
+					Uri:             "https://mcp.example.com/v1",
+					AllowedTools:    []string{"lookup", "query"},
+					AllowedMcpHosts: []string{"mcp.example.com"},
+				},
+			},
+		},
+	}
+
+	raw, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded pb.RunConfig
+	if err := proto.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	rc := runConfigFromProto(&decoded)
+
+	if len(rc.Tools.MCPServers) != 1 {
+		t.Fatalf("MCPServers: got %d entries, want 1", len(rc.Tools.MCPServers))
+	}
+	srv := rc.Tools.MCPServers[0]
+
+	wantTools := []string{"lookup", "query"}
+	if len(srv.AllowedTools) != len(wantTools) {
+		t.Fatalf("AllowedTools: got %v, want %v", srv.AllowedTools, wantTools)
+	}
+	for i, want := range wantTools {
+		if srv.AllowedTools[i] != want {
+			t.Errorf("AllowedTools[%d]: got %q, want %q", i, srv.AllowedTools[i], want)
+		}
+	}
+
+	wantHosts := []string{"mcp.example.com"}
+	if len(srv.AllowedMCPHosts) != len(wantHosts) {
+		t.Fatalf("AllowedMCPHosts: got %v, want %v", srv.AllowedMCPHosts, wantHosts)
+	}
+	for i, want := range wantHosts {
+		if srv.AllowedMCPHosts[i] != want {
+			t.Errorf("AllowedMCPHosts[%d]: got %q, want %q", i, srv.AllowedMCPHosts[i], want)
+		}
+	}
+}
+
+// TestRunConfigFromProto_MCPTrustFieldsAbsentWhenNil documents the
+// backward-compatible default from #393: an MCP server config that omits
+// the trust fields entirely must translate to nil/empty slices on the
+// types side, not a spurious default allowlist or host pin. Round-tripped
+// through Marshal/Unmarshal for the same reason as the populated case
+// above — proto3 zero-value (absent repeated field) behaviour is only
+// truly exercised on the wire, not on an in-memory struct literal.
+func TestRunConfigFromProto_MCPTrustFieldsAbsentWhenNil(t *testing.T) {
+	original := &pb.RunConfig{
+		Tools: &pb.ToolsConfig{
+			McpServers: []*pb.MCPServerConfig{
+				{
+					Name: "search",
+					Uri:  "https://mcp.example.com/v1",
+				},
+			},
+		},
+	}
+
+	raw, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded pb.RunConfig
+	if err := proto.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	rc := runConfigFromProto(&decoded)
+
+	if len(rc.Tools.MCPServers) != 1 {
+		t.Fatalf("MCPServers: got %d entries, want 1", len(rc.Tools.MCPServers))
+	}
+	srv := rc.Tools.MCPServers[0]
+
+	if len(srv.AllowedTools) != 0 {
+		t.Errorf("AllowedTools should be empty when proto field absent, got %v", srv.AllowedTools)
+	}
+	if len(srv.AllowedMCPHosts) != 0 {
+		t.Errorf("AllowedMCPHosts should be empty when proto field absent, got %v", srv.AllowedMCPHosts)
+	}
+}

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -1579,4 +1579,16 @@ message MCPServerConfig {
   // Optional. Secret reference for server authentication
   // (e.g. "secret://MCP_API_KEY"). Sent as a Bearer token.
   string api_key_ref = 3;
+
+  // Optional. Allowlist restricting which advertised tools the harness
+  // registers from this server, matched case-sensitively against the
+  // server-reported (unprefixed) tool name. Empty/unset registers every
+  // advertised tool (backward-compatible historical behaviour).
+  repeated string allowed_tools = 4;
+
+  // Optional. Pins the set of hostnames this server's URI may resolve to.
+  // When non-empty, the URI host must appear in this list (exact,
+  // case-insensitive match) in addition to passing the SSRF guard.
+  // Empty/unset applies no host pinning.
+  repeated string allowed_mcp_hosts = 5;
 }


### PR DESCRIPTION
## What

Carry `AllowedTools` and `AllowedMCPHosts` on `MCPServerConfig` over the gRPC/proto `RunConfig` path.

PR #393 added these two MCP trust controls to `types.MCPServerConfig` on the JSON `RunConfig` path, but the gRPC/proto path did not carry them. As a result, a `RunConfig` submitted over gRPC silently received `nil` for both — MCP tool allowlisting and host pinning were unreachable for gRPC callers.

## Changes

- **proto**: add two additive fields to the `MCPServerConfig` message — `repeated string allowed_tools = 4;` and `repeated string allowed_mcp_hosts = 5;`. Existing fields 1–3 are untouched (backward-compatible; empty/unset preserves historical behaviour: register every advertised tool, no host pinning).
- **generated**: regenerated `gen/harness/v1/harness.pb.go` via `just proto` (buf generate). No hand edits.
- **transport**: `toolsConfigFromProto` now threads `srv.AllowedTools` / `srv.AllowedMcpHosts` into `types.MCPServerConfig`. The gRPC `RunConfig` translation is one-directional (proto→types); there is no reverse path on main, so no other site needs threading.
- **tests**: two new tests in `grpc_translate_test.go` exercise a real `proto.Marshal` → `proto.Unmarshal` → translation round-trip (matching the sibling round-trip tests that guard against wire-tag/field-number drift): one asserts populated trust fields survive, one asserts nil/absent fields translate to empty (no spurious defaults).

The security semantics (allowlist filtering in `harness/internal/mcp/client.go`, host-pinning validation in `types/runconfig.go`) are unchanged — this change only decides whether the values arrive over gRPC.

## Verification

- `just` (build + full test suite) — pass.
- `just lint` (golangci-lint v2) — 0 issues.
- Reviewed by code-reviewer (no blocking findings) and spec-compliance-reviewer (COMPLIANT).

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AgBdi7aXRrPNThqDj2ohV
