### PR TITLE
tool: surface run_command timeouts as partial-output soft outcomes

### DIFF
--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -37,6 +37,7 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 			"Use this for build, test, format, lint, and other tooling invocations that have to actually run. " +
 			"Do not use for filesystem inspection that a dedicated tool covers — prefer read_file, list_directory, grep_files, find_files because they return structured, bounded output and do not need a shell. " +
 			"timeout is in seconds (default 30, max 300); the command is killed when the timeout elapses. " +
+			"On timeout this returns the partial stdout/stderr captured before the deadline plus a '[timed out after Ns]' marker, not a hard error, so act on the partial output or rerun with a longer timeout. " +
 			"Example: {\"command\": \"go test ./harness/internal/tool/...\", \"timeout\": 120}",
 		// #222 structured example, pinned to the description by TestBuiltinInputExamples_MatchDescription.
 		InputExamples:     []json.RawMessage{json.RawMessage(`{"command": "go test ./harness/internal/tool/...", "timeout": 120}`)},
@@ -83,46 +84,33 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 				if result == nil {
 					result = &executor.ExecResult{}
 				}
-				return timedOutRunCommandResult(result, timeoutSeconds)
+				return buildCommandResult(result, timeoutSeconds, true)
 			}
 
-			structured, marshalErr := json.Marshal(commandResult{
-				Stdout:         result.Stdout,
-				Stderr:         result.Stderr,
-				ExitCode:       result.ExitCode,
-				TimedOut:       false,
-				TimeoutSeconds: timeoutSeconds,
-			})
-			if marshalErr != nil {
-				return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
-			}
-
-			return tool.StructuredResult{
-				Text:       formatRunCommand(result.Stdout, result.Stderr, result.ExitCode),
-				Structured: structured,
-				Kind:       kindCommandResult,
-			}, nil
+			return buildCommandResult(result, timeoutSeconds, false)
 		},
 	}
 }
 
-// timedOutRunCommandResult builds the soft-outcome StructuredResult for a
-// run_command invocation killed by its timeout. result carries whatever
-// partial output the executor captured before the kill; result.ExitCode is
-// executor-dependent in this case (local.go leaves it 0, container.go and
-// k8s_execcore.go set -1) and never a meaningful status, since the process
-// never ran to completion — callers must gate on TimedOut and never read
-// ExitCode as a real exit status when it is true. The Text fallback appends
-// an unambiguous "[timed out after Ns]" marker after the normal
-// formatRunCommand rendering so a model reading only Text (not Structured)
-// can still distinguish a timeout from a clean exit; formatRunCommand itself
-// stays byte-identical to its pre-#231/#489 contract.
-func timedOutRunCommandResult(result *executor.ExecResult, timeoutSeconds int) (tool.StructuredResult, error) {
+// buildCommandResult builds the StructuredResult for a run_command
+// invocation, covering both the clean-exit and timed-out-soft-outcome cases
+// (timedOut). On timeout, result carries whatever partial output the
+// executor captured before the kill; result.ExitCode is executor-dependent
+// in that case (local.go leaves it 0, container.go and k8s_execcore.go set
+// -1) and never a meaningful status, since the process never ran to
+// completion — callers must gate on TimedOut and never read ExitCode as a
+// real exit status when it is true. The Text fallback appends an
+// unambiguous "[timed out after Ns]" marker after the normal
+// formatRunCommand rendering when timedOut, so a model reading only Text
+// (not Structured) can still distinguish a timeout from a clean exit;
+// formatRunCommand itself stays byte-identical to its pre-#231/#489
+// contract.
+func buildCommandResult(result *executor.ExecResult, timeoutSeconds int, timedOut bool) (tool.StructuredResult, error) {
 	structured, marshalErr := json.Marshal(commandResult{
 		Stdout:         result.Stdout,
 		Stderr:         result.Stderr,
 		ExitCode:       result.ExitCode,
-		TimedOut:       true,
+		TimedOut:       timedOut,
 		TimeoutSeconds: timeoutSeconds,
 	})
 	if marshalErr != nil {
@@ -130,7 +118,9 @@ func timedOutRunCommandResult(result *executor.ExecResult, timeoutSeconds int) (
 	}
 
 	text := formatRunCommand(result.Stdout, result.Stderr, result.ExitCode)
-	text += fmt.Sprintf("\n[timed out after %ds]", timeoutSeconds)
+	if timedOut {
+		text += fmt.Sprintf("\n[timed out after %ds]", timeoutSeconds)
+	}
 
 	return tool.StructuredResult{
 		Text:       text,

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -3,6 +3,7 @@ package builtins
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -68,15 +69,27 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 
 			result, err := exec.Exec(ctx, params.Command, timeout)
 			if err != nil {
-				return tool.StructuredResult{}, err
+				if !errors.Is(err, executor.ErrTimeout) {
+					return tool.StructuredResult{}, err
+				}
+				// #489's executors return partial output alongside the
+				// wrapped ErrTimeout, so a genuine timeout is a soft
+				// outcome the model can act on (e.g. rerun with a longer
+				// timeout or narrow the command) rather than a hard tool
+				// error. result can in principle still be nil if the
+				// executor was cut off before producing one at all
+				// (e.g. a control-plane deadline before exec even
+				// started); handle that defensively instead of panicking.
+				if result == nil {
+					result = &executor.ExecResult{}
+				}
+				return timedOutRunCommandResult(result, timeoutSeconds)
 			}
 
 			structured, marshalErr := json.Marshal(commandResult{
-				Stdout:   result.Stdout,
-				Stderr:   result.Stderr,
-				ExitCode: result.ExitCode,
-				// A timeout surfaces as the err above, so a result reaching
-				// here always completed within the bound.
+				Stdout:         result.Stdout,
+				Stderr:         result.Stderr,
+				ExitCode:       result.ExitCode,
 				TimedOut:       false,
 				TimeoutSeconds: timeoutSeconds,
 			})
@@ -91,6 +104,37 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 			}, nil
 		},
 	}
+}
+
+// timedOutRunCommandResult builds the soft-outcome StructuredResult for a
+// run_command invocation killed by its timeout. result carries whatever
+// partial output the executor captured before the kill (result.ExitCode is
+// the executor's zero value, not a sentinel, since the process never ran to
+// completion — callers must not read it as a real exit status). The Text
+// fallback appends an unambiguous "[timed out after Ns]" marker after the
+// normal formatRunCommand rendering so a model reading only Text (not
+// Structured) can still distinguish a timeout from a clean exit; formatRunCommand
+// itself stays byte-identical to its pre-#231/#489 contract.
+func timedOutRunCommandResult(result *executor.ExecResult, timeoutSeconds int) (tool.StructuredResult, error) {
+	structured, marshalErr := json.Marshal(commandResult{
+		Stdout:         result.Stdout,
+		Stderr:         result.Stderr,
+		ExitCode:       result.ExitCode,
+		TimedOut:       true,
+		TimeoutSeconds: timeoutSeconds,
+	})
+	if marshalErr != nil {
+		return tool.StructuredResult{}, fmt.Errorf("marshal structured result: %w", marshalErr)
+	}
+
+	text := formatRunCommand(result.Stdout, result.Stderr, result.ExitCode)
+	text += fmt.Sprintf("\n[timed out after %ds]", timeoutSeconds)
+
+	return tool.StructuredResult{
+		Text:       text,
+		Structured: structured,
+		Kind:       kindCommandResult,
+	}, nil
 }
 
 // formatRunCommand renders the canonical text output for run_command:

--- a/harness/internal/tool/builtins/shell.go
+++ b/harness/internal/tool/builtins/shell.go
@@ -108,13 +108,15 @@ func RunCommandTool(exec executor.Executor) *tool.Tool {
 
 // timedOutRunCommandResult builds the soft-outcome StructuredResult for a
 // run_command invocation killed by its timeout. result carries whatever
-// partial output the executor captured before the kill (result.ExitCode is
-// the executor's zero value, not a sentinel, since the process never ran to
-// completion — callers must not read it as a real exit status). The Text
-// fallback appends an unambiguous "[timed out after Ns]" marker after the
-// normal formatRunCommand rendering so a model reading only Text (not
-// Structured) can still distinguish a timeout from a clean exit; formatRunCommand
-// itself stays byte-identical to its pre-#231/#489 contract.
+// partial output the executor captured before the kill; result.ExitCode is
+// executor-dependent in this case (local.go leaves it 0, container.go and
+// k8s_execcore.go set -1) and never a meaningful status, since the process
+// never ran to completion — callers must gate on TimedOut and never read
+// ExitCode as a real exit status when it is true. The Text fallback appends
+// an unambiguous "[timed out after Ns]" marker after the normal
+// formatRunCommand rendering so a model reading only Text (not Structured)
+// can still distinguish a timeout from a clean exit; formatRunCommand itself
+// stays byte-identical to its pre-#231/#489 contract.
 func timedOutRunCommandResult(result *executor.ExecResult, timeoutSeconds int) (tool.StructuredResult, error) {
 	structured, marshalErr := json.Marshal(commandResult{
 		Stdout:         result.Stdout,

--- a/harness/internal/tool/builtins/shell_test.go
+++ b/harness/internal/tool/builtins/shell_test.go
@@ -3,6 +3,9 @@ package builtins
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,5 +50,94 @@ func TestRunCommandTool_TimeoutClampedTo300s(t *testing.T) {
 
 	if want := 300 * time.Second; gotTimeout != want {
 		t.Errorf("Exec timeout = %v, want %v (tool-layer clamp must stay independent of the raised executor cap)", gotTimeout, want)
+	}
+}
+
+// TestRunCommandTool_TimeoutReturnsPartialOutputAsSoftOutcome pins #489's
+// contract at the tool layer: an executor.Exec error that wraps
+// executor.ErrTimeout must not surface as a hard tool error, since every
+// executor implementation still returns whatever partial stdout/stderr it
+// captured before the kill. The handler must classify the error via
+// errors.Is (mirroring harness/internal/hook/runner.go's isTimeoutErr),
+// report TimedOut in the structured payload, preserve the partial output,
+// and make the timeout unambiguous in the Text fallback so a model reading
+// only Text (not Structured) can still tell a timeout apart from a clean
+// exit.
+func TestRunCommandTool_TimeoutReturnsPartialOutputAsSoftOutcome(t *testing.T) {
+	const timeout = 5 * time.Second
+	execErr := fmt.Errorf("%w after %s: %w", executor.ErrTimeout, timeout, context.DeadlineExceeded)
+
+	exec := &mockExecutor{
+		execFunc: func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+			return &executor.ExecResult{
+				Stdout: "partial stdout before kill\n",
+				Stderr: "partial stderr before kill\n",
+			}, execErr
+		},
+	}
+
+	tl := RunCommandTool(exec)
+	input := json.RawMessage(`{"command":"sleep 999","timeout":5}`)
+	got, err := tl.StructuredHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected hard error for a timeout: %v", err)
+	}
+
+	if got.Kind != kindCommandResult {
+		t.Errorf("Kind = %q, want %q", got.Kind, kindCommandResult)
+	}
+
+	var structured commandResult
+	if err := json.Unmarshal(got.Structured, &structured); err != nil {
+		t.Fatalf("unmarshal structured result: %v", err)
+	}
+	if !structured.TimedOut {
+		t.Errorf("structured.TimedOut = false, want true")
+	}
+	if structured.TimeoutSeconds != 5 {
+		t.Errorf("structured.TimeoutSeconds = %d, want 5", structured.TimeoutSeconds)
+	}
+	if structured.Stdout != "partial stdout before kill\n" {
+		t.Errorf("structured.Stdout = %q, want partial stdout preserved", structured.Stdout)
+	}
+	if structured.Stderr != "partial stderr before kill\n" {
+		t.Errorf("structured.Stderr = %q, want partial stderr preserved", structured.Stderr)
+	}
+
+	if !strings.Contains(got.Text, "partial stdout before kill") {
+		t.Errorf("Text = %q, want partial stdout preserved", got.Text)
+	}
+	if !strings.Contains(got.Text, "[timed out after 5s]") {
+		t.Errorf("Text = %q, want an explicit timed-out marker", got.Text)
+	}
+}
+
+// TestRunCommandTool_NonTimeoutErrorStillPropagates is the counterpart to
+// TestRunCommandTool_TimeoutReturnsPartialOutputAsSoftOutcome: an Exec error
+// that does NOT wrap executor.ErrTimeout (e.g. a plain context cancellation,
+// or any other exec failure) must still propagate as a hard tool error
+// exactly as before. This guards against a classification that is too
+// broad — errors.Is must exclude cancellation so a SIGTERM-driven shutdown
+// isn't mistaken for a timed-out command's soft outcome.
+func TestRunCommandTool_NonTimeoutErrorStillPropagates(t *testing.T) {
+	cancelErr := fmt.Errorf("command cancelled: %w", context.Canceled)
+
+	exec := &mockExecutor{
+		execFunc: func(_ context.Context, _ string, _ time.Duration) (*executor.ExecResult, error) {
+			return &executor.ExecResult{Stdout: "some output"}, cancelErr
+		},
+	}
+
+	tl := RunCommandTool(exec)
+	input := json.RawMessage(`{"command":"true","timeout":5}`)
+	got, err := tl.StructuredHandler(context.Background(), input)
+	if err == nil {
+		t.Fatalf("expected an error for a non-timeout Exec failure, got nil (result: %+v)", got)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want errors.Is(err, context.Canceled)", err)
+	}
+	if errors.Is(err, executor.ErrTimeout) {
+		t.Errorf("err = %v, must not satisfy errors.Is(err, executor.ErrTimeout)", err)
 	}
 }

--- a/harness/internal/tool/builtins/shell_test.go
+++ b/harness/internal/tool/builtins/shell_test.go
@@ -91,17 +91,15 @@ func TestRunCommandTool_TimeoutReturnsPartialOutputAsSoftOutcome(t *testing.T) {
 	if err := json.Unmarshal(got.Structured, &structured); err != nil {
 		t.Fatalf("unmarshal structured result: %v", err)
 	}
-	if !structured.TimedOut {
-		t.Errorf("structured.TimedOut = false, want true")
+	want := commandResult{
+		Stdout:         "partial stdout before kill\n",
+		Stderr:         "partial stderr before kill\n",
+		ExitCode:       0,
+		TimedOut:       true,
+		TimeoutSeconds: 5,
 	}
-	if structured.TimeoutSeconds != 5 {
-		t.Errorf("structured.TimeoutSeconds = %d, want 5", structured.TimeoutSeconds)
-	}
-	if structured.Stdout != "partial stdout before kill\n" {
-		t.Errorf("structured.Stdout = %q, want partial stdout preserved", structured.Stdout)
-	}
-	if structured.Stderr != "partial stderr before kill\n" {
-		t.Errorf("structured.Stderr = %q, want partial stderr preserved", structured.Stderr)
+	if structured != want {
+		t.Errorf("structured mismatch\n got: %+v\nwant: %+v", structured, want)
 	}
 
 	if !strings.Contains(got.Text, "partial stdout before kill") {

--- a/harness/internal/tool/builtins/structured.go
+++ b/harness/internal/tool/builtins/structured.go
@@ -29,9 +29,11 @@ const (
 // while still returning whatever partial stdout/stderr it captured (#489), so
 // RunCommandTool classifies that case via errors.Is and reports it as a soft
 // outcome — timedOut true, no handler error — rather than discarding the
-// output. exitCode is the executor's zero value (not a real exit status) when
-// timedOut is true, since the process never ran to completion. timeoutSeconds
-// records the bound that was in effect either way.
+// output. exitCode is executor-dependent when timedOut is true (local.go
+// leaves it 0; container.go and k8s_execcore.go set -1), so it carries no
+// meaningful status in that case — callers must gate on timedOut and never
+// read exitCode as a real exit code when it is true. timeoutSeconds records
+// the bound that was in effect either way.
 type commandResult struct {
 	Stdout         string `json:"stdout"`
 	Stderr         string `json:"stderr"`

--- a/harness/internal/tool/builtins/structured.go
+++ b/harness/internal/tool/builtins/structured.go
@@ -24,12 +24,14 @@ const (
 )
 
 // commandResult is the structured payload for run_command. timedOut reports
-// whether the command was killed by its timeout; in the current executor
-// contract a timeout surfaces as a handler error before the structured payload
-// is built, so on the success path timedOut is always false and timeoutSeconds
-// records the bound that was in effect. The field is retained so a future
-// executor that returns partial output on timeout can populate it without a
-// schema change.
+// whether the command was killed by its timeout: every executor wraps
+// executor.ErrTimeout into the error it returns on a genuine deadline expiry
+// while still returning whatever partial stdout/stderr it captured (#489), so
+// RunCommandTool classifies that case via errors.Is and reports it as a soft
+// outcome — timedOut true, no handler error — rather than discarding the
+// output. exitCode is the executor's zero value (not a real exit status) when
+// timedOut is true, since the process never ran to completion. timeoutSeconds
+// records the bound that was in effect either way.
 type commandResult struct {
 	Stdout         string `json:"stdout"`
 	Stderr         string `json:"stderr"`


### PR DESCRIPTION
Wires PR #489's executor timeout/partial-output support through the
`run_command` builtin. Before this, the tool discarded the executor result and
returned a bare error on any `Exec` error — silently throwing away exactly the
partial output an operator needs most when a command hangs. PR #489 gave every
`Executor.Exec` a classifiable `executor.ErrTimeout` plus partial output on a
genuine timeout; `run_command` now consumes it, mirroring the established
pattern at `harness/internal/hook/runner.go:131`.

Refs #342 (the `TimedOut` half — the `Column` half stays open pending a
maintainer byte-vs-rune decision). Refs #351.

## Behaviour

On timeout (`errors.Is(err, executor.ErrTimeout)`) with a non-nil result, the
tool returns a soft-outcome `StructuredResult`: `timed_out: true`, the partial
stdout/stderr captured before the deadline, and a `[timed out after Ns]` marker
in the text fallback, so the model sees actionable output rather than a hard
error. The tool Description now documents this. A nil result on timeout falls
back defensively. Cancelled (not timed-out) commands and all other errors keep
their existing hard-error behaviour — `errors.Is` correctly excludes
`context.Canceled`.

Note: `ExitCode` on timeout is executor-dependent (local leaves 0; container
and k8s set -1) and is not a meaningful status when `timed_out` is true —
callers must gate on `timed_out`, never read `ExitCode`. The doc comments say
so. (The triage report's claim of a uniform -1 was verified wrong during
implementation.)

## Deliberate scope decisions

- Non-timeout errors still discard partial output (asymmetry vs the hook
  runner, which preserves output on cancellation too). Left as-is — cancelled
  runs rarely benefit; extension can be a follow-up if wanted.
- `run_command` output is not secret-scrubbed on either the pre-existing
  success path or the new timeout path. This is a pre-existing gap, NOT a
  regression, and it intersects open PR #495 (run-scoped command-output capture
  with scrubbing) and #496 (scrub-on-write); fixing it here would collide with
  that work.
- PR #495 touches this same `run_command` surface. Whichever merges second
  rebases, and the timeout soft-outcome must integrate with #495's capture
  pipeline at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AgBdi7aXRrPNThqDj2ohV