### PR TITLE
core, executor: sandbox identity token exchange + git-proxy env wiring (#516 PR C)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -250,13 +250,13 @@ posture is that the control plane issues `exp` covering the run's
 configured wall-clock budget (plus slack), and narrows blast radius
 through per-token scope claims and proxy-side policy instead of a
 short lifetime. The optional `sandbox_token_response.expires_at`
-field (Unix seconds) is designed to let the harness compare the
-token's actual expiry against the run's budget and emit a
-scrub-safe warning when the token is shorter-lived than the run — a
-signal that the run may fail partway through with authentication
-errors rather than a stirrup-side bug. That comparison is not yet
-wired: this PR is wire/types-only, and the check lands with the
-token-exchange helper (issue #516 Part C).
+field (Unix seconds) lets the harness compare the token's actual
+expiry against the run's budget and emit a scrub-safe warning when
+the token is shorter-lived than the run — a signal that the run may
+fail partway through with authentication errors rather than a
+stirrup-side bug. The harness performs that comparison
+(`sandboxidentity.WarnIfExpiresBeforeBudget`) immediately after a
+successful token exchange, before the sandbox is created.
 
 ## Container image
 

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rxbynerd/stirrup/harness/internal/provider/quirks"
 	"github.com/rxbynerd/stirrup/harness/internal/router"
 	"github.com/rxbynerd/stirrup/harness/internal/ruleoftwo"
+	"github.com/rxbynerd/stirrup/harness/internal/sandboxidentity"
 	"github.com/rxbynerd/stirrup/harness/internal/security"
 	"github.com/rxbynerd/stirrup/harness/internal/security/codescanner"
 	"github.com/rxbynerd/stirrup/harness/internal/tool"
@@ -101,12 +102,50 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 		return nil, fmt.Errorf("build prompt builder: %w", err)
 	}
 
+	// 2b. Sandbox identity token exchange (issue #516 Part A) and sandbox
+	// env composition (issue #516 Part B), when
+	// config.Executor.SandboxIdentity is configured. Runs before
+	// buildExecutor (step 3): the composed env — which carries the secret
+	// token — is passed into the executor's construction so a sandbox
+	// never comes up without it, and a failed/declined/timed-out exchange
+	// aborts the run before any sandbox is created (fail-closed).
+	var sandboxExtraEnv []executor.EnvPair
+	if si := config.Executor.SandboxIdentity; si != nil {
+		// tp is the transport this function was invoked with (the stirrup
+		// job control-plane entrypoint pre-establishes it). A nil tp means
+		// BuildLoopWithTransport would build its own transport later, at
+		// step 6 — after the executor. Sandbox identity issuance is only
+		// supported against a caller-supplied transport, since the token
+		// exchange must complete before the executor is built.
+		// ValidateRunConfig's transport=grpc check does not catch a nil tp
+		// here (a bare BuildLoop(ctx, config) call with
+		// transport.type=grpc still reaches this branch with tp==nil), so
+		// this is a defensive, not redundant, guard.
+		if tp == nil {
+			return nil, fmt.Errorf("executor.sandboxIdentity requires a pre-established transport (only supported via the control-plane job entrypoint, e.g. \"stirrup job\")")
+		}
+
+		result, exchErr := sandboxidentity.Exchange(ctx, tp, si.Audience, 0)
+		if exchErr != nil {
+			return nil, fmt.Errorf("executor.sandboxIdentity: %w", exchErr)
+		}
+		if config.Timeout != nil {
+			sandboxidentity.WarnIfExpiresBeforeBudget(result.ExpiresAt, *config.Timeout, time.Now())
+		}
+
+		composed := sandboxidentity.ComposeEnv(si.EffectiveEnvVar(), result.Token, config.Executor.GitProxy)
+		sandboxExtraEnv = make([]executor.EnvPair, len(composed))
+		for i, e := range composed {
+			sandboxExtraEnv[i] = executor.EnvPair{Name: e.Name, Value: e.Value}
+		}
+	}
+
 	// 3. Executor (built early because context strategy may need it).
 	// Thread the security logger into the container executor so the
 	// in-process egress proxy (started when network.mode == "allowlist")
 	// can emit egress_allowed / egress_blocked events through the same
 	// SecurityLogger used for path/file events.
-	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
+	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger, sandboxExtraEnv)
 	if err != nil {
 		return nil, fmt.Errorf("build executor: %w", err)
 	}
@@ -943,7 +982,13 @@ func buildContextStrategy(cfg types.ContextStrategyConfig, prov provider.Provide
 	}
 }
 
-func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets security.SecretStore, secLogger *security.SecurityLogger) (executor.Executor, error) {
+// buildExecutor constructs the run's executor. extraEnv carries the
+// composed sandbox identity / git-proxy environment (issue #516) computed
+// by the caller before this function runs; it is only honoured by the
+// container and k8s/k8s-sandbox cases — ValidateRunConfig restricts
+// ExecutorConfig.SandboxIdentity/GitProxy to those executor types, so
+// extraEnv is empty for every other case by construction.
+func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets security.SecretStore, secLogger *security.SecurityLogger, extraEnv []executor.EnvPair) (executor.Executor, error) {
 	switch cfg.Type {
 	case "local", "":
 		workspace := cfg.Workspace
@@ -975,6 +1020,7 @@ func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets securi
 			Runtime:           cfg.Runtime,
 			RegistryAllowlist: cfg.RegistryAllowlist,
 			EgressSecurity:    secLogger,
+			ExtraEnv:          extraEnv,
 		})
 	case "k8s", "k8s-sandbox":
 		// ValidateRunConfig already enforces Image and K8sNamespace for the
@@ -1001,6 +1047,7 @@ func buildExecutor(ctx context.Context, cfg types.ExecutorConfig, secrets securi
 			Network:            cfg.Network,
 			EgressProxyURL:     cfg.K8sEgressProxyURL,
 			Security:           secLogger,
+			ExtraEnv:           extraEnv,
 		}
 		if cfg.Type == "k8s-sandbox" {
 			return executor.NewAgentSandboxExecutor(ctx, k8sCfg)

--- a/harness/internal/core/factory.go
+++ b/harness/internal/core/factory.go
@@ -133,7 +133,10 @@ func BuildLoopWithTransport(ctx context.Context, config *types.RunConfig, tp tra
 			sandboxidentity.WarnIfExpiresBeforeBudget(result.ExpiresAt, *config.Timeout, time.Now())
 		}
 
-		composed := sandboxidentity.ComposeEnv(si.EffectiveEnvVar(), result.Token, config.Executor.GitProxy)
+		composed, composeErr := sandboxidentity.ComposeEnv(si.EffectiveEnvVar(), result.Token, config.Executor.GitProxy)
+		if composeErr != nil {
+			return nil, fmt.Errorf("executor.sandboxIdentity: %w", composeErr)
+		}
 		sandboxExtraEnv = make([]executor.EnvPair, len(composed))
 		for i, e := range composed {
 			sandboxExtraEnv[i] = executor.EnvPair{Name: e.Name, Value: e.Value}

--- a/harness/internal/core/factory_sandboxidentity_test.go
+++ b/harness/internal/core/factory_sandboxidentity_test.go
@@ -11,9 +11,13 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/rxbynerd/stirrup/harness/internal/sandboxidentity"
 	"github.com/rxbynerd/stirrup/types"
 )
+
+func boolPtr(b bool) *bool { return &b }
 
 // fakeControlPlaneTransport is a minimal transport.Transport fake standing
 // in for the control plane's gRPC stream. It auto-responds to a
@@ -31,20 +35,36 @@ type fakeControlPlaneTransport struct {
 
 	respondToken     string
 	respondExpiresAt *int64
+
+	// respondIsError/respondReason, when respondIsError is true, deliver a
+	// control-plane decline instead of a success response (B-INT case a).
+	respondIsError bool
+	respondReason  string
+	// noRespond, when true, never delivers a response at all — the fake
+	// control plane emits no sandbox_token_response, simulating a hung or
+	// unreachable control plane so the caller's ctx/timeout is what ends
+	// the wait (B-INT case b).
+	noRespond bool
 }
 
 func (f *fakeControlPlaneTransport) Emit(event types.HarnessEvent) error {
 	f.mu.Lock()
 	f.emitted = append(f.emitted, event)
+	noRespond := f.noRespond
 	f.mu.Unlock()
 
-	if event.Type == "sandbox_token_request" {
-		f.deliver(types.ControlEvent{
+	if event.Type == "sandbox_token_request" && !noRespond {
+		resp := types.ControlEvent{
 			Type:      "sandbox_token_response",
 			RequestID: event.RequestID,
 			Token:     f.respondToken,
 			ExpiresAt: f.respondExpiresAt,
-		})
+		}
+		if f.respondIsError {
+			resp.IsError = boolPtr(true)
+			resp.Reason = f.respondReason
+		}
+		f.deliver(resp)
 	}
 	return nil
 }
@@ -97,6 +117,7 @@ func fakeDockerEngine(t *testing.T) (socketPath string, createBody *containerCre
 
 		switch {
 		case r.Method == http.MethodPost && apiPath == "/containers/create":
+			capture.recordCreateCall()
 			_ = json.NewDecoder(r.Body).Decode(capture)
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"Id":"test-container-id"}`))
@@ -122,9 +143,15 @@ func fakeDockerEngine(t *testing.T) (socketPath string, createBody *containerCre
 }
 
 // containerCreateCapture decodes only the fields this test needs from the
-// Docker Engine API's POST /containers/create request body.
+// Docker Engine API's POST /containers/create request body. createCalls
+// (guarded by mu, since the fake server's handler runs on its own
+// goroutine) counts how many times /containers/create was hit — the
+// fail-closed integration tests (B-INT) assert this stays zero.
 type containerCreateCapture struct {
 	Env []string `json:"Env"`
+
+	mu          sync.Mutex
+	createCalls int
 }
 
 func (c *containerCreateCapture) envMap() map[string]string {
@@ -136,6 +163,18 @@ func (c *containerCreateCapture) envMap() map[string]string {
 		}
 	}
 	return out
+}
+
+func (c *containerCreateCapture) recordCreateCall() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.createCalls++
+}
+
+func (c *containerCreateCapture) createCallCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.createCalls
 }
 
 // TestBuildLoopWithTransport_SandboxIdentity_ContainerEnvWiring is the
@@ -297,5 +336,133 @@ func TestBuildLoopWithTransport_SandboxIdentity_NilTransportFailsClosed(t *testi
 	}
 	if !strings.Contains(err.Error(), "sandboxIdentity") {
 		t.Errorf("error should reference sandboxIdentity, got: %v", err)
+	}
+}
+
+// sandboxIdentityFailClosedConfig builds the shared RunConfig for the B-INT
+// fail-closed integration tests below: a container executor (so
+// fakeDockerEngine can observe whether /containers/create was ever hit) with
+// executor.sandboxIdentity configured and no gitProxy (irrelevant to these
+// failure modes, all of which abort before ComposeEnv runs). The provider
+// BaseURL is a closed local port — never dialed, since every case here fails
+// before the loop is otherwise assembled — mirroring
+// TestBuildLoopWithTransport_SandboxIdentity_NilTransportFailsClosed above.
+func sandboxIdentityFailClosedConfig(t *testing.T, runID string) *types.RunConfig {
+	t.Helper()
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+	timeout := 30
+	return &types.RunConfig{
+		RunID:           runID,
+		Mode:            "execution",
+		Prompt:          "hello",
+		Provider:        types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: "http://127.0.0.1:1"},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor: types.ExecutorConfig{
+			Type:      "container",
+			Image:     "ubuntu:26.04",
+			Workspace: t.TempDir(),
+			Network:   &types.NetworkConfig{Mode: "none"},
+			SandboxIdentity: &types.SandboxIdentityConfig{
+				Source:   "control-plane",
+				Audience: "https://haybale.internal",
+				EnvVar:   "HAYBALE_TOKEN",
+			},
+		},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		Transport:        types.TransportConfig{Type: "grpc"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+}
+
+// TestBuildLoopWithTransport_SandboxIdentity_DeclineNoContainerCreate is
+// B-INT case (a): the control plane responds with IsError: true. A unit
+// test on sandboxidentity.Exchange already proves Exchange itself fails
+// closed on a decline; this test proves the *factory* honours that error
+// before reaching the executor layer — a regression that swapped step
+// order, dropped the error check, or logged-and-continued would pass every
+// other currently committed test but must fail this one, because the fake
+// Docker Engine below would then observe a real /containers/create call.
+func TestBuildLoopWithTransport_SandboxIdentity_DeclineNoContainerCreate(t *testing.T) {
+	sock, capture, cleanupEngine := fakeDockerEngine(t)
+	defer cleanupEngine()
+	t.Setenv("DOCKER_HOST", "unix://"+sock)
+
+	tp := &fakeControlPlaneTransport{respondIsError: true, respondReason: "no issuer configured"}
+	config := sandboxIdentityFailClosedConfig(t, "sandboxidentity-decline-test")
+
+	_, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err == nil {
+		t.Fatal("expected an error when the control plane declines the sandbox identity exchange")
+	}
+	if !strings.Contains(err.Error(), "declined") {
+		t.Errorf("error should name the decline failure mode, got: %v", err)
+	}
+	if got := capture.createCallCount(); got != 0 {
+		t.Errorf("fake Docker Engine recorded %d /containers/create call(s), want 0 (sandbox must not be created before a declined exchange)", got)
+	}
+}
+
+// TestBuildLoopWithTransport_SandboxIdentity_TimeoutNoContainerCreate is
+// B-INT case (b): the control plane never responds. BuildLoopWithTransport
+// is invoked with a short-lived ctx (rather than waiting out
+// sandboxidentity.DefaultTimeout's 60s) so the ctx branch of Exchange's
+// underlying transport.Correlator.Await ends the wait quickly; the failure
+// mode under test — cancellation/timeout aborting before sandbox creation —
+// is the same one a real control-plane outage or network partition would
+// trigger via the 60s default.
+func TestBuildLoopWithTransport_SandboxIdentity_TimeoutNoContainerCreate(t *testing.T) {
+	sock, capture, cleanupEngine := fakeDockerEngine(t)
+	defer cleanupEngine()
+	t.Setenv("DOCKER_HOST", "unix://"+sock)
+
+	tp := &fakeControlPlaneTransport{noRespond: true}
+	config := sandboxIdentityFailClosedConfig(t, "sandboxidentity-timeout-test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := BuildLoopWithTransport(ctx, config, tp)
+	if err == nil {
+		t.Fatal("expected an error when the control plane never responds")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("error should name the cancellation/timeout failure mode, got: %v", err)
+	}
+	if got := capture.createCallCount(); got != 0 {
+		t.Errorf("fake Docker Engine recorded %d /containers/create call(s), want 0 (sandbox must not be created before a timed-out exchange)", got)
+	}
+}
+
+// TestBuildLoopWithTransport_SandboxIdentity_OversizeTokenNoContainerCreate
+// is B-INT case (c): the control plane responds successfully, but with a
+// token exceeding sandboxidentity.MaxTokenBytes. Exchange treats this as a
+// hard failure (never truncated-and-used); this test proves the factory
+// aborts before sandbox creation rather than passing the oversized token
+// through.
+func TestBuildLoopWithTransport_SandboxIdentity_OversizeTokenNoContainerCreate(t *testing.T) {
+	sock, capture, cleanupEngine := fakeDockerEngine(t)
+	defer cleanupEngine()
+	t.Setenv("DOCKER_HOST", "unix://"+sock)
+
+	tp := &fakeControlPlaneTransport{respondToken: strings.Repeat("a", sandboxidentity.MaxTokenBytes+1)}
+	config := sandboxIdentityFailClosedConfig(t, "sandboxidentity-oversize-test")
+
+	_, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err == nil {
+		t.Fatal("expected an error for an oversized sandbox identity token")
+	}
+	if !strings.Contains(err.Error(), "byte cap") {
+		t.Errorf("error should name the oversize failure mode, got: %v", err)
+	}
+	if got := capture.createCallCount(); got != 0 {
+		t.Errorf("fake Docker Engine recorded %d /containers/create call(s), want 0 (sandbox must not be created before an oversize-token failure)", got)
 	}
 }

--- a/harness/internal/core/factory_sandboxidentity_test.go
+++ b/harness/internal/core/factory_sandboxidentity_test.go
@@ -1,0 +1,301 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// fakeControlPlaneTransport is a minimal transport.Transport fake standing
+// in for the control plane's gRPC stream. It auto-responds to a
+// sandbox_token_request with a configurable sandbox_token_response,
+// mirroring permission/askupstream_test.go's mockTransport — the wire-level
+// proto round-trip for the new sandbox_token_request/response fields
+// (Audience, Token, ExpiresAt, IsError) is already covered by PR A's
+// harness/internal/transport/grpc_translate_test.go, so this integration
+// test exercises the seam BuildLoopWithTransport actually consumes
+// (transport.Transport) rather than re-dialing a real gRPC connection.
+type fakeControlPlaneTransport struct {
+	mu       sync.Mutex
+	handlers []func(types.ControlEvent)
+	emitted  []types.HarnessEvent
+
+	respondToken     string
+	respondExpiresAt *int64
+}
+
+func (f *fakeControlPlaneTransport) Emit(event types.HarnessEvent) error {
+	f.mu.Lock()
+	f.emitted = append(f.emitted, event)
+	f.mu.Unlock()
+
+	if event.Type == "sandbox_token_request" {
+		f.deliver(types.ControlEvent{
+			Type:      "sandbox_token_response",
+			RequestID: event.RequestID,
+			Token:     f.respondToken,
+			ExpiresAt: f.respondExpiresAt,
+		})
+	}
+	return nil
+}
+
+func (f *fakeControlPlaneTransport) OnControl(handler func(types.ControlEvent)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers = append(f.handlers, handler)
+}
+
+func (f *fakeControlPlaneTransport) Close() error { return nil }
+
+func (f *fakeControlPlaneTransport) deliver(event types.ControlEvent) {
+	f.mu.Lock()
+	handlers := make([]func(types.ControlEvent), len(f.handlers))
+	copy(handlers, f.handlers)
+	f.mu.Unlock()
+	for _, h := range handlers {
+		h(event)
+	}
+}
+
+// fakeDockerEngine stands up a minimal fake Docker Engine API server on a
+// temporary Unix socket, capturing the body of the /containers/create
+// request. Mirrors executor.mockEngineServer, duplicated here because that
+// helper is unexported test-only code in a different package.
+func fakeDockerEngine(t *testing.T) (socketPath string, createBody *containerCreateCapture, cleanup func()) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "sbid-de-")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	sock := filepath.Join(dir, "s.sock")
+
+	listener, err := net.Listen("unix", sock)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("listen on unix socket: %v", err)
+	}
+
+	capture := &containerCreateCapture{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		apiPath := r.URL.Path
+		if idx := strings.Index(apiPath[1:], "/"); idx >= 0 {
+			apiPath = apiPath[idx+1:]
+		}
+
+		switch {
+		case r.Method == http.MethodPost && apiPath == "/containers/create":
+			_ = json.NewDecoder(r.Body).Decode(capture)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"test-container-id"}`))
+		case r.Method == http.MethodPost && strings.HasPrefix(apiPath, "/containers/") && strings.HasSuffix(apiPath, "/start"):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && strings.HasPrefix(apiPath, "/containers/") && strings.HasSuffix(apiPath, "/stop"):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && strings.HasPrefix(apiPath, "/containers/"):
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		}
+	})
+
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(listener) }()
+
+	return sock, capture, func() {
+		_ = srv.Close()
+		_ = listener.Close()
+		_ = os.RemoveAll(dir)
+	}
+}
+
+// containerCreateCapture decodes only the fields this test needs from the
+// Docker Engine API's POST /containers/create request body.
+type containerCreateCapture struct {
+	Env []string `json:"Env"`
+}
+
+func (c *containerCreateCapture) envMap() map[string]string {
+	out := map[string]string{}
+	for _, kv := range c.Env {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 {
+			out[parts[0]] = parts[1]
+		}
+	}
+	return out
+}
+
+// TestBuildLoopWithTransport_SandboxIdentity_ContainerEnvWiring is the
+// issue #516 acceptance integration test: given executor.sandboxIdentity +
+// executor.gitProxy, transport=grpc, executor=container, the harness
+// requests a sandbox_token_request after the fake control plane's
+// task_assignment-equivalent (BuildLoopWithTransport is invoked directly
+// with the RunConfig, matching how stirrup job calls it post-assignment),
+// and the created container's env carries the token var plus the four
+// GIT_CONFIG_* pairs the issue's canonical example specifies.
+func TestBuildLoopWithTransport_SandboxIdentity_ContainerEnvWiring(t *testing.T) {
+	sock, capture, cleanupEngine := fakeDockerEngine(t)
+	defer cleanupEngine()
+	t.Setenv("DOCKER_HOST", "unix://"+sock)
+
+	server := newOpenAIServer(t, nil, nil, nil)
+	defer server.Close()
+
+	tp := &fakeControlPlaneTransport{respondToken: "the-jwt-token"}
+
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:           "sandboxidentity-integration-test",
+		Mode:            "execution",
+		Prompt:          "hello",
+		Provider:        types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: server.URL},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor: types.ExecutorConfig{
+			Type:      "container",
+			Image:     "ubuntu:26.04",
+			Workspace: t.TempDir(),
+			Network:   &types.NetworkConfig{Mode: "none"},
+			SandboxIdentity: &types.SandboxIdentityConfig{
+				Source:   "control-plane",
+				Audience: "https://haybale.internal",
+				EnvVar:   "HAYBALE_TOKEN",
+			},
+			GitProxy: &types.GitProxyConfig{
+				URL:         "http://haybale.internal:8466",
+				Hosts:       []string{"github.com"},
+				RewriteSsh:  true,
+				TokenEnvVar: "HAYBALE_TOKEN",
+			},
+		},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		Transport:        types.TransportConfig{Type: "grpc"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+
+	loop, err := BuildLoopWithTransport(context.Background(), config, tp)
+	if err != nil {
+		t.Fatalf("BuildLoopWithTransport() error: %v", err)
+	}
+	defer func() { _ = loop.Close() }()
+
+	env := capture.envMap()
+	if got := env["HAYBALE_TOKEN"]; got != "the-jwt-token" {
+		t.Errorf("HAYBALE_TOKEN = %q, want %q", got, "the-jwt-token")
+	}
+	if got := env["GIT_CONFIG_COUNT"]; got != "4" {
+		t.Errorf("GIT_CONFIG_COUNT = %q, want %q", got, "4")
+	}
+
+	wantInsteadOfKey := "url.http://haybale.internal:8466/github.com/.insteadOf"
+	wantValues := map[string]bool{
+		"https://github.com/":   false,
+		"git@github.com:":       false,
+		"ssh://git@github.com/": false,
+	}
+	credKey := "credential.http://haybale.internal:8466/.helper"
+	var credValue string
+	for i := 0; i < 4; i++ {
+		key := env["GIT_CONFIG_KEY_"+strconv.Itoa(i)]
+		value := env["GIT_CONFIG_VALUE_"+strconv.Itoa(i)]
+		switch key {
+		case wantInsteadOfKey:
+			wantValues[value] = true
+		case credKey:
+			credValue = value
+		default:
+			t.Errorf("unexpected GIT_CONFIG_KEY_%d %q", i, key)
+		}
+	}
+	for v, seen := range wantValues {
+		if !seen {
+			t.Errorf("missing insteadOf value %q", v)
+		}
+	}
+	wantCredValue := `!f() { echo username=x-access-token; echo "password=$HAYBALE_TOKEN"; }; f`
+	if credValue != wantCredValue {
+		t.Errorf("credential helper = %q, want %q", credValue, wantCredValue)
+	}
+
+	// The control plane must have seen exactly one sandbox_token_request,
+	// carrying the configured audience.
+	var requests []types.HarnessEvent
+	for _, e := range tp.emitted {
+		if e.Type == "sandbox_token_request" {
+			requests = append(requests, e)
+		}
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected exactly one sandbox_token_request, got %d", len(requests))
+	}
+	if requests[0].Audience != "https://haybale.internal" {
+		t.Errorf("Audience = %q, want https://haybale.internal", requests[0].Audience)
+	}
+}
+
+// TestBuildLoopWithTransport_SandboxIdentity_NilTransportFailsClosed pins
+// the defensive guard: sandboxIdentity is only usable against a
+// pre-established transport (the control-plane job entrypoint). A nil tp
+// must fail closed before any sandbox is created, even though
+// ValidateRunConfig has already accepted transport.type=grpc.
+func TestBuildLoopWithTransport_SandboxIdentity_NilTransportFailsClosed(t *testing.T) {
+	timeout := 30
+	config := &types.RunConfig{
+		RunID:           "sandboxidentity-nil-transport-test",
+		Mode:            "execution",
+		Prompt:          "hello",
+		Provider:        types.ProviderConfig{Type: "openai-compatible", APIKeyRef: "secret://TEST_OPENAI_KEY", BaseURL: "http://127.0.0.1:1"},
+		ModelRouter:     types.ModelRouterConfig{Type: "static", Provider: "openai-compatible", Model: "test"},
+		PromptBuilder:   types.PromptBuilderConfig{Type: "default"},
+		ContextStrategy: types.ContextStrategyConfig{Type: "sliding-window"},
+		Executor: types.ExecutorConfig{
+			Type:      "container",
+			Image:     "ubuntu:26.04",
+			Workspace: t.TempDir(),
+			Network:   &types.NetworkConfig{Mode: "none"},
+			SandboxIdentity: &types.SandboxIdentityConfig{
+				Source:   "control-plane",
+				Audience: "https://haybale.internal",
+			},
+		},
+		EditStrategy:     types.EditStrategyConfig{Type: "multi"},
+		Verifier:         types.VerifierConfig{Type: "none"},
+		PermissionPolicy: types.PermissionPolicyConfig{Type: "allow-all"},
+		GitStrategy:      types.GitStrategyConfig{Type: "none"},
+		Transport:        types.TransportConfig{Type: "grpc", Address: "127.0.0.1:1"},
+		TraceEmitter:     types.TraceEmitterConfig{Type: "jsonl"},
+		RuleOfTwo:        disableRuleOfTwo(),
+		MaxTurns:         2,
+		Timeout:          &timeout,
+	}
+	t.Setenv("TEST_OPENAI_KEY", "test-key")
+
+	_, err := BuildLoopWithTransport(context.Background(), config, nil)
+	if err == nil {
+		t.Fatal("expected an error when sandboxIdentity is set but no transport was pre-established")
+	}
+	if !strings.Contains(err.Error(), "sandboxIdentity") {
+		t.Errorf("error should reference sandboxIdentity, got: %v", err)
+	}
+}

--- a/harness/internal/core/factory_test.go
+++ b/harness/internal/core/factory_test.go
@@ -1068,7 +1068,7 @@ func TestBuildExecutor_Local(t *testing.T) {
 	exec, err := buildExecutor(context.Background(), types.ExecutorConfig{
 		Type:      "local",
 		Workspace: workspace,
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1080,7 +1080,7 @@ func TestBuildExecutor_Local(t *testing.T) {
 func TestBuildExecutor_EmptyTypeDefaultsToLocal(t *testing.T) {
 	exec, err := buildExecutor(context.Background(), types.ExecutorConfig{
 		Workspace: t.TempDir(),
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1090,7 +1090,7 @@ func TestBuildExecutor_EmptyTypeDefaultsToLocal(t *testing.T) {
 }
 
 func TestBuildExecutor_LocalDefaultsWorkspaceToCwd(t *testing.T) {
-	exec, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "local"}, nil, nil)
+	exec, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "local"}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1100,7 +1100,7 @@ func TestBuildExecutor_LocalDefaultsWorkspaceToCwd(t *testing.T) {
 }
 
 func TestBuildExecutor_API_MissingVcsBackend(t *testing.T) {
-	_, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "api"}, nil, nil)
+	_, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "api"}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for api without vcsBackend")
 	}
@@ -1118,7 +1118,7 @@ func TestBuildExecutor_API_BadRepoFormat(t *testing.T) {
 			Repo:      "invalid-no-slash",
 			Ref:       "main",
 		},
-	}, secrets, nil)
+	}, secrets, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for bad repo format")
 	}
@@ -1136,7 +1136,7 @@ func TestBuildExecutor_API_ValidConfig(t *testing.T) {
 			Repo:      "owner/repo",
 			Ref:       "main",
 		},
-	}, secrets, nil)
+	}, secrets, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1146,7 +1146,7 @@ func TestBuildExecutor_API_ValidConfig(t *testing.T) {
 }
 
 func TestBuildExecutor_Container_MissingImage(t *testing.T) {
-	_, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "container"}, nil, nil)
+	_, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "container"}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for container without image")
 	}
@@ -1156,7 +1156,7 @@ func TestBuildExecutor_Container_MissingImage(t *testing.T) {
 }
 
 func TestBuildExecutor_None_ValidConfig(t *testing.T) {
-	exec, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "none"}, nil, nil)
+	exec, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "none"}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1170,7 +1170,7 @@ func TestBuildExecutor_None_ValidConfig(t *testing.T) {
 }
 
 func TestBuildExecutor_UnsupportedType(t *testing.T) {
-	_, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "microvm"}, nil, nil)
+	_, err := buildExecutor(context.Background(), types.ExecutorConfig{Type: "microvm"}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for unsupported type")
 	}
@@ -1183,7 +1183,7 @@ func TestBuildExecutor_K8s_MissingImage(t *testing.T) {
 	_, err := buildExecutor(context.Background(), types.ExecutorConfig{
 		Type:         "k8s",
 		K8sNamespace: "default",
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for k8s without image")
 	}
@@ -1196,7 +1196,7 @@ func TestBuildExecutor_K8s_MissingNamespace(t *testing.T) {
 	_, err := buildExecutor(context.Background(), types.ExecutorConfig{
 		Type:  "k8s",
 		Image: "busybox",
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for k8s without namespace")
 	}
@@ -1217,7 +1217,7 @@ func TestBuildExecutor_K8s_TakesK8sPath(t *testing.T) {
 		Image:         "busybox",
 		K8sNamespace:  "default",
 		K8sKubeconfig: filepath.Join(t.TempDir(), "does-not-exist.kubeconfig"),
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err == nil {
 		// A success would mean a cluster was reachable; that is fine but not
 		// the cluster-free case this test targets.
@@ -1232,7 +1232,7 @@ func TestBuildExecutor_K8sSandbox_MissingImage(t *testing.T) {
 	_, err := buildExecutor(context.Background(), types.ExecutorConfig{
 		Type:         "k8s-sandbox",
 		K8sNamespace: "default",
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for k8s-sandbox without image")
 	}
@@ -1245,7 +1245,7 @@ func TestBuildExecutor_K8sSandbox_MissingNamespace(t *testing.T) {
 	_, err := buildExecutor(context.Background(), types.ExecutorConfig{
 		Type:  "k8s-sandbox",
 		Image: "busybox",
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for k8s-sandbox without namespace")
 	}
@@ -1268,7 +1268,7 @@ func TestBuildExecutor_K8sSandbox_TakesAgentSandboxPath(t *testing.T) {
 		K8sNamespace:  "default",
 		Network:       &types.NetworkConfig{Mode: "none"},
 		K8sKubeconfig: filepath.Join(t.TempDir(), "does-not-exist.kubeconfig"),
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err == nil {
 		// A success would mean a cluster was reachable; that is fine but not
 		// the cluster-free case this test targets.

--- a/harness/internal/core/preflight.go
+++ b/harness/internal/core/preflight.go
@@ -373,7 +373,10 @@ func preflightExecutorConstruct(
 		}
 	}
 
-	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger)
+	// extraEnv is nil: a dry run performs no live token exchange (issue
+	// #516 — Preflight is structural/metadata-only, per the Preflighter
+	// seam's contract), so there is nothing to compose here.
+	exec, err := buildExecutor(ctx, config.Executor, secrets, secLogger, nil)
 	if err != nil {
 		return executorBuildResult{err: err, hint: executorHint(config.Executor.Type)}
 	}

--- a/harness/internal/executor/agentsandbox.go
+++ b/harness/internal/executor/agentsandbox.go
@@ -263,7 +263,7 @@ func NewAgentSandboxExecutor(ctx context.Context, cfg K8sExecutorConfig) (*Agent
 		return nil, fmt.Errorf("generate sandbox name: %w", err)
 	}
 
-	spec := buildSandboxPodSpec(cfg, proxyEnv)
+	spec := buildSandboxPodSpec(cfg, proxyEnv, cfg.ExtraEnv)
 	applyAgentSandboxAdmissionDeltas(&spec)
 
 	// Install the egress NetworkPolicy BEFORE creating the Sandbox, for the same

--- a/harness/internal/executor/agentsandbox_test.go
+++ b/harness/internal/executor/agentsandbox_test.go
@@ -26,7 +26,7 @@ func baseSandboxCfg() K8sExecutorConfig {
 func TestApplyAgentSandboxAdmissionDeltas(t *testing.T) {
 	t.Run("forces gvisor even when runtime was empty", func(t *testing.T) {
 		cfg := baseSandboxCfg() // Runtime unset → buildSandboxPodSpec leaves RuntimeClassName nil
-		spec := buildSandboxPodSpec(cfg, nil)
+		spec := buildSandboxPodSpec(cfg, nil, nil)
 		if spec.RuntimeClassName != nil {
 			t.Fatalf("precondition: base spec RuntimeClassName = %v, want nil", spec.RuntimeClassName)
 		}
@@ -38,7 +38,7 @@ func TestApplyAgentSandboxAdmissionDeltas(t *testing.T) {
 
 	t.Run("fills default cpu+mem limits and requests when resources nil", func(t *testing.T) {
 		cfg := baseSandboxCfg()
-		spec := buildSandboxPodSpec(cfg, nil)
+		spec := buildSandboxPodSpec(cfg, nil, nil)
 		// Precondition: no resources pinned (cfg.Resources nil).
 		if len(spec.Containers[0].Resources.Limits) != 0 {
 			t.Fatalf("precondition: base container has limits %v, want none", spec.Containers[0].Resources.Limits)
@@ -67,7 +67,7 @@ func TestApplyAgentSandboxAdmissionDeltas(t *testing.T) {
 	t.Run("preserves caller-set resources", func(t *testing.T) {
 		cfg := baseSandboxCfg()
 		cfg.Resources = &types.ResourceLimits{CPUs: 2, MemoryMB: 1024}
-		spec := buildSandboxPodSpec(cfg, nil)
+		spec := buildSandboxPodSpec(cfg, nil, nil)
 		// Precondition: the caller's values are already on the base spec via
 		// resourcesToPodResources.
 		wantCPU := resource.MustParse("2")
@@ -93,7 +93,7 @@ func TestApplyAgentSandboxAdmissionDeltas(t *testing.T) {
 		// admission policy requires BOTH cpu and memory limits.
 		cfg := baseSandboxCfg()
 		cfg.Resources = &types.ResourceLimits{MemoryMB: 1024}
-		spec := buildSandboxPodSpec(cfg, nil)
+		spec := buildSandboxPodSpec(cfg, nil, nil)
 		applyAgentSandboxAdmissionDeltas(&spec)
 
 		res := spec.Containers[0].Resources
@@ -112,7 +112,7 @@ func TestApplyAgentSandboxAdmissionDeltas(t *testing.T) {
 	t.Run("merges nodeSelector with a pre-existing entry", func(t *testing.T) {
 		cfg := baseSandboxCfg()
 		cfg.NodeSelector = map[string]string{"disktype": "ssd"}
-		spec := buildSandboxPodSpec(cfg, nil)
+		spec := buildSandboxPodSpec(cfg, nil, nil)
 		applyAgentSandboxAdmissionDeltas(&spec)
 
 		if spec.NodeSelector[gkeSandboxRuntimeKey] != gkeSandboxRuntimeValue {
@@ -125,7 +125,7 @@ func TestApplyAgentSandboxAdmissionDeltas(t *testing.T) {
 
 	t.Run("adds the gvisor toleration and is idempotent", func(t *testing.T) {
 		cfg := baseSandboxCfg()
-		spec := buildSandboxPodSpec(cfg, nil)
+		spec := buildSandboxPodSpec(cfg, nil, nil)
 
 		applyAgentSandboxAdmissionDeltas(&spec)
 		applyAgentSandboxAdmissionDeltas(&spec) // second call must not duplicate
@@ -152,7 +152,7 @@ func TestBuildSandboxObject(t *testing.T) {
 	const ns, name = "default", "stirrup-abc123"
 
 	cfg := baseSandboxCfg()
-	spec := buildSandboxPodSpec(cfg, nil)
+	spec := buildSandboxPodSpec(cfg, nil, nil)
 	applyAgentSandboxAdmissionDeltas(&spec)
 
 	before := time.Now()

--- a/harness/internal/executor/agentsandbox_test.go
+++ b/harness/internal/executor/agentsandbox_test.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/rxbynerd/stirrup/harness/internal/sandboxidentity"
 	"github.com/rxbynerd/stirrup/types"
 )
 
@@ -17,6 +18,67 @@ func baseSandboxCfg() K8sExecutorConfig {
 		Image:     "busybox",
 		Namespace: "default",
 		Network:   &types.NetworkConfig{Mode: "none"},
+	}
+}
+
+// TestBuildSandboxPodSpec_ProxyAndExtraEnvAdditive is B-K8S:
+// buildSandboxPodSpec is the shared env-merge block for both the k8s and
+// k8s-sandbox executors (issue #516) — the production GKE deployment
+// target. Every other test in this file calls it with extraEnv == nil, so
+// the shared "proxyEnv + extraEnv" append block (harness/internal/executor/k8s.go's
+// buildSandboxPodSpec) has no coverage proving both sets survive together:
+// a broken index, wrong append order, or accidental overwrite of proxyEnv
+// would not be caught by anything else here. This test supplies a
+// non-empty proxyEnv (HTTP(S)_PROXY/NO_PROXY, issue #42) alongside a
+// realistic non-empty extraEnv (the sandbox identity token plus the
+// GIT_CONFIG_* pairs sandboxidentity.ComposeEnv produces, issue #516) and
+// asserts both land on the Pod additively.
+func TestBuildSandboxPodSpec_ProxyAndExtraEnvAdditive(t *testing.T) {
+	cfg := baseSandboxCfg()
+	proxyEnv := []corev1.EnvVar{
+		{Name: "HTTP_PROXY", Value: "http://proxy.internal:8080"},
+		{Name: "HTTPS_PROXY", Value: "http://proxy.internal:8080"},
+		{Name: "NO_PROXY", Value: "localhost,127.0.0.1,::1"},
+	}
+
+	composed, err := sandboxidentity.ComposeEnv("HAYBALE_TOKEN", "the-jwt-token", &types.GitProxyConfig{
+		URL:        "http://haybale.internal:8466",
+		Hosts:      []string{"github.com"},
+		RewriteSsh: true,
+	})
+	if err != nil {
+		t.Fatalf("ComposeEnv() error: %v", err)
+	}
+	extraEnv := make([]EnvPair, len(composed))
+	for i, e := range composed {
+		extraEnv[i] = EnvPair{Name: e.Name, Value: e.Value}
+	}
+	if len(proxyEnv) == 0 || len(extraEnv) == 0 {
+		t.Fatalf("precondition: both proxyEnv (%d) and extraEnv (%d) must be non-empty", len(proxyEnv), len(extraEnv))
+	}
+
+	spec := buildSandboxPodSpec(cfg, proxyEnv, extraEnv)
+
+	gotEnv := spec.Containers[0].Env
+	wantLen := len(proxyEnv) + len(extraEnv)
+	if len(gotEnv) != wantLen {
+		t.Fatalf("Containers[0].Env has %d entries, want %d (proxyEnv + extraEnv, additive)", len(gotEnv), wantLen)
+	}
+
+	// proxyEnv must occupy the leading entries, in order — buildSandboxPodSpec
+	// appends proxyEnv first, then extraEnv.
+	for i, want := range proxyEnv {
+		if gotEnv[i].Name != want.Name || gotEnv[i].Value != want.Value {
+			t.Errorf("Env[%d] = %+v, want proxyEnv entry %+v", i, gotEnv[i], want)
+		}
+	}
+	// extraEnv must follow, in order, with none of proxyEnv's entries
+	// truncated, overwritten, or reordered away.
+	for i, want := range extraEnv {
+		idx := len(proxyEnv) + i
+		if gotEnv[idx].Name != want.Name || gotEnv[idx].Value != want.Value {
+			t.Errorf("Env[%d] = %+v, want extraEnv entry %+v", idx, gotEnv[idx], want)
+		}
 	}
 }
 

--- a/harness/internal/executor/container.go
+++ b/harness/internal/executor/container.go
@@ -86,6 +86,12 @@ type ContainerExecutorConfig struct {
 	// per-request egress_allowed / egress_blocked events flow through the
 	// same SecurityLogger the executor uses for path/file events.
 	EgressSecurity egressproxy.SecurityEventEmitter
+	// ExtraEnv is appended to the container's environment after the
+	// HTTP(S)_PROXY/NO_PROXY entries (when Network.Mode == "allowlist"),
+	// regardless of network mode. Populated by the factory from a
+	// sandbox identity token exchange (issue #516) when
+	// ExecutorConfig.SandboxIdentity is configured; empty otherwise.
+	ExtraEnv []EnvPair
 }
 
 // ContainerExecutor implements Executor by running operations inside a
@@ -259,6 +265,10 @@ func NewContainerExecutorWithContext(ctx context.Context, cfg ContainerExecutorC
 		// only the proxy's listen address; that drop is privilege-sensitive
 		// and not portable to macOS Docker Desktop. Tracked separately so
 		// this v1 ships with the limitation honestly documented.
+	}
+
+	for _, e := range cfg.ExtraEnv {
+		env = append(env, e.Name+"="+e.Value)
 	}
 
 	if cfg.Resources != nil {

--- a/harness/internal/executor/envpair.go
+++ b/harness/internal/executor/envpair.go
@@ -1,0 +1,14 @@
+package executor
+
+// EnvPair is a single sandbox environment variable entry, shared by
+// ContainerExecutorConfig.ExtraEnv and K8sExecutorConfig.ExtraEnv (issue
+// #516). Each executor config converts it to its own native env
+// representation ("KEY=VALUE" strings for the container executor,
+// corev1.EnvVar for the k8s family) — this type deliberately carries no
+// executor-specific dependency so callers outside this package (the
+// factory) need not import k8s client types just to compose an env
+// variable.
+type EnvPair struct {
+	Name  string
+	Value string
+}

--- a/harness/internal/executor/k8s.go
+++ b/harness/internal/executor/k8s.go
@@ -109,6 +109,11 @@ type K8sExecutorConfig struct {
 	// reach the same monitoring surface as the container and local
 	// executors. The factory (issue #16) passes the run's emitter through.
 	Security SecurityEventEmitter
+	// ExtraEnv is appended to the sandbox container's environment after
+	// the HTTP(S)_PROXY/NO_PROXY entries (proxyEnv). Populated by the
+	// factory from a sandbox identity token exchange (issue #516) when
+	// ExecutorConfig.SandboxIdentity is configured; empty otherwise.
+	ExtraEnv []EnvPair
 }
 
 // K8sExecutor implements Executor by running operations inside a sandbox
@@ -190,7 +195,7 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 			Namespace: cfg.Namespace,
 			Labels:    podLabels(podName),
 		},
-		Spec: buildSandboxPodSpec(cfg, proxyEnv),
+		Spec: buildSandboxPodSpec(cfg, proxyEnv, cfg.ExtraEnv),
 	}
 
 	// Install the egress NetworkPolicy BEFORE creating the Pod. The Pod name
@@ -246,11 +251,22 @@ func NewK8sExecutor(ctx context.Context, cfg K8sExecutorConfig) (*K8sExecutor, e
 }
 
 // buildSandboxPodSpec builds the hardened agent Pod spec shared by the k8s and
-// k8s-sandbox executors. proxyEnv is the already-computed HTTP(S)_PROXY env.
-func buildSandboxPodSpec(cfg K8sExecutorConfig, proxyEnv []corev1.EnvVar) corev1.PodSpec {
+// k8s-sandbox executors. proxyEnv is the already-computed HTTP(S)_PROXY env;
+// extraEnv is appended after it (issue #516 — a sandbox identity token and,
+// when configured, the git-proxy GIT_CONFIG_* pairs).
+func buildSandboxPodSpec(cfg K8sExecutorConfig, proxyEnv []corev1.EnvVar, extraEnv []EnvPair) corev1.PodSpec {
 	serviceAccount := cfg.ServiceAccountName
 	if serviceAccount == "" {
 		serviceAccount = "default"
+	}
+
+	env := proxyEnv
+	if len(extraEnv) > 0 {
+		env = make([]corev1.EnvVar, 0, len(proxyEnv)+len(extraEnv))
+		env = append(env, proxyEnv...)
+		for _, e := range extraEnv {
+			env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
+		}
 	}
 
 	return corev1.PodSpec{
@@ -294,7 +310,7 @@ func buildSandboxPodSpec(cfg K8sExecutorConfig, proxyEnv []corev1.EnvVar) corev1
 				Image:        cfg.Image,
 				Command:      []string{"/bin/sh", "-c", "sleep infinity"},
 				WorkingDir:   k8sWorkspace,
-				Env:          proxyEnv,
+				Env:          env,
 				Resources:    resourcesToPodResources(cfg.Resources),
 				VolumeMounts: []corev1.VolumeMount{{Name: k8sWorkspaceVolume, MountPath: k8sWorkspace}},
 				SecurityContext: &corev1.SecurityContext{

--- a/harness/internal/sandboxidentity/env.go
+++ b/harness/internal/sandboxidentity/env.go
@@ -2,6 +2,7 @@ package sandboxidentity
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/rxbynerd/stirrup/types"
@@ -25,6 +26,29 @@ type EnvVar struct {
 // haybale strips the username and authenticates solely on the password.
 const credentialHelperTemplate = `!f() { echo username=x-access-token; echo "password=$%s"; }; f`
 
+// posixEnvVarNamePattern duplicates types.posixEnvVarNamePattern. ComposeEnv
+// interpolates envVar unescaped into credentialHelperTemplate's shell
+// string, so this package must not rely solely on
+// types.ValidateRunConfig having already run before it reaches this
+// function — a future refactor that reorders validation, or a new caller
+// that bypasses it, must not reopen the shell-injection shape. Duplicating
+// the character class across the types/harness boundary mirrors the
+// existing gitProxyAllowlistDefaultPort precedent in types/runconfig.go.
+var posixEnvVarNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// reservedEnvVarNames are the egress-proxy variables the container and k8s
+// executors set unconditionally in "allowlist" network mode (see
+// proxyEnvFor in harness/internal/executor/k8s_netpol.go and the
+// equivalent literal block in container.go — both only ever set the
+// upper-case forms). A sandbox identity envVar colliding with one of these
+// would silently append after, and likely override, the proxy URL rather
+// than failing validation up front.
+var reservedEnvVarNames = map[string]bool{
+	"HTTP_PROXY":  true,
+	"HTTPS_PROXY": true,
+	"NO_PROXY":    true,
+}
+
 // ComposeEnv builds the ordered sandbox environment variables that carry a
 // sandbox identity token (and, when gp is non-nil, the non-secret git
 // configuration that routes git operations through a proxy such as
@@ -47,10 +71,22 @@ const credentialHelperTemplate = `!f() { echo username=x-access-token; echo "pas
 // multi-valued config the way repeated lines in a config file would. A
 // single credential.<gp.URL>/.helper entry follows every host's insteadOf
 // rules — one proxy authenticates every rewritten host.
-func ComposeEnv(envVar, token string, gp *types.GitProxyConfig) []EnvVar {
+//
+// Returns an error, composing nothing, when envVar fails the
+// posixEnvVarNamePattern check or collides with a reservedEnvVarNames entry
+// — defense in depth so this function's safety does not rest entirely on
+// its caller (types.ValidateRunConfig) having already run.
+func ComposeEnv(envVar, token string, gp *types.GitProxyConfig) ([]EnvVar, error) {
+	if !posixEnvVarNamePattern.MatchString(envVar) {
+		return nil, fmt.Errorf("sandboxidentity: envVar %q is not a valid POSIX environment variable name", envVar)
+	}
+	if reservedEnvVarNames[envVar] {
+		return nil, fmt.Errorf("sandboxidentity: envVar %q collides with a reserved egress-proxy environment variable", envVar)
+	}
+
 	out := []EnvVar{{Name: envVar, Value: token}}
 	if gp == nil {
-		return out
+		return out, nil
 	}
 
 	var keys, values []string
@@ -75,5 +111,5 @@ func ComposeEnv(envVar, token string, gp *types.GitProxyConfig) []EnvVar {
 			EnvVar{Name: fmt.Sprintf("GIT_CONFIG_VALUE_%d", i), Value: values[i]},
 		)
 	}
-	return out
+	return out, nil
 }

--- a/harness/internal/sandboxidentity/env.go
+++ b/harness/internal/sandboxidentity/env.go
@@ -1,0 +1,79 @@
+package sandboxidentity
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// EnvVar is a single sandbox environment variable entry. Composed env is
+// returned as an ordered slice (not a map) because the GIT_CONFIG_KEY_n /
+// GIT_CONFIG_VALUE_n encoding is positional: git reads the numbered pairs in
+// order, and a repeated key (one per rewritten URL form) must appear at its
+// own index to be honoured as a multi-valued config entry.
+type EnvVar struct {
+	Name  string
+	Value string
+}
+
+// credentialHelperTemplate is the inline shell credential helper haybale's
+// docs/stirrup-integration.md documents: git invokes it as
+// `credential.<proxyURL>/.helper`, and it echoes the token from the sandbox
+// environment variable named by %s as the Basic-auth password. username is
+// a fixed placeholder ("x-access-token", the GitHub App convention) since
+// haybale strips the username and authenticates solely on the password.
+const credentialHelperTemplate = `!f() { echo username=x-access-token; echo "password=$%s"; }; f`
+
+// ComposeEnv builds the ordered sandbox environment variables that carry a
+// sandbox identity token (and, when gp is non-nil, the non-secret git
+// configuration that routes git operations through a proxy such as
+// haybale). It is a pure function — no I/O — so it is directly
+// unit-testable against the issue's "Composed sandbox env" canonical
+// example.
+//
+// envVar is the sandbox environment variable name the token is injected as
+// (SandboxIdentityConfig.EffectiveEnvVar() / GitProxyConfig.EffectiveTokenEnvVar()
+// — ValidateRunConfig guarantees the two agree when both are set). token is
+// the raw JWT from a successful Exchange.
+//
+// The first returned entry is always <envVar>=<token>. When gp is nil, that
+// is the only entry (a bare sandbox identity token with no git-proxy
+// consumer). When gp is non-nil, GIT_CONFIG_COUNT and the numbered
+// GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n pairs follow: for each host in
+// gp.Hosts, an "https://" insteadOf rewrite, plus (when gp.RewriteSsh) the
+// scp-style "git@host:" and "ssh://git@host/" forms — all three sharing the
+// same key, since git appends repeated GIT_CONFIG_KEY_n entries as
+// multi-valued config the way repeated lines in a config file would. A
+// single credential.<gp.URL>/.helper entry follows every host's insteadOf
+// rules — one proxy authenticates every rewritten host.
+func ComposeEnv(envVar, token string, gp *types.GitProxyConfig) []EnvVar {
+	out := []EnvVar{{Name: envVar, Value: token}}
+	if gp == nil {
+		return out
+	}
+
+	var keys, values []string
+	for _, host := range gp.Hosts {
+		insteadOfKey := fmt.Sprintf("url.%s/%s/.insteadOf", gp.URL, host)
+		keys = append(keys, insteadOfKey)
+		values = append(values, fmt.Sprintf("https://%s/", host))
+		if gp.RewriteSsh {
+			keys = append(keys, insteadOfKey)
+			values = append(values, fmt.Sprintf("git@%s:", host))
+			keys = append(keys, insteadOfKey)
+			values = append(values, fmt.Sprintf("ssh://git@%s/", host))
+		}
+	}
+	keys = append(keys, fmt.Sprintf("credential.%s/.helper", gp.URL))
+	values = append(values, fmt.Sprintf(credentialHelperTemplate, envVar))
+
+	out = append(out, EnvVar{Name: "GIT_CONFIG_COUNT", Value: strconv.Itoa(len(keys))})
+	for i := range keys {
+		out = append(out,
+			EnvVar{Name: fmt.Sprintf("GIT_CONFIG_KEY_%d", i), Value: keys[i]},
+			EnvVar{Name: fmt.Sprintf("GIT_CONFIG_VALUE_%d", i), Value: values[i]},
+		)
+	}
+	return out
+}

--- a/harness/internal/sandboxidentity/env_test.go
+++ b/harness/internal/sandboxidentity/env_test.go
@@ -18,7 +18,10 @@ func TestComposeEnv_Canonical(t *testing.T) {
 		RewriteSsh: true,
 	}
 
-	got := ComposeEnv("HAYBALE_TOKEN", "the-token", gp)
+	got, err := ComposeEnv("HAYBALE_TOKEN", "the-token", gp)
+	if err != nil {
+		t.Fatalf("ComposeEnv() error: %v", err)
+	}
 
 	want := []EnvVar{
 		{Name: "HAYBALE_TOKEN", Value: "the-token"},
@@ -41,7 +44,10 @@ func TestComposeEnv_Canonical(t *testing.T) {
 // TestComposeEnv_NoGitProxy asserts a bare sandbox identity token (no
 // GitProxy consumer) composes to exactly one entry.
 func TestComposeEnv_NoGitProxy(t *testing.T) {
-	got := ComposeEnv("HAYBALE_TOKEN", "the-token", nil)
+	got, err := ComposeEnv("HAYBALE_TOKEN", "the-token", nil)
+	if err != nil {
+		t.Fatalf("ComposeEnv() error: %v", err)
+	}
 	want := []EnvVar{{Name: "HAYBALE_TOKEN", Value: "the-token"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ComposeEnv(nil gitProxy) = %#v, want %#v", got, want)
@@ -57,7 +63,10 @@ func TestComposeEnv_RewriteSshFalse(t *testing.T) {
 		Hosts: []string{"github.com"},
 	}
 
-	got := ComposeEnv("HAYBALE_TOKEN", "tok", gp)
+	got, err := ComposeEnv("HAYBALE_TOKEN", "tok", gp)
+	if err != nil {
+		t.Fatalf("ComposeEnv() error: %v", err)
+	}
 
 	want := []EnvVar{
 		{Name: "HAYBALE_TOKEN", Value: "tok"},
@@ -81,7 +90,10 @@ func TestComposeEnv_MultiHost(t *testing.T) {
 		RewriteSsh: true,
 	}
 
-	got := ComposeEnv("HAYBALE_TOKEN", "tok", gp)
+	got, err := ComposeEnv("HAYBALE_TOKEN", "tok", gp)
+	if err != nil {
+		t.Fatalf("ComposeEnv() error: %v", err)
+	}
 
 	// 3 insteadOf entries per host * 2 hosts + 1 credential helper = 7.
 	wantCount := "7"
@@ -134,7 +146,10 @@ func TestComposeEnv_CustomEnvVarName(t *testing.T) {
 		Hosts: []string{"github.com"},
 	}
 
-	got := ComposeEnv("MY_CUSTOM_TOKEN", "tok", gp)
+	got, err := ComposeEnv("MY_CUSTOM_TOKEN", "tok", gp)
+	if err != nil {
+		t.Fatalf("ComposeEnv() error: %v", err)
+	}
 
 	firstEntry := got[0]
 	if firstEntry.Name != "MY_CUSTOM_TOKEN" || firstEntry.Value != "tok" {
@@ -150,5 +165,70 @@ func TestComposeEnv_CustomEnvVarName(t *testing.T) {
 	wantHelper := `!f() { echo username=x-access-token; echo "password=$MY_CUSTOM_TOKEN"; }; f`
 	if helperValue != wantHelper {
 		t.Errorf("credential helper = %q, want %q", helperValue, wantHelper)
+	}
+}
+
+// TestComposeEnv_NonPosixEnvVarRejected asserts S-COMPOSEENV-DEFENSE:
+// ComposeEnv must not trust its caller's envVar shape and interpolate a
+// shell metacharacter into credentialHelperTemplate. This holds even
+// though types.ValidateRunConfig already rejects the same shape upstream —
+// the guard here is defense in depth, not redundant, per the doc comment
+// on posixEnvVarNamePattern.
+func TestComposeEnv_NonPosixEnvVarRejected(t *testing.T) {
+	gp := &types.GitProxyConfig{URL: "http://haybale.internal:8466", Hosts: []string{"github.com"}}
+
+	cases := []struct {
+		name   string
+		envVar string
+	}{
+		{"shell metacharacter", `TOKEN"; rm -rf /; echo "`},
+		{"embedded space", "TOKEN VAR"},
+		{"leading digit", "1TOKEN"},
+		{"empty", ""},
+		{"hyphen", "TOKEN-VAR"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ComposeEnv(tc.envVar, "tok", gp)
+			if err == nil {
+				t.Fatalf("ComposeEnv(%q) = %#v, nil; want an error", tc.envVar, got)
+			}
+			if got != nil {
+				t.Errorf("ComposeEnv(%q) returned non-nil output %#v alongside an error", tc.envVar, got)
+			}
+		})
+	}
+}
+
+// TestComposeEnv_ReservedEnvVarRejected asserts S-COMPOSEENV-DEFENSE: an
+// envVar colliding with one of the egress-proxy variables the container/k8s
+// executors set (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) is rejected rather than
+// silently appended after — and likely overriding — the proxy URL.
+func TestComposeEnv_ReservedEnvVarRejected(t *testing.T) {
+	for _, envVar := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		t.Run(envVar, func(t *testing.T) {
+			got, err := ComposeEnv(envVar, "tok", nil)
+			if err == nil {
+				t.Fatalf("ComposeEnv(%q) = %#v, nil; want an error", envVar, got)
+			}
+			if got != nil {
+				t.Errorf("ComposeEnv(%q) returned non-nil output %#v alongside an error", envVar, got)
+			}
+		})
+	}
+}
+
+// TestComposeEnv_ReservedEnvVarLowercaseAllowed pins the scope of the
+// reserved-name guard: only the exact upper-case forms the container/k8s
+// executors set (see proxyEnvFor / container.go, which never set a
+// lower-case http_proxy/https_proxy/no_proxy) are rejected. A lower-case
+// name is a valid, non-colliding POSIX identifier.
+func TestComposeEnv_ReservedEnvVarLowercaseAllowed(t *testing.T) {
+	got, err := ComposeEnv("http_proxy", "tok", nil)
+	if err != nil {
+		t.Fatalf("ComposeEnv(\"http_proxy\") unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "http_proxy" || got[0].Value != "tok" {
+		t.Errorf("ComposeEnv(\"http_proxy\") = %#v, want [{http_proxy tok}]", got)
 	}
 }

--- a/harness/internal/sandboxidentity/env_test.go
+++ b/harness/internal/sandboxidentity/env_test.go
@@ -1,0 +1,154 @@
+package sandboxidentity
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestComposeEnv_Canonical pins the issue's "Composed sandbox env" example
+// byte-for-byte: gitProxy.url "http://haybale.internal:8466", hosts
+// ["github.com"], rewriteSsh true, envVar "HAYBALE_TOKEN". This is the
+// acceptance oracle for issue #516 Part B/C.
+func TestComposeEnv_Canonical(t *testing.T) {
+	gp := &types.GitProxyConfig{
+		URL:        "http://haybale.internal:8466",
+		Hosts:      []string{"github.com"},
+		RewriteSsh: true,
+	}
+
+	got := ComposeEnv("HAYBALE_TOKEN", "the-token", gp)
+
+	want := []EnvVar{
+		{Name: "HAYBALE_TOKEN", Value: "the-token"},
+		{Name: "GIT_CONFIG_COUNT", Value: "4"},
+		{Name: "GIT_CONFIG_KEY_0", Value: "url.http://haybale.internal:8466/github.com/.insteadOf"},
+		{Name: "GIT_CONFIG_VALUE_0", Value: "https://github.com/"},
+		{Name: "GIT_CONFIG_KEY_1", Value: "url.http://haybale.internal:8466/github.com/.insteadOf"},
+		{Name: "GIT_CONFIG_VALUE_1", Value: "git@github.com:"},
+		{Name: "GIT_CONFIG_KEY_2", Value: "url.http://haybale.internal:8466/github.com/.insteadOf"},
+		{Name: "GIT_CONFIG_VALUE_2", Value: "ssh://git@github.com/"},
+		{Name: "GIT_CONFIG_KEY_3", Value: "credential.http://haybale.internal:8466/.helper"},
+		{Name: "GIT_CONFIG_VALUE_3", Value: `!f() { echo username=x-access-token; echo "password=$HAYBALE_TOKEN"; }; f`},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ComposeEnv canonical mismatch:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestComposeEnv_NoGitProxy asserts a bare sandbox identity token (no
+// GitProxy consumer) composes to exactly one entry.
+func TestComposeEnv_NoGitProxy(t *testing.T) {
+	got := ComposeEnv("HAYBALE_TOKEN", "the-token", nil)
+	want := []EnvVar{{Name: "HAYBALE_TOKEN", Value: "the-token"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ComposeEnv(nil gitProxy) = %#v, want %#v", got, want)
+	}
+}
+
+// TestComposeEnv_RewriteSshFalse asserts only the https insteadOf form is
+// emitted per host when RewriteSsh is false: 1 insteadOf + 1 credential
+// helper = 2 GIT_CONFIG entries.
+func TestComposeEnv_RewriteSshFalse(t *testing.T) {
+	gp := &types.GitProxyConfig{
+		URL:   "http://haybale.internal:8466",
+		Hosts: []string{"github.com"},
+	}
+
+	got := ComposeEnv("HAYBALE_TOKEN", "tok", gp)
+
+	want := []EnvVar{
+		{Name: "HAYBALE_TOKEN", Value: "tok"},
+		{Name: "GIT_CONFIG_COUNT", Value: "2"},
+		{Name: "GIT_CONFIG_KEY_0", Value: "url.http://haybale.internal:8466/github.com/.insteadOf"},
+		{Name: "GIT_CONFIG_VALUE_0", Value: "https://github.com/"},
+		{Name: "GIT_CONFIG_KEY_1", Value: "credential.http://haybale.internal:8466/.helper"},
+		{Name: "GIT_CONFIG_VALUE_1", Value: `!f() { echo username=x-access-token; echo "password=$HAYBALE_TOKEN"; }; f`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ComposeEnv(rewriteSsh=false) mismatch:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestComposeEnv_MultiHost asserts each host in Hosts gets its own repeated
+// insteadOf block, and exactly one credential helper covers all of them.
+func TestComposeEnv_MultiHost(t *testing.T) {
+	gp := &types.GitProxyConfig{
+		URL:        "http://haybale.internal:8466",
+		Hosts:      []string{"github.com", "gitlab.example.com"},
+		RewriteSsh: true,
+	}
+
+	got := ComposeEnv("HAYBALE_TOKEN", "tok", gp)
+
+	// 3 insteadOf entries per host * 2 hosts + 1 credential helper = 7.
+	wantCount := "7"
+	if got[1].Name != "GIT_CONFIG_COUNT" || got[1].Value != wantCount {
+		t.Fatalf("GIT_CONFIG_COUNT = %+v, want value %q", got[1], wantCount)
+	}
+
+	// The final numbered entry must be the single credential helper.
+	last := got[len(got)-2]
+	lastVal := got[len(got)-1]
+	if last.Name != "GIT_CONFIG_KEY_6" || last.Value != "credential.http://haybale.internal:8466/.helper" {
+		t.Errorf("final key entry = %+v, want credential helper at index 6", last)
+	}
+	if lastVal.Name != "GIT_CONFIG_VALUE_6" {
+		t.Errorf("final value entry name = %q, want GIT_CONFIG_VALUE_6", lastVal.Name)
+	}
+
+	// Exactly one credential.*.helper entry across the whole output.
+	credCount := 0
+	for _, e := range got {
+		if e.Value == "credential.http://haybale.internal:8466/.helper" {
+			credCount++
+		}
+	}
+	if credCount != 1 {
+		t.Errorf("expected exactly one credential helper key, got %d", credCount)
+	}
+
+	// Both hosts' insteadOf keys must be present.
+	for _, host := range gp.Hosts {
+		wantKey := "url.http://haybale.internal:8466/" + host + "/.insteadOf"
+		found := 0
+		for _, e := range got {
+			if e.Value == wantKey {
+				found++
+			}
+		}
+		if found != 3 {
+			t.Errorf("host %s: expected 3 insteadOf key occurrences (rewriteSsh=true), got %d", host, found)
+		}
+	}
+}
+
+// TestComposeEnv_CustomEnvVarName asserts the credential helper references
+// the caller-supplied variable name, not a hardcoded "HAYBALE_TOKEN" — the
+// env-composition function must generalise beyond haybale's default.
+func TestComposeEnv_CustomEnvVarName(t *testing.T) {
+	gp := &types.GitProxyConfig{
+		URL:   "http://proxy.internal:9000",
+		Hosts: []string{"github.com"},
+	}
+
+	got := ComposeEnv("MY_CUSTOM_TOKEN", "tok", gp)
+
+	firstEntry := got[0]
+	if firstEntry.Name != "MY_CUSTOM_TOKEN" || firstEntry.Value != "tok" {
+		t.Errorf("first entry = %+v, want {MY_CUSTOM_TOKEN tok}", firstEntry)
+	}
+
+	var helperValue string
+	for _, e := range got {
+		if e.Name == "GIT_CONFIG_VALUE_1" {
+			helperValue = e.Value
+		}
+	}
+	wantHelper := `!f() { echo username=x-access-token; echo "password=$MY_CUSTOM_TOKEN"; }; f`
+	if helperValue != wantHelper {
+		t.Errorf("credential helper = %q, want %q", helperValue, wantHelper)
+	}
+}

--- a/harness/internal/sandboxidentity/exchange.go
+++ b/harness/internal/sandboxidentity/exchange.go
@@ -1,0 +1,137 @@
+// Package sandboxidentity requests a control-plane-issued sandbox identity
+// token over the gRPC control stream (issue #516 Part A) and composes the
+// non-secret sandbox environment that wires it into a git-credential proxy
+// such as haybale (issue #516 Part B). The token-exchange helper mirrors
+// harness/internal/permission/askupstream.go's correlation template: emit a
+// request, block with a bounded fail-closed timeout on the matching
+// response.
+package sandboxidentity
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rxbynerd/stirrup/harness/internal/transport"
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// DefaultTimeout is the default duration to wait for a sandbox_token_response
+// from the control plane before timing out. Matches
+// permission.DefaultAskUpstreamTimeout for consistency: both are "wait for a
+// control-plane response before proceeding" timeouts, and the run must abort
+// before sandbox creation on either the timeout or an explicit decline —
+// there is no partial-credential fallback.
+const DefaultTimeout = 60 * time.Second
+
+// MaxTokenBytes caps the length of the control-plane-supplied token. The
+// control plane is partially trusted (see harness/internal/core/types.go's
+// maxAsyncToolResultBytes precedent for control-plane-supplied content); an
+// oversized token is treated as a hard failure rather than truncated, since a
+// truncated JWT is not a usable credential and silently swallowing the
+// excess would hide a misbehaving or compromised control plane.
+const MaxTokenBytes = 16 * 1024
+
+// Transport is the minimal transport surface Exchange needs. Declared
+// locally (rather than depending on transport.Transport's full interface,
+// which also requires Close) to keep the package's dependency surface
+// narrow and testable, mirroring permission.Transport.
+type Transport interface {
+	Emit(event types.HarnessEvent) error
+	OnControl(handler func(event types.ControlEvent))
+}
+
+// Result carries the outcome of a successful token exchange.
+type Result struct {
+	// Token is the signed JWT sandbox identity token. SENSITIVE: callers
+	// must never log, trace, transcribe, or persist it to RunConfig.
+	Token string
+	// ExpiresAt is the token's optional Unix-seconds expiry, as reported by
+	// the control plane. Nil when the control plane did not report one.
+	ExpiresAt *int64
+}
+
+// tokenResponse is the payload extractTokenResponse delivers through the
+// correlator. It exists so Exchange never handles a *types.ControlEvent
+// directly beyond the single destructuring point in extractTokenResponse —
+// CF-1 (issue #516 carry-forward): the raw ControlEvent must never reach a
+// log call or a %v/%+v format verb, since that would echo Token.
+type tokenResponse struct {
+	token     string
+	expiresAt *int64
+	isError   bool
+	reason    string
+}
+
+// extractTokenResponse turns a control event into a tokenResponse payload,
+// or returns an empty id to ignore unrelated events. This is the ONLY place
+// permitted to read event.Token — every other function in this package
+// receives the already-destructured tokenResponse or Result.
+func extractTokenResponse(event types.ControlEvent) (string, any) {
+	if event.Type != "sandbox_token_response" {
+		return "", nil
+	}
+	return event.RequestID, tokenResponse{
+		token:     event.Token,
+		expiresAt: event.ExpiresAt,
+		isError:   event.IsError != nil && *event.IsError,
+		reason:    event.Reason,
+	}
+}
+
+// Exchange requests a sandbox identity token from the control plane
+// (HarnessEvent{Type: "sandbox_token_request"}) and blocks until the
+// matching sandbox_token_response ControlEvent arrives, timeout elapses, or
+// ctx is cancelled. Fail-closed on every non-success outcome: a timeout, a
+// control-plane decline (ControlEvent.IsError), an oversized token, or an
+// empty token all return an error and a zero Result, with no partial
+// credential ever surfaced to the caller. Callers (the factory) must abort
+// sandbox creation on any returned error.
+//
+// If timeout is non-positive, DefaultTimeout (60s) is used.
+//
+// audience is the intended JWT "aud" claim (RunConfig
+// executor.sandboxIdentity.audience); it is informational to the control
+// plane, which may override it.
+func Exchange(ctx context.Context, t Transport, audience string, timeout time.Duration) (Result, error) {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	correlator := transport.NewCorrelator("sbid")
+	correlator.AttachTo(t, extractTokenResponse)
+
+	payload, err := correlator.Await(ctx, timeout, func(requestID string) error {
+		return t.Emit(types.HarnessEvent{
+			Type:      "sandbox_token_request",
+			RequestID: requestID,
+			Audience:  audience,
+		})
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("sandbox identity token exchange: %w", err)
+	}
+
+	resp, ok := payload.(tokenResponse)
+	if !ok {
+		// Defensive: extractTokenResponse only ever delivers tokenResponse,
+		// so reaching this branch means the correlator was wired with a
+		// different extractor than installed above.
+		return Result{}, fmt.Errorf("sandbox identity token exchange: unexpected payload type %T", payload)
+	}
+
+	if resp.isError {
+		return Result{}, fmt.Errorf("sandbox identity token exchange declined by control plane: %s", resp.reason)
+	}
+	if resp.token == "" {
+		return Result{}, fmt.Errorf("sandbox identity token exchange: control plane returned an empty token")
+	}
+	if len(resp.token) > MaxTokenBytes {
+		// Never include the token's content, only its length — a truncated
+		// JWT is not a usable credential, so this fails closed rather than
+		// truncating-and-using.
+		return Result{}, fmt.Errorf("sandbox identity token exchange: token exceeds %d byte cap (got %d bytes)", MaxTokenBytes, len(resp.token))
+	}
+
+	return Result{Token: resp.token, ExpiresAt: resp.expiresAt}, nil
+}

--- a/harness/internal/sandboxidentity/exchange.go
+++ b/harness/internal/sandboxidentity/exchange.go
@@ -93,6 +93,11 @@ func extractTokenResponse(event types.ControlEvent) (string, any) {
 // audience is the intended JWT "aud" claim (RunConfig
 // executor.sandboxIdentity.audience); it is informational to the control
 // plane, which may override it.
+//
+// Exchange mints a fresh transport.Correlator per call rather than reusing
+// one across calls, so at most one Exchange should be in flight per t at a
+// time (matched today: the sole call site, factory.go's
+// BuildLoopWithTransport, invokes Exchange at most once per Transport).
 func Exchange(ctx context.Context, t Transport, audience string, timeout time.Duration) (Result, error) {
 	if timeout <= 0 {
 		timeout = DefaultTimeout

--- a/harness/internal/sandboxidentity/exchange_test.go
+++ b/harness/internal/sandboxidentity/exchange_test.go
@@ -1,0 +1,273 @@
+package sandboxidentity
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// mockTransport implements the Transport interface for testing, mirroring
+// permission/askupstream_test.go's mockTransport.
+type mockTransport struct {
+	mu       sync.Mutex
+	emitted  []types.HarnessEvent
+	handlers []func(types.ControlEvent)
+	emitErr  error
+
+	// respond, when set, is invoked synchronously from Emit with the
+	// emitted event's RequestID; it returns the ControlEvent to deliver
+	// (or false to deliver nothing, e.g. to simulate a timeout).
+	respond func(requestID string) (types.ControlEvent, bool)
+}
+
+func (m *mockTransport) Emit(event types.HarnessEvent) error {
+	m.mu.Lock()
+	if m.emitErr != nil {
+		m.mu.Unlock()
+		return m.emitErr
+	}
+	m.emitted = append(m.emitted, event)
+	respond := m.respond
+	m.mu.Unlock()
+
+	if respond != nil {
+		if ce, ok := respond(event.RequestID); ok {
+			m.deliver(ce)
+		}
+	}
+	return nil
+}
+
+func (m *mockTransport) OnControl(handler func(types.ControlEvent)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers = append(m.handlers, handler)
+}
+
+func (m *mockTransport) deliver(event types.ControlEvent) {
+	m.mu.Lock()
+	handlers := make([]func(types.ControlEvent), len(m.handlers))
+	copy(handlers, m.handlers)
+	m.mu.Unlock()
+	for _, h := range handlers {
+		h(event)
+	}
+}
+
+func (m *mockTransport) lastEmitted() *types.HarnessEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.emitted) == 0 {
+		return nil
+	}
+	e := m.emitted[len(m.emitted)-1]
+	return &e
+}
+
+func boolPtr(b bool) *bool    { return &b }
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestExchange_Success(t *testing.T) {
+	mt := &mockTransport{
+		respond: func(requestID string) (types.ControlEvent, bool) {
+			return types.ControlEvent{
+				Type:      "sandbox_token_response",
+				RequestID: requestID,
+				Token:     "the-jwt",
+				ExpiresAt: int64Ptr(1234),
+			}, true
+		},
+	}
+
+	result, err := Exchange(context.Background(), mt, "https://haybale.internal", time.Second)
+	if err != nil {
+		t.Fatalf("Exchange() error: %v", err)
+	}
+	if result.Token != "the-jwt" {
+		t.Errorf("Token = %q, want %q", result.Token, "the-jwt")
+	}
+	if result.ExpiresAt == nil || *result.ExpiresAt != 1234 {
+		t.Errorf("ExpiresAt = %v, want 1234", result.ExpiresAt)
+	}
+
+	emitted := mt.lastEmitted()
+	if emitted == nil {
+		t.Fatal("expected a sandbox_token_request to be emitted")
+	}
+	if emitted.Type != "sandbox_token_request" {
+		t.Errorf("Type = %q, want sandbox_token_request", emitted.Type)
+	}
+	if emitted.Audience != "https://haybale.internal" {
+		t.Errorf("Audience = %q, want https://haybale.internal", emitted.Audience)
+	}
+	if emitted.RequestID == "" {
+		t.Error("RequestID should be set on the outbound request")
+	}
+}
+
+// TestExchange_Timeout asserts fail-closed behaviour: no response within
+// the bounded wait returns an error and a zero Result, never a partial or
+// default token.
+func TestExchange_Timeout(t *testing.T) {
+	mt := &mockTransport{} // never responds
+
+	result, err := Exchange(context.Background(), mt, "aud", 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if result.Token != "" {
+		t.Errorf("expected empty token on timeout, got %q", result.Token)
+	}
+}
+
+// TestExchange_ContextCancelled asserts cancellation also fails closed.
+func TestExchange_ContextCancelled(t *testing.T) {
+	mt := &mockTransport{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := Exchange(ctx, mt, "aud", time.Second)
+	if err == nil {
+		t.Fatal("expected an error from a cancelled context, got nil")
+	}
+	if result.Token != "" {
+		t.Errorf("expected empty token, got %q", result.Token)
+	}
+}
+
+// TestExchange_Decline asserts a control-plane decline (IsError) aborts
+// with an error incorporating Reason, never proceeding with a token.
+func TestExchange_Decline(t *testing.T) {
+	mt := &mockTransport{
+		respond: func(requestID string) (types.ControlEvent, bool) {
+			return types.ControlEvent{
+				Type:      "sandbox_token_response",
+				RequestID: requestID,
+				IsError:   boolPtr(true),
+				Reason:    "no issuer configured",
+			}, true
+		},
+	}
+
+	result, err := Exchange(context.Background(), mt, "aud", time.Second)
+	if err == nil {
+		t.Fatal("expected an error from a declined exchange")
+	}
+	if !strings.Contains(err.Error(), "no issuer configured") {
+		t.Errorf("error %q should incorporate the decline reason", err.Error())
+	}
+	if result.Token != "" {
+		t.Errorf("expected empty token on decline, got %q", result.Token)
+	}
+}
+
+// TestExchange_OverCap asserts a token exceeding MaxTokenBytes is treated
+// as an error and never truncated-and-used.
+func TestExchange_OverCap(t *testing.T) {
+	oversized := strings.Repeat("a", MaxTokenBytes+1)
+	mt := &mockTransport{
+		respond: func(requestID string) (types.ControlEvent, bool) {
+			return types.ControlEvent{
+				Type:      "sandbox_token_response",
+				RequestID: requestID,
+				Token:     oversized,
+			}, true
+		},
+	}
+
+	result, err := Exchange(context.Background(), mt, "aud", time.Second)
+	if err == nil {
+		t.Fatal("expected an error for an oversized token")
+	}
+	if result.Token != "" {
+		t.Error("an oversized token must not be returned, truncated or otherwise")
+	}
+	if strings.Contains(err.Error(), oversized) {
+		t.Error("error message must not contain the raw oversized token content")
+	}
+}
+
+// TestExchange_EmptyToken asserts a success-shaped response (IsError not
+// set) carrying no token is still treated as a failure rather than an
+// empty-string credential silently flowing into env composition.
+func TestExchange_EmptyToken(t *testing.T) {
+	mt := &mockTransport{
+		respond: func(requestID string) (types.ControlEvent, bool) {
+			return types.ControlEvent{
+				Type:      "sandbox_token_response",
+				RequestID: requestID,
+			}, true
+		},
+	}
+
+	_, err := Exchange(context.Background(), mt, "aud", time.Second)
+	if err == nil {
+		t.Fatal("expected an error for an empty token")
+	}
+}
+
+// TestExchange_NoTokenInLogs is the CF-1 carry-forward test (issue #516):
+// no slog record emitted during a token exchange (success, decline,
+// timeout, or over-cap) may contain the literal token value, and returned
+// errors must not surface it either. Exchange must destructure
+// ControlEvent to named fields rather than %v/%+v-formatting or
+// json.Marshal-ing the whole struct.
+func TestExchange_NoTokenInLogs(t *testing.T) {
+	const secretToken = "eyJhbGciOiJFUzI1NiJ9.super-secret-payload-value.signature-goes-here"
+
+	var buf strings.Builder
+	handler := slog.NewTextHandler(&buf, nil)
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(prevDefault)
+
+	mt := &mockTransport{
+		respond: func(requestID string) (types.ControlEvent, bool) {
+			return types.ControlEvent{
+				Type:      "sandbox_token_response",
+				RequestID: requestID,
+				Token:     secretToken,
+				ExpiresAt: int64Ptr(time.Now().Add(time.Hour).Unix()),
+			}, true
+		},
+	}
+
+	result, err := Exchange(context.Background(), mt, "aud", time.Second)
+	if err != nil {
+		t.Fatalf("Exchange() error: %v", err)
+	}
+	if result.Token != secretToken {
+		t.Fatalf("sanity check: expected the returned token to equal the secret fixture")
+	}
+
+	if strings.Contains(buf.String(), secretToken) {
+		t.Errorf("token leaked into slog output: %s", buf.String())
+	}
+
+	// Also exercise the decline and over-cap paths, which construct error
+	// strings from response fields — confirm neither leaks a token value
+	// through fmt.Errorf.
+	mtDecline := &mockTransport{
+		respond: func(requestID string) (types.ControlEvent, bool) {
+			return types.ControlEvent{
+				Type:      "sandbox_token_response",
+				RequestID: requestID,
+				IsError:   boolPtr(true),
+				Reason:    "issuer down",
+			}, true
+		},
+	}
+	_, declineErr := Exchange(context.Background(), mtDecline, "aud", time.Second)
+	if declineErr == nil || strings.Contains(declineErr.Error(), secretToken) {
+		t.Errorf("decline error must not contain the token: %v", declineErr)
+	}
+
+	if strings.Contains(buf.String(), secretToken) {
+		t.Errorf("token leaked into slog output after decline path: %s", buf.String())
+	}
+}

--- a/harness/internal/sandboxidentity/exchange_test.go
+++ b/harness/internal/sandboxidentity/exchange_test.go
@@ -125,6 +125,36 @@ func TestExchange_Timeout(t *testing.T) {
 	}
 }
 
+// TestExchange_DefaultTimeoutWhenZero verifies the timeout<=0 → DefaultTimeout
+// fallback — the shape factory.go uses in production
+// (sandboxidentity.Exchange(ctx, tp, si.Audience, 0)) — actually takes
+// effect rather than firing a zero-duration timer. Mirrors
+// transport.TestCorrelator_DefaultTimeoutWhenZero's technique: we cannot
+// wait out the full 60s default, so cancel via ctx after a short delay and
+// assert the call did not return near-instantly.
+func TestExchange_DefaultTimeoutWhenZero(t *testing.T) {
+	mt := &mockTransport{} // never responds
+
+	ctx, cancel := context.WithCancel(context.Background())
+	start := time.Now()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := Exchange(ctx, mt, "aud", 0)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected an error from the cancelled context")
+	}
+	if result.Token != "" {
+		t.Errorf("expected empty token, got %q", result.Token)
+	}
+	if elapsed < 15*time.Millisecond {
+		t.Errorf("returned too quickly (%s) — a zero timeout may have fired immediately instead of falling back to DefaultTimeout", elapsed)
+	}
+}
+
 // TestExchange_ContextCancelled asserts cancellation also fails closed.
 func TestExchange_ContextCancelled(t *testing.T) {
 	mt := &mockTransport{}

--- a/harness/internal/sandboxidentity/git_credential_test.go
+++ b/harness/internal/sandboxidentity/git_credential_test.go
@@ -1,0 +1,126 @@
+package sandboxidentity
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rxbynerd/stirrup/types"
+)
+
+// TestComposeEnv_GitCredentialHelper_StubHaybale is the issue #516
+// "stub-haybale" acceptance test: it drives a REAL git binary against a
+// stub HTTP server standing in for haybale, using ONLY the env
+// ComposeEnv produces, and asserts the Basic-auth password git presents
+// equals the sandbox identity token. This is feasible without a real
+// sandbox because the GIT_CONFIG_* env vars are honoured by the git
+// process itself, independent of whether it runs on the host or inside a
+// container/Pod — the executor plumb-through (container_test.go /
+// factory_sandboxidentity_test.go) already proves the env reaches the
+// sandbox; this test proves git actually uses it the way the issue's
+// acceptance criteria describe.
+//
+// No live E2E and no external network: the stub server binds 127.0.0.1
+// only, and the "github.com" host is never contacted — the insteadOf
+// rewrite is exactly what prevents that.
+func TestComposeEnv_GitCredentialHelper_StubHaybale(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not found in PATH")
+	}
+
+	const wantToken = "test-jwt-sandbox-identity-token"
+
+	var (
+		mu           sync.Mutex
+		sawNoAuth    bool
+		capturedUser string
+		capturedPass string
+		sawAuth      bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		mu.Lock()
+		if !ok {
+			sawNoAuth = true
+		} else {
+			sawAuth = true
+			capturedUser = user
+			capturedPass = pass
+		}
+		mu.Unlock()
+
+		if !ok {
+			// Prompt git to retry with the credential helper's output, the
+			// same way haybale (or any git smart-HTTP server) would.
+			w.Header().Set("WWW-Authenticate", `Basic realm="haybale-stub"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// The stub does not need to speak the full smart-HTTP protocol —
+		// once the credential has been captured, failing the request is
+		// sufficient; the test only asserts what was presented, not that
+		// the clone succeeded.
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	gp := &types.GitProxyConfig{
+		URL:   server.URL,
+		Hosts: []string{"github.com"},
+	}
+	env := ComposeEnv("HAYBALE_TOKEN", wantToken, gp)
+
+	path, ok := os.LookupEnv("PATH")
+	if !ok {
+		t.Fatal("PATH is not set in the test process environment")
+	}
+	envStrings := []string{
+		"PATH=" + path,
+		"HOME=" + t.TempDir(),
+		// Isolate from the host's real git config (a developer machine's
+		// global credential.helper or insteadOf rules would otherwise
+		// interfere with — or mask a regression in — the composed config
+		// this test exists to verify).
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_TERMINAL_PROMPT=0",
+	}
+	for _, e := range env {
+		envStrings = append(envStrings, e.Name+"="+e.Value)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// ls-remote performs a single info/refs discovery request — everything
+	// the credential helper / insteadOf rewrite needs to be exercised,
+	// without the overhead (or on-disk side effects) of a full clone.
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "https://github.com/rxbynerd/dressage.git")
+	cmd.Env = envStrings
+	// Intentionally ignore the error: the stub always fails the
+	// authenticated request (by design, see above), so git is expected to
+	// exit non-zero. What matters is what it presented on the wire.
+	_ = cmd.Run()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !sawNoAuth {
+		t.Error("expected an initial unauthenticated request (git should probe before invoking the credential helper)")
+	}
+	if !sawAuth {
+		t.Fatal("expected a follow-up request carrying Basic auth from the composed credential helper")
+	}
+	if capturedUser != "x-access-token" {
+		t.Errorf("Basic-auth username = %q, want %q", capturedUser, "x-access-token")
+	}
+	if capturedPass != wantToken {
+		t.Errorf("Basic-auth password = %q, want the sandbox identity token %q", capturedPass, wantToken)
+	}
+}

--- a/harness/internal/sandboxidentity/git_credential_test.go
+++ b/harness/internal/sandboxidentity/git_credential_test.go
@@ -28,6 +28,14 @@ import (
 // No live E2E and no external network: the stub server binds 127.0.0.1
 // only, and the "github.com" host is never contacted — the insteadOf
 // rewrite is exactly what prevents that.
+//
+// AC#2 requires both the "https://" form and the "git@host:"/"ssh://"
+// insteadOf rewriting to route through the proxy. The scp/ssh forms were
+// previously pinned only by exact-string-match in env_test.go, never
+// driven through a real git binary — a subtle insteadOf-rewrite
+// regression specific to the ssh form would not have been caught by
+// anything that actually invokes git. The "ssh scp-form" subtest below
+// closes that gap (S-SSH-COV).
 func TestComposeEnv_GitCredentialHelper_StubHaybale(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git binary not found in PATH")
@@ -35,95 +43,109 @@ func TestComposeEnv_GitCredentialHelper_StubHaybale(t *testing.T) {
 
 	const wantToken = "test-jwt-sandbox-identity-token"
 
-	var (
-		mu           sync.Mutex
-		sawNoAuth    bool
-		capturedUser string
-		capturedPass string
-		sawAuth      bool
-	)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok := r.BasicAuth()
-		mu.Lock()
-		if !ok {
-			sawNoAuth = true
-		} else {
-			sawAuth = true
-			capturedUser = user
-			capturedPass = pass
-		}
-		mu.Unlock()
-
-		if !ok {
-			// Prompt git to retry with the credential helper's output, the
-			// same way haybale (or any git smart-HTTP server) would.
-			w.Header().Set("WWW-Authenticate", `Basic realm="haybale-stub"`)
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		// The stub does not need to speak the full smart-HTTP protocol —
-		// once the credential has been captured, failing the request is
-		// sufficient; the test only asserts what was presented, not that
-		// the clone succeeded.
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	gp := &types.GitProxyConfig{
-		URL:   server.URL,
-		Hosts: []string{"github.com"},
-	}
-	env, err := ComposeEnv("HAYBALE_TOKEN", wantToken, gp)
-	if err != nil {
-		t.Fatalf("ComposeEnv() error: %v", err)
+	cases := []struct {
+		name       string
+		remote     string
+		rewriteSsh bool
+	}{
+		{name: "https", remote: "https://github.com/rxbynerd/dressage.git", rewriteSsh: false},
+		{name: "ssh scp-form", remote: "git@github.com:rxbynerd/dressage.git", rewriteSsh: true},
 	}
 
-	path, ok := os.LookupEnv("PATH")
-	if !ok {
-		t.Fatal("PATH is not set in the test process environment")
-	}
-	envStrings := []string{
-		"PATH=" + path,
-		"HOME=" + t.TempDir(),
-		// Isolate from the host's real git config (a developer machine's
-		// global credential.helper or insteadOf rules would otherwise
-		// interfere with — or mask a regression in — the composed config
-		// this test exists to verify).
-		"GIT_CONFIG_GLOBAL=/dev/null",
-		"GIT_CONFIG_SYSTEM=/dev/null",
-		"GIT_TERMINAL_PROMPT=0",
-	}
-	for _, e := range env {
-		envStrings = append(envStrings, e.Name+"="+e.Value)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				mu           sync.Mutex
+				sawNoAuth    bool
+				capturedUser string
+				capturedPass string
+				sawAuth      bool
+			)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				user, pass, ok := r.BasicAuth()
+				mu.Lock()
+				if !ok {
+					sawNoAuth = true
+				} else {
+					sawAuth = true
+					capturedUser = user
+					capturedPass = pass
+				}
+				mu.Unlock()
 
-	// ls-remote performs a single info/refs discovery request — everything
-	// the credential helper / insteadOf rewrite needs to be exercised,
-	// without the overhead (or on-disk side effects) of a full clone.
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", "https://github.com/rxbynerd/dressage.git")
-	cmd.Env = envStrings
-	// Intentionally ignore the error: the stub always fails the
-	// authenticated request (by design, see above), so git is expected to
-	// exit non-zero. What matters is what it presented on the wire.
-	_ = cmd.Run()
+				if !ok {
+					// Prompt git to retry with the credential helper's output, the
+					// same way haybale (or any git smart-HTTP server) would.
+					w.Header().Set("WWW-Authenticate", `Basic realm="haybale-stub"`)
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				// The stub does not need to speak the full smart-HTTP protocol —
+				// once the credential has been captured, failing the request is
+				// sufficient; the test only asserts what was presented, not that
+				// the clone succeeded.
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
 
-	mu.Lock()
-	defer mu.Unlock()
+			gp := &types.GitProxyConfig{
+				URL:        server.URL,
+				Hosts:      []string{"github.com"},
+				RewriteSsh: tc.rewriteSsh,
+			}
+			env, err := ComposeEnv("HAYBALE_TOKEN", wantToken, gp)
+			if err != nil {
+				t.Fatalf("ComposeEnv() error: %v", err)
+			}
 
-	if !sawNoAuth {
-		t.Error("expected an initial unauthenticated request (git should probe before invoking the credential helper)")
-	}
-	if !sawAuth {
-		t.Fatal("expected a follow-up request carrying Basic auth from the composed credential helper")
-	}
-	if capturedUser != "x-access-token" {
-		t.Errorf("Basic-auth username = %q, want %q", capturedUser, "x-access-token")
-	}
-	if capturedPass != wantToken {
-		t.Errorf("Basic-auth password = %q, want the sandbox identity token %q", capturedPass, wantToken)
+			path, ok := os.LookupEnv("PATH")
+			if !ok {
+				t.Fatal("PATH is not set in the test process environment")
+			}
+			envStrings := []string{
+				"PATH=" + path,
+				"HOME=" + t.TempDir(),
+				// Isolate from the host's real git config (a developer machine's
+				// global credential.helper or insteadOf rules would otherwise
+				// interfere with — or mask a regression in — the composed config
+				// this test exists to verify).
+				"GIT_CONFIG_GLOBAL=/dev/null",
+				"GIT_CONFIG_SYSTEM=/dev/null",
+				"GIT_TERMINAL_PROMPT=0",
+			}
+			for _, e := range env {
+				envStrings = append(envStrings, e.Name+"="+e.Value)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			// ls-remote performs a single info/refs discovery request — everything
+			// the credential helper / insteadOf rewrite needs to be exercised,
+			// without the overhead (or on-disk side effects) of a full clone.
+			cmd := exec.CommandContext(ctx, "git", "ls-remote", tc.remote)
+			cmd.Env = envStrings
+			// Intentionally ignore the error: the stub always fails the
+			// authenticated request (by design, see above), so git is expected to
+			// exit non-zero. What matters is what it presented on the wire.
+			_ = cmd.Run()
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if !sawNoAuth {
+				t.Error("expected an initial unauthenticated request (git should probe before invoking the credential helper)")
+			}
+			if !sawAuth {
+				t.Fatal("expected a follow-up request carrying Basic auth from the composed credential helper")
+			}
+			if capturedUser != "x-access-token" {
+				t.Errorf("Basic-auth username = %q, want %q", capturedUser, "x-access-token")
+			}
+			if capturedPass != wantToken {
+				t.Errorf("Basic-auth password = %q, want the sandbox identity token %q", capturedPass, wantToken)
+			}
+		})
 	}
 }

--- a/harness/internal/sandboxidentity/git_credential_test.go
+++ b/harness/internal/sandboxidentity/git_credential_test.go
@@ -74,7 +74,10 @@ func TestComposeEnv_GitCredentialHelper_StubHaybale(t *testing.T) {
 		URL:   server.URL,
 		Hosts: []string{"github.com"},
 	}
-	env := ComposeEnv("HAYBALE_TOKEN", wantToken, gp)
+	env, err := ComposeEnv("HAYBALE_TOKEN", wantToken, gp)
+	if err != nil {
+		t.Fatalf("ComposeEnv() error: %v", err)
+	}
 
 	path, ok := os.LookupEnv("PATH")
 	if !ok {

--- a/harness/internal/sandboxidentity/warn.go
+++ b/harness/internal/sandboxidentity/warn.go
@@ -1,0 +1,41 @@
+package sandboxidentity
+
+import (
+	"log/slog"
+	"time"
+)
+
+// WarnIfExpiresBeforeBudget emits a scrub-safe slog.Warn (issue #516 CF-2)
+// when a token's reported expiry is earlier than the run's configured
+// wall-clock budget. The env is frozen at sandbox creation, so a token that
+// expires mid-run would fail authentication for any git operation issued
+// after expiry (e.g. a hooks.postRun push); this is a heads-up for the
+// operator/control-plane implementer, not a fail-closed condition — the v1
+// posture (see docs/deployment.md) is that the control plane is expected to
+// size exp to the run's budget, and this warning surfaces the case where it
+// did not.
+//
+// Deliberately logs only the two Unix timestamps being compared, never the
+// token itself — this call site must not receive the token value at all
+// (see Exchange's Result, which separates Token from ExpiresAt).
+//
+// Uses the package-level slog logger (not a caller-supplied *slog.Logger)
+// because this runs in BuildLoopWithTransport before the run's
+// scrub-wrapped structured logger is constructed (factory step 3, ahead of
+// step 5's observability.NewLoggerWithExport) — the same constraint
+// types.warnGitProxyAllowlistGap already works under. The warning content
+// itself is scrub-safe by construction (two Unix-second integers), so the
+// absence of the scrub-wrapping is not a leak risk.
+func WarnIfExpiresBeforeBudget(expiresAt *int64, runBudgetSeconds int, now time.Time) {
+	if expiresAt == nil || runBudgetSeconds <= 0 {
+		return
+	}
+	budgetDeadline := now.Add(time.Duration(runBudgetSeconds) * time.Second).Unix()
+	if *expiresAt < budgetDeadline {
+		slog.Warn(
+			"sandbox identity token expires before the run's configured wall-clock budget; git operations issued late in the run (e.g. a hooks.postRun push) may fail authentication",
+			"tokenExpiresAtUnix", *expiresAt,
+			"runBudgetDeadlineUnix", budgetDeadline,
+		)
+	}
+}

--- a/harness/internal/sandboxidentity/warn_test.go
+++ b/harness/internal/sandboxidentity/warn_test.go
@@ -1,0 +1,63 @@
+package sandboxidentity
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWarnIfExpiresBeforeBudget is the CF-2 carry-forward test (issue
+// #516): the harness warns (scrub-safe) when the token's reported expiry
+// is earlier than the run's configured wall-clock budget.
+func TestWarnIfExpiresBeforeBudget(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		expiresAt   *int64
+		budgetSecs  int
+		wantWarning bool
+	}{
+		{
+			name:        "expires before budget warns",
+			expiresAt:   int64Ptr(now.Add(5 * time.Minute).Unix()),
+			budgetSecs:  3600,
+			wantWarning: true,
+		},
+		{
+			name:        "expires after budget is silent",
+			expiresAt:   int64Ptr(now.Add(2 * time.Hour).Unix()),
+			budgetSecs:  3600,
+			wantWarning: false,
+		},
+		{
+			name:        "nil expiry is silent",
+			expiresAt:   nil,
+			budgetSecs:  3600,
+			wantWarning: false,
+		},
+		{
+			name:        "zero budget is silent (nothing to compare against)",
+			expiresAt:   int64Ptr(now.Unix()),
+			budgetSecs:  0,
+			wantWarning: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			prevDefault := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+			defer slog.SetDefault(prevDefault)
+
+			WarnIfExpiresBeforeBudget(tc.expiresAt, tc.budgetSecs, now)
+
+			gotWarning := strings.Contains(buf.String(), "expires before the run's configured wall-clock budget")
+			if gotWarning != tc.wantWarning {
+				t.Errorf("warning emitted = %v, want %v (log output: %q)", gotWarning, tc.wantWarning, buf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

PR **C** of the 4-PR stack for issue #516 — the core runtime wiring. Requests a sandbox identity token from the control plane over the existing gRPC stream (fail-closed), composes the non-secret git-proxy env, and injects both into the sandbox at creation. Builds on PR A (event pair) and PR B (RunConfig surface). Docs land in PR D.

Stacked on PR B (#518, `feat/issue-516-runconfig-surface`). Review against its base branch.

## What changed

- New private package `harness/internal/sandboxidentity/`:
  - `Exchange(ctx, transport, audience, timeout) (Result, error)` — emits `sandbox_token_request`, blocks on the correlated `sandbox_token_response` via the existing `transport.Correlator` (same primitive as `permission/askupstream.go`); **fail-closed 60s** default; **16 KiB** token entry cap; handles the `is_error`+`reason` decline form. Destructures `ControlEvent` and never logs/`%v`-formats it (token never touches logs — CF-1).
  - `ComposeEnv(envVar, token, *GitProxyConfig) []EnvVar` — pure, no I/O; reproduces the issue's composed-env block byte-for-byte (token var + `GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n` incl. the three repeated-`insteadOf` rewrites for https/scp-ssh/ssh-url and the inline credential helper).
  - `WarnIfExpiresBeforeBudget(...)` — scrub-safe `slog.Warn` when `expires_at` < run wall-clock budget (CF-2).
- Executor plumb-through: `executor/envpair.go` + extra-env threading into `container.go` and `buildSandboxPodSpec` (`k8s.go`, `agentsandbox.go`).
- Factory wiring in `BuildLoopWithTransport` **before** `buildExecutor` — `core/loop.go` untouched (loop purity preserved). Nil-transport → fail-closed error.

## Tests

- Unit: canonical env (exact match), rewriteSsh=false, multi-host, non-default envVar, timeout fail-closed, decline handling, 16 KiB over-cap, CF-1 no-token-in-logs, CF-2 expiry warning.
- Integration (`core/factory_sandboxidentity_test.go`): fake in-process transport auto-responds to `sandbox_token_request`; fake Docker Engine API on a unix socket captures `POST /containers/create` and asserts `HAYBALE_TOKEN` + all 4 `GIT_CONFIG_*` pairs. Nil-transport fail-closed pinned.
- Stub-haybale (`sandboxidentity/git_credential_test.go`): drives a real `git ls-remote` (isolated env) against an `httptest.Server` using only `ComposeEnv`'s output; asserts the captured Basic-auth password equals the token. No network, no live haybale.

## Deviations / notes

- The integration test uses a fake `transport.Transport` seam rather than a literal bufconn `grpc.Server`; PR A's `grpc_translate_test.go` already covers the proto wire round-trip for the new fields, so this test exercises the seam `BuildLoopWithTransport` actually consumes.
- v1 restriction: sandbox identity issuance requires a pre-established transport (the `stirrup job` control-plane entrypoint). A bare `BuildLoop` with `transport.type=grpc` builds its transport after the executor and fails closed with a clear error. (Documented in PR D.)
- Overlap: `core/factory.go`, `core/factory_test.go`, `executor/container.go` are also touched by open PR #495 — different regions, no functional conflict; normal merge-sequence resolution when both land.

## Test evidence

- `just` (build + test, testcache cleared): all packages `ok`.
- `just lint`: `0 issues`. `go test -race` on executor/core/sandboxidentity clean.

Issue #516 is closed by PR D only (the final PR in this stack); this PR carries no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CS8eU446ivtvsRgHNDroTN
