### PR TITLE
trace: copy InternalName and Kind through scrubTurnRecord

### DIFF
--- a/harness/internal/trace/jsonl.go
+++ b/harness/internal/trace/jsonl.go
@@ -326,18 +326,20 @@ func scrubTurnRecord(t types.TurnRecord) types.TurnRecord {
 	}
 	for i, tc := range t.ToolCalls {
 		out.ToolCalls[i] = types.ToolCallRecord{
-			ID:         tc.ID,
-			Name:       tc.Name,
-			Input:      scrubRawJSON(tc.Input),
-			Output:     security.Scrub(tc.Output),
-			DurationMs: tc.DurationMs,
-			Success:    tc.Success,
+			ID:           tc.ID,
+			Name:         tc.Name,
+			InternalName: tc.InternalName,
+			Input:        scrubRawJSON(tc.Input),
+			Output:       security.Scrub(tc.Output),
+			DurationMs:   tc.DurationMs,
+			Success:      tc.Success,
 			// The structured payload (issue #231) carries the same
 			// untrusted content as Output — a command transcript or file
 			// excerpt that can hold credentials — so it is scrubbed on the
 			// same footing. scrubRawJSON preserves a valid json.RawMessage
 			// shape on disk even when a secret straddles a JSON token.
 			Structured: scrubRawJSON(tc.Structured),
+			Kind:       tc.Kind,
 		}
 	}
 	return out

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -318,9 +318,16 @@ func TestJSONLTraceEmitter_RecordTurnRecord_Scrubs(t *testing.T) {
 // non-zero value, runs it through scrubTurnRecord, and asserts every
 // field that scrubTurnRecord does not intentionally transform for
 // secret-scrubbing purposes (Input, Output, Structured) round-trips
-// unchanged. A field left at its zero value in the output — because a
-// new field was added to the struct but never wired into the rebuild
-// loop — fails this test immediately.
+// unchanged.
+//
+// That round-trip check is only as strong as the `in` fixture below:
+// a new ToolCallRecord field left unset in `in` would compare
+// zero-to-zero and pass silently even if scrubTurnRecord never
+// copies it. So this test first asserts the fixture itself is
+// complete — every field of `in` must be non-zero — before trusting
+// the round-trip comparison. Together, the two checks force whoever
+// adds a field to types.ToolCallRecord to populate it here as well
+// as wire it into scrubTurnRecord, or watch this test fail.
 func TestScrubTurnRecord_ToolCallRecord_FieldCompleteness(t *testing.T) {
 	// scrubbedFields are intentionally transformed by scrubTurnRecord
 	// (secret-shaped content is redacted) and so are exempt from the
@@ -344,6 +351,15 @@ func TestScrubTurnRecord_ToolCallRecord_FieldCompleteness(t *testing.T) {
 		Structured:   json.RawMessage(`{"kind":"file_edit"}`),
 		Kind:         "file_edit",
 	}
+
+	rtIn := reflect.TypeOf(in)
+	inFixtureVal := reflect.ValueOf(in)
+	for i := 0; i < rtIn.NumField(); i++ {
+		if inFixtureVal.Field(i).IsZero() {
+			t.Fatalf("fixture field %q is zero — populate every field when adding one to ToolCallRecord, then update this test", rtIn.Field(i).Name)
+		}
+	}
+
 	turn := types.TurnRecord{Turn: 1, ToolCalls: []types.ToolCallRecord{in}}
 
 	out := scrubTurnRecord(turn)

--- a/harness/internal/trace/jsonl_test.go
+++ b/harness/internal/trace/jsonl_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -301,6 +302,72 @@ func TestJSONLTraceEmitter_RecordTurnRecord_Scrubs(t *testing.T) {
 	// At least one [REDACTED] marker proves the scrubber ran.
 	if !strings.Contains(on_disk, "[REDACTED]") {
 		t.Errorf("expected [REDACTED] placeholder in scrubbed trace, got:\n%s", on_disk)
+	}
+}
+
+// TestScrubTurnRecord_ToolCallRecord_FieldCompleteness guards
+// scrubTurnRecord's explicit field-by-field ToolCallRecord rebuild
+// (issue #423). Because the rebuild names each field individually
+// rather than copying the source struct wholesale, a future field
+// added to types.ToolCallRecord compiles cleanly but is silently
+// dropped from every persisted trace unless a matching copy line is
+// added here too — exactly what happened to InternalName and Kind.
+// This mirrors TestToolCallSummary_StructuralParityWithTrace in
+// types/runtrace_test.go, but checks values rather than shape: it
+// builds a ToolCallRecord with every field set to a distinct
+// non-zero value, runs it through scrubTurnRecord, and asserts every
+// field that scrubTurnRecord does not intentionally transform for
+// secret-scrubbing purposes (Input, Output, Structured) round-trips
+// unchanged. A field left at its zero value in the output — because a
+// new field was added to the struct but never wired into the rebuild
+// loop — fails this test immediately.
+func TestScrubTurnRecord_ToolCallRecord_FieldCompleteness(t *testing.T) {
+	// scrubbedFields are intentionally transformed by scrubTurnRecord
+	// (secret-shaped content is redacted) and so are exempt from the
+	// verbatim round-trip check below; their scrubbing behaviour is
+	// covered separately by TestJSONLTraceEmitter_RecordTurnRecord_Scrubs
+	// and the other Scrubs* tests in this file.
+	scrubbedFields := map[string]bool{
+		"Input":      true,
+		"Output":     true,
+		"Structured": true,
+	}
+
+	in := types.ToolCallRecord{
+		ID:           "tool-call-id",
+		Name:         "run_command",
+		InternalName: "internal_run_command",
+		Input:        json.RawMessage(`{"cmd":"ls"}`),
+		Output:       "plain output text",
+		DurationMs:   1234,
+		Success:      true,
+		Structured:   json.RawMessage(`{"kind":"file_edit"}`),
+		Kind:         "file_edit",
+	}
+	turn := types.TurnRecord{Turn: 1, ToolCalls: []types.ToolCallRecord{in}}
+
+	out := scrubTurnRecord(turn)
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("scrubTurnRecord: got %d tool calls, want 1", len(out.ToolCalls))
+	}
+	got := out.ToolCalls[0]
+
+	inVal := reflect.ValueOf(in)
+	gotVal := reflect.ValueOf(got)
+	rt := reflect.TypeOf(in)
+	for i := 0; i < rt.NumField(); i++ {
+		name := rt.Field(i).Name
+		if scrubbedFields[name] {
+			if gotVal.Field(i).IsZero() {
+				t.Errorf("field %s: got zero value after scrubbing a non-empty input; scrubTurnRecord dropped it instead of scrubbing it", name)
+			}
+			continue
+		}
+		wantField := inVal.Field(i).Interface()
+		gotField := gotVal.Field(i).Interface()
+		if !reflect.DeepEqual(gotField, wantField) {
+			t.Errorf("field %s not copied verbatim by scrubTurnRecord: got %#v, want %#v", name, gotField, wantField)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

`scrubTurnRecord` (`harness/internal/trace/jsonl.go`) rebuilds each `types.ToolCallRecord` field-by-field before the JSONL trace is persisted, but silently dropped `InternalName` and `Kind`. This copies both fields through and guards the explicit-copy rebuild against future regressions.

## Why

Under a toolset profile (#234), JSONL `turn_record` lines lost the alias→internal binding that `InternalName` exists to make auditable. `Kind` (the structured-envelope shape name, #231) was dropped alongside, so a persisted `Structured` payload arrived without its declared kind. The OTel content-capture path consumes `scrubTurnRecord` output, so its unpaired-record fallback span synthesised `InternalName` from the scrubbed copy and always got `""` — now it gets the real value.

Neither field is secret-bearing; both are bounded, config-derived identifiers, so they are copied verbatim like `ID`/`Name` rather than passed through the scrubber. The drop was an accidental omission in the explicit-copy rebuild, not a scrubbing decision.

## How

- Copy `InternalName` and `Kind` verbatim in the rebuild loop. The explicit-allowlist style is retained deliberately — the explicit field list is the drop mechanism.
- Add `TestScrubTurnRecord_ToolCallRecord_FieldCompleteness`: a reflection guard that (1) asserts the fully-populated input fixture leaves no `ToolCallRecord` field at its zero value — forcing the next person who adds a field to update the fixture — and (2) verifies every non-scrubbed field round-trips through `scrubTurnRecord`. The guard was proven by a deliberate zero-field failure run.

## Review

Reviewed by code-reviewer (0 blocking), spec-compliance-reviewer (compliant), and security-reviewer (verbatim copy of bounded identifiers confirmed safe; scrub of Input/Output/Structured unchanged). `just test` and `just lint` clean.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AgBdi7aXRrPNThqDj2ohV
