### PR TITLE
proto, types: sandbox identity token event pair (#516 PR A)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,6 +20,10 @@ sequenceDiagram
     H->>CP: HarnessEvent{type:"ready", harness_version}
     H->>H: Write /tmp/healthy (liveness probe)
     CP->>H: ControlEvent{type:"task_assignment", task: RunConfig}
+    opt Sandbox identity token requested
+        H->>CP: sandbox_token_request
+        CP-->>H: sandbox_token_response
+    end
     H->>H: Build AgenticLoop with the supplied RunConfig
     loop For each turn
         H->>CP: heartbeat (every 30s)
@@ -121,15 +125,23 @@ IMDS, GitHub Actions OIDC). See
    with a 5-minute timeout. A `cancel` event received before
    assignment is honoured: the harness exits cleanly without
    running anything.
-5. **Build and run.** Once the `RunConfig` arrives, the wall-clock
+5. **Sandbox identity token** *(optional)*. When the run wants a
+   sandbox identity token (e.g. to authenticate a git proxy such as
+   Haybale), the harness sends a
+   `HarnessEvent{type:"sandbox_token_request"}` and blocks, fail-closed,
+   for up to 60 seconds on the matching `sandbox_token_response` —
+   before any sandbox is created. See [Sandbox identity token
+   issuance](#sandbox-identity-token-issuance-control-plane-implementers)
+   below for the full contract.
+6. **Build and run.** Once the `RunConfig` arrives, the wall-clock
    timeout is applied to the context, the agentic loop is built via
    `core.BuildLoopWithTransport` reusing the existing gRPC transport,
    and execution begins.
-6. **Stream events.** Throughout the run the harness emits
+7. **Stream events.** Throughout the run the harness emits
    `text_delta`, `tool_call`, `tool_result`, `heartbeat` (every 30
    s), and — depending on the permission policy — `permission_request`
    events. Async tools may emit `tool_result_request`.
-7. **Done.** A final `HarnessEvent{type:"done", stop_reason, trace}`
+8. **Done.** A final `HarnessEvent{type:"done", stop_reason, trace}`
    carries the run metrics and the reason the loop ended
    (`end_turn`, `max_turns`, `timeout`, `stalled`, `tool_failures`,
    `cancelled`, `budget_exceeded`, `error`, `setup_failed`,
@@ -145,15 +157,75 @@ IMDS, GitHub Actions OIDC). See
    `verification_failed`, `verification_error`, and `max_tokens` on
    top of the loop's stop reasons. `trace.stop_reason` mirrors it for
    backward compatibility.
-8. **Follow-up grace** *(optional)*. If `STIRRUP_FOLLOWUP_GRACE > 0`,
+9. **Follow-up grace** *(optional)*. If `STIRRUP_FOLLOWUP_GRACE > 0`,
    the stream stays open for that many seconds so the control plane
    can deliver `user_response` events that resume the loop.
-9. **Exit.** The liveness probe file is removed; the process exits 0
-   on success or non-zero on transport / build / runtime failure.
+10. **Exit.** The liveness probe file is removed; the process exits 0
+    on success or non-zero on transport / build / runtime failure.
 
 The full event vocabulary lives in
 [`proto/harness/v1/harness.proto`](../proto/harness/v1/harness.proto) —
 that is the source of truth for the wire contract.
+
+### Sandbox identity token issuance (control-plane implementers)
+
+Some sandbox executors need a short-lived credential to authenticate
+outbound git operations through a proxy such as
+[Haybale](https://github.com/rxbynerd/haybale). The harness never
+holds a signing key or a long-lived credential itself; it requests a
+token from the control plane once per run, over the same `RunTask`
+stream used for everything else.
+
+- **`sandbox_token_request`** (`HarnessEvent`) — sent once per run,
+  after `task_assignment` and before the sandbox is created. Carries
+  `request_id` (correlation) and `audience`, the intended JWT `aud`
+  claim (e.g. `https://haybale.internal`). The event deliberately
+  carries no harness-asserted identity field: the control plane
+  derives the run identity from the authenticated stream the task was
+  assigned on, not from anything in the request body.
+- **`sandbox_token_response`** (`ControlEvent`) — echoes `request_id`
+  and carries `token`, the signed JWT. `token` is sensitive: the
+  harness never logs, traces, or persists it, and it never enters
+  `RunConfig`. A control plane that cannot issue a token responds
+  with `is_error: true` and a human-readable `reason` rather than
+  staying silent — the harness treats a missing or late response the
+  same way it treats an explicit error.
+
+A control plane implementing this contract must:
+
+1. Mint a JWT per the consuming proxy's identity contract — for
+   Haybale, its [`docs/jwt-identity.md`](https://github.com/rxbynerd/haybale/blob/main/docs/jwt-identity.md).
+   The mechanism is generic ("sandbox identity token"), not
+   Haybale-specific: other consumers (artifact registries, package
+   proxies) can reuse the same exchange with their own token
+   contract.
+2. Sign with its own key and publish the corresponding JWKS at the
+   URL the consuming proxy is configured to fetch from. Stirrup never
+   holds a signing key.
+3. Scope the `sub` claim to `run-<RunID>` (the `RunConfig.run_id` of
+   the run being serviced), so the proxy's audit log correlates with
+   stirrup's own tracing.
+
+**Fail-closed wait.** The harness blocks on the matching
+`sandbox_token_response` for up to 60 seconds — the same default as
+the `ask-upstream` permission-response timeout. A response that
+arrives late, or not at all, aborts the run before the sandbox is
+created; the run ends with `done{stop_reason:"error"}` rather than
+leaving a partially-provisioned, tokenless sandbox behind.
+
+**Token lifetime.** Haybale recommends an `exp` of 15 minutes or
+less, but the token is baked into the sandbox environment once, at
+creation time, and in-sandbox refresh is out of scope for now (it
+requires a bootstrap-auth channel that does not exist yet). The v1
+posture is that the control plane issues `exp` covering the run's
+configured wall-clock budget (plus slack), and narrows blast radius
+through per-token scope claims and proxy-side policy instead of a
+short lifetime. The optional `sandbox_token_response.expires_at`
+field (Unix seconds) lets the harness compare the token's actual
+expiry against the run's budget and emit a scrub-safe warning when
+the token is shorter-lived than the run — a signal that the run may
+fail partway through with authentication errors rather than a
+stirrup-side bug.
 
 ## Container image
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,9 +74,10 @@ results, permission responses — would transit in cleartext, and
 any endpoint that can reach the harness's dial target could pose
 as the control plane. Secrets are less exposed than they appear
 (API keys travel as `secret://` references, never raw values, and
-the transport scrubs secret-shaped strings from outbound events),
-but the stream contents and the control channel itself are
-unprotected.
+the transport scrubs secret-shaped strings from outbound events) —
+except the sandbox identity token (`ControlEvent.token`), which is
+the raw signed JWT itself and receives no such protection — but the
+stream contents and the control channel itself are unprotected.
 
 Transport TLS configuration is planned post-v0.1. The internal
 transport constructor already accepts TLS credentials
@@ -191,6 +192,20 @@ stream used for everything else.
   staying silent — the harness treats a missing or late response the
   same way it treats an explicit error.
 
+**Transport trust boundary.** Unlike API keys, `token` is not a
+`secret://` reference — it is the raw signed JWT, and it rides the
+same plaintext-by-default `RunTask` stream as every other event (see
+[Transport security posture](#transport-security-posture-v01)).
+Requesting a sandbox identity token therefore requires, at minimum,
+the same-host / private-network / mesh-mTLS posture described there:
+the token is long-lived (see Token lifetime, below) and unencrypted
+by default, so it is a materially higher-value credential than the
+rest of the stream. Do not opt a run into the sandbox identity token
+flow across an untrusted network until transport TLS — the internal
+transport already accepts `transport.WithTLSCredentials`, but there
+is no `RunConfig` / CLI surface to reach it yet — is wired to a
+config surface.
+
 A control plane implementing this contract must:
 
 1. Mint a JWT per the consuming proxy's identity contract — for
@@ -205,6 +220,16 @@ A control plane implementing this contract must:
 3. Scope the `sub` claim to `run-<RunID>` (the `RunConfig.run_id` of
    the run being serviced), so the proxy's audit log correlates with
    stirrup's own tracing.
+4. Validate `audience` against its own configured audience list
+   before minting — the harness sends `audience` as a hint, not an
+   authorization; a control plane that mints against an unvalidated
+   value has no assurance the resulting token is scoped to a
+   consumer it actually intends to trust.
+5. Provision the per-run scope — e.g. a `policy.yaml`-style rule
+   confining `run-<RunID>` to exactly the repos and verbs the run
+   needs — before or as part of issuing the token. This is a
+   provisioning prerequisite the control plane or operator handles;
+   it is not part of the wire exchange itself.
 
 **Fail-closed wait.** The harness blocks on the matching
 `sandbox_token_response` for up to 60 seconds — the same default as
@@ -221,11 +246,13 @@ posture is that the control plane issues `exp` covering the run's
 configured wall-clock budget (plus slack), and narrows blast radius
 through per-token scope claims and proxy-side policy instead of a
 short lifetime. The optional `sandbox_token_response.expires_at`
-field (Unix seconds) lets the harness compare the token's actual
-expiry against the run's budget and emit a scrub-safe warning when
-the token is shorter-lived than the run — a signal that the run may
-fail partway through with authentication errors rather than a
-stirrup-side bug.
+field (Unix seconds) is designed to let the harness compare the
+token's actual expiry against the run's budget and emit a
+scrub-safe warning when the token is shorter-lived than the run — a
+signal that the run may fail partway through with authentication
+errors rather than a stirrup-side bug. That comparison is not yet
+wired: this PR is wire/types-only, and the check lands with the
+token-exchange helper (issue #516 Part C).
 
 ## Container image
 

--- a/gen/harness/v1/harness.pb.go
+++ b/gen/harness/v1/harness.pb.go
@@ -95,6 +95,20 @@ const (
 //	  (Best-effort signal; the control plane should call the provider's
 //	  batch-cancel endpoint. The harness does not retry or block on a
 //	  response — cancellation is fire-and-forget.)
+//
+//	"sandbox_token_request"
+//	  - request_id: unique ID for this request; the control plane must echo it
+//	                back in the corresponding sandbox_token_response ControlEvent.
+//	  - audience:   the intended JWT `aud` claim for the sandbox identity
+//	                token (e.g. "https://haybale.internal"). Informational —
+//	                the control plane may override it.
+//	  Sent once per run, after task_assignment and before the sandbox is
+//	  created, when the run wants a sandbox identity token. Deliberately
+//	  carries no harness-asserted identity field: the control plane derives
+//	  the run identity from the authenticated stream the task was assigned
+//	  on, never from the request body. The harness blocks on the matching
+//	  sandbox_token_response under a fail-closed 60s timeout; a timeout
+//	  aborts the run before any sandbox is created.
 type HarnessEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. The event type discriminator.
@@ -102,7 +116,7 @@ type HarnessEvent struct {
 	//
 	//	"warning", "heartbeat", "ready", "permission_request",
 	//	"tool_result_request", "batch_submission", "batch_waiting",
-	//	"batch_cancel_request".
+	//	"batch_cancel_request", "sandbox_token_request".
 	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	// Incremental text fragment from the model. Set on "text_delta" events.
 	Text string `protobuf:"bytes,2,opt,name=text,proto3" json:"text,omitempty"`
@@ -137,8 +151,12 @@ type HarnessEvent struct {
 	// Build version of the harness binary. Set on "ready" events. The control
 	// plane may use this to verify compatibility before sending a task.
 	HarnessVersion string `protobuf:"bytes,13,opt,name=harness_version,json=harnessVersion,proto3" json:"harness_version,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// The intended JWT `aud` claim for the sandbox identity token. Set on
+	// "sandbox_token_request" events. Informational to the control plane,
+	// which may override it when minting the token.
+	Audience      string `protobuf:"bytes,14,opt,name=audience,proto3" json:"audience,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *HarnessEvent) Reset() {
@@ -262,6 +280,13 @@ func (x *HarnessEvent) GetHarnessVersion() string {
 	return ""
 }
 
+func (x *HarnessEvent) GetAudience() string {
+	if x != nil {
+		return x.Audience
+	}
+	return ""
+}
+
 // ControlEvent is sent from the control plane to the harness.
 //
 // Each event has a type discriminator; only the fields relevant to that type
@@ -308,13 +333,28 @@ func (x *HarnessEvent) GetHarnessVersion() string {
 //	  - content:    JSON-encoded BatchResult payload (response or err).
 //	  - is_error:   true for non-success result types (batch_expired,
 //	                batch_cancelled, invalid_request_error, server_error).
+//
+//	"sandbox_token_response"
+//	  - request_id:  must match the request_id from the corresponding
+//	                 sandbox_token_request HarnessEvent.
+//	  - token:       the signed JWT sandbox identity token. SENSITIVE:
+//	                 never logged, traced, or persisted to RunConfig —
+//	                 treated as opaque secret material for the run's
+//	                 lifetime.
+//	  - expires_at:  optional Unix-seconds expiry of token, so the harness
+//	                 can warn (scrub-safe) when it is shorter than the
+//	                 run's configured wall-clock budget.
+//	  - is_error:    when true, the control plane could not issue a token;
+//	                 reason carries a human-readable explanation. The
+//	                 harness treats this the same as a timeout — the run
+//	                 aborts before the sandbox is created.
 type ControlEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. The event type discriminator.
 	// Valid values: "task_assignment", "user_response", "cancel",
 	//
 	//	"permission_response", "tool_result_response",
-	//	"batch_result".
+	//	"batch_result", "sandbox_token_response".
 	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	// The run configuration. Set on "task_assignment" events only. This is the
 	// composition root that drives all harness behaviour for the run.
@@ -328,16 +368,31 @@ type ControlEvent struct {
 	// The permission decision. Set on "permission_response" events.
 	// True = allow the tool call to proceed. False = deny.
 	Allowed *OptionalBool `protobuf:"bytes,5,opt,name=allowed,proto3" json:"allowed,omitempty"`
-	// Human-readable explanation for a denial. Set on "permission_response"
-	// events when allowed is false. Passed to the model as context.
+	// Human-readable explanation. Set on "permission_response" events when
+	// allowed is false (passed to the model as context), and on
+	// "sandbox_token_response" events when is_error is true (why the control
+	// plane could not issue a token).
 	Reason string `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`
 	// Async tool result payload. Set on "tool_result_response" events. Delivered
 	// to the agentic loop verbatim as the async tool's output content.
 	Content string `protobuf:"bytes,7,opt,name=content,proto3" json:"content,omitempty"`
 	// When true on a "tool_result_response", the loop marks the resulting
-	// ToolResult as an error so the model sees it as a tool failure. Wrapped
-	// to distinguish unset from explicit-false (proto3 scalar default).
-	IsError       *OptionalBool `protobuf:"bytes,8,opt,name=is_error,json=isError,proto3" json:"is_error,omitempty"`
+	// ToolResult as an error so the model sees it as a tool failure. When true
+	// on a "sandbox_token_response", the control plane could not issue a
+	// token; reason carries the explanation and token / expires_at are unset.
+	// Wrapped to distinguish unset from explicit-false (proto3 scalar
+	// default).
+	IsError *OptionalBool `protobuf:"bytes,8,opt,name=is_error,json=isError,proto3" json:"is_error,omitempty"`
+	// The signed JWT sandbox identity token. Set on "sandbox_token_response"
+	// events when is_error is false. SENSITIVE: never logged, traced, or
+	// persisted to RunConfig — the harness treats this as opaque secret
+	// material for the run's lifetime.
+	Token string `protobuf:"bytes,9,opt,name=token,proto3" json:"token,omitempty"`
+	// Optional. Unix-seconds expiry of token. Set on "sandbox_token_response"
+	// events. Declared `optional` so unset is wire-distinguishable from an
+	// explicit 0 (epoch), letting the harness tell "the control plane did not
+	// report an expiry" from "the token expires at the epoch".
+	ExpiresAt     *int64 `protobuf:"varint,10,opt,name=expires_at,json=expiresAt,proto3,oneof" json:"expires_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -426,6 +481,20 @@ func (x *ControlEvent) GetIsError() *OptionalBool {
 		return x.IsError
 	}
 	return nil
+}
+
+func (x *ControlEvent) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *ControlEvent) GetExpiresAt() int64 {
+	if x != nil && x.ExpiresAt != nil {
+		return *x.ExpiresAt
+	}
+	return 0
 }
 
 // OptionalBool wraps a boolean so we can distinguish "not set" from "false"
@@ -4028,7 +4097,7 @@ var File_harness_v1_harness_proto protoreflect.FileDescriptor
 
 const file_harness_v1_harness_proto_rawDesc = "" +
 	"\n" +
-	"\x18harness/v1/harness.proto\x12\x12stirrup.harness.v1\"\xfe\x02\n" +
+	"\x18harness/v1/harness.proto\x12\x12stirrup.harness.v1\"\x9a\x03\n" +
 	"\fHarnessEvent\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
 	"\x04text\x18\x02 \x01(\tR\x04text\x12\x0e\n" +
@@ -4045,7 +4114,8 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\n" +
 	"request_id\x18\v \x01(\tR\trequestId\x12\x1b\n" +
 	"\ttool_name\x18\f \x01(\tR\btoolName\x12'\n" +
-	"\x0fharness_version\x18\r \x01(\tR\x0eharnessVersion\"\xc4\x02\n" +
+	"\x0fharness_version\x18\r \x01(\tR\x0eharnessVersion\x12\x1a\n" +
+	"\baudience\x18\x0e \x01(\tR\baudience\"\x8d\x03\n" +
 	"\fControlEvent\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x121\n" +
 	"\x04task\x18\x02 \x01(\v2\x1d.stirrup.harness.v1.RunConfigR\x04task\x12#\n" +
@@ -4055,7 +4125,12 @@ const file_harness_v1_harness_proto_rawDesc = "" +
 	"\aallowed\x18\x05 \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aallowed\x12\x16\n" +
 	"\x06reason\x18\x06 \x01(\tR\x06reason\x12\x18\n" +
 	"\acontent\x18\a \x01(\tR\acontent\x12;\n" +
-	"\bis_error\x18\b \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aisError\"$\n" +
+	"\bis_error\x18\b \x01(\v2 .stirrup.harness.v1.OptionalBoolR\aisError\x12\x14\n" +
+	"\x05token\x18\t \x01(\tR\x05token\x12\"\n" +
+	"\n" +
+	"expires_at\x18\n" +
+	" \x01(\x03H\x00R\texpiresAt\x88\x01\x01B\r\n" +
+	"\v_expires_at\"$\n" +
 	"\fOptionalBool\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\bR\x05value\"\x9e\x11\n" +
 	"\tRunConfig\x12\x15\n" +
@@ -4458,6 +4533,7 @@ func file_harness_v1_harness_proto_init() {
 	if File_harness_v1_harness_proto != nil {
 		return
 	}
+	file_harness_v1_harness_proto_msgTypes[1].OneofWrappers = []any{}
 	file_harness_v1_harness_proto_msgTypes[3].OneofWrappers = []any{}
 	file_harness_v1_harness_proto_msgTypes[8].OneofWrappers = []any{}
 	file_harness_v1_harness_proto_msgTypes[11].OneofWrappers = []any{}

--- a/harness/internal/transport/grpc_translate.go
+++ b/harness/internal/transport/grpc_translate.go
@@ -21,6 +21,7 @@ func harnessEventToProto(e types.HarnessEvent) *pb.HarnessEvent {
 		RequestId:      e.RequestID,
 		ToolName:       e.ToolName,
 		HarnessVersion: e.HarnessVersion,
+		Audience:       e.Audience,
 	}
 
 	if e.Trace != nil {
@@ -39,6 +40,7 @@ func controlEventFromProto(pe *pb.ControlEvent) types.ControlEvent {
 		RequestID:    pe.RequestId,
 		Reason:       pe.Reason,
 		Content:      pe.Content,
+		Token:        pe.Token,
 	}
 
 	if pe.Allowed != nil {
@@ -49,6 +51,11 @@ func controlEventFromProto(pe *pb.ControlEvent) types.ControlEvent {
 	if pe.IsError != nil {
 		v := pe.IsError.Value
 		e.IsError = &v
+	}
+
+	if pe.ExpiresAt != nil {
+		v := *pe.ExpiresAt
+		e.ExpiresAt = &v
 	}
 
 	if pe.Task != nil {

--- a/harness/internal/transport/grpc_translate_test.go
+++ b/harness/internal/transport/grpc_translate_test.go
@@ -1253,6 +1253,113 @@ func TestRunConfigFromProto_MCPTrustFieldsPreserved(t *testing.T) {
 	}
 }
 
+// TestHarnessEventToProto_AudiencePreserved guards the Audience field
+// added for sandbox_token_request (issue #516 Part A) against the same
+// silent-drop class of regression flagged by gh-95/gh-117/gh-118/gh-100: a
+// HarnessEvent's Audience must survive the internal-to-proto hop
+// unmodified, since it is the only signal the control plane gets for the
+// intended JWT `aud` claim.
+func TestHarnessEventToProto_AudiencePreserved(t *testing.T) {
+	e := types.HarnessEvent{
+		Type:      "sandbox_token_request",
+		RequestID: "req-1",
+		Audience:  "https://haybale.internal",
+	}
+
+	pe := harnessEventToProto(e)
+
+	if pe.Audience != "https://haybale.internal" {
+		t.Errorf("Audience: got %q, want %q", pe.Audience, "https://haybale.internal")
+	}
+	if pe.RequestId != "req-1" {
+		t.Errorf("RequestId: got %q, want %q", pe.RequestId, "req-1")
+	}
+}
+
+// TestControlEventFromProto_SandboxTokenFieldsPreserved guards Token and
+// ExpiresAt (issue #516 Part A) against the same silent-drop regression
+// class as gh-95/gh-117/gh-118/gh-100. The token/expires_at case exercises
+// the actual wire path (Marshal -> Unmarshal) so the optional int64
+// unset-vs-explicit-zero distinction on ExpiresAt — the same concern
+// Temperature and Batch.MaxWaitSeconds guard above — is pinned rather than
+// assumed from an in-memory pointer copy.
+func TestControlEventFromProto_SandboxTokenFieldsPreserved(t *testing.T) {
+	t.Run("token and expires_at round-trip", func(t *testing.T) {
+		var exp int64 = 1700003600
+		original := &pb.ControlEvent{
+			Type:      "sandbox_token_response",
+			RequestId: "req-1",
+			Token:     "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJydW4tMSJ9.sig",
+			ExpiresAt: &exp,
+		}
+
+		raw, err := proto.Marshal(original)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded pb.ControlEvent
+		if err := proto.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		e := controlEventFromProto(&decoded)
+
+		if e.Token != original.Token {
+			t.Errorf("Token: got %q, want %q", e.Token, original.Token)
+		}
+		if e.ExpiresAt == nil {
+			t.Fatal("ExpiresAt: got nil, want non-nil pointer")
+		}
+		if *e.ExpiresAt != exp {
+			t.Errorf("ExpiresAt: got %d, want %d", *e.ExpiresAt, exp)
+		}
+	})
+
+	t.Run("expires_at unset stays nil", func(t *testing.T) {
+		original := &pb.ControlEvent{
+			Type:      "sandbox_token_response",
+			RequestId: "req-2",
+			Token:     "some-token",
+		}
+
+		raw, err := proto.Marshal(original)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded pb.ControlEvent
+		if err := proto.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		e := controlEventFromProto(&decoded)
+
+		if e.ExpiresAt != nil {
+			t.Errorf("ExpiresAt should be nil when proto field is unset, got %v", *e.ExpiresAt)
+		}
+	})
+
+	t.Run("is_error and reason round-trip for a decline", func(t *testing.T) {
+		original := &pb.ControlEvent{
+			Type:      "sandbox_token_response",
+			RequestId: "req-3",
+			IsError:   &pb.OptionalBool{Value: true},
+			Reason:    "no issuer configured",
+		}
+
+		e := controlEventFromProto(original)
+
+		if e.IsError == nil || !*e.IsError {
+			t.Fatalf("IsError: got %v, want pointer to true", e.IsError)
+		}
+		if e.Reason != "no issuer configured" {
+			t.Errorf("Reason: got %q, want %q", e.Reason, "no issuer configured")
+		}
+		if e.Token != "" {
+			t.Errorf("Token should be empty on an error response, got %q", e.Token)
+		}
+	})
+}
+
 // TestRunConfigFromProto_MCPTrustFieldsAbsentWhenNil documents the
 // backward-compatible default from #393: an MCP server config that omits
 // the trust fields entirely must translate to nil/empty slices on the

--- a/proto/harness/v1/harness.proto
+++ b/proto/harness/v1/harness.proto
@@ -103,12 +103,26 @@ service HarnessService {
 //     (Best-effort signal; the control plane should call the provider's
 //     batch-cancel endpoint. The harness does not retry or block on a
 //     response — cancellation is fire-and-forget.)
+//
+//   "sandbox_token_request"
+//     - request_id: unique ID for this request; the control plane must echo it
+//                   back in the corresponding sandbox_token_response ControlEvent.
+//     - audience:   the intended JWT `aud` claim for the sandbox identity
+//                   token (e.g. "https://haybale.internal"). Informational —
+//                   the control plane may override it.
+//     Sent once per run, after task_assignment and before the sandbox is
+//     created, when the run wants a sandbox identity token. Deliberately
+//     carries no harness-asserted identity field: the control plane derives
+//     the run identity from the authenticated stream the task was assigned
+//     on, never from the request body. The harness blocks on the matching
+//     sandbox_token_response under a fail-closed 60s timeout; a timeout
+//     aborts the run before any sandbox is created.
 message HarnessEvent {
   // Required. The event type discriminator.
   // Valid values: "text_delta", "tool_call", "tool_result", "done", "error",
   //              "warning", "heartbeat", "ready", "permission_request",
   //              "tool_result_request", "batch_submission", "batch_waiting",
-  //              "batch_cancel_request".
+  //              "batch_cancel_request", "sandbox_token_request".
   string type = 1;
 
   // Incremental text fragment from the model. Set on "text_delta" events.
@@ -154,6 +168,11 @@ message HarnessEvent {
   // Build version of the harness binary. Set on "ready" events. The control
   // plane may use this to verify compatibility before sending a task.
   string harness_version = 13;
+
+  // The intended JWT `aud` claim for the sandbox identity token. Set on
+  // "sandbox_token_request" events. Informational to the control plane,
+  // which may override it when minting the token.
+  string audience = 14;
 }
 
 // ControlEvent is sent from the control plane to the harness.
@@ -202,11 +221,26 @@ message HarnessEvent {
 //     - content:    JSON-encoded BatchResult payload (response or err).
 //     - is_error:   true for non-success result types (batch_expired,
 //                   batch_cancelled, invalid_request_error, server_error).
+//
+//   "sandbox_token_response"
+//     - request_id:  must match the request_id from the corresponding
+//                    sandbox_token_request HarnessEvent.
+//     - token:       the signed JWT sandbox identity token. SENSITIVE:
+//                    never logged, traced, or persisted to RunConfig —
+//                    treated as opaque secret material for the run's
+//                    lifetime.
+//     - expires_at:  optional Unix-seconds expiry of token, so the harness
+//                    can warn (scrub-safe) when it is shorter than the
+//                    run's configured wall-clock budget.
+//     - is_error:    when true, the control plane could not issue a token;
+//                    reason carries a human-readable explanation. The
+//                    harness treats this the same as a timeout — the run
+//                    aborts before the sandbox is created.
 message ControlEvent {
   // Required. The event type discriminator.
   // Valid values: "task_assignment", "user_response", "cancel",
   //              "permission_response", "tool_result_response",
-  //              "batch_result".
+  //              "batch_result", "sandbox_token_response".
   string type = 1;
 
   // The run configuration. Set on "task_assignment" events only. This is the
@@ -225,8 +259,10 @@ message ControlEvent {
   // True = allow the tool call to proceed. False = deny.
   OptionalBool allowed = 5;
 
-  // Human-readable explanation for a denial. Set on "permission_response"
-  // events when allowed is false. Passed to the model as context.
+  // Human-readable explanation. Set on "permission_response" events when
+  // allowed is false (passed to the model as context), and on
+  // "sandbox_token_response" events when is_error is true (why the control
+  // plane could not issue a token).
   string reason = 6;
 
   // Async tool result payload. Set on "tool_result_response" events. Delivered
@@ -234,9 +270,24 @@ message ControlEvent {
   string content = 7;
 
   // When true on a "tool_result_response", the loop marks the resulting
-  // ToolResult as an error so the model sees it as a tool failure. Wrapped
-  // to distinguish unset from explicit-false (proto3 scalar default).
+  // ToolResult as an error so the model sees it as a tool failure. When true
+  // on a "sandbox_token_response", the control plane could not issue a
+  // token; reason carries the explanation and token / expires_at are unset.
+  // Wrapped to distinguish unset from explicit-false (proto3 scalar
+  // default).
   OptionalBool is_error = 8;
+
+  // The signed JWT sandbox identity token. Set on "sandbox_token_response"
+  // events when is_error is false. SENSITIVE: never logged, traced, or
+  // persisted to RunConfig — the harness treats this as opaque secret
+  // material for the run's lifetime.
+  string token = 9;
+
+  // Optional. Unix-seconds expiry of token. Set on "sandbox_token_response"
+  // events. Declared `optional` so unset is wire-distinguishable from an
+  // explicit 0 (epoch), letting the harness tell "the control plane did not
+  // report an expiry" from "the token expires at the epoch".
+  optional int64 expires_at = 10;
 }
 
 // OptionalBool wraps a boolean so we can distinguish "not set" from "false"

--- a/types/events.go
+++ b/types/events.go
@@ -322,6 +322,13 @@ func Float64Ptr(v float64) *float64 {
 //     cancels or its wall-clock cap fires and the operator opted into
 //     CancelBundleOnRunCancel; RequestID echoes the submission so the
 //     control plane can cancel the matching provider-side batch entry.
+//   - "sandbox_token_request" — emitted once per run, after task_assignment
+//     and before the sandbox is created, when the run wants a sandbox
+//     identity token (e.g. to authenticate a git proxy such as Haybale).
+//     RequestID correlates with the incoming "sandbox_token_response"
+//     ControlEvent; Audience carries the intended JWT `aud` claim.
+//     Deliberately carries no harness-asserted identity field — the
+//     control plane derives run identity from the authenticated stream.
 type HarnessEvent struct {
 	Type           string          `json:"type"`
 	Text           string          `json:"text,omitempty"`
@@ -333,9 +340,10 @@ type HarnessEvent struct {
 	StopReason     string          `json:"stopReason,omitempty"`
 	Message        string          `json:"message,omitempty"`
 	Trace          *RunTrace       `json:"trace,omitempty"`
-	RequestID      string          `json:"requestId,omitempty"`      // correlates permission/tool-result requests with their responses
+	RequestID      string          `json:"requestId,omitempty"`      // correlates permission/tool-result/sandbox-token requests with their responses
 	ToolName       string          `json:"toolName,omitempty"`       // tool name on permission_request and tool_result_request
 	HarnessVersion string          `json:"harnessVersion,omitempty"` // harness build version (set on "ready" events)
+	Audience       string          `json:"audience,omitempty"`       // intended JWT aud claim (sandbox_token_request only); informational, the control plane may override it
 }
 
 // ControlEvent is an event received from the control plane.
@@ -354,15 +362,37 @@ type HarnessEvent struct {
 //     RequestID echoes the originating submission; Content carries the JSON
 //     BatchResult (provider response on success, BatchResultError on failure)
 //     consumed by harness/internal/provider.decodeBatchResult.
+//   - "sandbox_token_response" — completes a "sandbox_token_request"
+//     HarnessEvent. RequestID echoes the originating request; Token carries
+//     the signed JWT sandbox identity token (SENSITIVE — never logged,
+//     traced, transcribed, or written to RunConfig); ExpiresAt optionally
+//     carries the token's Unix-seconds expiry so the harness can warn when
+//     it is shorter than the run's configured wall-clock budget. IsError,
+//     when true, means the control plane could not issue a token — Reason
+//     carries why, and the harness treats it like a timeout: the run aborts
+//     before the sandbox is created.
 type ControlEvent struct {
 	Type         string     `json:"type"`
 	Task         *RunConfig `json:"task,omitempty"`
 	UserResponse string     `json:"userResponse,omitempty"`
 	RequestID    string     `json:"requestId,omitempty"` // correlates response with the originating request
 	Allowed      *bool      `json:"allowed,omitempty"`   // permission decision (permission_response only)
-	Reason       string     `json:"reason,omitempty"`    // explanation for denial (permission_response only)
+	Reason       string     `json:"reason,omitempty"`    // explanation for denial (permission_response) or issuance failure (sandbox_token_response)
 	Content      string     `json:"content,omitempty"`   // async tool result payload (tool_result_response only)
-	IsError      *bool      `json:"isError,omitempty"`   // mark async tool result as an error (tool_result_response only)
+	IsError      *bool      `json:"isError,omitempty"`   // mark async tool result as an error (tool_result_response), or a token issuance failure (sandbox_token_response)
+
+	// Token is the signed JWT sandbox identity token (sandbox_token_response
+	// only, when IsError is not true). SENSITIVE: the harness must never
+	// log, trace, transcribe, or write this to RunConfig — treat it as
+	// opaque secret material scoped to the run's lifetime. The oidc_jwt
+	// log-scrubber pattern (harness/internal/security/logscrubber.go) is a
+	// backstop only; code on this path must not rely on it deliberately.
+	Token string `json:"token,omitempty"`
+
+	// ExpiresAt is the optional Unix-seconds expiry of Token
+	// (sandbox_token_response only). A nil value means the control plane
+	// did not report an expiry.
+	ExpiresAt *int64 `json:"expiresAt,omitempty"`
 }
 
 // HarnessLifecycleEvent represents lifecycle signals sent on the transport.


### PR DESCRIPTION
## Summary

PR **A** of a 4-PR stack implementing issue #516 (sandbox identity token issuance over gRPC + haybale git-proxy sandbox wiring). This PR is **Part A, proto/types only**: it adds the gRPC stream event pair for requesting a sandbox identity token from the control plane, and specifies the exchange for control-plane implementers. No RunConfig surface, validation, executor wiring, or token-exchange logic — those land in PRs B/C/D.

## What changed

- `proto/harness/v1/harness.proto`: new `sandbox_token_request` (harness → CP) carrying `audience`; `sandbox_token_response` (CP → harness) carrying `token` (sensitive JWT), optional `expires_at`, and an `is_error` + `reason` decline form. Correlated via the existing `request_id`, mirroring the `permission_*` / `tool_result_*` pairs. Regenerated `gen/harness/v1/harness.pb.go` via `just proto`.
- `types/events.go`: Go-side mirror of the new fields with doc-comments; `Token` marked as secret material (never logged/traced/persisted/in RunConfig).
- `harness/internal/transport/grpc_translate.go` (+ round-trip test): mechanical wire-crossing for the new fields, matching the precedent set by the `tool_result` pair (commit `35d808b9`) and the project's silent-drop regression tests (gh-95/117/118/100).
- `docs/deployment.md`: extends the `stirrup job` lifecycle + sequence diagram and adds a control-plane spec section — what the request means, minting a conformant JWT (haybale `docs/jwt-identity.md` as the concrete consumer contract), `sub = run-<RunID>`, JWKS, the fail-closed 60s wait, the `is_error`+`reason` decline form, and the token-lifetime posture (`exp` covers run wall-clock budget; in-sandbox refresh deferred).

## Design decisions (from #516)

- Generic `sandbox_token_request` naming with an `audience` field — reusable by future non-git consumers.
- Deliberately no harness-asserted identity: the control plane derives run identity from the authenticated stream (mutual-partial-trust posture, issue #104 stamping invariant).
- Decline form is an `is_error` flag + `reason`, not a distinct event type.

## Test evidence

- `just` (build + test): all packages `ok`.
- `just lint` (golangci-lint v2): `0 issues`.

Stacked PR; base `main`. Issue #516 is closed by PR D only (the final PR in this stack); this PR carries no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CS8eU446ivtvsRgHNDroTN
