### PR TITLE
provider: consolidate adapter deps into shared AdapterDeps struct

### DIFF
--- a/harness/internal/provider/anthropic.go
+++ b/harness/internal/provider/anthropic.go
@@ -16,7 +16,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
-	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
@@ -55,14 +54,14 @@ const (
 
 // AnthropicAdapter implements ProviderAdapter for the Anthropic Messages API.
 type AnthropicAdapter struct {
-	bearer      credential.BearerTokenFunc
-	authMode    AuthMode
-	httpClient  *http.Client
-	baseURL     string                 // overridable for testing
-	Tracer      oteltrace.Tracer       // optional, set by factory for span instrumentation
-	Metrics     *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
-	RetryPolicy RetryPolicy            // optional, set by factory; zero value disables retry
-	Logger      *slog.Logger           // optional, set by factory; nil falls back to slog.Default()
+	bearer     credential.BearerTokenFunc
+	authMode   AuthMode
+	httpClient *http.Client
+	baseURL    string // overridable for testing
+
+	// AdapterDeps carries the factory-injected Tracer/Metrics/RetryPolicy/
+	// Logger; see its doc comment for the field-by-field contract.
+	AdapterDeps
 
 	// Registry resolves per-(provider, model) quirks at the top of every
 	// Stream call. The constructor seeds it with quirks.DefaultRegistry()

--- a/harness/internal/provider/gemini.go
+++ b/harness/internal/provider/gemini.go
@@ -18,7 +18,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
-	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
@@ -69,18 +68,9 @@ type GeminiAdapter struct {
 	// "gemini-{streamN}-{partIdx}".
 	streamCounter atomic.Int64
 
-	// Tracer and Metrics are field-injected by the factory after
-	// construction. Both nil-safe at every call site.
-	Tracer  oteltrace.Tracer
-	Metrics *observability.Metrics
-
-	// RetryPolicy is field-injected by the factory; zero value disables
-	// retry (single attempt). Mirrors the OpenAICompatibleAdapter pattern.
-	RetryPolicy RetryPolicy
-
-	// Logger is field-injected by the factory; nil falls back to
-	// slog.Default(). Used for the per-Stream quirks debug log line.
-	Logger *slog.Logger
+	// AdapterDeps carries the factory-injected Tracer/Metrics/RetryPolicy/
+	// Logger; see its doc comment for the field-by-field contract.
+	AdapterDeps
 
 	// Registry resolves per-(provider, model) wire-shape and behaviour
 	// overrides at the top of every Stream call. The constructor seeds

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -386,18 +386,6 @@ func openAIWireTokenKey(f quirks.OpenAITokenField) string {
 	return "max_completion_tokens"
 }
 
-// ruleDescriptions returns the Description field of each rule in the
-// supplied slice, preserving order. Returned as a non-nil empty slice
-// when the input is empty so the slog.Any attribute renders as `[]`
-// rather than `null` — easier to grep and parse downstream.
-func ruleDescriptions(rules []quirks.Rule) []string {
-	out := make([]string, 0, len(rules))
-	for _, r := range rules {
-		out = append(out, r.Description)
-	}
-	return out
-}
-
 // summarizeReplayCaptures sums per-path piece counts and the string-or-
 // JSON-encoded length of every captured value across the whole map. The
 // same length proxy logReplayFieldsCapture uses (raw string length for
@@ -431,9 +419,9 @@ func summarizeReplayCaptures(capture map[string][]any) (totalCount, totalLen int
 // not echo into any log sink. Operators get presence + size; the rule
 // fired observably without leaking the content.
 //
-// Shared by both adapters so the log shape stays uniform; the
-// helper lives in openai.go because that is where ruleDescriptions
-// already sits.
+// Shared by both adapters so the log shape stays uniform; the helper
+// lives in openai.go because that is its only non-test caller besides
+// gemini.go.
 func logReplayFieldsCapture(ctx context.Context, logger *slog.Logger, providerType, model string, capture map[string][]any) {
 	if logger == nil {
 		logger = slog.Default()

--- a/harness/internal/provider/openai.go
+++ b/harness/internal/provider/openai.go
@@ -19,7 +19,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
-	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
@@ -83,10 +82,11 @@ type OpenAICompatibleAdapter struct {
 	baseURL      string
 	apiKeyHeader string
 	queryParams  map[string]string
-	Tracer       oteltrace.Tracer       // optional, set by factory for span instrumentation
-	Metrics      *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
-	RetryPolicy  RetryPolicy            // optional, set by factory; zero value disables retry
-	Logger       *slog.Logger           // optional, set by factory; nil falls back to slog.Default()
+
+	// AdapterDeps carries the factory-injected Tracer/Metrics/RetryPolicy/
+	// Logger; see its doc comment for the field-by-field contract.
+	AdapterDeps
+
 	// Registry resolves per-(provider, model) wire-shape and behaviour
 	// overrides at the top of every Stream call. The constructor seeds
 	// this with quirks.DefaultRegistry() so callers that ignore the
@@ -138,7 +138,7 @@ func NewOpenAICompatibleAdapter(bearer credential.BearerTokenFunc, baseURL strin
 		baseURL:       baseURL,
 		apiKeyHeader:  auth.APIKeyHeader,
 		queryParams:   auth.QueryParams,
-		RetryPolicy:   retry,
+		AdapterDeps:   AdapterDeps{RetryPolicy: retry},
 		Registry:      quirks.DefaultRegistry(),
 		strictSchemas: newStrictSchemaCache(),
 	}

--- a/harness/internal/provider/openai_responses.go
+++ b/harness/internal/provider/openai_responses.go
@@ -18,7 +18,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/rxbynerd/stirrup/harness/internal/credential"
-	"github.com/rxbynerd/stirrup/harness/internal/observability"
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/types"
@@ -54,10 +53,11 @@ type OpenAIResponsesAdapter struct {
 	baseURL      string
 	apiKeyHeader string
 	queryParams  map[string]string
-	Tracer       oteltrace.Tracer       // optional, set by factory for span instrumentation
-	Metrics      *observability.Metrics // optional, set by factory for metric recording (nil means no recording)
-	RetryPolicy  RetryPolicy            // optional, set by factory; zero value disables retry
-	Logger       *slog.Logger           // optional, set by factory; nil falls back to slog.Default()
+
+	// AdapterDeps carries the factory-injected Tracer/Metrics/RetryPolicy/
+	// Logger; see its doc comment for the field-by-field contract.
+	AdapterDeps
+
 	// Registry resolves per-(provider, model) quirks at the top of
 	// every Stream call. No rules target openai-responses in v1; the
 	// field exists so the integration point is in place when a

--- a/harness/internal/provider/provider_util.go
+++ b/harness/internal/provider/provider_util.go
@@ -1,6 +1,42 @@
 package provider
 
-import "github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+import (
+	"log/slog"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/rxbynerd/stirrup/harness/internal/observability"
+	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+)
+
+// AdapterDeps carries the cross-cutting dependencies the factory injects
+// into every streaming provider adapter (Anthropic, OpenAICompatible,
+// OpenAIResponses, Gemini) after construction. Each field is optional and
+// nil-safe at every call site:
+//
+//   - Tracer: set by factory.go for span instrumentation; a nil Tracer
+//     means no spans are recorded.
+//   - Metrics: set by factory.go for metric recording; nil means no
+//     recording.
+//   - RetryPolicy: set by factory.go (or passed into the constructor, for
+//     OpenAICompatibleAdapter) from the resolved provider.retry config;
+//     the zero value disables retry (single attempt, no backoff).
+//   - Logger: set by factory.go to the run's ScrubHandler-backed logger;
+//     nil falls back to slog.Default().
+//
+// Adapters embed AdapterDeps anonymously so existing field access
+// (adapter.Tracer, adapter.Metrics, ...) is unchanged — the struct exists
+// to give the four adapters one definition of this dependency set instead
+// of four independently-maintained copies. Registry (*quirks.Registry) is
+// deliberately NOT part of this struct: each adapter resolves quirks
+// differently (e.g. Gemini's ReplayFields gating), so it stays
+// adapter-local.
+type AdapterDeps struct {
+	Tracer      oteltrace.Tracer
+	Metrics     *observability.Metrics
+	RetryPolicy RetryPolicy
+	Logger      *slog.Logger
+}
 
 // ruleDescriptions returns the Description field of each rule in the
 // supplied slice, preserving order. Returned as a non-nil empty slice

--- a/harness/internal/provider/provider_util.go
+++ b/harness/internal/provider/provider_util.go
@@ -1,0 +1,21 @@
+package provider
+
+import "github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
+
+// ruleDescriptions returns the Description field of each rule in the
+// supplied slice, preserving order. Returned as a non-nil empty slice
+// when the input is empty so the slog.Any attribute renders as `[]`
+// rather than `null` — easier to grep and parse downstream.
+//
+// Shared by every adapter's quirks-application log line (openai.go,
+// openai_responses.go, gemini.go, anthropic.go) — it lived only in
+// openai.go historically, which meant three other adapters depended on
+// an openai-local helper. Consolidated here so it has exactly one
+// definition with no adapter-specific home.
+func ruleDescriptions(rules []quirks.Rule) []string {
+	out := make([]string, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, r.Description)
+	}
+	return out
+}


### PR DESCRIPTION
Consolidates the four provider adapters' duplicated dependency fields into a
shared struct, and relocates `ruleDescriptions` to a shared file. Pure
structural refactor — no behavioural change. Part of the `tool-use debacle`
re-triage; addresses two watch-list items from #351 whose triggers fired as a
side effect of the Sonnet-5 quirks work (PR #449) giving Anthropic a fourth
copy of the same field set.

Refs #351.

## What changed

- `provider: relocate ruleDescriptions to shared file` — `ruleDescriptions`
  moved from `openai.go` into a new `provider_util.go`; it now has exactly one
  definition, referenced from all four adapters (openai, openai_responses,
  gemini, anthropic).
- `provider: consolidate adapter Tracer/Metrics/RetryPolicy/Logger into
  AdapterDeps` — the identical `Tracer`/`Metrics`/`RetryPolicy`/`Logger` field
  set is extracted into an exported `AdapterDeps` struct, embedded anonymously
  in all four adapter structs. Field promotion keeps existing `adapter.Tracer`
  (etc.) access unchanged, so zero test call sites needed edits.

`Registry *quirks.Registry` was deliberately left adapter-local (each adapter
resolves it differently — e.g. Gemini's ReplayFields gating), per the scope
brief.

## Two deliberate deviations (both review-verified)

- `core/factory.go` was NOT changed. Collapsing its two-stage per-field
  assignment into a single `AdapterDeps{...}` literal would zero the
  `RetryPolicy` set earlier in `buildAdapter`; anonymous embedding means the
  existing promoted-field assignments compile and behave identically. Both
  reviewers independently confirmed this is the correct call.
- No `Logger` was added to `GeminiAdapter` — it already had one with a nil
  fallback, so the "add for consistency" sub-goal was moot, not skipped.

## Notes

- A remaining `ruleDescriptions`/Bedrock-adjacent scope-asymmetry nit is
  recorded on #351 as a watch-list item; no code change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AgBdi7aXRrPNThqDj2ohV