### PR TITLE
core: cap RunResult.finalAssistantText to protect the STIRRUP_RESULT line

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -470,6 +470,30 @@ stdout. The default JSONL trace writes to a file (or to nothing when
 `STIRRUP_RESULT` line. A future JSONL emitter that writes to stdout
 would conflict with `--output=json`.
 
+`RunResult.FinalAssistantText` carries the loop's last assistant
+text onto the `STIRRUP_RESULT` line and any configured `resultSink`.
+An unbounded value here risks exceeding the per-entry size limit most
+log transports enforce (Cloud Logging's is roughly 256 KiB); a
+truncated log entry corrupts the trailing JSON and defeats a
+`grep | tail -n1`-style extraction of the line.
+
+`resultSink.maxFinalAssistantTextBytes` bounds the field. Zero or
+unset uses the default of 128 KiB — sized to leave headroom under a
+256 KiB entry ceiling once the rest of the `RunResult` envelope and
+JSON string escaping are accounted for. A positive value overrides
+the default; a negative value fails validation. The bound applies
+regardless of `resultSink.type`, including `none`: it protects the
+`RunResult` value itself, so an embedder reading `RunResult` directly
+gets the same guarantee as the `stdout-json` sink.
+
+Truncation is explicit, not silent. When the field is cut, the
+harness appends the marker `... [truncated by harness]` and sets
+`RunResult.FinalAssistantTextTruncated` to `true`. Truncation never
+splits a multi-byte UTF-8 rune, so the emitted JSON stays well-formed.
+The cap and the marker apply only to the `RunResult` copy of the
+text — the full, untruncated text is still recorded on the trace
+(JSONL / GCS / OTel) independently of `resultSink`.
+
 ### Workspace export
 
 At end-of-run the executor's workspace can be tarred, gzipped, and

--- a/harness/cmd/stirrup/cmd/root.go
+++ b/harness/cmd/stirrup/cmd/root.go
@@ -141,7 +141,15 @@ func hookSummaryCounts(results []types.HookExecution) (ran, failed int) {
 // ran" would conflate "verifier passed silently" with "verifier was
 // not configured"; the wire shape uses presence of the optional
 // VerifierResult pointer to disambiguate.
-func buildRunResult(rt *types.RunTrace) types.RunResult {
+//
+// maxFinalAssistantTextBytes caps FinalAssistantText on the returned
+// RunResult (issue #463) — resolve it via
+// (*types.ResultSinkConfig).ResolvedMaxFinalAssistantTextBytes before
+// calling. This bounds only the RunResult copy: rt.FinalAssistantText
+// itself is left untouched, and the trace emitters (which record the
+// full text independently via RecordFinalAssistantText) never see the
+// cap.
+func buildRunResult(rt *types.RunTrace, maxFinalAssistantTextBytes int) types.RunResult {
 	if rt == nil {
 		// A nil RunTrace means the loop produced no trace at all —
 		// every other code path returns a structurally valid one,
@@ -153,14 +161,16 @@ func buildRunResult(rt *types.RunTrace) types.RunResult {
 		// consumers detect the no-trace case explicitly.
 		return types.RunResult{SchemaVersion: 1, Outcome: "internal-error"}
 	}
+	finalText, truncated := types.CapFinalAssistantText(rt.FinalAssistantText, maxFinalAssistantTextBytes)
 	res := types.RunResult{
-		SchemaVersion:      1,
-		RunID:              rt.ID,
-		Outcome:            rt.Outcome,
-		Turns:              rt.Turns,
-		TokenUsage:         rt.TokenUsage,
-		DurationMs:         rt.CompletedAt.Sub(rt.StartedAt).Milliseconds(),
-		FinalAssistantText: rt.FinalAssistantText,
+		SchemaVersion:               1,
+		RunID:                       rt.ID,
+		Outcome:                     rt.Outcome,
+		Turns:                       rt.Turns,
+		TokenUsage:                  rt.TokenUsage,
+		DurationMs:                  rt.CompletedAt.Sub(rt.StartedAt).Milliseconds(),
+		FinalAssistantText:          finalText,
+		FinalAssistantTextTruncated: truncated,
 	}
 	if n := len(rt.VerificationResults); n > 0 {
 		last := rt.VerificationResults[n-1]
@@ -242,7 +252,7 @@ func emitRunResult(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace
 		slog.Warn("build resultSink", "err", err)
 		return
 	}
-	if err := sink.Emit(ctx, buildRunResult(rt)); err != nil {
+	if err := sink.Emit(ctx, buildRunResult(rt, cfg.ResultSink.ResolvedMaxFinalAssistantTextBytes())); err != nil {
 		slog.Warn("emit resultSink", "err", err)
 	}
 }
@@ -295,7 +305,7 @@ func emitRunOutput(ctx context.Context, cfg *types.RunConfig, rt *types.RunTrace
 		// before delegating so emitRunResult does not produce a second
 		// line. Any non-stdout sink stays untouched (different channel).
 		stdoutSink := resultsink.NewStdoutJSONSink()
-		if err := stdoutSink.Emit(ctx, buildRunResult(rt)); err != nil {
+		if err := stdoutSink.Emit(ctx, buildRunResult(rt, cfg.ResultSink.ResolvedMaxFinalAssistantTextBytes())); err != nil {
 			slog.Warn("emit --output=json", "err", err)
 		}
 		if cfg.ResultSink == nil || cfg.ResultSink.Type == "stdout-json" {

--- a/harness/cmd/stirrup/cmd/root_test.go
+++ b/harness/cmd/stirrup/cmd/root_test.go
@@ -117,7 +117,7 @@ func (f fakeExporter) Export(_ context.Context, _, _ string) error { return f.er
 // Consumers parsing the stdout-json line distinguish a no-trace path
 // from an empty-Outcome run on this sentinel.
 func TestBuildRunResult_NilTrace(t *testing.T) {
-	got := buildRunResult(nil)
+	got := buildRunResult(nil, types.DefaultMaxFinalAssistantTextBytes)
 	if got.SchemaVersion != 1 {
 		t.Errorf("SchemaVersion = %d, want 1", got.SchemaVersion)
 	}
@@ -151,7 +151,7 @@ func TestBuildRunResult_WithVerificationResult(t *testing.T) {
 			{Passed: true, Feedback: "second pass green"},
 		},
 	}
-	got := buildRunResult(rt)
+	got := buildRunResult(rt, types.DefaultMaxFinalAssistantTextBytes)
 	if got.Outcome != "success" {
 		t.Errorf("Outcome = %q, want success", got.Outcome)
 	}
@@ -181,7 +181,7 @@ func TestBuildRunResult_NoVerificationResultsLeavesVerdictNil(t *testing.T) {
 		ID:      "run-2",
 		Outcome: "success",
 	}
-	if got := buildRunResult(rt); got.VerifierVerdict != nil {
+	if got := buildRunResult(rt, types.DefaultMaxFinalAssistantTextBytes); got.VerifierVerdict != nil {
 		t.Errorf("VerifierVerdict = %+v, want nil", got.VerifierVerdict)
 	}
 }
@@ -207,9 +207,12 @@ func TestBuildRunResult_FinalAssistantText(t *testing.T) {
 				Outcome:            "success",
 				FinalAssistantText: tc.traceIn,
 			}
-			got := buildRunResult(rt)
+			got := buildRunResult(rt, types.DefaultMaxFinalAssistantTextBytes)
 			if got.FinalAssistantText != tc.wantText {
 				t.Errorf("FinalAssistantText = %q, want %q", got.FinalAssistantText, tc.wantText)
+			}
+			if got.FinalAssistantTextTruncated {
+				t.Errorf("FinalAssistantTextTruncated = true, want false: text is well under the default cap")
 			}
 			encoded, err := json.Marshal(got)
 			if err != nil {
@@ -222,7 +225,75 @@ func TestBuildRunResult_FinalAssistantText(t *testing.T) {
 			if tc.wantText != "" && !hasField {
 				t.Errorf("populated FinalAssistantText should be present in JSON, got %s", encoded)
 			}
+			if strings.Contains(string(encoded), "finalAssistantTextTruncated") {
+				t.Errorf("finalAssistantTextTruncated=false should be omitted from JSON, got %s", encoded)
+			}
 		})
+	}
+}
+
+// TestBuildRunResult_FinalAssistantTextCappedAndFlagged pins issue
+// #463: a RunTrace.FinalAssistantText longer than the resolved cap is
+// truncated on the RunResult copy, the truncation marker is appended,
+// and FinalAssistantTextTruncated is set — while rt itself (the
+// RunTrace the trace emitters read via RecordFinalAssistantText) is
+// left untouched by buildRunResult.
+func TestBuildRunResult_FinalAssistantTextCappedAndFlagged(t *testing.T) {
+	longText := strings.Repeat("a", 100)
+	rt := &types.RunTrace{
+		ID:                 "run-cap",
+		Outcome:            "success",
+		FinalAssistantText: longText,
+	}
+	const maxBytes = 10
+	got := buildRunResult(rt, maxBytes)
+
+	wantPrefix := strings.Repeat("a", maxBytes)
+	if !strings.HasPrefix(got.FinalAssistantText, wantPrefix) {
+		t.Errorf("FinalAssistantText = %q, want prefix %q", got.FinalAssistantText, wantPrefix)
+	}
+	if !strings.HasSuffix(got.FinalAssistantText, "[truncated by harness]") {
+		t.Errorf("FinalAssistantText = %q, want truncation marker suffix", got.FinalAssistantText)
+	}
+	if !got.FinalAssistantTextTruncated {
+		t.Error("FinalAssistantTextTruncated = false, want true")
+	}
+	if len(got.FinalAssistantText) <= maxBytes {
+		t.Errorf("capped FinalAssistantText len = %d, want > cap %d (marker must still be present)", len(got.FinalAssistantText), maxBytes)
+	}
+
+	// buildRunResult must not mutate the RunTrace it was given: trace
+	// emitters record the full text independently via
+	// RecordFinalAssistantText and must see the untruncated value.
+	if rt.FinalAssistantText != longText {
+		t.Errorf("rt.FinalAssistantText was mutated to %q, want untouched %q", rt.FinalAssistantText, longText)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"finalAssistantTextTruncated":true`) {
+		t.Errorf("marshalled RunResult missing finalAssistantTextTruncated:true, got %s", encoded)
+	}
+}
+
+// TestBuildRunResult_FinalAssistantTextUnderCapUntouched pins the
+// non-truncation path with an explicit small cap: text at or under the
+// cap passes through unmodified and FinalAssistantTextTruncated stays
+// false.
+func TestBuildRunResult_FinalAssistantTextUnderCapUntouched(t *testing.T) {
+	rt := &types.RunTrace{
+		ID:                 "run-under-cap",
+		Outcome:            "success",
+		FinalAssistantText: "short answer",
+	}
+	got := buildRunResult(rt, 1024)
+	if got.FinalAssistantText != "short answer" {
+		t.Errorf("FinalAssistantText = %q, want unmodified %q", got.FinalAssistantText, "short answer")
+	}
+	if got.FinalAssistantTextTruncated {
+		t.Error("FinalAssistantTextTruncated = true, want false")
 	}
 }
 
@@ -239,7 +310,7 @@ func TestBuildRunResult_HookFailuresCounted(t *testing.T) {
 			{Phase: "postRun", Index: 1, Command: "true", Skipped: true},         // skipped, not a failure
 		},
 	}
-	got := buildRunResult(rt)
+	got := buildRunResult(rt, types.DefaultMaxFinalAssistantTextBytes)
 	if got.HookFailures != 1 {
 		t.Errorf("HookFailures = %d, want 1 (skipped entries must not count)", got.HookFailures)
 	}
@@ -250,7 +321,7 @@ func TestBuildRunResult_HookFailuresCounted(t *testing.T) {
 // must resolve HookFailures to zero.
 func TestBuildRunResult_NoHookResultsLeavesHookFailuresZero(t *testing.T) {
 	rt := &types.RunTrace{ID: "run-no-hooks", Outcome: "success"}
-	got := buildRunResult(rt)
+	got := buildRunResult(rt, types.DefaultMaxFinalAssistantTextBytes)
 	if got.HookFailures != 0 {
 		t.Errorf("HookFailures = %d, want 0", got.HookFailures)
 	}

--- a/harness/internal/resultsink/resultsink_test.go
+++ b/harness/internal/resultsink/resultsink_test.go
@@ -100,6 +100,51 @@ func TestStdoutJSONSink_FinalAssistantText(t *testing.T) {
 	}
 }
 
+// TestStdoutJSONSink_FinalAssistantTextTruncated pins the wire
+// behaviour of the issue #463 truncation flag through the sink: the
+// sink itself applies no cap (that happens upstream in buildRunResult)
+// — it simply serialises whatever RunResult it is given, so a
+// FinalAssistantTextTruncated=true round-trips through the emitted
+// JSON and a false value is omitted by the omitempty tag.
+func TestStdoutJSONSink_FinalAssistantTextTruncated(t *testing.T) {
+	cases := []struct {
+		name      string
+		truncated bool
+		wantKey   bool
+	}{
+		{"truncated", true, true},
+		{"not truncated", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			sink := NewStdoutJSONSinkTo(&buf)
+			res := types.RunResult{
+				SchemaVersion:               1,
+				RunID:                       "run-cap",
+				Outcome:                     "success",
+				FinalAssistantText:          "the answer is 42... [truncated by harness]",
+				FinalAssistantTextTruncated: tc.truncated,
+			}
+			if err := sink.Emit(context.Background(), res); err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(buf.String(), StdoutResultSentinel))
+			hasKey := strings.Contains(payload, "finalAssistantTextTruncated")
+			if hasKey != tc.wantKey {
+				t.Errorf("finalAssistantTextTruncated key present = %v, want %v\npayload=%q", hasKey, tc.wantKey, payload)
+			}
+			var decoded types.RunResult
+			if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+				t.Fatalf("unmarshal payload: %v\npayload=%q", err, payload)
+			}
+			if decoded.FinalAssistantTextTruncated != tc.truncated {
+				t.Errorf("decoded FinalAssistantTextTruncated = %v, want %v", decoded.FinalAssistantTextTruncated, tc.truncated)
+			}
+		})
+	}
+}
+
 func TestNoneSink_NoOp(t *testing.T) {
 	sink := NoneSink{}
 	if err := sink.Emit(context.Background(), types.RunResult{}); err != nil {

--- a/types/result.go
+++ b/types/result.go
@@ -14,6 +14,58 @@
 // removing a field.
 package types
 
+import "unicode/utf8"
+
+// DefaultMaxFinalAssistantTextBytes bounds RunResult.FinalAssistantText
+// when a run does not set ResultSinkConfig.MaxFinalAssistantTextBytes
+// (or sets it to zero). Cloud Logging caps a single log entry at
+// roughly 256 KiB; the stdout-json result sink serialises the entire
+// RunResult envelope — not just this field — onto one STIRRUP_RESULT
+// line, and JSON string escaping can expand the text further, so
+// bounding this field to 128 KiB leaves headroom under the entry
+// ceiling for the rest of the envelope and any escaping overhead.
+const DefaultMaxFinalAssistantTextBytes = 1 << 17 // 128 KiB
+
+// finalAssistantTextTruncationMarker is appended to
+// RunResult.FinalAssistantText when CapFinalAssistantText truncates it.
+// Mirrors asyncResultTruncationSuffix in harness/internal/core/types.go
+// so both truncation surfaces read the same to an operator scanning
+// logs.
+const finalAssistantTextTruncationMarker = "... [truncated by harness]"
+
+// CapFinalAssistantText truncates s to at most maxBytes bytes of
+// pre-marker content and appends finalAssistantTextTruncationMarker
+// when truncation occurs. The returned capped string is therefore up
+// to len(finalAssistantTextTruncationMarker) bytes longer than
+// maxBytes. Exported so the RunResult builder (harness/cmd/stirrup/cmd,
+// outside this package) can apply the cap without duplicating the
+// rune-boundary logic.
+//
+// Truncation always lands on a UTF-8 rune boundary: FinalAssistantText
+// is model-produced text that must stay valid UTF-8 so the
+// STIRRUP_RESULT JSON line stays well-formed, so — unlike
+// extractAsyncToolResult's byte-boundary truncation of untrusted
+// control-plane content — this backs off to the start of the rune
+// straddling the cut rather than splitting it.
+//
+// maxBytes < 0 is treated as 0 rather than "no cap": callers resolve
+// the effective cap via ResultSinkConfig.ResolvedMaxFinalAssistantTextBytes
+// before calling this helper, so a negative value here should not
+// silently pass the string through unbounded.
+func CapFinalAssistantText(s string, maxBytes int) (capped string, truncated bool) {
+	if maxBytes < 0 {
+		maxBytes = 0
+	}
+	if len(s) <= maxBytes {
+		return s, false
+	}
+	end := maxBytes
+	for end > 0 && !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end] + finalAssistantTextTruncationMarker, true
+}
+
 // RunResult is the payload all resultSink adapters serialise at the end
 // of a run. Constructed from the existing RunTrace at end-of-run.
 //
@@ -57,6 +109,13 @@ type RunResult struct {
 	// failure). Callers that framed their prompt for JSON output parse
 	// this field; for free-form runs it is informational.
 	FinalAssistantText string `json:"finalAssistantText,omitempty"`
+
+	// FinalAssistantTextTruncated is true when FinalAssistantText was
+	// truncated to satisfy ResultSinkConfig.ResolvedMaxFinalAssistantTextBytes
+	// (issue #463). The full, untruncated text is still available on the
+	// trace via the trace emitter's RecordFinalAssistantText — this flag
+	// only describes the copy carried on this RunResult.
+	FinalAssistantTextTruncated bool `json:"finalAssistantTextTruncated,omitempty"`
 
 	// VerifierVerdict is the optional verifier outcome, present only
 	// when a verifier ran. Distinct from VerificationResult (the

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -1,0 +1,181 @@
+package types
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestCapFinalAssistantText_UnderCapPassesThrough pins the fast path:
+// a string shorter than (or equal to) the cap is returned unmodified
+// with truncated=false, and no marker is appended.
+func TestCapFinalAssistantText_UnderCapPassesThrough(t *testing.T) {
+	cases := []struct {
+		name    string
+		s       string
+		maxByte int
+	}{
+		{"empty string, positive cap", "", 10},
+		{"empty string, zero cap", "", 0},
+		{"shorter than marker", "hi", 100},
+		{"exactly at cap", "hello", 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, truncated := CapFinalAssistantText(tc.s, tc.maxByte)
+			if truncated {
+				t.Errorf("truncated = true, want false for %q under cap %d", tc.s, tc.maxByte)
+			}
+			if got != tc.s {
+				t.Errorf("capped = %q, want %q unmodified", got, tc.s)
+			}
+		})
+	}
+}
+
+// TestCapFinalAssistantText_ASCIIBoundary pins the simple case: an
+// ASCII string longer than the cap is cut exactly at the byte boundary
+// (every ASCII byte is a rune boundary) and the marker is appended.
+func TestCapFinalAssistantText_ASCIIBoundary(t *testing.T) {
+	s := "0123456789"
+	got, truncated := CapFinalAssistantText(s, 4)
+	if !truncated {
+		t.Fatal("truncated = false, want true")
+	}
+	wantPrefix := "0123"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("capped = %q, want prefix %q", got, wantPrefix)
+	}
+	if !strings.HasSuffix(got, finalAssistantTextTruncationMarker) {
+		t.Errorf("capped = %q, want suffix %q", got, finalAssistantTextTruncationMarker)
+	}
+	if got != wantPrefix+finalAssistantTextTruncationMarker {
+		t.Errorf("capped = %q, want %q", got, wantPrefix+finalAssistantTextTruncationMarker)
+	}
+}
+
+// TestCapFinalAssistantText_MultibyteRuneStraddlesCap is the load-
+// bearing case: the cap lands in the middle of a multibyte rune, so
+// the helper must back off to the start of that rune rather than
+// splitting it (which would corrupt the UTF-8 encoding and, downstream,
+// the STIRRUP_RESULT JSON line).
+func TestCapFinalAssistantText_MultibyteRuneStraddlesCap(t *testing.T) {
+	// "a" (1 byte) + "€" (3 bytes, U+20AC) + "b" (1 byte) = 5 bytes total.
+	s := "a€b"
+	if len(s) != 5 {
+		t.Fatalf("test fixture len(s) = %d, want 5", len(s))
+	}
+	// Cap at 2 bytes lands inside the 3-byte € encoding (bytes 1-3).
+	got, truncated := CapFinalAssistantText(s, 2)
+	if !truncated {
+		t.Fatal("truncated = false, want true")
+	}
+	prefix := strings.TrimSuffix(got, finalAssistantTextTruncationMarker)
+	if prefix != "a" {
+		t.Errorf("capped prefix = %q, want %q (the straddled rune must be dropped entirely)", prefix, "a")
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("capped = %q is not valid UTF-8", got)
+	}
+}
+
+// TestCapFinalAssistantText_MultibyteRuneExactlyAtCap pins the other
+// edge of the same boundary logic: when the cap lands exactly on the
+// end of a multibyte rune (a valid rune-start boundary for the next
+// rune), the cut must include the full preceding rune rather than
+// backing off further than necessary.
+func TestCapFinalAssistantText_MultibyteRuneExactlyAtCap(t *testing.T) {
+	s := "a€b" // a(1) + €(3) + b(1)
+	got, truncated := CapFinalAssistantText(s, 4)
+	if !truncated {
+		t.Fatal("truncated = false, want true")
+	}
+	prefix := strings.TrimSuffix(got, finalAssistantTextTruncationMarker)
+	if prefix != "a€" {
+		t.Errorf("capped prefix = %q, want %q (cap exactly at rune boundary keeps the full rune)", prefix, "a€")
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("capped = %q is not valid UTF-8", got)
+	}
+}
+
+// TestCapFinalAssistantText_CapSmallerThanSingleRune pins the extreme
+// case: a cap of 0 (or one that cannot fit even the first rune) drops
+// the entire straddled rune and returns just the marker.
+func TestCapFinalAssistantText_CapSmallerThanSingleRune(t *testing.T) {
+	s := "€" // a single 3-byte rune
+	got, truncated := CapFinalAssistantText(s, 1)
+	if !truncated {
+		t.Fatal("truncated = false, want true")
+	}
+	if got != finalAssistantTextTruncationMarker {
+		t.Errorf("capped = %q, want just the marker %q", got, finalAssistantTextTruncationMarker)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("capped = %q is not valid UTF-8", got)
+	}
+}
+
+// TestCapFinalAssistantText_ZeroCapOnNonEmptyString pins maxBytes==0
+// against non-empty input: the entire string is dropped and only the
+// marker remains.
+func TestCapFinalAssistantText_ZeroCapOnNonEmptyString(t *testing.T) {
+	got, truncated := CapFinalAssistantText("hello", 0)
+	if !truncated {
+		t.Fatal("truncated = false, want true")
+	}
+	if got != finalAssistantTextTruncationMarker {
+		t.Errorf("capped = %q, want just the marker %q", got, finalAssistantTextTruncationMarker)
+	}
+}
+
+// TestCapFinalAssistantText_NegativeCapTreatedAsZero pins the
+// documented negative-cap behaviour: a negative maxBytes must not
+// panic or index out of range, and behaves identically to maxBytes==0.
+func TestCapFinalAssistantText_NegativeCapTreatedAsZero(t *testing.T) {
+	got, truncated := CapFinalAssistantText("hello", -5)
+	if !truncated {
+		t.Fatal("truncated = false, want true")
+	}
+	if got != finalAssistantTextTruncationMarker {
+		t.Errorf("capped = %q, want just the marker %q", got, finalAssistantTextTruncationMarker)
+	}
+}
+
+// TestCapFinalAssistantText_StringShorterThanMarker pins a case that
+// could confuse an implementation that compares the input length
+// against the marker length instead of maxBytes: a short string that
+// still needs truncation (cap smaller than the string) must still get
+// the full marker appended even though the marker itself is longer
+// than the truncated prefix.
+func TestCapFinalAssistantText_StringShorterThanMarker(t *testing.T) {
+	s := "hello world" // 11 bytes, well under len(marker)
+	got, truncated := CapFinalAssistantText(s, 3)
+	if !truncated {
+		t.Fatal("truncated = false, want true")
+	}
+	want := "hel" + finalAssistantTextTruncationMarker
+	if got != want {
+		t.Errorf("capped = %q, want %q", got, want)
+	}
+}
+
+// TestResolvedMaxFinalAssistantTextBytes pins the default-resolution
+// rules: a nil ResultSinkConfig, an unset (zero) field, and a
+// negative-would-be-invalid field (rejected by validation, but the
+// resolver is defensive) all fall back to the documented default; a
+// positive override is passed through unchanged.
+func TestResolvedMaxFinalAssistantTextBytes(t *testing.T) {
+	var nilCfg *ResultSinkConfig
+	if got := nilCfg.ResolvedMaxFinalAssistantTextBytes(); got != DefaultMaxFinalAssistantTextBytes {
+		t.Errorf("nil config: ResolvedMaxFinalAssistantTextBytes() = %d, want default %d", got, DefaultMaxFinalAssistantTextBytes)
+	}
+	unset := &ResultSinkConfig{Type: "stdout-json"}
+	if got := unset.ResolvedMaxFinalAssistantTextBytes(); got != DefaultMaxFinalAssistantTextBytes {
+		t.Errorf("unset field: ResolvedMaxFinalAssistantTextBytes() = %d, want default %d", got, DefaultMaxFinalAssistantTextBytes)
+	}
+	override := &ResultSinkConfig{Type: "stdout-json", MaxFinalAssistantTextBytes: 4096}
+	if got := override.ResolvedMaxFinalAssistantTextBytes(); got != 4096 {
+		t.Errorf("override: ResolvedMaxFinalAssistantTextBytes() = %d, want 4096", got)
+	}
+}

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -1415,6 +1415,29 @@ type ResultSinkConfig struct {
 	// consulted. Carrying attributes on a non-"gcp-pubsub" type is
 	// rejected for the same reason as Topic.
 	Attributes map[string]string `json:"attributes,omitempty"`
+
+	// MaxFinalAssistantTextBytes bounds RunResult.FinalAssistantText
+	// (issue #463). Zero (the default) means
+	// DefaultMaxFinalAssistantTextBytes; use
+	// ResolvedMaxFinalAssistantTextBytes rather than reading this field
+	// directly. Unlike Topic/Attributes this is not gated to a single
+	// sink type: it bounds the RunResult field itself, so it applies
+	// regardless of which sink (or none) consumes the result — an
+	// embedder reading RunResult directly benefits from the same bound
+	// as the stdout-json sink.
+	MaxFinalAssistantTextBytes int `json:"maxFinalAssistantTextBytes,omitempty"`
+}
+
+// ResolvedMaxFinalAssistantTextBytes returns c.MaxFinalAssistantTextBytes,
+// or DefaultMaxFinalAssistantTextBytes when c is nil or the field is
+// unset (<= 0). Callers building a RunResult should use this instead of
+// reading MaxFinalAssistantTextBytes directly so a nil ResultSink (the
+// "no sink configured" case) still yields a sane cap.
+func (c *ResultSinkConfig) ResolvedMaxFinalAssistantTextBytes() int {
+	if c == nil || c.MaxFinalAssistantTextBytes <= 0 {
+		return DefaultMaxFinalAssistantTextBytes
+	}
+	return c.MaxFinalAssistantTextBytes
 }
 
 // ToolsConfig holds the tool configuration.
@@ -4502,6 +4525,13 @@ func validateResultSinkConfig(cfg *ResultSinkConfig, errs *[]string) {
 			"resultSink.attributes is only valid when type is \"gcp-pubsub\" (got type %q)",
 			cfg.Type,
 		))
+	}
+	// MaxFinalAssistantTextBytes bounds the RunResult field, not a
+	// per-adapter wire detail, so — unlike Topic/Attributes — it is not
+	// gated to a single sink type. Zero is allowed (means "use the
+	// default"); only a negative value is a config error.
+	if cfg.MaxFinalAssistantTextBytes < 0 {
+		*errs = append(*errs, "resultSink.maxFinalAssistantTextBytes must be non-negative")
 	}
 }
 

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -5705,6 +5705,44 @@ func TestValidateRunConfig_ResultSink_InvalidType(t *testing.T) {
 	}
 }
 
+// TestValidateRunConfig_ResultSink_MaxFinalAssistantTextBytes pins
+// issue #463's validation: zero (the "use the default" sentinel) and
+// any positive override pass, a negative value is rejected, and —
+// unlike Topic/Attributes — the field is accepted on every implemented
+// sink type because it bounds the RunResult field itself rather than a
+// per-adapter wire detail.
+func TestValidateRunConfig_ResultSink_MaxFinalAssistantTextBytes(t *testing.T) {
+	t.Run("zero is the default sentinel and passes", func(t *testing.T) {
+		c := validConfig()
+		c.ResultSink = &ResultSinkConfig{Type: "stdout-json", MaxFinalAssistantTextBytes: 0}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("expected zero MaxFinalAssistantTextBytes to pass, got: %v", err)
+		}
+	})
+	t.Run("positive override passes", func(t *testing.T) {
+		c := validConfig()
+		c.ResultSink = &ResultSinkConfig{Type: "stdout-json", MaxFinalAssistantTextBytes: 4096}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("expected positive MaxFinalAssistantTextBytes to pass, got: %v", err)
+		}
+	})
+	t.Run("negative is rejected", func(t *testing.T) {
+		c := validConfig()
+		c.ResultSink = &ResultSinkConfig{Type: "stdout-json", MaxFinalAssistantTextBytes: -1}
+		err := ValidateRunConfig(c)
+		if err == nil || !strings.Contains(err.Error(), "resultSink.maxFinalAssistantTextBytes must be non-negative") {
+			t.Errorf("expected maxFinalAssistantTextBytes-non-negative error, got: %v", err)
+		}
+	})
+	t.Run("positive override passes on type=none too", func(t *testing.T) {
+		c := validConfig()
+		c.ResultSink = &ResultSinkConfig{Type: "none", MaxFinalAssistantTextBytes: 4096}
+		if err := ValidateRunConfig(c); err != nil {
+			t.Fatalf("expected MaxFinalAssistantTextBytes on type=none to pass (bounds RunResult, not a sink wire detail), got: %v", err)
+		}
+	})
+}
+
 // --- executor.workspaceExportTo ---
 
 func TestValidateRunConfig_WorkspaceExportTo_ValidGS(t *testing.T) {


### PR DESCRIPTION
## What

`RunResult.FinalAssistantText` (populated since #462) had no length bound. The `stdout-json` result sink serialises the whole `RunResult` onto a single `STIRRUP_RESULT {json}` line; a very long final answer produces a very long line that log transports (e.g. Cloud Logging's ~256 KiB per-entry limit) can truncate, corrupting the JSON and defeating `grep | tail -n1` extraction. This introduces a documented byte cap, mirroring the existing `maxAsyncToolResultBytes` pattern.

## Design decisions

- **Default cap:** `DefaultMaxFinalAssistantTextBytes = 1 << 17` (128 KiB). The `STIRRUP_RESULT` line wraps the text plus the rest of the `RunResult` envelope, and JSON string escaping can expand the text, so bounding the field to 128 KiB leaves headroom under the ~256 KiB entry ceiling.
- **Configurable override:** `resultSink.maxFinalAssistantTextBytes` on `ResultSinkConfig`. Zero/unset means "use the default"; a nil-safe resolver returns the default when the config is absent or the value is non-positive. Validation rejects a negative value; the field is not gated to a specific sink type (it bounds the `RunResult` field for all sinks as defense-in-depth, since embedders may consume `RunResult` directly).
- **Explicit, not silent, truncation:** truncation appends a marker suffix **and** sets a new `RunResult.FinalAssistantTextTruncated` bool flag, so a consumer can detect the truncation rather than silently trusting a clipped answer.
- **UTF-8 rune boundary:** truncation backs off to a rune boundary rather than splitting a multibyte rune, keeping the field valid UTF-8 so the emitted JSON stays well-formed. (This differs from the async byte-truncation, which deliberately does not assume UTF-8.)
- **Result-sink field only, not the trace:** the cap is applied in `buildRunResult`, reading a copy of `rt.FinalAssistantText`. The JSONL/GCS/OTel trace emitters still record the full text via `RecordFinalAssistantText` — the persisted evidence is unchanged; only the small result-sink answer payload is bounded.

## How

- `types/result.go`: `DefaultMaxFinalAssistantTextBytes`, the truncation marker, the rune-safe cap helper, and the `FinalAssistantTextTruncated` field.
- `types/runconfig.go`: the `maxFinalAssistantTextBytes` config field, its resolver, and negative-value validation.
- `harness/cmd/stirrup/cmd/root.go`: apply the resolved cap in `buildRunResult`.
- `docs/configuration.md`: document the field in the resultSink section (impersonal voice).
- Tests cover the rune-boundary helper (boundary exactly at cap, multibyte rune straddling the cap, empty/short strings, cap smaller than a rune), config validation, and the sink round-trip.

## Review

Reviewed by code-reviewer and spec-compliance-reviewer (0 blocking). `just build`, `just test`, and `just lint` clean.

## Related follow-up

The cap bounds the raw text length; JSON string escaping can still inflate the serialised bytes above the pre-escape cap. That interaction is tracked separately in #504 and intentionally out of scope here.

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AgBdi7aXRrPNThqDj2ohV
