### PR TITLE
types: sandboxIdentity + gitProxy RunConfig surface (#516 PR B)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1022,11 +1022,11 @@ request these fields configure.
 |---|---|---|
 | `sandboxIdentity.source` | Token issuer. Closed set. | Required; only `"control-plane"` is supported |
 | `sandboxIdentity.audience` | Intended JWT `aud` claim. Informational — the control plane may override it. | `""` |
-| `sandboxIdentity.envVar` | Sandbox environment variable the token is injected as. | `""` → `HAYBALE_TOKEN` |
-| `gitProxy.url` | The proxy's base URL, e.g. `http://haybale.internal:8466`. | Required when `gitProxy` is set |
-| `gitProxy.hosts` | Git hosts to rewrite through the proxy, e.g. `["github.com"]`. | `[]` |
+| `sandboxIdentity.envVar` | Sandbox environment variable the token is injected as. | `""` → `HAYBALE_TOKEN`; non-empty values must match `^[A-Za-z_][A-Za-z0-9_]*$` |
+| `gitProxy.url` | The proxy's base URL, e.g. `http://haybale.internal:8466`. | Required when `gitProxy` is set; must be an absolute `http`/`https` URL with a host |
+| `gitProxy.hosts` | Git hosts to rewrite through the proxy, e.g. `["github.com"]`. | Required (at least one host) when `gitProxy` is set |
 | `gitProxy.rewriteSsh` | Also rewrite the `git@<host>:` and `ssh://git@<host>/` URL forms, not just `https://<host>/`. | `false` |
-| `gitProxy.tokenEnvVar` | Environment variable the composed git-credential helper reads the token from. Must resolve to the same value as `sandboxIdentity.envVar` (both apply the same `HAYBALE_TOKEN` default when empty). | `""` → `HAYBALE_TOKEN` |
+| `gitProxy.tokenEnvVar` | Environment variable the composed git-credential helper reads the token from. Must resolve to the same value as `sandboxIdentity.envVar` (both apply the same `HAYBALE_TOKEN` default when empty). | `""` → `HAYBALE_TOKEN`; non-empty values must match `^[A-Za-z_][A-Za-z0-9_]*$` |
 
 Both blocks are optional and pointer-typed: a `RunConfig` with neither
 set validates exactly as it did before this feature existed,
@@ -1056,6 +1056,21 @@ below are gated on anything but the blocks' own presence.
   `HAYBALE_TOKEN` default when left empty, so two unset fields match
   by default; an explicit value on one side with no matching
   explicit value on the other is a mismatch and a validation error.
+- **`gitProxy.url` is required and must be a well-formed endpoint.**
+  An empty `gitProxy.url` is a validation error, and a non-empty one
+  must parse as an absolute URL with scheme `http` or `https` and a
+  non-empty host — the same shape check `guardRail.endpoint` applies.
+- **`gitProxy.hosts` must name at least one host.** `hosts` is what
+  drives how many proxy rewrite rules get composed; an empty list
+  would let the block validate cleanly while silently routing
+  nothing through the proxy, so it is a validation error.
+- **`sandboxIdentity.envVar` and `gitProxy.tokenEnvVar` must be legal
+  POSIX environment variable names when non-empty.** Both names are
+  interpolated into a shell credential-helper string when the sandbox
+  git configuration is composed, so each must match
+  `^[A-Za-z_][A-Za-z0-9_]*$`. This is a charset check only — it does
+  not block semantically sensitive but syntactically valid names such
+  as `PATH`.
 
 Operators using `executor.network.mode: "allowlist"` should add the
 proxy's `host:port` to `executor.network.allowlist` (as in the
@@ -1067,7 +1082,9 @@ error) when `gitProxy.url`'s `host:port` is absent from the
 allowlist in `allowlist` mode; the check is a plain exact-match
 against `gitProxy.url`, so an allowlist entry that only covers the
 proxy host via a wildcard (`*.internal:8466`) may still trigger a
-spurious warning even though the sandbox has a working route.
+spurious warning even though the sandbox has a working route — the
+common case being a proxy already covered by a wildcard-subdomain
+allowlist entry, where the warning is expected and can be ignored.
 
 ## Limits and budgets
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -982,6 +982,93 @@ before the session starts, submit an artifact after it ends:
 }
 ```
 
+## Sandbox identity and git-proxy wiring
+
+`executor.sandboxIdentity` and `executor.gitProxy` (issue #516)
+request a short-lived, control-plane-issued credential ("sandbox
+identity token") for the sandbox and compose the non-secret git
+configuration that routes clone/push traffic for private
+repositories through a git-credential proxy such as
+[haybale](https://github.com/rxbynerd/haybale). Neither block carries
+the token itself — `RunConfig` and its `Redact()`ed form never see
+the JWT; only the (non-secret) request shape and env-var wiring live
+here. See [`deployment.md`'s "Sandbox identity token
+issuance"](deployment.md#sandbox-identity-token-issuance-control-plane-implementers)
+for the gRPC wire contract a control plane implements to answer the
+request these fields configure.
+
+```json
+"executor": {
+  "type": "container",
+  "sandboxIdentity": {
+    "source": "control-plane",
+    "audience": "https://haybale.internal",
+    "envVar": "HAYBALE_TOKEN"
+  },
+  "gitProxy": {
+    "url": "http://haybale.internal:8466",
+    "hosts": ["github.com"],
+    "rewriteSsh": true,
+    "tokenEnvVar": "HAYBALE_TOKEN"
+  },
+  "network": {
+    "mode": "allowlist",
+    "allowlist": ["haybale.internal:8466"]
+  }
+}
+```
+
+| Field | Meaning | Default / bound |
+|---|---|---|
+| `sandboxIdentity.source` | Token issuer. Closed set. | Required; only `"control-plane"` is supported |
+| `sandboxIdentity.audience` | Intended JWT `aud` claim. Informational — the control plane may override it. | `""` |
+| `sandboxIdentity.envVar` | Sandbox environment variable the token is injected as. | `""` → `HAYBALE_TOKEN` |
+| `gitProxy.url` | The proxy's base URL, e.g. `http://haybale.internal:8466`. | Required when `gitProxy` is set |
+| `gitProxy.hosts` | Git hosts to rewrite through the proxy, e.g. `["github.com"]`. | `[]` |
+| `gitProxy.rewriteSsh` | Also rewrite the `git@<host>:` and `ssh://git@<host>/` URL forms, not just `https://<host>/`. | `false` |
+| `gitProxy.tokenEnvVar` | Environment variable the composed git-credential helper reads the token from. Must resolve to the same value as `sandboxIdentity.envVar` (both apply the same `HAYBALE_TOKEN` default when empty). | `""` → `HAYBALE_TOKEN` |
+
+Both blocks are optional and pointer-typed: a `RunConfig` with neither
+set validates exactly as it did before this feature existed,
+regardless of `transport` or `executor.type` — none of the rules
+below are gated on anything but the blocks' own presence.
+
+`ValidateRunConfig` enforces:
+
+- **`transport: "grpc"` is required.** Requesting a sandbox identity
+  token means asking the control plane over the gRPC control stream;
+  `stdio` has no upstream to ask. Setting `sandboxIdentity` or
+  `gitProxy` under `transport: "stdio"` (or the unset/default
+  transport) is a validation error.
+- **Executor scope (v1).** `sandboxIdentity` / `gitProxy` are only
+  valid for `executor.type` `"container"`, `"k8s"`, or
+  `"k8s-sandbox"` — the executors that create a sandbox environment
+  the harness controls at creation time. `"local"` is deferred (a
+  developer machine already carries its own git credentials);
+  `"api"` and `"none"` have no sandbox environment to inject into.
+- **`gitProxy` requires `sandboxIdentity`.** v1's only token source
+  is control-plane issuance via `sandboxIdentity` — a `gitProxy`
+  block with no `sandboxIdentity` names an environment variable that
+  would never be populated, so the combination is a validation
+  error rather than a silent no-op.
+- **`gitProxy.tokenEnvVar` must match the effective
+  `sandboxIdentity.envVar`.** Both fields apply the same
+  `HAYBALE_TOKEN` default when left empty, so two unset fields match
+  by default; an explicit value on one side with no matching
+  explicit value on the other is a mismatch and a validation error.
+
+Operators using `executor.network.mode: "allowlist"` should add the
+proxy's `host:port` to `executor.network.allowlist` (as in the
+example above) and deliberately leave the git hosts themselves
+(`github.com`) off it, so the proxy is the only route to them — Ring
+2's egress allowlist otherwise gives the sandbox no route to the
+proxy at all. `ValidateRunConfig` warns (via `slog`, not a validation
+error) when `gitProxy.url`'s `host:port` is absent from the
+allowlist in `allowlist` mode; the check is a plain exact-match
+against `gitProxy.url`, so an allowlist entry that only covers the
+proxy host via a wildcard (`*.internal:8466`) may still trigger a
+spurious warning even though the sandbox has a working route.
+
 ## Limits and budgets
 
 `ValidateRunConfig` enforces hard caps on values that could otherwise

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -133,7 +133,11 @@ IMDS, GitHub Actions OIDC). See
    for up to 60 seconds on the matching `sandbox_token_response` —
    before any sandbox is created. See [Sandbox identity token
    issuance](#sandbox-identity-token-issuance-control-plane-implementers)
-   below for the full contract.
+   below for the full contract, and [configuration.md's "Sandbox
+   identity and git-proxy
+   wiring"](configuration.md#sandbox-identity-and-git-proxy-wiring)
+   for the `executor.sandboxIdentity` / `executor.gitProxy`
+   `RunConfig` fields that request it.
 6. **Build and run.** Once the `RunConfig` arrives, the wall-clock
    timeout is applied to the context, the agentic loop is built via
    `core.BuildLoopWithTransport` reusing the existing gRPC transport,

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"unicode"
@@ -1130,6 +1131,26 @@ type ExecutorConfig struct {
 	// silently. Future S3 / Azure Blob support will broaden the scheme
 	// set.
 	WorkspaceExportTo string `json:"workspaceExportTo,omitempty"`
+
+	// SandboxIdentity, when set, requests a control-plane-issued sandbox
+	// identity token over the gRPC control stream before sandbox
+	// creation and injects it into the sandbox environment (issue #516
+	// Part A/B). Requires Transport.Type == "grpc" (stdio has no
+	// upstream to request a token from) and Type in {"container",
+	// "k8s", "k8s-sandbox"} — the executor types that actually create a
+	// sandbox environment to inject into. The token itself never enters
+	// RunConfig; see docs/deployment.md for the wire-level exchange.
+	SandboxIdentity *SandboxIdentityConfig `json:"sandboxIdentity,omitempty"`
+
+	// GitProxy, when set, composes non-secret git configuration
+	// (GIT_CONFIG_* env pairs) that route git operations against Hosts
+	// through a git-credential proxy such as haybale
+	// (github.com/rxbynerd/haybale), authenticated with the token
+	// SandboxIdentity requested (issue #516 Part B). TokenEnvVar must
+	// name the same environment variable SandboxIdentity populates, so
+	// GitProxy requires SandboxIdentity to also be set. Subject to the
+	// same Transport/Type restrictions as SandboxIdentity.
+	GitProxy *GitProxyConfig `json:"gitProxy,omitempty"`
 }
 
 // VcsBackendConfig selects the VCS backend for the API executor.
@@ -1152,6 +1173,93 @@ type ResourceLimits struct {
 	MemoryMB int     `json:"memoryMb"`
 	DiskMB   int     `json:"diskMb"`
 	PIDs     int     `json:"pids"`
+}
+
+// DefaultSandboxIdentityEnvVar is the sandbox environment variable a
+// sandbox identity token is injected as when SandboxIdentityConfig.EnvVar
+// (or GitProxyConfig.TokenEnvVar) is left empty. Named after haybale
+// (github.com/rxbynerd/haybale), the v1 (and so far only) consumer.
+const DefaultSandboxIdentityEnvVar = "HAYBALE_TOKEN"
+
+// SandboxIdentityConfig requests a control-plane-issued sandbox identity
+// token over the gRPC control stream (issue #516 Part A). The harness
+// sends a sandbox_token_request after task assignment and before sandbox
+// creation, then injects the returned JWT into the sandbox environment
+// under the variable EffectiveEnvVar names. The token itself is never
+// written to RunConfig, a trace, or a transcript — see
+// docs/deployment.md for the wire-level exchange this config requests.
+type SandboxIdentityConfig struct {
+	// Source names the token issuer. "control-plane" — the only
+	// supported value in v1 — requests issuance from the control plane
+	// the harness is already streaming to over gRPC.
+	Source string `json:"source"`
+
+	// Audience is the intended JWT "aud" claim, e.g.
+	// "https://haybale.internal". Informational to the control plane,
+	// which may override it.
+	Audience string `json:"audience,omitempty"`
+
+	// EnvVar names the sandbox environment variable the token is
+	// injected as. Empty resolves to DefaultSandboxIdentityEnvVar via
+	// EffectiveEnvVar.
+	EnvVar string `json:"envVar,omitempty"`
+}
+
+// EffectiveEnvVar returns the sandbox environment variable name a token
+// requested by cfg is injected as: EnvVar verbatim when set, else
+// DefaultSandboxIdentityEnvVar. A nil cfg returns the default so callers
+// (validation and, later, env-composition wiring) need not nil-check
+// first — the single source of truth for the default-resolution rule
+// GitProxyConfig.EffectiveTokenEnvVar must agree with.
+func (cfg *SandboxIdentityConfig) EffectiveEnvVar() string {
+	if cfg == nil || cfg.EnvVar == "" {
+		return DefaultSandboxIdentityEnvVar
+	}
+	return cfg.EnvVar
+}
+
+// GitProxyConfig composes non-secret git configuration (GIT_CONFIG_* env
+// pairs, issue #516 Part B) that rewrites git operations against Hosts
+// through a git-credential proxy such as haybale
+// (github.com/rxbynerd/haybale), authenticating with the token
+// SandboxIdentityConfig requested. All fields here are non-secret: the
+// JWT itself is carried only by the environment variable EffectiveTokenEnvVar
+// names, never by RunConfig.
+type GitProxyConfig struct {
+	// URL is the proxy's base URL, e.g. "http://haybale.internal:8466".
+	// Operators should also add its host:port to
+	// ExecutorConfig.Network.Allowlist when Network.Mode ==
+	// "allowlist" — ValidateRunConfig warns, but does not error, when
+	// it is absent.
+	URL string `json:"url"`
+
+	// Hosts lists the git hosts to rewrite through the proxy, e.g.
+	// ["github.com"]. Operators should deliberately leave these hosts
+	// off Network.Allowlist so the proxy is the only route to them.
+	Hosts []string `json:"hosts,omitempty"`
+
+	// RewriteSsh additionally rewrites the "git@<host>:" and
+	// "ssh://git@<host>/" URL forms, not just "https://<host>/".
+	RewriteSsh bool `json:"rewriteSsh,omitempty"`
+
+	// TokenEnvVar must name the same environment variable
+	// SandboxIdentityConfig.EnvVar populates — ValidateRunConfig rejects
+	// a mismatch between the effective values of the two. The composed
+	// git-credential helper reads the token from this variable.
+	TokenEnvVar string `json:"tokenEnvVar,omitempty"`
+}
+
+// EffectiveTokenEnvVar returns the sandbox environment variable name the
+// git-credential helper GitProxyConfig composes reads the token from:
+// TokenEnvVar verbatim when set, else DefaultSandboxIdentityEnvVar — the
+// same default SandboxIdentityConfig.EffectiveEnvVar applies, since v1
+// ties both fields to a single token variable. A nil cfg returns the
+// default so callers need not nil-check first.
+func (cfg *GitProxyConfig) EffectiveTokenEnvVar() string {
+	if cfg == nil || cfg.TokenEnvVar == "" {
+		return DefaultSandboxIdentityEnvVar
+	}
+	return cfg.TokenEnvVar
 }
 
 // ToolDispatchConfig tunes the parallel async-tool dispatch loop. The
@@ -2289,6 +2397,7 @@ func ValidateRunConfig(config *RunConfig) error {
 	validateK8sExecutor(config.Executor, &errs)
 	validateNoneExecutor(config.Executor, &errs)
 	validateResourceLimits(config.Executor.Resources, &errs)
+	validateSandboxIdentity(config, &errs)
 	validateOptionalType("editStrategy", config.EditStrategy.Type, validEditStrategyTypes, &errs)
 	validateEditStrategyFuzzyThreshold(config.EditStrategy, &errs)
 	validateOptionalType("permissionPolicy", config.PermissionPolicy.Type, validPermissionPolicyTypes, &errs)
@@ -4829,6 +4938,135 @@ func validateK8sEgressProxy(cfg ExecutorConfig, errs *[]string) {
 			*errs = append(*errs, "executor.k8sEgressProxyUrl is only valid when executor.network.mode is \"allowlist\"")
 		}
 	}
+}
+
+// validSandboxIdentitySources is the closed set of legal
+// SandboxIdentityConfig.Source values. "control-plane" is the only
+// supported issuer in v1 (issue #516): the harness requests a token from
+// the control plane it is already streaming to over gRPC.
+var validSandboxIdentitySources = map[string]bool{
+	"control-plane": true,
+}
+
+// sandboxIdentityCapableExecutors is the closed set of executor types
+// that may configure ExecutorConfig.SandboxIdentity / GitProxy (issue
+// #516, "Scope restrictions (v1)"): only these executors create a
+// sandbox environment the harness controls at creation time. "local" is
+// deferred (a developer machine already carries its own git
+// credentials); "api" and "none" have no sandbox environment to inject
+// into at all.
+var sandboxIdentityCapableExecutors = map[string]bool{
+	"container":   true,
+	"k8s":         true,
+	"k8s-sandbox": true,
+}
+
+// validateSandboxIdentity enforces the cross-field invariants on
+// ExecutorConfig.SandboxIdentity and .GitProxy (issue #516 Part B). Both
+// blocks are pointers and every rule below is strictly gated on their
+// presence, so a bare RunConfig with neither set validates cleanly
+// regardless of Transport or Executor.Type — this function must never
+// fire on a default/defaulted config.
+func validateSandboxIdentity(config *RunConfig, errs *[]string) {
+	si := config.Executor.SandboxIdentity
+	gp := config.Executor.GitProxy
+	if si == nil && gp == nil {
+		return
+	}
+
+	// gRPC-only: stdio has no upstream control plane to request a token
+	// from. Mirrors the ask-upstream permission-policy and
+	// ruleOfTwo.runtime.onDetect="ask-upstream" checks elsewhere in this
+	// file.
+	if config.Transport.Type != "grpc" {
+		*errs = append(*errs, "executor.sandboxIdentity/executor.gitProxy requires transport=grpc (stdio has no upstream control plane to issue a sandbox identity token)")
+	}
+
+	if !sandboxIdentityCapableExecutors[config.Executor.Type] {
+		*errs = append(*errs, fmt.Sprintf(
+			"executor.sandboxIdentity/executor.gitProxy is only valid for executor.type \"container\", \"k8s\", or \"k8s-sandbox\" (got %q)",
+			config.Executor.Type))
+	}
+
+	if si != nil && !validSandboxIdentitySources[si.Source] {
+		*errs = append(*errs, fmt.Sprintf(
+			"unsupported executor.sandboxIdentity.source %q; only \"control-plane\" is supported", si.Source))
+	}
+
+	if gp != nil {
+		if si == nil {
+			// v1's only token source is control-plane issuance via
+			// sandboxIdentity (see SandboxIdentityConfig doc comment): a
+			// gitProxy with no sandboxIdentity block names an env var
+			// that would never be populated. Treated as a configuration
+			// error rather than a silent no-op.
+			*errs = append(*errs, "executor.gitProxy requires executor.sandboxIdentity to be set (v1 has no other token source, so gitProxy.tokenEnvVar would never be populated)")
+		} else if siEnv, gpEnv := si.EffectiveEnvVar(), gp.EffectiveTokenEnvVar(); siEnv != gpEnv {
+			*errs = append(*errs, fmt.Sprintf(
+				"executor.gitProxy.tokenEnvVar %q must match the effective executor.sandboxIdentity.envVar %q",
+				gpEnv, siEnv))
+		}
+	}
+
+	warnGitProxyAllowlistGap(config)
+}
+
+// gitProxyAllowlistDefaultPort mirrors defaultAllowPort in
+// harness/internal/executor/egressproxy/matcher.go: a bare-host
+// allowlist entry with no explicit ":port" suffix implies :443.
+// Duplicated as a constant rather than imported — types/ cannot depend
+// on harness/internal/... across the module boundary (see go.work) —
+// keep the two in sync if the egress proxy's default port ever changes.
+const gitProxyAllowlistDefaultPort = 443
+
+// warnGitProxyAllowlistGap emits a scrub-safe slog warning — never a
+// ValidateRunConfig error, per the issue's "nice-to-have" framing — when
+// GitProxy.URL's host:port is absent from Executor.Network.Allowlist
+// while Network.Mode == "allowlist". A missing entry leaves the sandbox
+// with no egress route to the proxy at all (Ring 2 fails closed), which
+// is a real operator footgun worth flagging, but this is intentionally
+// a plain exact-match check, not a full reimplementation of
+// egressproxy.Matcher's wildcard semantics: an operator covering the
+// proxy host with a "*.example.com"-style wildcard entry may see a
+// spurious warning here, which is an acceptable false positive for a
+// non-blocking diagnostic (the actual enforcement point is the egress
+// proxy itself, which does implement wildcards).
+func warnGitProxyAllowlistGap(config *RunConfig) {
+	gp := config.Executor.GitProxy
+	if gp == nil || gp.URL == "" {
+		return
+	}
+	network := config.Executor.Network
+	if network == nil || network.Mode != "allowlist" {
+		return
+	}
+	u, err := url.Parse(gp.URL)
+	if err != nil || u.Hostname() == "" {
+		return
+	}
+	host := strings.ToLower(u.Hostname())
+	port := gitProxyAllowlistDefaultPort
+	switch {
+	case u.Port() != "":
+		if n, convErr := strconv.Atoi(u.Port()); convErr == nil && n > 0 && n <= 65535 {
+			port = n
+		}
+	case u.Scheme == "http":
+		port = 80
+	}
+
+	wantExact := fmt.Sprintf("%s:%d", host, port)
+	for _, entry := range network.Allowlist {
+		e := strings.ToLower(strings.TrimSpace(entry))
+		if e == wantExact || (port == gitProxyAllowlistDefaultPort && e == host) {
+			return
+		}
+	}
+	slog.Warn(
+		"executor.gitProxy.url host:port is not present in executor.network.allowlist; the sandbox has no egress route to the git proxy in allowlist mode",
+		"gitProxyHost", host,
+		"gitProxyPort", port,
+	)
 }
 
 // validateResourceLimits rejects negative resource bounds. A negative

--- a/types/runconfig.go
+++ b/types/runconfig.go
@@ -4961,6 +4961,16 @@ var sandboxIdentityCapableExecutors = map[string]bool{
 	"k8s-sandbox": true,
 }
 
+// posixEnvVarNamePattern bounds SandboxIdentityConfig.EnvVar and
+// GitProxyConfig.TokenEnvVar to legal POSIX environment variable names.
+// PR C's env-composition interpolates the *name* (not the token value)
+// into a double-quoted shell credential-helper string; this is an
+// injection-shape guard only — it deliberately does not deny
+// semantically-risky-but-syntactically-valid names like PATH or
+// LD_PRELOAD, matching observabilityLabelPattern's precedent of a plain
+// charset check rather than a semantic denylist.
+var posixEnvVarNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // validateSandboxIdentity enforces the cross-field invariants on
 // ExecutorConfig.SandboxIdentity and .GitProxy (issue #516 Part B). Both
 // blocks are pointers and every rule below is strictly gated on their
@@ -4988,12 +4998,36 @@ func validateSandboxIdentity(config *RunConfig, errs *[]string) {
 			config.Executor.Type))
 	}
 
-	if si != nil && !validSandboxIdentitySources[si.Source] {
-		*errs = append(*errs, fmt.Sprintf(
-			"unsupported executor.sandboxIdentity.source %q; only \"control-plane\" is supported", si.Source))
+	if si != nil {
+		if !validSandboxIdentitySources[si.Source] {
+			*errs = append(*errs, fmt.Sprintf(
+				"unsupported executor.sandboxIdentity.source %q; only \"control-plane\" is supported", si.Source))
+		}
+		if si.EnvVar != "" && !posixEnvVarNamePattern.MatchString(si.EnvVar) {
+			*errs = append(*errs, fmt.Sprintf(
+				"executor.sandboxIdentity.envVar %q must be a valid POSIX environment variable name", si.EnvVar))
+		}
 	}
 
 	if gp != nil {
+		// gitProxy.url is required and, when present, must be an
+		// absolute http(s) URL with a host — mirrors
+		// validateGuardRailEndpoint's shape check on GuardRailConfig.Endpoint.
+		if gp.URL == "" {
+			*errs = append(*errs, "executor.gitProxy.url is required when executor.gitProxy is set")
+		} else {
+			validateGuardRailEndpoint(gp.URL, "executor.gitProxy.url", errs)
+		}
+
+		if len(gp.Hosts) == 0 {
+			*errs = append(*errs, "executor.gitProxy.hosts must contain at least one host when executor.gitProxy is set")
+		}
+
+		if gp.TokenEnvVar != "" && !posixEnvVarNamePattern.MatchString(gp.TokenEnvVar) {
+			*errs = append(*errs, fmt.Sprintf(
+				"executor.gitProxy.tokenEnvVar %q must be a valid POSIX environment variable name", gp.TokenEnvVar))
+		}
+
 		if si == nil {
 			// v1's only token source is control-plane issuance via
 			// sandboxIdentity (see SandboxIdentityConfig doc comment): a
@@ -5044,7 +5078,11 @@ func warnGitProxyAllowlistGap(config *RunConfig) {
 	if err != nil || u.Hostname() == "" {
 		return
 	}
-	host := strings.ToLower(u.Hostname())
+	// TrimSuffix matches egressproxy.canonicaliseHost's trailing-dot
+	// handling: "haybale.internal." and "haybale.internal" are the same
+	// FQDN (RFC 1034 §3.1), so a trailing dot in gitProxy.url must not
+	// produce a spurious warning against a dot-free allowlist entry.
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
 	port := gitProxyAllowlistDefaultPort
 	switch {
 	case u.Port() != "":

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -7414,6 +7414,55 @@ func TestRedact_HooksPassThrough(t *testing.T) {
 	}
 }
 
+// TestRedact_SandboxIdentityAndGitProxyPassThrough pins the issue #516
+// invariant that the sandbox identity token itself never enters
+// RunConfig: every field on SandboxIdentityConfig and GitProxyConfig is
+// non-secret operator configuration (there is no "secret://"-style
+// reference in either block for Redact to strip), so Redact() must leave
+// both blocks byte-for-byte unchanged.
+func TestRedact_SandboxIdentityAndGitProxyPassThrough(t *testing.T) {
+	rc := RunConfig{
+		Executor: ExecutorConfig{
+			SandboxIdentity: &SandboxIdentityConfig{
+				Source:   "control-plane",
+				Audience: "https://haybale.internal",
+				EnvVar:   "HAYBALE_TOKEN",
+			},
+			GitProxy: &GitProxyConfig{
+				URL:         "http://haybale.internal:8466",
+				Hosts:       []string{"github.com"},
+				RewriteSsh:  true,
+				TokenEnvVar: "HAYBALE_TOKEN",
+			},
+		},
+	}
+	redacted := rc.Redact()
+
+	if redacted.Executor.SandboxIdentity == nil {
+		t.Fatal("Redact must not drop SandboxIdentity")
+	}
+	if *redacted.Executor.SandboxIdentity != *rc.Executor.SandboxIdentity {
+		t.Errorf("SandboxIdentity must pass through unchanged, got: %+v, want: %+v",
+			redacted.Executor.SandboxIdentity, rc.Executor.SandboxIdentity)
+	}
+
+	if redacted.Executor.GitProxy == nil {
+		t.Fatal("Redact must not drop GitProxy")
+	}
+	if redacted.Executor.GitProxy.URL != rc.Executor.GitProxy.URL {
+		t.Errorf("GitProxy.URL = %q, want unchanged %q", redacted.Executor.GitProxy.URL, rc.Executor.GitProxy.URL)
+	}
+	if redacted.Executor.GitProxy.RewriteSsh != rc.Executor.GitProxy.RewriteSsh {
+		t.Error("GitProxy.RewriteSsh must pass through unchanged")
+	}
+	if redacted.Executor.GitProxy.TokenEnvVar != rc.Executor.GitProxy.TokenEnvVar {
+		t.Errorf("GitProxy.TokenEnvVar = %q, want unchanged %q", redacted.Executor.GitProxy.TokenEnvVar, rc.Executor.GitProxy.TokenEnvVar)
+	}
+	if len(redacted.Executor.GitProxy.Hosts) != 1 || redacted.Executor.GitProxy.Hosts[0] != "github.com" {
+		t.Errorf("GitProxy.Hosts must pass through unchanged, got: %v", redacted.Executor.GitProxy.Hosts)
+	}
+}
+
 func TestHooksConfig_JSONRoundTrip(t *testing.T) {
 	rc := RunConfig{
 		Hooks: &HooksConfig{
@@ -7720,6 +7769,312 @@ func TestValidateRunConfig_NoneExecutorBuiltInToolFailFast(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("expected tool %q to validate cleanly, got: %v", tc.tool, err)
+			}
+		})
+	}
+}
+
+// --- SandboxIdentityConfig / GitProxyConfig (issue #516 Part B) ---
+
+// sandboxIdentityValidConfig returns the minimal RunConfig the
+// sandboxIdentity/gitProxy validation rules validate cleanly against:
+// container executor, grpc transport, a matching envVar pair. Individual
+// tests perturb one field at a time.
+func sandboxIdentityValidConfig() *RunConfig {
+	c := validConfig()
+	c.Transport = TransportConfig{Type: "grpc"}
+	c.Executor = ExecutorConfig{
+		Type: "container",
+		SandboxIdentity: &SandboxIdentityConfig{
+			Source:   "control-plane",
+			Audience: "https://haybale.internal",
+			EnvVar:   "HAYBALE_TOKEN",
+		},
+		GitProxy: &GitProxyConfig{
+			URL:         "http://haybale.internal:8466",
+			Hosts:       []string{"github.com"},
+			RewriteSsh:  true,
+			TokenEnvVar: "HAYBALE_TOKEN",
+		},
+	}
+	return c
+}
+
+// TestValidateRunConfig_SandboxIdentityDefaultConfigStillValid pins the
+// "defaulting-layer trap" the issue brief calls out explicitly: a bare
+// RunConfig has neither SandboxIdentity nor GitProxy set, so none of the
+// new rules may fire regardless of Transport or Executor.Type, and no
+// default-injection layer may populate the blocks.
+func TestValidateRunConfig_SandboxIdentityDefaultConfigStillValid(t *testing.T) {
+	c := validConfig()
+	c.Transport = TransportConfig{Type: "grpc"}
+	c.Executor = ExecutorConfig{Type: "container"}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("default container+grpc config with no sandboxIdentity/gitProxy must validate cleanly, got: %v", err)
+	}
+	if c.Executor.SandboxIdentity != nil {
+		t.Error("ValidateRunConfig must not inject a SandboxIdentity block")
+	}
+	if c.Executor.GitProxy != nil {
+		t.Error("ValidateRunConfig must not inject a GitProxy block")
+	}
+
+	// Also confirm the plain default RunConfig (stdio transport, unset
+	// executor.type) still validates cleanly — the rules must never
+	// fire purely on the absence of an explicit transport/executor.
+	if err := ValidateRunConfig(validConfig()); err != nil {
+		t.Fatalf("bare default config must validate cleanly, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_SandboxIdentityRequiresGRPC(t *testing.T) {
+	cases := []struct {
+		name      string
+		transport string
+		wantErr   bool
+	}{
+		{"grpc_passes", "grpc", false},
+		{"stdio_fails", "stdio", true},
+		{"empty_transport_fails", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sandboxIdentityValidConfig()
+			c.Transport = TransportConfig{Type: tc.transport}
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for sandboxIdentity with transport %q, got nil", tc.transport)
+				}
+				if !strings.Contains(err.Error(), "requires transport=grpc") {
+					t.Errorf("expected error to mention requires transport=grpc, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("sandboxIdentity with grpc transport should pass, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_SandboxIdentityRequiresGRPC_GitProxyOnly confirms
+// the grpc-only rule fires from a GitProxy block alone (no
+// SandboxIdentity) — the issue brief calls this out explicitly as "(or
+// gitProxy)". GitProxy without SandboxIdentity also trips its own
+// cross-field rule, so this only checks the transport error is present.
+func TestValidateRunConfig_SandboxIdentityRequiresGRPC_GitProxyOnly(t *testing.T) {
+	c := validConfig()
+	c.Transport = TransportConfig{Type: "stdio"}
+	c.Executor = ExecutorConfig{
+		Type:     "container",
+		GitProxy: &GitProxyConfig{URL: "http://haybale.internal:8466", TokenEnvVar: "HAYBALE_TOKEN"},
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected rejection for gitProxy with stdio transport, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires transport=grpc") {
+		t.Errorf("expected error to mention requires transport=grpc, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_SandboxIdentityExecutorTypeGating(t *testing.T) {
+	cases := []struct {
+		name     string
+		executor ExecutorConfig
+		wantErr  bool
+	}{
+		{
+			name:     "container_passes",
+			executor: ExecutorConfig{Type: "container"},
+			wantErr:  false,
+		},
+		{
+			name: "k8s_passes",
+			executor: ExecutorConfig{
+				Type:         "k8s",
+				Image:        "ghcr.io/rxbynerd/stirrup:latest",
+				K8sNamespace: "default",
+				Network:      &NetworkConfig{Mode: "none"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "k8s_sandbox_passes",
+			executor: ExecutorConfig{
+				Type:         "k8s-sandbox",
+				Image:        "ghcr.io/rxbynerd/stirrup:latest",
+				K8sNamespace: "default",
+				Network:      &NetworkConfig{Mode: "none"},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "local_deferred_fails",
+			executor: ExecutorConfig{Type: "local"},
+			wantErr:  true,
+		},
+		{
+			name:     "unset_type_fails",
+			executor: ExecutorConfig{},
+			wantErr:  true,
+		},
+		{
+			name:     "api_fails",
+			executor: ExecutorConfig{Type: "api", VcsBackend: &VcsBackendConfig{Type: "github", Repo: "rxbynerd/stirrup"}},
+			wantErr:  true,
+		},
+		{
+			name:     "none_fails",
+			executor: ExecutorConfig{Type: "none"},
+			wantErr:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			c.Transport = TransportConfig{Type: "grpc"}
+			tc.executor.SandboxIdentity = &SandboxIdentityConfig{Source: "control-plane", EnvVar: "HAYBALE_TOKEN"}
+			tc.executor.GitProxy = &GitProxyConfig{URL: "http://haybale.internal:8466", TokenEnvVar: "HAYBALE_TOKEN"}
+			c.Executor = tc.executor
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for executor.type %q, got nil", tc.executor.Type)
+				}
+				if !strings.Contains(err.Error(), "is only valid for executor.type \"container\", \"k8s\", or \"k8s-sandbox\"") {
+					t.Errorf("expected executor-type gating error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("executor.type %q should pass, got: %v", tc.executor.Type, err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_SandboxIdentitySourceClosedSet(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		wantErr bool
+	}{
+		{"control_plane_passes", "control-plane", false},
+		{"empty_fails", "", true},
+		{"unknown_fails", "self-signed", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sandboxIdentityValidConfig()
+			c.Executor.SandboxIdentity.Source = tc.source
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for source %q, got nil", tc.source)
+				}
+				if !strings.Contains(err.Error(), "unsupported executor.sandboxIdentity.source") {
+					t.Errorf("expected unsupported-source error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("source %q should pass, got: %v", tc.source, err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_GitProxyRequiresSandboxIdentity pins the
+// cross-field decision documented on GitProxyConfig: v1's only token
+// source is control-plane issuance via SandboxIdentity, so a GitProxy
+// block with no SandboxIdentity references an env var that would never
+// be populated. Treated as a configuration error, not a silent no-op.
+func TestValidateRunConfig_GitProxyRequiresSandboxIdentity(t *testing.T) {
+	c := validConfig()
+	c.Transport = TransportConfig{Type: "grpc"}
+	c.Executor = ExecutorConfig{
+		Type:     "container",
+		GitProxy: &GitProxyConfig{URL: "http://haybale.internal:8466", TokenEnvVar: "HAYBALE_TOKEN"},
+	}
+	err := ValidateRunConfig(c)
+	if err == nil {
+		t.Fatal("expected rejection for gitProxy without sandboxIdentity, got nil")
+	}
+	if !strings.Contains(err.Error(), "executor.gitProxy requires executor.sandboxIdentity to be set") {
+		t.Errorf("expected gitProxy-requires-sandboxIdentity error, got: %v", err)
+	}
+}
+
+func TestValidateRunConfig_GitProxyTokenEnvVarConsistency(t *testing.T) {
+	cases := []struct {
+		name        string
+		identityEnv string
+		gitProxyEnv string
+		wantErr     bool
+	}{
+		{"explicit_match", "HAYBALE_TOKEN", "HAYBALE_TOKEN", false},
+		{"both_default_match", "", "", false},
+		{"identity_explicit_gitproxy_default_mismatch", "CUSTOM_TOKEN", "", true},
+		{"explicit_mismatch", "HAYBALE_TOKEN", "OTHER_TOKEN", true},
+		{"identity_default_gitproxy_explicit_match", "", "HAYBALE_TOKEN", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sandboxIdentityValidConfig()
+			c.Executor.SandboxIdentity.EnvVar = tc.identityEnv
+			c.Executor.GitProxy.TokenEnvVar = tc.gitProxyEnv
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for identityEnv=%q gitProxyEnv=%q, got nil", tc.identityEnv, tc.gitProxyEnv)
+				}
+				if !strings.Contains(err.Error(), "must match the effective executor.sandboxIdentity.envVar") {
+					t.Errorf("expected envVar-consistency error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("identityEnv=%q gitProxyEnv=%q should pass, got: %v", tc.identityEnv, tc.gitProxyEnv, err)
+			}
+		})
+	}
+}
+
+func TestValidateRunConfig_GitProxyAllowlistWarning(t *testing.T) {
+	const wantMsg = "executor.gitProxy.url host:port is not present in executor.network.allowlist"
+	cases := []struct {
+		name      string
+		mode      string
+		allowlist []string
+		wantWarn  bool
+	}{
+		{"exact_hostport_present_no_warn", "allowlist", []string{"haybale.internal:8466"}, false},
+		{"missing_from_allowlist_warns", "allowlist", []string{"other.example.com:8466"}, true},
+		{"empty_allowlist_warns", "allowlist", nil, true},
+		{"none_mode_no_warn", "none", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			originalLogger := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(originalLogger) })
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+			c := sandboxIdentityValidConfig()
+			c.Executor.Network = &NetworkConfig{Mode: tc.mode, Allowlist: tc.allowlist}
+			if err := ValidateRunConfig(c); err != nil {
+				t.Fatalf("allowlist warning path must not produce a hard error, got: %v", err)
+			}
+
+			logs := logBuf.String()
+			if tc.wantWarn {
+				if !strings.Contains(logs, "level=WARN") || !strings.Contains(logs, wantMsg) {
+					t.Errorf("expected allowlist-gap warning, got: %s", logs)
+				}
+			} else if strings.Contains(logs, wantMsg) {
+				t.Errorf("did not expect allowlist-gap warning, got: %s", logs)
 			}
 		})
 	}

--- a/types/runconfig_test.go
+++ b/types/runconfig_test.go
@@ -7827,6 +7827,26 @@ func TestValidateRunConfig_SandboxIdentityDefaultConfigStillValid(t *testing.T) 
 	}
 }
 
+// TestValidateRunConfig_SandboxIdentityAloneStillValid pins the
+// simplest legal shape: SandboxIdentity set, GitProxy nil.
+// validateSandboxIdentity does not require GitProxy, so this must
+// validate cleanly — the missing counterpart to
+// TestValidateRunConfig_SandboxIdentityDefaultConfigStillValid, which
+// only proves the bare-default (neither block set) case.
+func TestValidateRunConfig_SandboxIdentityAloneStillValid(t *testing.T) {
+	c := validConfig()
+	c.Transport = TransportConfig{Type: "grpc"}
+	c.Executor = ExecutorConfig{
+		Type: "container",
+		SandboxIdentity: &SandboxIdentityConfig{
+			Source: "control-plane",
+		},
+	}
+	if err := ValidateRunConfig(c); err != nil {
+		t.Fatalf("sandboxIdentity alone (no gitProxy) must validate cleanly, got: %v", err)
+	}
+}
+
 func TestValidateRunConfig_SandboxIdentityRequiresGRPC(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -7936,7 +7956,7 @@ func TestValidateRunConfig_SandboxIdentityExecutorTypeGating(t *testing.T) {
 			c := validConfig()
 			c.Transport = TransportConfig{Type: "grpc"}
 			tc.executor.SandboxIdentity = &SandboxIdentityConfig{Source: "control-plane", EnvVar: "HAYBALE_TOKEN"}
-			tc.executor.GitProxy = &GitProxyConfig{URL: "http://haybale.internal:8466", TokenEnvVar: "HAYBALE_TOKEN"}
+			tc.executor.GitProxy = &GitProxyConfig{URL: "http://haybale.internal:8466", Hosts: []string{"github.com"}, TokenEnvVar: "HAYBALE_TOKEN"}
 			c.Executor = tc.executor
 			err := ValidateRunConfig(c)
 			if tc.wantErr {
@@ -7981,6 +8001,48 @@ func TestValidateRunConfig_SandboxIdentitySourceClosedSet(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("source %q should pass, got: %v", tc.source, err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_SandboxIdentityEnvVarShape pins the
+// injection-shape guard on SandboxIdentityConfig.EnvVar: PR C
+// interpolates the name (not the token value) into a double-quoted
+// shell credential-helper string, so a non-empty EnvVar must match
+// posixEnvVarNamePattern. This is a charset check only — it does not
+// deny semantically-risky-but-valid names like PATH.
+func TestValidateRunConfig_SandboxIdentityEnvVarShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		envVar  string
+		wantErr bool
+	}{
+		{"valid", "HAYBALE_TOKEN", false},
+		{"empty_uses_default", "", false},
+		{"space", "HAYBALE TOKEN", true},
+		{"equals_sign", "TOKEN=x", true},
+		{"leading_digit", "1TOKEN", true},
+		{"shell_metacharacter", `HAYBALE"; rm -rf /; echo "`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sandboxIdentityValidConfig()
+			c.Executor.GitProxy = nil
+			c.Executor.SandboxIdentity.EnvVar = tc.envVar
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for envVar %q, got nil", tc.envVar)
+				}
+				if !strings.Contains(err.Error(), "executor.sandboxIdentity.envVar") ||
+					!strings.Contains(err.Error(), "must be a valid POSIX environment variable name") {
+					t.Errorf("expected POSIX envVar shape error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("envVar %q should pass, got: %v", tc.envVar, err)
 			}
 		})
 	}
@@ -8042,18 +8104,138 @@ func TestValidateRunConfig_GitProxyTokenEnvVarConsistency(t *testing.T) {
 	}
 }
 
+// TestValidateRunConfig_GitProxyURLValidation pins the requirement,
+// documented but previously unvalidated, that gitProxy.url is required
+// and must be an absolute http(s) URL with a host — mirrors
+// validateGuardRailEndpoint's shape check on GuardRailConfig.Endpoint.
+func TestValidateRunConfig_GitProxyURLValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr string // substring; empty means the URL should pass
+	}{
+		{"empty_url_required", "", "executor.gitProxy.url is required when executor.gitProxy is set"},
+		{"malformed_no_scheme_or_host", "not-a-url", "must use scheme http or https"},
+		{"malformed_missing_protocol_scheme", "://bad", "must be a valid URL"},
+		{"non_http_scheme", "ftp://host:21", "must use scheme http or https"},
+		{"valid_url", "http://haybale.internal:8466", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sandboxIdentityValidConfig()
+			c.Executor.GitProxy.URL = tc.url
+			err := ValidateRunConfig(c)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("url %q should pass, got: %v", tc.url, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected rejection for url %q, got nil", tc.url)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error to mention %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_GitProxyTokenEnvVarShape pins the
+// injection-shape guard on GitProxyConfig.TokenEnvVar — the
+// gitProxy.tokenEnvVar equivalent of
+// TestValidateRunConfig_SandboxIdentityEnvVarShape.
+func TestValidateRunConfig_GitProxyTokenEnvVarShape(t *testing.T) {
+	cases := []struct {
+		name        string
+		tokenEnvVar string
+		wantErr     bool
+	}{
+		{"valid", "HAYBALE_TOKEN", false},
+		{"empty_uses_default", "", false},
+		{"space", "HAYBALE TOKEN", true},
+		{"equals_sign", "TOKEN=x", true},
+		{"leading_digit", "1TOKEN", true},
+		{"shell_metacharacter", `HAYBALE"; rm -rf /; echo "`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sandboxIdentityValidConfig()
+			c.Executor.GitProxy.TokenEnvVar = tc.tokenEnvVar
+			err := ValidateRunConfig(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for tokenEnvVar %q, got nil", tc.tokenEnvVar)
+				}
+				if !strings.Contains(err.Error(), "executor.gitProxy.tokenEnvVar") ||
+					!strings.Contains(err.Error(), "must be a valid POSIX environment variable name") {
+					t.Errorf("expected POSIX tokenEnvVar shape error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("tokenEnvVar %q should pass, got: %v", tc.tokenEnvVar, err)
+			}
+		})
+	}
+}
+
+// TestValidateRunConfig_GitProxyHostsRequired pins the requirement that
+// a configured gitProxy block names at least one host to rewrite —
+// Hosts is what drives how many proxy rewrite rules get composed, so an
+// empty list would leave the block validating cleanly while silently
+// doing nothing.
+func TestValidateRunConfig_GitProxyHostsRequired(t *testing.T) {
+	cases := []struct {
+		name  string
+		hosts []string
+	}{
+		{"nil_hosts", nil},
+		{"empty_hosts", []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sandboxIdentityValidConfig()
+			c.Executor.GitProxy.Hosts = tc.hosts
+			err := ValidateRunConfig(c)
+			if err == nil {
+				t.Fatalf("expected rejection for hosts %v, got nil", tc.hosts)
+			}
+			if !strings.Contains(err.Error(), "executor.gitProxy.hosts must contain at least one host when executor.gitProxy is set") {
+				t.Errorf("expected gitProxy.hosts-required error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateRunConfig_GitProxyAllowlistWarning(t *testing.T) {
 	const wantMsg = "executor.gitProxy.url host:port is not present in executor.network.allowlist"
 	cases := []struct {
 		name      string
 		mode      string
 		allowlist []string
-		wantWarn  bool
+		// url overrides sandboxIdentityValidConfig's default gitProxy.url
+		// ("http://haybale.internal:8466") when non-empty, to exercise
+		// warnGitProxyAllowlistGap's port-defaulting branches.
+		url      string
+		wantWarn bool
 	}{
-		{"exact_hostport_present_no_warn", "allowlist", []string{"haybale.internal:8466"}, false},
-		{"missing_from_allowlist_warns", "allowlist", []string{"other.example.com:8466"}, true},
-		{"empty_allowlist_warns", "allowlist", nil, true},
-		{"none_mode_no_warn", "none", nil, false},
+		{"exact_hostport_present_no_warn", "allowlist", []string{"haybale.internal:8466"}, "", false},
+		{"missing_from_allowlist_warns", "allowlist", []string{"other.example.com:8466"}, "", true},
+		{"empty_allowlist_warns", "allowlist", nil, "", true},
+		{"none_mode_no_warn", "none", nil, "", false},
+		// (a) no explicit port on an http:// URL hits the implicit
+		// port-80 default (types/runconfig.go's "case u.Scheme ==
+		// http" branch); the allowlist entry matches that default
+		// exactly, so no warning.
+		{"http_no_port_defaults_to_80_no_warn", "allowlist", []string{"haybale.internal:80"}, "http://haybale.internal", false},
+		// (b) no explicit port on an https:// URL falls through to the
+		// gitProxyAllowlistDefaultPort (443) default; a bare-hostname
+		// allowlist entry (no ":port" suffix) matches it via the
+		// "convenience match" shortcut the GitProxyConfig.URL doc
+		// comment describes, so no warning even though the entry has
+		// no explicit port.
+		{"default_port_bare_host_allowlist_shortcut_no_warn", "allowlist", []string{"haybale.internal"}, "https://haybale.internal", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -8063,6 +8245,9 @@ func TestValidateRunConfig_GitProxyAllowlistWarning(t *testing.T) {
 			slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
 
 			c := sandboxIdentityValidConfig()
+			if tc.url != "" {
+				c.Executor.GitProxy.URL = tc.url
+			}
 			c.Executor.Network = &NetworkConfig{Mode: tc.mode, Allowlist: tc.allowlist}
 			if err := ValidateRunConfig(c); err != nil {
 				t.Fatalf("allowlist warning path must not produce a hard error, got: %v", err)
@@ -8077,5 +8262,109 @@ func TestValidateRunConfig_GitProxyAllowlistWarning(t *testing.T) {
 				t.Errorf("did not expect allowlist-gap warning, got: %s", logs)
 			}
 		})
+	}
+}
+
+// TestSandboxIdentityAndGitProxyConfig_JSONRoundTrip mirrors
+// TestHooksConfig_JSONRoundTrip: pins that every field on
+// SandboxIdentityConfig and GitProxyConfig survives a JSON round trip
+// unchanged when populated.
+func TestSandboxIdentityAndGitProxyConfig_JSONRoundTrip(t *testing.T) {
+	rc := RunConfig{
+		Executor: ExecutorConfig{
+			SandboxIdentity: &SandboxIdentityConfig{
+				Source:   "control-plane",
+				Audience: "https://haybale.internal",
+				EnvVar:   "HAYBALE_TOKEN",
+			},
+			GitProxy: &GitProxyConfig{
+				URL:         "http://haybale.internal:8466",
+				Hosts:       []string{"github.com"},
+				RewriteSsh:  true,
+				TokenEnvVar: "HAYBALE_TOKEN",
+			},
+		},
+	}
+	data, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got RunConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Executor.SandboxIdentity == nil || *got.Executor.SandboxIdentity != *rc.Executor.SandboxIdentity {
+		t.Errorf("SandboxIdentity round-trip: got %+v, want %+v", got.Executor.SandboxIdentity, rc.Executor.SandboxIdentity)
+	}
+	if got.Executor.GitProxy == nil {
+		t.Fatal("GitProxy must survive JSON round-trip as non-nil")
+	}
+	if got.Executor.GitProxy.URL != rc.Executor.GitProxy.URL ||
+		len(got.Executor.GitProxy.Hosts) != 1 || got.Executor.GitProxy.Hosts[0] != "github.com" ||
+		got.Executor.GitProxy.RewriteSsh != rc.Executor.GitProxy.RewriteSsh ||
+		got.Executor.GitProxy.TokenEnvVar != rc.Executor.GitProxy.TokenEnvVar {
+		t.Errorf("GitProxy round-trip: got %+v, want %+v", got.Executor.GitProxy, rc.Executor.GitProxy)
+	}
+}
+
+// TestRunConfig_SandboxIdentityGitProxyOmitEmptyFields mirrors
+// TestRunConfig_HooksOmittedWhenNil: pins the omitempty JSON tags on
+// SandboxIdentityConfig.Audience/EnvVar and
+// GitProxyConfig.Hosts/RewriteSsh/TokenEnvVar (omitted when left at
+// their zero value), and confirms Source and URL — which carry no
+// omitempty tag — instead round-trip as present, empty-string keys.
+func TestRunConfig_SandboxIdentityGitProxyOmitEmptyFields(t *testing.T) {
+	rc := RunConfig{
+		Executor: ExecutorConfig{
+			SandboxIdentity: &SandboxIdentityConfig{},
+			GitProxy:        &GitProxyConfig{},
+		},
+	}
+	data, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	for _, absentKey := range []string{`"audience"`, `"envVar"`, `"hosts"`, `"rewriteSsh"`, `"tokenEnvVar"`} {
+		if strings.Contains(s, absentKey) {
+			t.Errorf("expected no %s key when unset, got: %s", absentKey, s)
+		}
+	}
+	if !strings.Contains(s, `"source":""`) {
+		t.Errorf("expected source key present as empty string, got: %s", s)
+	}
+	if !strings.Contains(s, `"url":""`) {
+		t.Errorf("expected url key present as empty string, got: %s", s)
+	}
+
+	var got RunConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Executor.SandboxIdentity == nil || got.Executor.SandboxIdentity.Source != "" {
+		t.Errorf("expected SandboxIdentity.Source to round-trip as empty string, got: %+v", got.Executor.SandboxIdentity)
+	}
+	if got.Executor.GitProxy == nil || got.Executor.GitProxy.URL != "" {
+		t.Errorf("expected GitProxy.URL to round-trip as empty string, got: %+v", got.Executor.GitProxy)
+	}
+}
+
+// TestSandboxIdentityConfig_EffectiveEnvVar_NilReceiver pins the
+// documented contract on EffectiveEnvVar: "a nil cfg returns the
+// default so callers need not nil-check first."
+func TestSandboxIdentityConfig_EffectiveEnvVar_NilReceiver(t *testing.T) {
+	var cfg *SandboxIdentityConfig
+	if got := cfg.EffectiveEnvVar(); got != DefaultSandboxIdentityEnvVar {
+		t.Errorf("nil *SandboxIdentityConfig.EffectiveEnvVar() = %q, want %q", got, DefaultSandboxIdentityEnvVar)
+	}
+}
+
+// TestGitProxyConfig_EffectiveTokenEnvVar_NilReceiver pins the
+// documented contract on EffectiveTokenEnvVar: "a nil cfg returns the
+// default so callers need not nil-check first."
+func TestGitProxyConfig_EffectiveTokenEnvVar_NilReceiver(t *testing.T) {
+	var cfg *GitProxyConfig
+	if got := cfg.EffectiveTokenEnvVar(); got != DefaultSandboxIdentityEnvVar {
+		t.Errorf("nil *GitProxyConfig.EffectiveTokenEnvVar() = %q, want %q", got, DefaultSandboxIdentityEnvVar)
 	}
 }


### PR DESCRIPTION
## Summary

PR **B** of the 4-PR stack for issue #516. Adds the **RunConfig surface** for sandbox identity tokens and git-proxy wiring, plus `ValidateRunConfig` rules and documentation. No runtime behaviour yet — the token-exchange helper and executor env composition land in PR C.

Stacked on PR A (#517, `feat/issue-516-token-events`). Review this PR against its base branch.

## What changed

- `types/runconfig.go`:
  - `SandboxIdentityConfig` (`executor.sandboxIdentity`): `source` (only `control-plane`), `audience`, `envVar` (default `HAYBALE_TOKEN`).
  - `GitProxyConfig` (`executor.gitProxy`): `url`, `hosts`, `rewriteSsh`, `tokenEnvVar`.
  - Nil-safe default helpers `EffectiveEnvVar()` / `EffectiveTokenEnvVar()` and exported `DefaultSandboxIdentityEnvVar = "HAYBALE_TOKEN"` (PR C should call these rather than reimplement the fallback).
  - `ValidateRunConfig` rules, gated strictly on `SandboxIdentity != nil || GitProxy != nil` so a bare RunConfig is untouched:
    - grpc-only (stdio → error);
    - executor-type scope `{container, k8s, k8s-sandbox}` (local/api/none → error; `replay` is not a real executor type on main);
    - `source` enum (`control-plane` only);
    - `gitProxy` without `sandboxIdentity` → error (v1 has no other token source);
    - `tokenEnvVar` must match the effective `sandboxIdentity.envVar`;
    - non-fatal `slog.Warn` when `gitProxy.url` host:port is absent from `executor.network.allowlist` in allowlist mode.
- `types/runconfig_test.go`: table-driven coverage for every rule above, the default-config-still-valid case, and a `Redact()` assertion proving the new blocks carry no secret material (the token never enters RunConfig).
- `docs/configuration.md`: documents both blocks, constraints, and the allowlist guidance; cross-links `docs/deployment.md`'s wire contract.

## Design decisions (from #516)

- Two separate blocks: token issuance is generic; git-proxy wiring is one consumer.
- All fields non-secret; `Redact()` needs no new stripping (asserted by test).
- `audience` is a control-plane hint, not an authorization assertion (documented in PR A's deployment.md).

## Test evidence

- `just` (build + test): all packages `ok`.
- `just lint`: `0 issues`.

Issue #516 is closed by PR D only (the final PR in this stack); this PR carries no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CS8eU446ivtvsRgHNDroTN
